### PR TITLE
test: verify CI perf-smoke fix (will close, do not merge)

### DIFF
--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,6 +1,6 @@
 # GraphCompose release process
 
-This is the canonical release runbook for GraphCompose 1.x.
+This is the canonical release runbook for GraphCompose 1.x releases.
 
 - JitPack — `com.github.DemchaAV:GraphCompose:v<version>` (current)
 - Maven Central — `io.github.demchaav:graphcompose:<version>` (planned, v1.7+)


### PR DESCRIPTION
Throwaway PR to confirm the perf-smoke job passes against the merged workflow + benchmark fixes from main. Will close without merging once green. The 1-character doc tweak is a no-op — present only to give GitHub something to PR.