### PR TITLE
chore: update PDFBox to 3.0.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
         <kotlin.version>2.2.20</kotlin.version>
         <logback.version>1.5.18</logback.version>
         <lombok.version>1.18.38</lombok.version>
-        <pdfbox.version>3.0.5</pdfbox.version>
+        <pdfbox.version>3.0.7</pdfbox.version>
         <poi.version>5.4.0</poi.version>
         <javafx.version>21.0.2</javafx.version>
         <slf4j.version>2.0.17</slf4j.version>


### PR DESCRIPTION
## Summary

Updates Apache PDFBox from 3.0.5 to 3.0.7 (patch on the v1.5 line).

## Validation

- [x] `./mvnw clean test` — 672 tests pass
- [x] `./mvnw clean verify` — full canonical gate green (jar built: `graphcompose-1.5.0.jar`)
- [x] All 30 example PDFs regenerated via `GenerateAllExamples` — no errors
- [x] Visual regression tests pass against committed baselines:
  - `PdfVisualRegressionTest` (9 tests)
  - `ShapeContainerVisualRegressionTest` (3 tests)

## Notes

- Single-line change in [pom.xml](pom.xml) — PDFBox is consumed only via the `${pdfbox.version}` property, no other refs to update.
- Branch was cut from `origin/main` (v1.5.0 + 2 post-release fixes) so this lands cleanly as v1.5.x patch territory; `develop` (v1.6.0-beta.1) will pick up the bump on the next sync from `main`.