### PR TITLE
v1.6.1 prep: Java 17 baseline migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,10 +42,20 @@ jobs:
             test
 
   build-and-test:
-    name: Build and run tests
+    name: Build and run tests (JDK ${{ matrix.java }})
     if: github.event_name != 'schedule'
     needs: architecture-and-documentation-guards
     runs-on: ubuntu-latest
+    strategy:
+      # Don't cancel sibling matrix jobs on the first failure — a
+      # regression on one JDK is informative even if other JDKs are
+      # still running.
+      fail-fast: false
+      matrix:
+        # 17 = baseline, 21 = previous baseline still supported,
+        # 25 = current LTS, validates the byte-buddy / Mockito 5.23
+        # bumps that #10 motivated.
+        java: ['17', '21', '25']
     env:
       JAVA_TOOL_OPTIONS: -Djava.awt.headless=true
 
@@ -53,17 +63,21 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Temurin JDK 17
+      - name: Set up Temurin JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '17'
+          java-version: ${{ matrix.java }}
           cache: maven
 
       - name: Build and run tests
         run: ./mvnw -B -ntp clean verify
 
       - name: Generate Javadoc
+        # Run only on the baseline JDK — Javadoc output is identical
+        # across JVMs and one pass is enough to catch broken @link
+        # references.
+        if: matrix.java == '17'
         run: ./mvnw -B -ntp javadoc:javadoc
 
   examples-generation:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - develop
   pull_request:
-    branches:
-      - main
+    # Run CI for any incoming PR regardless of the base branch so
+    # feature branches targeting `develop` (e.g. v1.7 prep) also
+    # exercise the full pipeline.
   workflow_dispatch:
   schedule:
     - cron: '0 5 * * 1'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Temurin JDK 21
+      - name: Set up Temurin JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: '17'
           cache: maven
 
       - name: Run guards
@@ -51,11 +51,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Temurin JDK 21
+      - name: Set up Temurin JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: '17'
           cache: maven
 
       - name: Build and run tests
@@ -76,11 +76,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Temurin JDK 21
+      - name: Set up Temurin JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: '17'
           cache: maven
 
       - name: Install root artifact
@@ -114,11 +114,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Temurin JDK 21
+      - name: Set up Temurin JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: '17'
           cache: maven
 
       - name: Install root artifact
@@ -153,11 +153,11 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set up Temurin JDK 21
+      - name: Set up Temurin JDK 17
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: '21'
+          java-version: '17'
           cache: maven
 
       - name: Restore benchmark history cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,44 @@
 All notable changes to GraphCompose are documented here. Versions
 follow semantic versioning; release dates are ISO 8601.
 
+## v1.7.0 — Planned
+
+The "broad reach" release. Drops the Java 21 baseline in favour of
+Java 17+ to widen enterprise adoption without losing any author-
+facing surface. Co-developed with external contributor
+[@jottinger](https://github.com/jottinger) ([#8](https://github.com/DemchaAV/GraphCompose/issues/8),
+[#10](https://github.com/DemchaAV/GraphCompose/issues/10)).
+
+### Toolchain
+
+- **Java 17 baseline** — `<maven.compiler.release>` flips from `21`
+  to `17` across `pom.xml`, `examples/pom.xml`, and `benchmarks/pom.xml`.
+  Author-facing API is unchanged; the engine source drops
+  Java 21–only constructs (switch-with-type-patterns, `List.getFirst()`)
+  in favour of Java 17–compatible forms. CI runs against
+  Temurin JDK 17.
+- **Dependency refresh + CVE pass.** Bumps Jackson `2.20.1 → 2.21.3`,
+  Logback `1.5.18 → 1.5.32`, Lombok `1.18.38 → 1.18.46`, POI
+  `5.4.0 → 5.5.1`, SnakeYAML `2.4 → 2.6`, AssertJ `3.27.3 → 3.27.6`,
+  JUnit `5.12.2 → 5.14.4`, Mockito `5.20.0 → 5.23.0`. Adds explicit
+  ByteBuddy `1.18.7` so Mockito works on the Java 25+ access rules.
+  Maven plugin bumps: `maven-compiler-plugin 3.13 → 3.15`,
+  `maven-surefire-plugin 3.2.5 → 3.5.5`, `exec-maven-plugin 3.5 → 3.6.2`.
+
+### Distribution
+
+- **Maven Central** is the planned primary distribution channel
+  ([#7](https://github.com/DemchaAV/GraphCompose/issues/7)). JitPack
+  stays as a documented fallback.
+
+### Non-goals
+
+- No public-API breakage on the engine surface.
+- No Templates v3 work — Templates v2 remains the canonical author
+  surface.
+
+---
+
 ## v1.6.0 — 2026-05-07
 
 The "expressive" release. Closes the remaining canonical-vs-legacy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,22 +3,28 @@
 All notable changes to GraphCompose are documented here. Versions
 follow semantic versioning; release dates are ISO 8601.
 
-## v1.7.0 — Planned
+## v1.6.1 — Planned
 
-The "broad reach" release. Drops the Java 21 baseline in favour of
-Java 17+ to widen enterprise adoption without losing any author-
-facing surface. Co-developed with external contributor
-[@jottinger](https://github.com/jottinger) ([#8](https://github.com/DemchaAV/GraphCompose/issues/8),
+Maintenance + compatibility patch. Drops the Java 21 source/target
+baseline to **Java 17+** so the library can ship into older
+enterprise stacks without a fork, and refreshes test/build
+dependencies. **No public API change** — engine, DSL, themes,
+templates, and backend records all stay source-compatible with
+v1.6.0; existing v1.6.0 callers compile and behave unchanged.
+
+Co-developed with external contributor
+[@jottinger](https://github.com/jottinger)
+([#8](https://github.com/DemchaAV/GraphCompose/issues/8),
 [#10](https://github.com/DemchaAV/GraphCompose/issues/10)).
 
 ### Toolchain
 
-- **Java 17 baseline** — `<maven.compiler.release>` flips from `21`
+- **Java 17 baseline.** `<maven.compiler.release>` flips from `21`
   to `17` across `pom.xml`, `examples/pom.xml`, and `benchmarks/pom.xml`.
-  Author-facing API is unchanged; the engine source drops
-  Java 21–only constructs (switch-with-type-patterns, `List.getFirst()`)
-  in favour of Java 17–compatible forms. CI runs against
-  Temurin JDK 17.
+  Engine source loses the Java 21–only constructs
+  (switch-with-type-patterns, switch-with-deconstruction,
+  `List.getFirst()`, `Thread.threadId()`) in favour of Java 17
+  –compatible forms. CI runs against Temurin JDK 17.
 - **Dependency refresh + CVE pass.** Bumps Jackson `2.20.1 → 2.21.3`,
   Logback `1.5.18 → 1.5.32`, Lombok `1.18.38 → 1.18.46`, POI
   `5.4.0 → 5.5.1`, SnakeYAML `2.4 → 2.6`, AssertJ `3.27.3 → 3.27.6`,
@@ -27,17 +33,12 @@ facing surface. Co-developed with external contributor
   Maven plugin bumps: `maven-compiler-plugin 3.13 → 3.15`,
   `maven-surefire-plugin 3.2.5 → 3.5.5`, `exec-maven-plugin 3.5 → 3.6.2`.
 
-### Distribution
+### Looking ahead
 
-- **Maven Central** is the planned primary distribution channel
-  ([#7](https://github.com/DemchaAV/GraphCompose/issues/7)). JitPack
-  stays as a documented fallback.
-
-### Non-goals
-
-- No public-API breakage on the engine surface.
-- No Templates v3 work — Templates v2 remains the canonical author
-  surface.
+Maven Central distribution
+([#7](https://github.com/DemchaAV/GraphCompose/issues/7)) remains
+on the **v1.7.0** roadmap alongside the JMH benchmark migration;
+v1.6.1 stays on JitPack as a maintenance release.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://github.com/DemchaAV/GraphCompose/actions/workflows/ci.yml?query=branch%3Amain"><img src="https://img.shields.io/github/actions/workflow/status/DemchaAV/GraphCompose/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"/></a>
   <a href="https://github.com/DemchaAV/GraphCompose/releases/latest"><img src="https://img.shields.io/github/v/release/DemchaAV/GraphCompose?style=for-the-badge&label=Release" alt="Latest release"/></a>
   <a href="https://jitpack.io/#DemchaAV/GraphCompose"><img src="https://img.shields.io/jitpack/v/github/DemchaAV/GraphCompose?style=for-the-badge&label=JitPack" alt="JitPack"/></a>
-  <img src="https://img.shields.io/badge/Java-21-orange?style=for-the-badge&logo=openjdk" alt="Java 21"/>
+  <img src="https://img.shields.io/badge/Java-17%2B-orange?style=for-the-badge&logo=openjdk" alt="Java 17+"/>
   <img src="https://img.shields.io/badge/PDFBox-3.0-red?style=for-the-badge" alt="PDFBox 3.0"/>
   <img src="https://img.shields.io/badge/License-MIT-blue?style=for-the-badge" alt="MIT License"/>
 </p>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -17,11 +17,11 @@
 
     <properties>
         <graphcompose.version>1.6.0</graphcompose.version>
-        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.release>17</maven.compiler.release>
 
-        <junit.bom.version>5.12.2</junit.bom.version>
-        <assertj.version>3.27.3</assertj.version>
-        <logback.version>1.5.18</logback.version>
+        <junit.bom.version>5.14.4</junit.bom.version>
+        <assertj.version>3.27.6</assertj.version>
+        <logback.version>1.5.32</logback.version>
 
         <openhtmltopdf.version>1.0.10</openhtmltopdf.version>
         <itextpdf.version>5.5.13.3</itextpdf.version>
@@ -116,7 +116,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.13.0</version>
+                <version>3.15.0</version>
                 <configuration>
                     <release>${maven.compiler.release}</release>
                 </configuration>
@@ -124,12 +124,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.2.5</version>
+                <version>3.5.5</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
-                <version>3.5.0</version>
+                <version>3.6.2</version>
             </plugin>
         </plugins>
     </build>

--- a/benchmarks/src/main/java/com/demcha/compose/BenchmarkMedianTool.java
+++ b/benchmarks/src/main/java/com/demcha/compose/BenchmarkMedianTool.java
@@ -42,7 +42,7 @@ public final class BenchmarkMedianTool {
             reportFiles.add(new ReportFile(reportPath, JSON.readTree(Files.readAllBytes(reportPath))));
         }
 
-        SuiteType suiteType = detectSuiteType(reportFiles.getFirst().report());
+        SuiteType suiteType = detectSuiteType(reportFiles.get(0).report());
         for (ReportFile reportFile : reportFiles) {
             SuiteType currentType = detectSuiteType(reportFile.report());
             if (currentType != suiteType) {
@@ -58,7 +58,7 @@ public final class BenchmarkMedianTool {
     }
 
     private void aggregateCurrentSpeed(List<ReportFile> reportFiles) throws Exception {
-        JsonNode firstReport = reportFiles.getFirst().report();
+        JsonNode firstReport = reportFiles.get(0).report();
         String profile = firstReport.path("profile").asText("full");
         for (ReportFile reportFile : reportFiles) {
             String currentProfile = reportFile.report().path("profile").asText("full");
@@ -135,7 +135,7 @@ public final class BenchmarkMedianTool {
     }
 
     private List<CurrentSpeedLatencyMedianRow> aggregateCurrentSpeedLatency(List<ReportFile> reportFiles) {
-        List<JsonNode> firstRows = iterable(reportFiles.getFirst().report().path("latency"));
+        List<JsonNode> firstRows = iterable(reportFiles.get(0).report().path("latency"));
         Map<String, JsonNode> firstByScenario = indexBy(firstRows, "scenario");
 
         for (ReportFile reportFile : reportFiles) {
@@ -150,7 +150,7 @@ public final class BenchmarkMedianTool {
                     List<JsonNode> rows = reportFiles.stream()
                             .map(reportFile -> indexBy(iterable(reportFile.report().path("latency")), "scenario").get(scenario))
                             .toList();
-                    JsonNode exemplar = rows.getFirst();
+                    JsonNode exemplar = rows.get(0);
                     return new CurrentSpeedLatencyMedianRow(
                             scenario,
                             exemplar.path("description").asText(""),
@@ -166,7 +166,7 @@ public final class BenchmarkMedianTool {
     }
 
     private List<CurrentSpeedThroughputMedianRow> aggregateCurrentSpeedThroughput(List<ReportFile> reportFiles) {
-        List<JsonNode> firstRows = iterable(reportFiles.getFirst().report().path("throughput"));
+        List<JsonNode> firstRows = iterable(reportFiles.get(0).report().path("throughput"));
         Map<String, JsonNode> firstByScenario = indexThroughput(firstRows);
 
         for (ReportFile reportFile : reportFiles) {
@@ -181,7 +181,7 @@ public final class BenchmarkMedianTool {
                     List<JsonNode> rows = reportFiles.stream()
                             .map(reportFile -> indexThroughput(iterable(reportFile.report().path("throughput"))).get(key))
                             .toList();
-                    JsonNode exemplar = rows.getFirst();
+                    JsonNode exemplar = rows.get(0);
                     return new CurrentSpeedThroughputMedianRow(
                             exemplar.path("scenario").asText(),
                             exemplar.path("threads").asInt(),
@@ -196,7 +196,7 @@ public final class BenchmarkMedianTool {
         int warmupIterations = requireIntConsistency(reportFiles, "warmupIterations");
         int measurementIterations = requireIntConsistency(reportFiles, "measurementIterations");
 
-        List<JsonNode> firstRows = iterable(reportFiles.getFirst().report().path("libraries"));
+        List<JsonNode> firstRows = iterable(reportFiles.get(0).report().path("libraries"));
         Map<String, JsonNode> firstByLibrary = indexBy(firstRows, "library");
         for (ReportFile reportFile : reportFiles) {
             Map<String, JsonNode> currentByLibrary = indexBy(iterable(reportFile.report().path("libraries")), "library");
@@ -246,7 +246,7 @@ public final class BenchmarkMedianTool {
     }
 
     private static int requireIntConsistency(List<ReportFile> reportFiles, String fieldName) {
-        int expected = reportFiles.getFirst().report().path(fieldName).asInt();
+        int expected = reportFiles.get(0).report().path(fieldName).asInt();
         for (ReportFile reportFile : reportFiles) {
             int current = reportFile.report().path(fieldName).asInt();
             if (current != expected) {
@@ -259,7 +259,7 @@ public final class BenchmarkMedianTool {
     }
 
     private static List<Integer> requireIntegerArrayConsistency(List<ReportFile> reportFiles, String fieldName) {
-        List<Integer> expected = iterable(reportFiles.getFirst().report().path(fieldName)).stream()
+        List<Integer> expected = iterable(reportFiles.get(0).report().path(fieldName)).stream()
                 .map(JsonNode::asInt)
                 .toList();
         for (ReportFile reportFile : reportFiles) {

--- a/benchmarks/src/main/java/com/demcha/compose/ComparativeBenchmark.java
+++ b/benchmarks/src/main/java/com/demcha/compose/ComparativeBenchmark.java
@@ -95,14 +95,14 @@ public class ComparativeBenchmark {
         for (int i = 0; i < MEASUREMENT_ITERATIONS; i++) {
             System.gc(); // Форсируем сборку мусора перед каждым замером для чистоты аллокации
 
-            long startBytes = bean.getThreadAllocatedBytes(Thread.currentThread().threadId());
+            long startBytes = bean.getThreadAllocatedBytes(Thread.currentThread().getId());
             long startTime = System.nanoTime();
 
             // Выполняем задачу и получаем байты PDF
             byte[] pdfBytes = task.runAndGetBytes();
 
             long endTime = System.nanoTime();
-            long endBytes = bean.getThreadAllocatedBytes(Thread.currentThread().threadId());
+            long endBytes = bean.getThreadAllocatedBytes(Thread.currentThread().getId());
 
             totalTimeNs += (endTime - startTime);
             totalAllocatedBytes += (endBytes - startBytes);

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <graphcompose.version>${project.version}</graphcompose.version>
         <logback.version>1.5.18</logback.version>
-        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.release>17</maven.compiler.release>
 
         <junit.bom.version>5.12.2</junit.bom.version>
         <assertj.version>3.27.3</assertj.version>

--- a/examples/src/main/java/com/demcha/examples/support/WeeklyScheduleRenderer.java
+++ b/examples/src/main/java/com/demcha/examples/support/WeeklyScheduleRenderer.java
@@ -604,27 +604,27 @@ public final class WeeklyScheduleRenderer {
      * cells is always 4.
      */
     private static List<DocumentTableCell> dayCells(DayShift dayShift, Theme theme) {
-        if (dayShift == null) {
+        if (dayShift == null || dayShift instanceof DayShift.EmptyDay) {
             return List.of(emptyDayCell(theme));
         }
-        return switch (dayShift) {
-            case DayShift.EmptyDay e ->
-                    List.of(emptyDayCell(theme));
-            case DayShift.FullStatus(ShiftStatus s) ->
-                    List.of(fullStatusCell(s, theme));
-            case DayShift.CrossMeal(Shift shift) ->
-                    shiftAcrossDay(shift, theme);
-            case DayShift.Halves(Half lunch, Half dinner) ->
-                    mergedHalfCells(lunch, dinner, theme);
-        };
+        if (dayShift instanceof DayShift.FullStatus fs) {
+            return List.of(fullStatusCell(fs.status(), theme));
+        }
+        if (dayShift instanceof DayShift.CrossMeal cm) {
+            return shiftAcrossDay(cm.shift(), theme);
+        }
+        if (dayShift instanceof DayShift.Halves h) {
+            return mergedHalfCells(h.lunch(), h.dinner(), theme);
+        }
+        throw new IllegalStateException("Unhandled DayShift variant: " + dayShift);
     }
 
     private static List<DocumentTableCell> mergedHalfCells(Half lunch, Half dinner, Theme theme) {
         // Both halves on the same status fill → merge to colSpan(4).
-        if (lunch instanceof Half.StatusFill(ShiftStatus ls)
-                && dinner instanceof Half.StatusFill(ShiftStatus ds)
-                && ls == ds) {
-            return List.of(fullStatusCell(ls, theme));
+        if (lunch instanceof Half.StatusFill ls
+                && dinner instanceof Half.StatusFill ds
+                && ls.status() == ds.status()) {
+            return List.of(fullStatusCell(ls.status(), theme));
         }
         List<DocumentTableCell> cells = new ArrayList<>();
         cells.addAll(halfCells(lunch, theme));
@@ -633,11 +633,16 @@ public final class WeeklyScheduleRenderer {
     }
 
     private static List<DocumentTableCell> halfCells(Half half, Theme theme) {
-        return switch (half) {
-            case Half.Empty e -> List.of(emptyHalfCell(theme));
-            case Half.StatusFill(ShiftStatus s) -> List.of(statusHalfCell(s, theme));
-            case Half.Working(Shift shift) -> shiftHalfCells(shift, theme);
-        };
+        if (half instanceof Half.Empty) {
+            return List.of(emptyHalfCell(theme));
+        }
+        if (half instanceof Half.StatusFill sf) {
+            return List.of(statusHalfCell(sf.status(), theme));
+        }
+        if (half instanceof Half.Working w) {
+            return shiftHalfCells(w.shift(), theme);
+        }
+        throw new IllegalStateException("Unhandled Half variant: " + half);
     }
 
     private static DocumentTableCell emptyDayCell(Theme theme) {

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <properties>
         <!-- Toolchain -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.release>21</maven.compiler.release>
+        <maven.compiler.release>17</maven.compiler.release>
 
         <!-- Runtime / library dependencies -->
         <flexmark.version>0.64.8</flexmark.version>

--- a/pom.xml
+++ b/pom.xml
@@ -46,27 +46,28 @@
         <maven.compiler.release>21</maven.compiler.release>
 
         <!-- Runtime / library dependencies -->
-        <assertj.version>3.27.3</assertj.version>
         <flexmark.version>0.64.8</flexmark.version>
-        <jackson.bom.version>2.20.1</jackson.bom.version>
+        <jackson.bom.version>2.21.3</jackson.bom.version>
         <kotlin.version>2.2.20</kotlin.version>
-        <logback.version>1.5.18</logback.version>
-        <lombok.version>1.18.38</lombok.version>
+        <logback.version>1.5.32</logback.version>
+        <lombok.version>1.18.46</lombok.version>
         <pdfbox.version>3.0.7</pdfbox.version>
-        <poi.version>5.4.0</poi.version>
+        <poi.version>5.5.1</poi.version>
         <javafx.version>21.0.2</javafx.version>
         <slf4j.version>2.0.17</slf4j.version>
-        <snakeyaml.version>2.4</snakeyaml.version>
+        <snakeyaml.version>2.6</snakeyaml.version>
         <zxing.version>3.5.3</zxing.version>
 
         <!-- Test dependencies -->
-        <junit.bom.version>5.12.2</junit.bom.version>
-        <mockito.version>5.20.0</mockito.version>
+        <assertj.version>3.27.6</assertj.version>
+        <junit.bom.version>5.14.4</junit.bom.version>
+        <mockito.version>5.23.0</mockito.version>
+        <byteBuddy.version>1.18.7</byteBuddy.version>
 
         <!-- Build plugins -->
-        <maven.compiler.plugin.version>3.13.0</maven.compiler.plugin.version>
-        <maven.javadoc.plugin.version>3.8.0</maven.javadoc.plugin.version>
-        <maven.surefire.plugin.version>3.2.5</maven.surefire.plugin.version>
+        <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
+        <maven.javadoc.plugin.version>3.12.0</maven.javadoc.plugin.version>
+        <maven.surefire.plugin.version>3.5.5</maven.surefire.plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -208,6 +209,17 @@
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.bytebuddy</groupId>
+                    <artifactId>byte-buddy</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>net.bytebuddy</groupId>
+            <artifactId>byte-buddy</artifactId>
+            <version>${byteBuddy.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfShapeClipBeginRenderHandler.java
+++ b/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfShapeClipBeginRenderHandler.java
@@ -69,12 +69,18 @@ public final class PdfShapeClipBeginRenderHandler
         if (policy == ClipPolicy.CLIP_BOUNDS) {
             stream.addRect(x, y, width, height);
         } else { // CLIP_PATH
-            switch (outline) {
-                case ShapeOutline.Ellipse ignored -> addEllipsePath(stream, x, y, width, height);
-                case ShapeOutline.RoundedRectangle r -> addRoundedRectanglePath(
-                        stream, x, y, width, height,
+            /*
+             * This is code that the java 21 switch pattern matching was designed to avoid.
+             */
+            if (outline instanceof ShapeOutline.Ellipse) {
+                addEllipsePath(stream, x, y, width, height);
+            } else if (outline instanceof ShapeOutline.RoundedRectangle r) {
+                addRoundedRectanglePath(stream, x, y, width, height,
                         (float) Math.min(r.cornerRadius(), Math.min(width, height) / 2.0f));
-                case ShapeOutline.Rectangle ignored -> stream.addRect(x, y, width, height);
+            } else if (outline instanceof ShapeOutline.Rectangle) {
+                stream.addRect(x, y, width, height);
+            } else {
+                throw new IllegalStateException("Unknown outline: " + outline);
             }
         }
         // clip() pushes the current path onto the clipping path; the path

--- a/src/main/java/com/demcha/compose/document/layout/TextFlowSupport.java
+++ b/src/main/java/com/demcha/compose/document/layout/TextFlowSupport.java
@@ -238,7 +238,7 @@ public final class TextFlowSupport {
             return new PreparedSplitResult<>(head, tail);
         }
 
-        PreparedListItemLayout firstItem = layout.items().getFirst();
+        PreparedListItemLayout firstItem = layout.items().get(0);
         PreparedParagraphLayout itemLayout = firstItem.paragraphLayout();
         int maxLines = maxLinesThatFit(
                 itemLayout.visualLines(),
@@ -796,7 +796,7 @@ public final class TextFlowSupport {
                     result.add(currentPrefix + chunks.get(index));
                     currentPrefix = continuationPrefix;
                 }
-                currentLine = currentPrefix + chunks.getLast();
+                currentLine = currentPrefix + chunks.get(chunks.size() - 1);
                 hasContent = true;
             }
 
@@ -1451,7 +1451,7 @@ public final class TextFlowSupport {
         if (lines.isEmpty()) {
             return 0;
         }
-        if (availableHeight + EPS < lines.getFirst().lineHeight()) {
+        if (availableHeight + EPS < lines.get(0).lineHeight()) {
             return 0;
         }
 

--- a/src/main/java/com/demcha/compose/document/layout/definitions/ShapeContainerDefinition.java
+++ b/src/main/java/com/demcha/compose/document/layout/definitions/ShapeContainerDefinition.java
@@ -105,8 +105,9 @@ public final class ShapeContainerDefinition implements NodeDefinition<ShapeConta
         }
         Color awtFill = node.fillColor() == null ? null : node.fillColor().color();
         Stroke stroke = toStroke(node.stroke());
-        LayoutFragment outlineFragment = switch (outline) {
-            case ShapeOutline.Ellipse ignored -> new LayoutFragment(
+        LayoutFragment outlineFragment;
+        if (outline instanceof ShapeOutline.Ellipse) {
+            outlineFragment = new LayoutFragment(
                     placement.path(),
                     0,
                     padLeft,
@@ -114,7 +115,8 @@ public final class ShapeContainerDefinition implements NodeDefinition<ShapeConta
                     width,
                     height,
                     new EllipseFragmentPayload(awtFill, stroke, null, null));
-            case ShapeOutline.Rectangle ignored -> new LayoutFragment(
+        } else if (outline instanceof ShapeOutline.Rectangle) {
+            outlineFragment = new LayoutFragment(
                     placement.path(),
                     0,
                     padLeft,
@@ -122,7 +124,8 @@ public final class ShapeContainerDefinition implements NodeDefinition<ShapeConta
                     width,
                     height,
                     new ShapeFragmentPayload(awtFill, stroke, 0.0, null, null, null));
-            case ShapeOutline.RoundedRectangle r -> new LayoutFragment(
+        } else if (outline instanceof ShapeOutline.RoundedRectangle r) {
+            outlineFragment = new LayoutFragment(
                     placement.path(),
                     0,
                     padLeft,
@@ -130,7 +133,9 @@ public final class ShapeContainerDefinition implements NodeDefinition<ShapeConta
                     width,
                     height,
                     new ShapeFragmentPayload(awtFill, stroke, r.cornerRadius(), null, null, null));
-        };
+        } else {
+            throw new IllegalStateException("Unsupported shape outline: " + outline);
+        }
 
         List<LayoutFragment> opening = new ArrayList<>(4);
         boolean hasTransform = !node.transform().isIdentity();

--- a/src/main/java/com/demcha/compose/document/templates/components/Module.java
+++ b/src/main/java/com/demcha/compose/document/templates/components/Module.java
@@ -158,16 +158,25 @@ public final class Module {
     }
 
     private DocumentNode renderBody(BusinessTheme theme, Spacing spacing) {
-        return switch (body) {
-            case ParagraphBlock p -> renderParagraph(p, theme, spacing);
-            case BulletListBlock b -> renderList(b.items(), ListMarker.bullet(),
-                    "bullet", theme, spacing);
-            case NumberedListBlock n -> renderList(n.items(), ListMarker.custom("1."),
-                    "numbered", theme, spacing);
-            case MultiParagraphBlock m -> renderMultiParagraph(m, theme, spacing);
-            case IndentedBlock i -> renderIndented(i, theme, spacing);
-            case KeyValueBlock k -> renderKeyValue(k, theme, spacing);
-        };
+        if (body instanceof ParagraphBlock p) {
+            return renderParagraph(p, theme, spacing);
+        }
+        if (body instanceof BulletListBlock b) {
+            return renderList(b.items(), ListMarker.bullet(), "bullet", theme, spacing);
+        }
+        if (body instanceof NumberedListBlock n) {
+            return renderList(n.items(), ListMarker.custom("1."), "numbered", theme, spacing);
+        }
+        if (body instanceof MultiParagraphBlock m) {
+            return renderMultiParagraph(m, theme, spacing);
+        }
+        if (body instanceof IndentedBlock i) {
+            return renderIndented(i, theme, spacing);
+        }
+        if (body instanceof KeyValueBlock k) {
+            return renderKeyValue(k, theme, spacing);
+        }
+        throw new IllegalStateException("Unsupported module body: " + body);
     }
 
     private ParagraphNode renderParagraph(ParagraphBlock block, BusinessTheme theme, Spacing spacing) {

--- a/src/main/java/com/demcha/compose/document/templates/cv/presets/BlueBanner.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/presets/BlueBanner.java
@@ -215,39 +215,33 @@ public final class BlueBanner {
         }
 
         private void renderBody(SectionBuilder section, Block body) {
-            switch (body) {
-                case ParagraphBlock p -> renderParagraph(section, p.text());
-                case MultiParagraphBlock m -> {
-                    for (String line : m.paragraphs()) {
-                        WorkEntry entry = parseWorkEntry(line);
-                        if (entry != null) {
-                            renderWorkEntry(section, entry);
-                        } else {
-                            renderParagraph(section, line);
-                        }
+            if (body instanceof ParagraphBlock p) {
+                renderParagraph(section, p.text());
+            } else if (body instanceof MultiParagraphBlock m) {
+                for (String line : m.paragraphs()) {
+                    WorkEntry entry = parseWorkEntry(line);
+                    if (entry != null) {
+                        renderWorkEntry(section, entry);
+                    } else {
+                        renderParagraph(section, line);
                     }
                 }
-                case BulletListBlock b -> renderBulletList(section, b.items());
-                case NumberedListBlock n -> {
-                    for (String item : n.items()) {
-                        renderParagraph(section, item);
-                    }
+            } else if (body instanceof BulletListBlock b) {
+                renderBulletList(section, b.items());
+            } else if (body instanceof NumberedListBlock n) {
+                for (String item : n.items()) {
+                    renderParagraph(section, item);
                 }
-                case IndentedBlock i -> {
-                    for (IndentedBlock.Item item : i.items()) {
-                        String inline = (item.title().isBlank() ? "" : item.title())
-                                + (item.title().isBlank() || item.body().isBlank() ? "" : " - ")
-                                + (item.body().isBlank() ? "" : item.body());
-                        renderParagraph(section, inline);
-                    }
+            } else if (body instanceof IndentedBlock i) {
+                for (IndentedBlock.Item item : i.items()) {
+                    String inline = (item.title().isBlank() ? "" : item.title())
+                            + (item.title().isBlank() || item.body().isBlank() ? "" : " - ")
+                            + (item.body().isBlank() ? "" : item.body());
+                    renderParagraph(section, inline);
                 }
-                case KeyValueBlock kv -> {
-                    for (KeyValueBlock.Entry entry : kv.entries()) {
-                        renderKeyValueEntry(section, entry);
-                    }
-                }
-                default -> {
-                    // ignore other block kinds
+            } else if (body instanceof KeyValueBlock kv) {
+                for (KeyValueBlock.Entry entry : kv.entries()) {
+                    renderKeyValueEntry(section, entry);
                 }
             }
         }

--- a/src/main/java/com/demcha/compose/document/templates/cv/presets/BoxedSections.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/presets/BoxedSections.java
@@ -189,48 +189,40 @@ public final class BoxedSections {
         }
 
         private void renderBody(SectionBuilder section, Block body) {
-            switch (body) {
-                case ParagraphBlock p -> renderParagraph(section, p.text());
-                case MultiParagraphBlock m -> {
-                    for (String line : m.paragraphs()) {
-                        WorkEntry entry = parseWorkEntry(line);
-                        if (entry != null) {
-                            renderWorkEntry(section, entry);
-                        } else {
-                            renderParagraph(section, line);
-                        }
+            if (body instanceof ParagraphBlock p) {
+                renderParagraph(section, p.text());
+            } else if (body instanceof MultiParagraphBlock m) {
+                for (String line : m.paragraphs()) {
+                    WorkEntry entry = parseWorkEntry(line);
+                    if (entry != null) {
+                        renderWorkEntry(section, entry);
+                    } else {
+                        renderParagraph(section, line);
                     }
                 }
-                case BulletListBlock b -> {
-                    for (String item : b.items()) {
-                        WorkEntry entry = parseWorkEntry(item);
-                        if (entry != null) {
-                            renderWorkEntry(section, entry);
-                        } else {
-                            renderBulletItem(section, item);
-                        }
+            } else if (body instanceof BulletListBlock b) {
+                for (String item : b.items()) {
+                    WorkEntry entry = parseWorkEntry(item);
+                    if (entry != null) {
+                        renderWorkEntry(section, entry);
+                    } else {
+                        renderBulletItem(section, item);
                     }
                 }
-                case NumberedListBlock n -> {
-                    for (String item : n.items()) {
-                        renderParagraph(section, item);
-                    }
+            } else if (body instanceof NumberedListBlock n) {
+                for (String item : n.items()) {
+                    renderParagraph(section, item);
                 }
-                case IndentedBlock i -> {
-                    for (IndentedBlock.Item item : i.items()) {
-                        String inline = (item.title().isBlank() ? "" : item.title())
-                                + (item.title().isBlank() || item.body().isBlank() ? "" : " - ")
-                                + (item.body().isBlank() ? "" : item.body());
-                        renderParagraph(section, inline);
-                    }
+            } else if (body instanceof IndentedBlock i) {
+                for (IndentedBlock.Item item : i.items()) {
+                    String inline = (item.title().isBlank() ? "" : item.title())
+                            + (item.title().isBlank() || item.body().isBlank() ? "" : " - ")
+                            + (item.body().isBlank() ? "" : item.body());
+                    renderParagraph(section, inline);
                 }
-                case KeyValueBlock kv -> {
-                    for (KeyValueBlock.Entry entry : kv.entries()) {
-                        renderParagraph(section, entry.key() + ": " + entry.value());
-                    }
-                }
-                default -> {
-                    // ignore other block kinds
+            } else if (body instanceof KeyValueBlock kv) {
+                for (KeyValueBlock.Entry entry : kv.entries()) {
+                    renderParagraph(section, entry.key() + ": " + entry.value());
                 }
             }
         }

--- a/src/main/java/com/demcha/compose/document/templates/cv/presets/CenteredHeadline.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/presets/CenteredHeadline.java
@@ -216,39 +216,33 @@ public final class CenteredHeadline {
             section.spacing(4)
                     .padding(DocumentInsets.zero());
             Block body = module.body();
-            switch (body) {
-                case ParagraphBlock p -> renderParagraph(section, p.text());
-                case MultiParagraphBlock m -> {
-                    for (String line : m.paragraphs()) {
-                        WorkEntry entry = parseWorkEntry(line);
-                        if (entry != null) {
-                            renderWorkEntry(section, entry);
-                        } else {
-                            renderParagraph(section, line);
-                        }
+            if (body instanceof ParagraphBlock p) {
+                renderParagraph(section, p.text());
+            } else if (body instanceof MultiParagraphBlock m) {
+                for (String line : m.paragraphs()) {
+                    WorkEntry entry = parseWorkEntry(line);
+                    if (entry != null) {
+                        renderWorkEntry(section, entry);
+                    } else {
+                        renderParagraph(section, line);
                     }
                 }
-                case BulletListBlock b -> renderBulletList(section, b.items());
-                case NumberedListBlock n -> {
-                    for (String item : n.items()) {
-                        renderParagraph(section, item);
-                    }
+            } else if (body instanceof BulletListBlock b) {
+                renderBulletList(section, b.items());
+            } else if (body instanceof NumberedListBlock n) {
+                for (String item : n.items()) {
+                    renderParagraph(section, item);
                 }
-                case IndentedBlock i -> {
-                    for (IndentedBlock.Item item : i.items()) {
-                        String inline = (item.title().isBlank() ? "" : item.title())
-                                + (item.title().isBlank() || item.body().isBlank() ? "" : " - ")
-                                + (item.body().isBlank() ? "" : item.body());
-                        renderParagraph(section, inline);
-                    }
+            } else if (body instanceof IndentedBlock i) {
+                for (IndentedBlock.Item item : i.items()) {
+                    String inline = (item.title().isBlank() ? "" : item.title())
+                            + (item.title().isBlank() || item.body().isBlank() ? "" : " - ")
+                            + (item.body().isBlank() ? "" : item.body());
+                    renderParagraph(section, inline);
                 }
-                case KeyValueBlock kv -> {
-                    for (KeyValueBlock.Entry entry : kv.entries()) {
-                        renderKeyValueEntry(section, entry);
-                    }
-                }
-                default -> {
-                    // ignore other block kinds
+            } else if (body instanceof KeyValueBlock kv) {
+                for (KeyValueBlock.Entry entry : kv.entries()) {
+                    renderKeyValueEntry(section, entry);
                 }
             }
         }

--- a/src/main/java/com/demcha/compose/document/templates/cv/presets/ClassicSerif.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/presets/ClassicSerif.java
@@ -349,12 +349,16 @@ public final class ClassicSerif {
         }
         List<String> lines = new ArrayList<>();
         Block body = module.body();
-        switch (body) {
-            case ParagraphBlock p -> addLines(lines, p.text());
-            case MultiParagraphBlock m -> m.paragraphs().forEach(line -> addLines(lines, line));
-            case BulletListBlock b -> b.items().forEach(item -> addLines(lines, item));
-            case NumberedListBlock n -> n.items().forEach(item -> addLines(lines, item));
-            case IndentedBlock i -> i.items().forEach(item -> {
+        if (body instanceof ParagraphBlock p) {
+            addLines(lines, p.text());
+        } else if (body instanceof MultiParagraphBlock m) {
+            m.paragraphs().forEach(line -> addLines(lines, line));
+        } else if (body instanceof BulletListBlock b) {
+            b.items().forEach(item -> addLines(lines, item));
+        } else if (body instanceof NumberedListBlock n) {
+            n.items().forEach(item -> addLines(lines, item));
+        } else if (body instanceof IndentedBlock i) {
+            i.items().forEach(item -> {
                 String title = safe(item.title());
                 String bodyText = safe(item.body());
                 if (title.isBlank() && bodyText.isBlank()) {
@@ -368,11 +372,8 @@ public final class ClassicSerif {
                     lines.add(title + " | " + bodyText);
                 }
             });
-            case KeyValueBlock kv -> kv.entries().forEach(entry ->
-                    addLines(lines, entry.key() + ": " + entry.value()));
-            default -> {
-                // ignore other block kinds
-            }
+        } else if (body instanceof KeyValueBlock kv) {
+            kv.entries().forEach(entry -> addLines(lines, entry.key() + ": " + entry.value()));
         }
         return List.copyOf(lines);
     }

--- a/src/main/java/com/demcha/compose/document/templates/cv/presets/CompactMono.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/presets/CompactMono.java
@@ -299,12 +299,16 @@ public final class CompactMono {
         }
         List<String> lines = new ArrayList<>();
         Block body = module.body();
-        switch (body) {
-            case ParagraphBlock p -> addLines(lines, p.text());
-            case MultiParagraphBlock m -> m.paragraphs().forEach(line -> addLines(lines, line));
-            case BulletListBlock b -> b.items().forEach(item -> addLines(lines, item));
-            case NumberedListBlock n -> n.items().forEach(item -> addLines(lines, item));
-            case IndentedBlock i -> i.items().forEach(item -> {
+        if (body instanceof ParagraphBlock p) {
+            addLines(lines, p.text());
+        } else if (body instanceof MultiParagraphBlock m) {
+            m.paragraphs().forEach(line -> addLines(lines, line));
+        } else if (body instanceof BulletListBlock b) {
+            b.items().forEach(item -> addLines(lines, item));
+        } else if (body instanceof NumberedListBlock n) {
+            n.items().forEach(item -> addLines(lines, item));
+        } else if (body instanceof IndentedBlock i) {
+            i.items().forEach(item -> {
                 String title = safe(item.title());
                 String bodyText = safe(item.body());
                 if (title.isBlank() && bodyText.isBlank()) {
@@ -318,11 +322,8 @@ public final class CompactMono {
                     lines.add(title + " | " + bodyText);
                 }
             });
-            case KeyValueBlock kv -> kv.entries().forEach(entry ->
-                    addLines(lines, entry.key() + ": " + entry.value()));
-            default -> {
-                // ignore other block kinds
-            }
+        } else if (body instanceof KeyValueBlock kv) {
+            kv.entries().forEach(entry -> addLines(lines, entry.key() + ": " + entry.value()));
         }
         return List.copyOf(lines);
     }

--- a/src/main/java/com/demcha/compose/document/templates/cv/presets/EditorialBlue.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/presets/EditorialBlue.java
@@ -549,38 +549,30 @@ public final class EditorialBlue {
         }
 
         private void renderBody(SectionBuilder section, Block body) {
-            switch (body) {
-                case ParagraphBlock p -> renderParagraph(section, p.text());
-                case MultiParagraphBlock m -> {
-                    for (String line : m.paragraphs()) {
-                        renderParagraph(section, line);
-                    }
+            if (body instanceof ParagraphBlock p) {
+                renderParagraph(section, p.text());
+            } else if (body instanceof MultiParagraphBlock m) {
+                for (String line : m.paragraphs()) {
+                    renderParagraph(section, line);
                 }
-                case BulletListBlock b -> {
-                    for (String item : b.items()) {
-                        renderParagraph(section, item);
-                    }
+            } else if (body instanceof BulletListBlock b) {
+                for (String item : b.items()) {
+                    renderParagraph(section, item);
                 }
-                case NumberedListBlock n -> {
-                    for (String item : n.items()) {
-                        renderParagraph(section, item);
-                    }
+            } else if (body instanceof NumberedListBlock n) {
+                for (String item : n.items()) {
+                    renderParagraph(section, item);
                 }
-                case IndentedBlock i -> {
-                    for (IndentedBlock.Item item : i.items()) {
-                        String inline = (item.title().isBlank() ? "" : item.title())
-                                + (item.title().isBlank() || item.body().isBlank() ? "" : " - ")
-                                + (item.body().isBlank() ? "" : item.body());
-                        renderParagraph(section, inline);
-                    }
+            } else if (body instanceof IndentedBlock i) {
+                for (IndentedBlock.Item item : i.items()) {
+                    String inline = (item.title().isBlank() ? "" : item.title())
+                            + (item.title().isBlank() || item.body().isBlank() ? "" : " - ")
+                            + (item.body().isBlank() ? "" : item.body());
+                    renderParagraph(section, inline);
                 }
-                case KeyValueBlock kv -> {
-                    for (KeyValueBlock.Entry entry : kv.entries()) {
-                        renderKeyValueEntry(section, entry);
-                    }
-                }
-                default -> {
-                    // ignore other block kinds
+            } else if (body instanceof KeyValueBlock kv) {
+                for (KeyValueBlock.Entry entry : kv.entries()) {
+                    renderKeyValueEntry(section, entry);
                 }
             }
         }
@@ -668,12 +660,16 @@ public final class EditorialBlue {
         }
         List<String> lines = new ArrayList<>();
         Block body = module.body();
-        switch (body) {
-            case ParagraphBlock p -> addLines(lines, p.text());
-            case MultiParagraphBlock m -> m.paragraphs().forEach(line -> addLines(lines, line));
-            case BulletListBlock b -> b.items().forEach(item -> addLines(lines, item));
-            case NumberedListBlock n -> n.items().forEach(item -> addLines(lines, item));
-            case IndentedBlock i -> i.items().forEach(item -> {
+        if (body instanceof ParagraphBlock p) {
+            addLines(lines, p.text());
+        } else if (body instanceof MultiParagraphBlock m) {
+            m.paragraphs().forEach(line -> addLines(lines, line));
+        } else if (body instanceof BulletListBlock b) {
+            b.items().forEach(item -> addLines(lines, item));
+        } else if (body instanceof NumberedListBlock n) {
+            n.items().forEach(item -> addLines(lines, item));
+        } else if (body instanceof IndentedBlock i) {
+            i.items().forEach(item -> {
                 String title = safe(item.title());
                 String bodyText = safe(item.body());
                 if (title.isBlank() && bodyText.isBlank()) {
@@ -687,11 +683,8 @@ public final class EditorialBlue {
                     lines.add(title + " | " + bodyText);
                 }
             });
-            case KeyValueBlock kv -> kv.entries().forEach(entry ->
-                    addLines(lines, entry.key() + ": " + entry.value()));
-            default -> {
-                // ignore other block kinds
-            }
+        } else if (body instanceof KeyValueBlock kv) {
+            kv.entries().forEach(entry -> addLines(lines, entry.key() + ": " + entry.value()));
         }
         return List.copyOf(lines);
     }

--- a/src/main/java/com/demcha/compose/document/templates/cv/presets/EngineeringResume.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/presets/EngineeringResume.java
@@ -444,11 +444,14 @@ public final class EngineeringResume {
         }
         List<String> lines = new ArrayList<>();
         Block body = module.body();
-        switch (body) {
-            case ParagraphBlock p -> addLines(lines, p.text());
-            case MultiParagraphBlock m -> m.paragraphs().forEach(line -> addLines(lines, line));
-            case BulletListBlock b -> b.items().forEach(item -> addLines(lines, item));
-            case IndentedBlock i -> i.items().forEach(item -> {
+        if (body instanceof ParagraphBlock p) {
+            addLines(lines, p.text());
+        } else if (body instanceof MultiParagraphBlock m) {
+            m.paragraphs().forEach(line -> addLines(lines, line));
+        } else if (body instanceof BulletListBlock b) {
+            b.items().forEach(item -> addLines(lines, item));
+        } else if (body instanceof IndentedBlock i) {
+            i.items().forEach(item -> {
                 String title = safe(item.title());
                 String bodyText = safe(item.body());
                 if (title.isBlank() && bodyText.isBlank()) {
@@ -462,11 +465,8 @@ public final class EngineeringResume {
                     lines.add(title + " | " + bodyText);
                 }
             });
-            case KeyValueBlock kv -> kv.entries().forEach(entry ->
-                    addLines(lines, entry.key() + ": " + entry.value()));
-            default -> {
-                // ignore other block kinds
-            }
+        } else if (body instanceof KeyValueBlock kv) {
+            kv.entries().forEach(entry -> addLines(lines, entry.key() + ": " + entry.value()));
         }
         return List.copyOf(lines);
     }

--- a/src/main/java/com/demcha/compose/document/templates/cv/presets/Executive.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/presets/Executive.java
@@ -189,30 +189,26 @@ public final class Executive {
         }
 
         private void renderBody(SectionBuilder section, Block body) {
-            switch (body) {
-                case ParagraphBlock p -> renderParagraph(section, p.text());
-                case MultiParagraphBlock m -> {
-                    for (String line : m.paragraphs()) {
-                        renderParagraph(section, line);
-                    }
+            if (body instanceof ParagraphBlock p) {
+                renderParagraph(section, p.text());
+            } else if (body instanceof MultiParagraphBlock m) {
+                for (String line : m.paragraphs()) {
+                    renderParagraph(section, line);
                 }
-                case BulletListBlock b -> renderBulletList(section, b.items());
-                case NumberedListBlock n -> renderNumberedList(section, n.items());
-                case IndentedBlock i -> {
-                    for (IndentedBlock.Item item : i.items()) {
-                        String inline = (item.title().isBlank() ? "" : item.title())
-                                + (item.title().isBlank() || item.body().isBlank() ? "" : " - ")
-                                + (item.body().isBlank() ? "" : item.body());
-                        renderParagraph(section, inline);
-                    }
+            } else if (body instanceof BulletListBlock b) {
+                renderBulletList(section, b.items());
+            } else if (body instanceof NumberedListBlock n) {
+                renderNumberedList(section, n.items());
+            } else if (body instanceof IndentedBlock i) {
+                for (IndentedBlock.Item item : i.items()) {
+                    String inline = (item.title().isBlank() ? "" : item.title())
+                            + (item.title().isBlank() || item.body().isBlank() ? "" : " - ")
+                            + (item.body().isBlank() ? "" : item.body());
+                    renderParagraph(section, inline);
                 }
-                case KeyValueBlock kv -> {
-                    for (KeyValueBlock.Entry entry : kv.entries()) {
-                        renderParagraph(section, entry.key() + ": " + entry.value());
-                    }
-                }
-                default -> {
-                    // ignore other block kinds
+            } else if (body instanceof KeyValueBlock kv) {
+                for (KeyValueBlock.Entry entry : kv.entries()) {
+                    renderParagraph(section, entry.key() + ": " + entry.value());
                 }
             }
         }

--- a/src/main/java/com/demcha/compose/document/templates/cv/presets/MonogramSidebar.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/presets/MonogramSidebar.java
@@ -497,32 +497,34 @@ public final class MonogramSidebar {
         }
         List<String> result = new ArrayList<>();
         Block body = module.body();
-        switch (body) {
-            case ParagraphBlock p -> {
-                String t = safe(p.text()).trim();
-                if (!t.isBlank()) {
-                    result.add(t);
-                }
+        if (body instanceof ParagraphBlock p) {
+            String t = safe(p.text()).trim();
+            if (!t.isBlank()) {
+                result.add(t);
             }
-            case MultiParagraphBlock m -> m.paragraphs().forEach(line -> {
+        } else if (body instanceof MultiParagraphBlock m) {
+            m.paragraphs().forEach(line -> {
                 String t = safe(line).trim();
                 if (!t.isBlank()) {
                     result.add(t);
                 }
             });
-            case BulletListBlock b -> b.items().forEach(item -> {
+        } else if (body instanceof BulletListBlock b) {
+            b.items().forEach(item -> {
                 String t = safe(item).trim();
                 if (!t.isBlank()) {
                     result.add(t);
                 }
             });
-            case NumberedListBlock n -> n.items().forEach(item -> {
+        } else if (body instanceof NumberedListBlock n) {
+            n.items().forEach(item -> {
                 String t = safe(item).trim();
                 if (!t.isBlank()) {
                     result.add(t);
                 }
             });
-            case IndentedBlock i -> i.items().forEach(item -> {
+        } else if (body instanceof IndentedBlock i) {
+            i.items().forEach(item -> {
                 String title = safe(item.title());
                 String bodyText = safe(item.body());
                 if (title.isBlank() && bodyText.isBlank()) {
@@ -536,11 +538,8 @@ public final class MonogramSidebar {
                     result.add(title + " | " + bodyText);
                 }
             });
-            case KeyValueBlock kv -> kv.entries().forEach(entry ->
-                    result.add(entry.key() + ": " + entry.value()));
-            default -> {
-                // ignore other block kinds
-            }
+        } else if (body instanceof KeyValueBlock kv) {
+            kv.entries().forEach(entry -> result.add(entry.key() + ": " + entry.value()));
         }
         return result;
     }

--- a/src/main/java/com/demcha/compose/document/templates/cv/presets/NordicClean.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/presets/NordicClean.java
@@ -428,11 +428,14 @@ public final class NordicClean {
         }
         List<String> lines = new ArrayList<>();
         Block body = module.body();
-        switch (body) {
-            case ParagraphBlock p -> addLines(lines, p.text());
-            case MultiParagraphBlock m -> m.paragraphs().forEach(line -> addLines(lines, line));
-            case BulletListBlock b -> b.items().forEach(item -> addLines(lines, item));
-            case IndentedBlock i -> i.items().forEach(item -> {
+        if (body instanceof ParagraphBlock p) {
+            addLines(lines, p.text());
+        } else if (body instanceof MultiParagraphBlock m) {
+            m.paragraphs().forEach(line -> addLines(lines, line));
+        } else if (body instanceof BulletListBlock b) {
+            b.items().forEach(item -> addLines(lines, item));
+        } else if (body instanceof IndentedBlock i) {
+            i.items().forEach(item -> {
                 String title = safe(item.title());
                 String bodyText = safe(item.body());
                 if (title.isBlank() && bodyText.isBlank()) {
@@ -446,11 +449,8 @@ public final class NordicClean {
                     lines.add(title + " | " + bodyText);
                 }
             });
-            case KeyValueBlock kv -> kv.entries().forEach(entry ->
-                    addLines(lines, entry.key() + ": " + entry.value()));
-            default -> {
-                // other block kinds intentionally not surfaced here.
-            }
+        } else if (body instanceof KeyValueBlock kv) {
+            kv.entries().forEach(entry -> addLines(lines, entry.key() + ": " + entry.value()));
         }
         return List.copyOf(lines);
     }

--- a/src/main/java/com/demcha/compose/document/templates/cv/presets/Panel.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/presets/Panel.java
@@ -260,30 +260,26 @@ public final class Panel {
         }
 
         private void renderBody(SectionBuilder section, Block body) {
-            switch (body) {
-                case ParagraphBlock p -> renderParagraph(section, p.text());
-                case MultiParagraphBlock m -> {
-                    for (String line : m.paragraphs()) {
-                        renderParagraph(section, line);
-                    }
+            if (body instanceof ParagraphBlock p) {
+                renderParagraph(section, p.text());
+            } else if (body instanceof MultiParagraphBlock m) {
+                for (String line : m.paragraphs()) {
+                    renderParagraph(section, line);
                 }
-                case BulletListBlock b -> renderBulletList(section, b.items());
-                case NumberedListBlock n -> renderBulletList(section, n.items());
-                case IndentedBlock i -> {
-                    for (IndentedBlock.Item item : i.items()) {
-                        String inline = (item.title().isBlank() ? "" : item.title())
-                                + (item.title().isBlank() || item.body().isBlank() ? "" : " - ")
-                                + (item.body().isBlank() ? "" : item.body());
-                        renderParagraph(section, inline);
-                    }
+            } else if (body instanceof BulletListBlock b) {
+                renderBulletList(section, b.items());
+            } else if (body instanceof NumberedListBlock n) {
+                renderBulletList(section, n.items());
+            } else if (body instanceof IndentedBlock i) {
+                for (IndentedBlock.Item item : i.items()) {
+                    String inline = (item.title().isBlank() ? "" : item.title())
+                            + (item.title().isBlank() || item.body().isBlank() ? "" : " - ")
+                            + (item.body().isBlank() ? "" : item.body());
+                    renderParagraph(section, inline);
                 }
-                case KeyValueBlock kv -> {
-                    for (KeyValueBlock.Entry entry : kv.entries()) {
-                        renderKeyValueEntry(section, entry);
-                    }
-                }
-                default -> {
-                    // ignore other block kinds
+            } else if (body instanceof KeyValueBlock kv) {
+                for (KeyValueBlock.Entry entry : kv.entries()) {
+                    renderKeyValueEntry(section, entry);
                 }
             }
         }

--- a/src/main/java/com/demcha/compose/document/templates/cv/presets/SidebarPortrait.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/presets/SidebarPortrait.java
@@ -498,20 +498,18 @@ public final class SidebarPortrait {
         }
         List<String> result = new ArrayList<>();
         Block body = module.body();
-        switch (body) {
-            case ParagraphBlock p -> result.add(safe(p.text()).trim());
-            case MultiParagraphBlock m -> {
-                for (String line : m.paragraphs()) {
-                    String t = safe(line).trim();
-                    if (!t.isBlank()) {
-                        result.add(t);
-                    }
+        if (body instanceof ParagraphBlock p) {
+            result.add(safe(p.text()).trim());
+        } else if (body instanceof MultiParagraphBlock m) {
+            for (String line : m.paragraphs()) {
+                String t = safe(line).trim();
+                if (!t.isBlank()) {
+                    result.add(t);
                 }
             }
-            default -> {
-                for (String item : moduleItems(module)) {
-                    result.add(item);
-                }
+        } else {
+            for (String item : moduleItems(module)) {
+                result.add(item);
             }
         }
         return result;
@@ -523,32 +521,34 @@ public final class SidebarPortrait {
         }
         List<String> result = new ArrayList<>();
         Block body = module.body();
-        switch (body) {
-            case ParagraphBlock p -> {
-                String t = safe(p.text()).trim();
-                if (!t.isBlank()) {
-                    result.add(t);
-                }
+        if (body instanceof ParagraphBlock p) {
+            String t = safe(p.text()).trim();
+            if (!t.isBlank()) {
+                result.add(t);
             }
-            case MultiParagraphBlock m -> m.paragraphs().forEach(line -> {
+        } else if (body instanceof MultiParagraphBlock m) {
+            m.paragraphs().forEach(line -> {
                 String t = safe(line).trim();
                 if (!t.isBlank()) {
                     result.add(t);
                 }
             });
-            case BulletListBlock b -> b.items().forEach(item -> {
+        } else if (body instanceof BulletListBlock b) {
+            b.items().forEach(item -> {
                 String t = safe(item).trim();
                 if (!t.isBlank()) {
                     result.add(t);
                 }
             });
-            case NumberedListBlock n -> n.items().forEach(item -> {
+        } else if (body instanceof NumberedListBlock n) {
+            n.items().forEach(item -> {
                 String t = safe(item).trim();
                 if (!t.isBlank()) {
                     result.add(t);
                 }
             });
-            case IndentedBlock i -> i.items().forEach(item -> {
+        } else if (body instanceof IndentedBlock i) {
+            i.items().forEach(item -> {
                 String title = safe(item.title());
                 String bodyText = safe(item.body());
                 if (title.isBlank() && bodyText.isBlank()) {
@@ -562,11 +562,8 @@ public final class SidebarPortrait {
                     result.add(title + " | " + bodyText);
                 }
             });
-            case KeyValueBlock kv -> kv.entries().forEach(entry ->
-                    result.add(entry.key() + ": " + entry.value()));
-            default -> {
-                // ignore other block kinds
-            }
+        } else if (body instanceof KeyValueBlock kv) {
+            kv.entries().forEach(entry -> result.add(entry.key() + ": " + entry.value()));
         }
         return result;
     }

--- a/src/main/java/com/demcha/compose/document/templates/cv/presets/TimelineMinimal.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/presets/TimelineMinimal.java
@@ -426,12 +426,16 @@ public final class TimelineMinimal {
         }
         List<String> lines = new ArrayList<>();
         Block body = module.body();
-        switch (body) {
-            case ParagraphBlock p -> addLines(lines, p.text());
-            case MultiParagraphBlock m -> m.paragraphs().forEach(line -> addLines(lines, line));
-            case BulletListBlock b -> b.items().forEach(item -> addLines(lines, item));
-            case NumberedListBlock n -> n.items().forEach(item -> addLines(lines, item));
-            case IndentedBlock i -> i.items().forEach(item -> {
+        if (body instanceof ParagraphBlock p) {
+            addLines(lines, p.text());
+        } else if (body instanceof MultiParagraphBlock m) {
+            m.paragraphs().forEach(line -> addLines(lines, line));
+        } else if (body instanceof BulletListBlock b) {
+            b.items().forEach(item -> addLines(lines, item));
+        } else if (body instanceof NumberedListBlock n) {
+            n.items().forEach(item -> addLines(lines, item));
+        } else if (body instanceof IndentedBlock i) {
+            i.items().forEach(item -> {
                 String title = safe(item.title());
                 String bodyText = safe(item.body());
                 if (title.isBlank() && bodyText.isBlank()) {
@@ -445,11 +449,8 @@ public final class TimelineMinimal {
                     lines.add(title + " | " + bodyText);
                 }
             });
-            case KeyValueBlock kv -> kv.entries().forEach(entry ->
-                    addLines(lines, entry.key() + ": " + entry.value()));
-            default -> {
-                // ignore other block kinds
-            }
+        } else if (body instanceof KeyValueBlock kv) {
+            kv.entries().forEach(entry -> addLines(lines, entry.key() + ": " + entry.value()));
         }
         return List.copyOf(lines);
     }

--- a/src/main/java/com/demcha/compose/engine/font/Font.java
+++ b/src/main/java/com/demcha/compose/engine/font/Font.java
@@ -20,13 +20,16 @@ public interface Font<T> {
     T strikethrough();
 
     default T fontType(TextDecoration textDecoration) {
+        if (textDecoration == null) {
+            return defaultFont();
+        }
         return switch (textDecoration) {
             case BOLD -> bold();
             case ITALIC -> italic();
             case UNDERLINE -> underline();
             case BOLD_ITALIC -> boldItalic();
             case STRIKETHROUGH -> strikethrough();
-            case null, default -> defaultFont();
+            default -> defaultFont();
         };
     }
 
@@ -47,4 +50,3 @@ public interface Font<T> {
 
     ContentSize getTightBounds(String text, TextStyle style);
 }
-

--- a/src/main/java/com/demcha/compose/engine/layout/container/ContainerAligner.java
+++ b/src/main/java/com/demcha/compose/engine/layout/container/ContainerAligner.java
@@ -17,6 +17,7 @@ import com.demcha.compose.engine.components.style.Padding;
 import com.demcha.compose.engine.core.EntityManager;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -113,9 +114,11 @@ public class ContainerAligner {
          * The reverse logic is handled by the ReverseLayoutStrategy.
          */
         protected List<Entity> getOrderedChildren(Entity parent, EntityManager entityManager) {
-            return parent.getChildren().stream()
+            List<Entity> children = parent.getChildren().stream()
                     .map(id -> entityManager.getEntity(id).orElseThrow())
-                    .collect(Collectors.toList()).reversed();
+                    .collect(Collectors.toCollection(ArrayList::new));
+            java.util.Collections.reverse(children);
+            return children;
         }
 
         protected abstract void updateChildPosition(Entity child, Axes axes);
@@ -242,7 +245,8 @@ public class ContainerAligner {
             Align align = parent.getComponent(Align.class).orElseThrow();
             List<Entity> children = parent.getChildren().stream()
                     .map(id -> entityManager.getEntity(id).orElseThrow())
-                    .collect(Collectors.toList()).reversed();
+                    .collect(Collectors.toCollection(ArrayList::new));
+            java.util.Collections.reverse(children);
 
             double main = 0;
             double resolvedWidth = parent.getComponent(ContentSize.class)

--- a/src/test/java/com/demcha/compose/devtool/GraphComposeDevTool.java
+++ b/src/test/java/com/demcha/compose/devtool/GraphComposeDevTool.java
@@ -38,6 +38,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -51,20 +53,16 @@ public final class GraphComposeDevTool extends Application {
     private static final long FILE_DEBOUNCE_MILLIS = 250;
     private static final List<String> CHILD_FIRST_PREFIXES = List.of("com.demcha.");
     private static final List<String> PARENT_FIRST_PREFIXES = List.of("com.demcha.compose.devtool.");
+    private static final AtomicInteger REFRESH_THREAD_SEQUENCE = new AtomicInteger();
+    private static final AtomicInteger DEBOUNCE_THREAD_SEQUENCE = new AtomicInteger();
 
     private final DevToolWorkspace workspace = DevToolWorkspace.currentProject();
     private final PreviewCompiler compiler = new PreviewCompiler();
     private final float previewScale = PreviewScaleResolver.fromSystemProperties();
     private final ExecutorService refreshExecutor = Executors.newSingleThreadExecutor(
-            Thread.ofPlatform()
-                    .daemon()
-                    .name("graphcompose-devtool-refresh-", 0)
-                    .factory());
+            daemonThreadFactory("graphcompose-devtool-refresh-", REFRESH_THREAD_SEQUENCE));
     private final ScheduledExecutorService debounceExecutor = Executors.newSingleThreadScheduledExecutor(
-            Thread.ofPlatform()
-                    .daemon()
-                    .name("graphcompose-devtool-debounce-", 0)
-                    .factory());
+            daemonThreadFactory("graphcompose-devtool-debounce-", DEBOUNCE_THREAD_SEQUENCE));
     private final AtomicReference<RefreshRequest> pendingRequest = new AtomicReference<>();
     private final AtomicReference<ScheduledFuture<?>> pendingDebounce = new AtomicReference<>();
     private final AtomicReference<LoadedPreview> currentPreview = new AtomicReference<>();
@@ -88,6 +86,15 @@ public final class GraphComposeDevTool extends Application {
 
     public static void main(String[] args) {
         Application.launch(GraphComposeDevTool.class, args);
+    }
+
+    private static ThreadFactory daemonThreadFactory(String prefix, AtomicInteger sequence) {
+        return runnable -> {
+            Thread thread = new Thread(runnable);
+            thread.setDaemon(true);
+            thread.setName(prefix + sequence.getAndIncrement());
+            return thread;
+        };
     }
 
     @Override

--- a/src/test/java/com/demcha/compose/devtool/PreviewCompiler.java
+++ b/src/test/java/com/demcha/compose/devtool/PreviewCompiler.java
@@ -27,6 +27,8 @@ import java.util.regex.Pattern;
 public final class PreviewCompiler {
     private static final Pattern LOMBOK_VERSION_PATTERN =
             Pattern.compile("<lombok\\.version>([^<]+)</lombok\\.version>");
+    private static final Pattern MAVEN_COMPILER_RELEASE_PATTERN =
+            Pattern.compile("<maven\\.compiler\\.release>([^<]+)</maven\\.compiler\\.release>");
     private volatile List<String> cachedCompilerClasspath;
     private volatile Optional<Path> cachedLombokJar;
 
@@ -53,6 +55,13 @@ public final class PreviewCompiler {
 
         if (sourceFiles.isEmpty()) {
             return CompilationResult.failure("No Java sources found in watched source roots.", 0, 0);
+        }
+
+        int compilerRelease;
+        try {
+            compilerRelease = compilerRelease(workspace);
+        } catch (IllegalStateException ex) {
+            return CompilationResult.failure(ex.getMessage(), 0, sourceFiles.size());
         }
 
         Path outputDir = workspace.compiledOutputRoot().resolve("rev-" + revision);
@@ -84,8 +93,10 @@ public final class PreviewCompiler {
             var compilerClasspath = compilerClasspath(workspace);
 
             var options = new ArrayList<String>();
+            // Keep preview compilation aligned with the Maven project's declared
+            // target release instead of whatever newer JDK happens to run tests.
             options.add("--release");
-            options.add("21");
+            options.add(Integer.toString(compilerRelease));
             options.add("-encoding");
             options.add("UTF-8");
             options.add("-classpath");
@@ -138,6 +149,20 @@ public final class PreviewCompiler {
         }
     }
 
+    private int compilerRelease(DevToolWorkspace workspace) {
+        int runtimeRelease = Runtime.version().feature();
+        int configuredRelease = readCompilerReleaseFromPom(workspace.projectRoot())
+                .or(this::readCompilerReleaseFromCurrentProjectPom)
+                .orElse(runtimeRelease);
+
+        if (configuredRelease > runtimeRelease) {
+            throw new IllegalStateException(
+                    "Preview compiler requires JDK %d or newer, but tests are running on JDK %d."
+                            .formatted(configuredRelease, runtimeRelease));
+        }
+        return configuredRelease;
+    }
+
     private List<String> compilerClasspath(DevToolWorkspace workspace) {
         List<String> existing = cachedCompilerClasspath;
         if (existing != null) {
@@ -187,7 +212,20 @@ public final class PreviewCompiler {
                 .or(() -> findLatestInstalledLombokJar());
     }
 
+    private Optional<Integer> readCompilerReleaseFromCurrentProjectPom() {
+        return readCompilerReleaseFromPom(Path.of("").toAbsolutePath().normalize());
+    }
+
+    private Optional<Integer> readCompilerReleaseFromPom(Path projectRoot) {
+        return readPomProperty(projectRoot, MAVEN_COMPILER_RELEASE_PATTERN)
+                .flatMap(this::parseReleaseValue);
+    }
+
     private Optional<String> readLombokVersionFromPom(Path projectRoot) {
+        return readPomProperty(projectRoot, LOMBOK_VERSION_PATTERN);
+    }
+
+    private Optional<String> readPomProperty(Path projectRoot, Pattern pattern) {
         Path pom = projectRoot.resolve("pom.xml");
         if (Files.notExists(pom)) {
             return Optional.empty();
@@ -195,7 +233,7 @@ public final class PreviewCompiler {
 
         try {
             String content = Files.readString(pom, StandardCharsets.UTF_8);
-            Matcher matcher = LOMBOK_VERSION_PATTERN.matcher(content);
+            Matcher matcher = pattern.matcher(content);
             if (matcher.find()) {
                 return Optional.of(matcher.group(1).trim());
             }
@@ -204,6 +242,14 @@ public final class PreviewCompiler {
         }
 
         return Optional.empty();
+    }
+
+    private Optional<Integer> parseReleaseValue(String value) {
+        try {
+            return Optional.of(Integer.parseInt(value));
+        } catch (NumberFormatException ignored) {
+            return Optional.empty();
+        }
     }
 
     private Optional<Path> resolveLombokJar(String version) {

--- a/src/test/java/com/demcha/compose/devtool/RecursivePathWatcher.java
+++ b/src/test/java/com/demcha/compose/devtool/RecursivePathWatcher.java
@@ -43,10 +43,8 @@ public final class RecursivePathWatcher implements AutoCloseable {
         }
 
         running = true;
-        thread = Thread.ofPlatform()
-                .daemon()
-                .name("graphcompose-devtool-watch", 0)
-                .unstarted(this::processLoop);
+        thread = new Thread(this::processLoop, "graphcompose-devtool-watch");
+        thread.setDaemon(true);
         thread.start();
     }
 

--- a/src/test/java/com/demcha/compose/document/api/DocumentListNodeTest.java
+++ b/src/test/java/com/demcha/compose/document/api/DocumentListNodeTest.java
@@ -38,7 +38,7 @@ class DocumentListNodeTest {
                     .build();
 
             assertThat(root.children()).hasSize(1);
-            assertThat(root.children().getFirst()).isInstanceOf(ListNode.class);
+            assertThat(root.children().get(0)).isInstanceOf(ListNode.class);
 
             List<ParagraphFragmentPayload> payloads = paragraphPayloads(session.layoutGraph());
             assertThat(payloads).hasSize(3);
@@ -108,13 +108,13 @@ class DocumentListNodeTest {
                     .build();
 
             List<ParagraphFragmentPayload> payloads = paragraphPayloads(session.layoutGraph());
-            List<String> firstItemLines = payloads.getFirst().lines().stream()
+            List<String> firstItemLines = payloads.get(0).lines().stream()
                     .map(ParagraphLine::text)
                     .toList();
 
             assertThat(firstItemLines).hasSizeGreaterThan(1);
             assertThat(countOccurrences(String.join("\n", firstItemLines), "\u2022")).isEqualTo(1);
-            assertThat(payloads.get(1).lines().getFirst().text()).isEqualTo("\u2022 Tail");
+            assertThat(payloads.get(1).lines().get(0).text()).isEqualTo("\u2022 Tail");
         }
     }
 
@@ -137,15 +137,15 @@ class DocumentListNodeTest {
                     .build();
 
             List<ParagraphFragmentPayload> payloads = paragraphPayloads(session.layoutGraph());
-            List<String> firstItemLines = payloads.getFirst().lines().stream()
+            List<String> firstItemLines = payloads.get(0).lines().stream()
                     .map(ParagraphLine::text)
                     .toList();
 
             assertThat(payloads).hasSize(2);
             assertThat(firstItemLines).hasSizeGreaterThan(1);
-            assertThat(firstItemLines.getFirst()).startsWith("Alpha");
+            assertThat(firstItemLines.get(0)).startsWith("Alpha");
             assertThat(firstItemLines.get(1)).startsWith("  ");
-            assertThat(payloads.get(1).lines().getFirst().text()).startsWith("Beta");
+            assertThat(payloads.get(1).lines().get(0).text()).startsWith("Beta");
         }
     }
 
@@ -238,9 +238,9 @@ class DocumentListNodeTest {
                 assertThat(fragment.width()).isCloseTo(listNode.placementWidth(), within(0.01));
             });
 
-            ParagraphFragmentPayload first = paragraphPayload(fragments.getFirst());
+            ParagraphFragmentPayload first = paragraphPayload(fragments.get(0));
             ParagraphFragmentPayload middle = paragraphPayload(fragments.get(1));
-            ParagraphFragmentPayload last = paragraphPayload(fragments.getLast());
+            ParagraphFragmentPayload last = paragraphPayload(fragments.get(fragments.size() - 1));
 
             assertPadding(first.padding(), 3, 5, 0, 11);
             assertPadding(middle.padding(), 0, 5, 0, 11);
@@ -270,7 +270,7 @@ class DocumentListNodeTest {
 
     private static List<String> firstLineTexts(List<ParagraphFragmentPayload> payloads) {
         return payloads.stream()
-                .map(payload -> payload.lines().getFirst().text())
+                .map(payload -> payload.lines().get(0).text())
                 .toList();
     }
 

--- a/src/test/java/com/demcha/compose/document/api/DocumentSessionTest.java
+++ b/src/test/java/com/demcha/compose/document/api/DocumentSessionTest.java
@@ -129,8 +129,8 @@ class DocumentSessionTest {
 
             assertThat(session.roots()).containsExactly(root);
             assertThat(root.children()).hasSize(1);
-            assertThat(root.children().getFirst()).isInstanceOf(ParagraphNode.class);
-            assertThat(((ParagraphNode) root.children().getFirst()).text()).isEqualTo("Shortcut paragraph");
+            assertThat(root.children().get(0)).isInstanceOf(ParagraphNode.class);
+            assertThat(((ParagraphNode) root.children().get(0)).text()).isEqualTo("Shortcut paragraph");
             assertThat(session.layoutGraph().totalPages()).isEqualTo(1);
         }
     }
@@ -148,13 +148,13 @@ class DocumentSessionTest {
                     .addText("Composed paragraph")));
 
             assertThat(session.roots()).hasSize(1);
-            assertThat(session.roots().getFirst()).isInstanceOf(ContainerNode.class);
+            assertThat(session.roots().get(0)).isInstanceOf(ContainerNode.class);
 
-            ContainerNode root = (ContainerNode) session.roots().getFirst();
+            ContainerNode root = (ContainerNode) session.roots().get(0);
             assertThat(root.name()).isEqualTo("ComposeShortcut");
             assertThat(root.children()).hasSize(1);
-            assertThat(root.children().getFirst()).isInstanceOf(ParagraphNode.class);
-            assertThat(((ParagraphNode) root.children().getFirst()).text()).isEqualTo("Composed paragraph");
+            assertThat(root.children().get(0)).isInstanceOf(ParagraphNode.class);
+            assertThat(((ParagraphNode) root.children().get(0)).text()).isEqualTo("Composed paragraph");
             assertThat(session.layoutGraph().totalPages()).isEqualTo(1);
         }
     }
@@ -175,13 +175,13 @@ class DocumentSessionTest {
                     .build();
 
             assertThat(root.children()).hasSize(1);
-            assertThat(root.children().getFirst()).isInstanceOf(SectionNode.class);
+            assertThat(root.children().get(0)).isInstanceOf(SectionNode.class);
 
-            SectionNode section = (SectionNode) root.children().getFirst();
+            SectionNode section = (SectionNode) root.children().get(0);
             assertThat(section.name()).isEqualTo("Profile");
             assertThat(section.children()).hasSize(1);
-            assertThat(section.children().getFirst()).isInstanceOf(ParagraphNode.class);
-            assertThat(((ParagraphNode) section.children().getFirst()).text()).isEqualTo("Senior platform engineer");
+            assertThat(section.children().get(0)).isInstanceOf(ParagraphNode.class);
+            assertThat(((ParagraphNode) section.children().get(0)).text()).isEqualTo("Senior platform engineer");
             assertThat(session.layoutGraph().totalPages()).isEqualTo(1);
         }
     }
@@ -210,14 +210,14 @@ class DocumentSessionTest {
             LayoutGraph graph = session.layoutGraph();
 
             assertThat(graph.fragments()).hasSize(2);
-            assertThat(graph.fragments().getFirst().path()).contains("InfoCard[0]");
-            assertThat(graph.fragments().getFirst().payload())
+            assertThat(graph.fragments().get(0).path()).contains("InfoCard[0]");
+            assertThat(graph.fragments().get(0).payload())
                     .isInstanceOf(ShapeFragmentPayload.class);
             assertThat(graph.fragments().get(1).payload())
                     .isInstanceOf(ParagraphFragmentPayload.class);
 
             ShapeFragmentPayload payload =
-                    (ShapeFragmentPayload) graph.fragments().getFirst().payload();
+                    (ShapeFragmentPayload) graph.fragments().get(0).payload();
             assertThat(payload.fillColor()).isEqualTo(fill.color());
             assertThat(payload.stroke().strokeColor().color()).isEqualTo(DocumentColor.ROYAL_BLUE.color());
             assertThat(payload.stroke().width()).isEqualTo(0.8);
@@ -338,13 +338,13 @@ class DocumentSessionTest {
                     .build();
 
             assertThat(root.children()).hasSize(1);
-            assertThat(root.children().getFirst()).isInstanceOf(SectionNode.class);
+            assertThat(root.children().get(0)).isInstanceOf(SectionNode.class);
 
-            SectionNode module = (SectionNode) root.children().getFirst();
+            SectionNode module = (SectionNode) root.children().get(0);
             assertThat(module.name()).isEqualTo("TechnicalSkills");
             assertThat(module.children()).hasSize(5);
-            assertThat(module.children().getFirst()).isInstanceOf(ParagraphNode.class);
-            assertThat(((ParagraphNode) module.children().getFirst()).text()).isEqualTo("Technical Skills");
+            assertThat(module.children().get(0)).isInstanceOf(ParagraphNode.class);
+            assertThat(((ParagraphNode) module.children().get(0)).text()).isEqualTo("Technical Skills");
             assertThat(module.children().get(1)).isInstanceOf(ParagraphNode.class);
             assertThat(module.children().get(2)).isInstanceOf(ListNode.class);
             assertThat(module.children().get(3)).isInstanceOf(ListNode.class);
@@ -416,11 +416,11 @@ class DocumentSessionTest {
                     .build();
 
             assertThat(root.children()).hasSize(1);
-            assertThat(root.children().getFirst()).isInstanceOf(TableNode.class);
+            assertThat(root.children().get(0)).isInstanceOf(TableNode.class);
 
-            TableNode table = (TableNode) root.children().getFirst();
+            TableNode table = (TableNode) root.children().get(0);
             assertThat(table.rows()).hasSize(3);
-            assertThat(table.rows().getFirst())
+            assertThat(table.rows().get(0))
                     .extracting(DocumentTableCell::lines)
                     .containsExactly(List.of("Role"), List.of("Owner"), List.of("Status"));
             assertThat(table.rows().get(1))
@@ -467,16 +467,16 @@ class DocumentSessionTest {
             LayoutGraph graph = session.layoutGraph();
             assertThat(graph.totalPages()).isGreaterThan(1);
             assertThat(graph.nodes()).hasSize(1);
-            assertThat(graph.nodes().getFirst().startPage()).isEqualTo(0);
-            assertThat(graph.nodes().getFirst().endPage()).isGreaterThan(0);
+            assertThat(graph.nodes().get(0).startPage()).isEqualTo(0);
+            assertThat(graph.nodes().get(0).endPage()).isGreaterThan(0);
             assertThat(graph.fragments()).extracting(PlacedFragment::pageIndex).doesNotHaveDuplicates();
             assertThat(graph.fragments()).allSatisfy(fragment ->
                     assertThat(fragment.payload()).isInstanceOf(ParagraphFragmentPayload.class));
 
             ParagraphFragmentPayload firstPayload =
-                    (ParagraphFragmentPayload) graph.fragments().getFirst().payload();
+                    (ParagraphFragmentPayload) graph.fragments().get(0).payload();
             ParagraphFragmentPayload lastPayload =
-                    (ParagraphFragmentPayload) graph.fragments().getLast().payload();
+                    (ParagraphFragmentPayload) graph.fragments().get(graph.fragments().size() - 1).payload();
             assertThat(firstPayload.padding().top()).isEqualTo(4.0);
             assertThat(firstPayload.padding().bottom()).isEqualTo(0.0);
             assertThat(lastPayload.padding().top()).isEqualTo(0.0);
@@ -558,7 +558,7 @@ class DocumentSessionTest {
             assertThat(graph.fragments()).hasSize(1);
 
             ParagraphFragmentPayload payload =
-                    (ParagraphFragmentPayload) graph.fragments().getFirst().payload();
+                    (ParagraphFragmentPayload) graph.fragments().get(0).payload();
             assertThat(payload.lines())
                     .extracting(ParagraphLine::text)
                     .containsExactly("First line", "", "Second line");
@@ -832,7 +832,7 @@ class DocumentSessionTest {
 
             try (PDDocument document = Loader.loadPDF(pdfBytes)) {
                 BufferedImage image = new PDFRenderer(document).renderImageWithDPI(0, RENDER_DPI);
-                PlacedFragment fragment = graph.fragments().getFirst();
+                PlacedFragment fragment = graph.fragments().get(0);
 
                 assertThat(hasColorNear(
                         image,
@@ -884,7 +884,7 @@ class DocumentSessionTest {
 
             try (PDDocument document = Loader.loadPDF(pdfBytes)) {
                 BufferedImage image = new PDFRenderer(document).renderImageWithDPI(0, RENDER_DPI);
-                PlacedFragment fragment = graph.fragments().getFirst();
+                PlacedFragment fragment = graph.fragments().get(0);
 
                 assertThat(hasColorNear(
                         image,
@@ -1113,4 +1113,3 @@ class DocumentSessionTest {
                 && Math.abs(actual.getBlue() - expected.getBlue()) <= tolerancePerChannel;
     }
 }
-

--- a/src/test/java/com/demcha/compose/document/backend/fixed/pdf/PdfFixedLayoutBackendFeaturesTest.java
+++ b/src/test/java/com/demcha/compose/document/backend/fixed/pdf/PdfFixedLayoutBackendFeaturesTest.java
@@ -128,8 +128,8 @@ class PdfFixedLayoutBackendFeaturesTest {
             assertThat(firstChild.getTitle()).isEqualTo("Overview");
 
             assertThat(document.getPage(0).getAnnotations()).isNotEmpty();
-            assertThat(document.getPage(0).getAnnotations().getFirst()).isInstanceOf(PDAnnotationLink.class);
-            PDAnnotationLink annotation = (PDAnnotationLink) document.getPage(0).getAnnotations().getFirst();
+            assertThat(document.getPage(0).getAnnotations().get(0)).isInstanceOf(PDAnnotationLink.class);
+            PDAnnotationLink annotation = (PDAnnotationLink) document.getPage(0).getAnnotations().get(0);
             assertThat(annotation.getAction()).isInstanceOf(PDActionURI.class);
             assertThat(((PDActionURI) annotation.getAction()).getURI()).isEqualTo("https://example.com/docs");
 

--- a/src/test/java/com/demcha/compose/document/dsl/AddLinkShortcutTest.java
+++ b/src/test/java/com/demcha/compose/document/dsl/AddLinkShortcutTest.java
@@ -34,8 +34,8 @@ class AddLinkShortcutTest {
 
         try (PDDocument document = Loader.loadPDF(pdfBytes)) {
             assertThat(document.getPage(0).getAnnotations()).isNotEmpty();
-            assertThat(document.getPage(0).getAnnotations().getFirst()).isInstanceOf(PDAnnotationLink.class);
-            PDAnnotationLink link = (PDAnnotationLink) document.getPage(0).getAnnotations().getFirst();
+            assertThat(document.getPage(0).getAnnotations().get(0)).isInstanceOf(PDAnnotationLink.class);
+            PDAnnotationLink link = (PDAnnotationLink) document.getPage(0).getAnnotations().get(0);
             assertThat(link.getAction()).isInstanceOf(PDActionURI.class);
             assertThat(((PDActionURI) link.getAction()).getURI()).isEqualTo("https://example.com/docs");
             assertThat(new PDFTextStripper().getText(document)).contains("Documentation");
@@ -60,7 +60,7 @@ class AddLinkShortcutTest {
         }
 
         try (PDDocument document = Loader.loadPDF(pdfBytes)) {
-            PDAnnotationLink link = (PDAnnotationLink) document.getPage(0).getAnnotations().getFirst();
+            PDAnnotationLink link = (PDAnnotationLink) document.getPage(0).getAnnotations().get(0);
             assertThat(((PDActionURI) link.getAction()).getURI()).isEqualTo("mailto:author@example.dev");
         }
     }

--- a/src/test/java/com/demcha/compose/document/dsl/ListBuilderNestedTest.java
+++ b/src/test/java/com/demcha/compose/document/dsl/ListBuilderNestedTest.java
@@ -63,7 +63,7 @@ class ListBuilderNestedTest {
 
         assertThat(node.items()).isEmpty();
         assertThat(node.nestedItems()).hasSize(1);
-        ListItem parent = node.nestedItems().getFirst();
+        ListItem parent = node.nestedItems().get(0);
         assertThat(parent.label()).isEqualTo("Parent");
         assertThat(parent.children()).extracting(ListItem::label)
                 .containsExactly("Child A", "Child B");
@@ -200,11 +200,11 @@ class ListBuilderNestedTest {
                 .build();
 
         assertThat(node.nestedItems()).hasSize(1);
-        ListItem top = node.nestedItems().getFirst();
+        ListItem top = node.nestedItems().get(0);
         assertThat(top.marker()).isNotNull();
         assertThat(top.marker().value()).isEqualTo("- ");
         assertThat(top.children()).hasSize(1);
-        assertThat(top.children().getFirst().marker().value()).isEqualTo("→ ");
+        assertThat(top.children().get(0).marker().value()).isEqualTo("→ ");
     }
 
     @Test
@@ -251,10 +251,10 @@ class ListBuilderNestedTest {
                     .build();
 
             assertThat(root.children()).hasSize(1);
-            assertThat(root.children().getFirst()).isInstanceOf(ListNode.class);
-            ListNode listNode = (ListNode) root.children().getFirst();
+            assertThat(root.children().get(0)).isInstanceOf(ListNode.class);
+            ListNode listNode = (ListNode) root.children().get(0);
             assertThat(listNode.nestedItems()).hasSize(1);
-            assertThat(listNode.nestedItems().getFirst().children())
+            assertThat(listNode.nestedItems().get(0).children())
                     .extracting(ListItem::label)
                     .containsExactly("a1");
         }
@@ -285,7 +285,7 @@ class ListBuilderNestedTest {
                 .map(PlacedFragment::payload)
                 .filter(ParagraphFragmentPayload.class::isInstance)
                 .map(ParagraphFragmentPayload.class::cast)
-                .map(payload -> payload.lines().getFirst().text())
+                .map(payload -> payload.lines().get(0).text())
                 .toList();
     }
 }

--- a/src/test/java/com/demcha/compose/document/table/TableCellComposedContentTest.java
+++ b/src/test/java/com/demcha/compose/document/table/TableCellComposedContentTest.java
@@ -74,7 +74,7 @@ class TableCellComposedContentTest {
             assertThat(paragraphFragments).hasSize(1);
 
             ParagraphFragmentPayload childPayload = (ParagraphFragmentPayload)
-                    paragraphFragments.getFirst().payload();
+                    paragraphFragments.get(0).payload();
             // The paragraph wraps within the cell's inner width, so the
             // full sentence is split across two visual lines. Combine
             // them before checking the rendered text.

--- a/src/test/java/com/demcha/compose/document/templates/support/common/SessionTemplateComposeTargetTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/support/common/SessionTemplateComposeTargetTest.java
@@ -63,14 +63,14 @@ class SessionTemplateComposeTargetTest {
             target.finishDocument();
 
             assertThat(session.roots()).hasSize(1);
-            DocumentNode rootNode = session.roots().getFirst();
+            DocumentNode rootNode = session.roots().get(0);
             assertThat(rootNode).isInstanceOf(ContainerNode.class);
 
             ContainerNode root = (ContainerNode) rootNode;
             assertThat(root.children()).hasSize(1);
-            assertThat(root.children().getFirst()).isInstanceOf(SectionNode.class);
+            assertThat(root.children().get(0)).isInstanceOf(SectionNode.class);
 
-            SectionNode module = (SectionNode) root.children().getFirst();
+            SectionNode module = (SectionNode) root.children().get(0);
             assertThat(module.name()).isEqualTo("TechnicalSkills");
             assertThat(module.children()).hasSize(3);
             assertThat(module.children().get(0)).isInstanceOf(ParagraphNode.class);
@@ -111,8 +111,8 @@ class SessionTemplateComposeTargetTest {
                                             Margin.zero()))))));
             target.finishDocument();
 
-            ContainerNode root = (ContainerNode) session.roots().getFirst();
-            SectionNode module = (SectionNode) root.children().getFirst();
+            ContainerNode root = (ContainerNode) session.roots().get(0);
+            SectionNode module = (SectionNode) root.children().get(0);
 
             assertThat(module.children()).hasSize(2);
             assertThat(module.children().get(1)).isInstanceOf(ParagraphNode.class);

--- a/src/test/java/com/demcha/compose/engine/core/EngineComposerHarnessLayoutSnapshotTest.java
+++ b/src/test/java/com/demcha/compose/engine/core/EngineComposerHarnessLayoutSnapshotTest.java
@@ -155,7 +155,7 @@ class EngineComposerHarnessLayoutSnapshotTest {
         BlockTextData textData = blockEntity.getComponent(BlockTextData.class)
                 .orElseThrow(() -> new AssertionError("Missing BlockTextData for " + entityName));
 
-        return textData.lines().getFirst();
+        return textData.lines().get(0);
     }
 
     private EntityManager entityManager(EngineComposerHarness composer) throws Exception {

--- a/src/test/java/com/demcha/compose/engine/render/pdf/handlers/PdfLinkRenderHandlerTest.java
+++ b/src/test/java/com/demcha/compose/engine/render/pdf/handlers/PdfLinkRenderHandlerTest.java
@@ -42,9 +42,9 @@ class PdfLinkRenderHandlerTest {
             assertThat(rendered).isTrue();
             assertThat(document.getNumberOfPages()).isEqualTo(1);
             assertThat(document.getPage(0).getAnnotations()).hasSize(1);
-            assertThat(document.getPage(0).getAnnotations().getFirst()).isInstanceOf(PDAnnotationLink.class);
+            assertThat(document.getPage(0).getAnnotations().get(0)).isInstanceOf(PDAnnotationLink.class);
 
-            PDAnnotationLink annotation = (PDAnnotationLink) document.getPage(0).getAnnotations().getFirst();
+            PDAnnotationLink annotation = (PDAnnotationLink) document.getPage(0).getAnnotations().get(0);
             assertThat(annotation.getAction()).isInstanceOf(PDActionURI.class);
             assertThat(((PDActionURI) annotation.getAction()).getURI()).isEqualTo("https://example.com/profile");
             assertThat(annotation.getRectangle().getWidth()).isEqualTo(128.0f);

--- a/src/test/java/com/demcha/compose/engine/render/pdf/handlers/PdfTableRowRenderHandlerTest.java
+++ b/src/test/java/com/demcha/compose/engine/render/pdf/handlers/PdfTableRowRenderHandlerTest.java
@@ -141,9 +141,9 @@ class PdfTableRowRenderHandlerTest {
 
         assertThat(topLines).hasSize(2);
         assertThat(middleLines).hasSize(2);
-        assertThat(topLines.getFirst().baselineY()).isGreaterThan(middleLines.getFirst().baselineY());
-        assertThat(topLines.getFirst().baselineY() - topLines.get(1).baselineY()).isEqualTo(lineHeight);
-        assertThat(middleLines.getFirst().baselineY() - middleLines.get(1).baselineY()).isEqualTo(lineHeight);
+        assertThat(topLines.get(0).baselineY()).isGreaterThan(middleLines.get(0).baselineY());
+        assertThat(topLines.get(0).baselineY() - topLines.get(1).baselineY()).isEqualTo(lineHeight);
+        assertThat(middleLines.get(0).baselineY() - middleLines.get(1).baselineY()).isEqualTo(lineHeight);
     }
 
     @Test
@@ -171,6 +171,6 @@ class PdfTableRowRenderHandlerTest {
         double lineHeight = font.getLineHeight(cell.style().textStyle());
 
         assertThat(lines).hasSize(2);
-        assertThat(lines.getFirst().baselineY() - lines.get(1).baselineY()).isEqualTo(lineHeight + lineSpacing);
+        assertThat(lines.get(0).baselineY() - lines.get(1).baselineY()).isEqualTo(lineHeight + lineSpacing);
     }
 }

--- a/src/test/java/com/demcha/compose/testsupport/engine/assembly/TableBuilderTest.java
+++ b/src/test/java/com/demcha/compose/testsupport/engine/assembly/TableBuilderTest.java
@@ -41,8 +41,8 @@ class TableBuilderTest {
             TableRowData rowData = firstRow.getComponent(TableRowData.class).orElseThrow();
 
             assertThat(layoutData.columnWidths()).hasSize(2);
-            assertThat(layoutData.columnWidths().getFirst()).isEqualTo(120.0);
-            assertThat(rowData.cells().getFirst().width()).isEqualTo(120.0);
+            assertThat(layoutData.columnWidths().get(0)).isEqualTo(120.0);
+            assertThat(rowData.cells().get(0).width()).isEqualTo(120.0);
             assertThat(rowData.cells().get(1).width()).isEqualTo(layoutData.columnWidths().get(1));
             assertThat(layoutData.finalWidth()).isEqualTo(layoutData.columnWidths().stream().mapToDouble(Double::doubleValue).sum());
         }
@@ -119,13 +119,13 @@ class TableBuilderTest {
                     .getComponent(TableRowData.class)
                     .orElseThrow()
                     .cells()
-                    .getFirst();
+                    .get(0);
 
             TableResolvedCell secondRowFirstCell = child(table, 1)
                     .getComponent(TableRowData.class)
                     .orElseThrow()
                     .cells()
-                    .getFirst();
+                    .get(0);
 
             assertThat(firstRowFirstCell.style().fillColor()).isEqualTo(ComponentColor.RED);
             assertThat(firstRowFirstCell.style().padding()).isEqualTo(Padding.of(8));
@@ -181,7 +181,7 @@ class TableBuilderTest {
                     .getComponent(TableRowData.class)
                     .orElseThrow()
                     .cells()
-                    .getFirst();
+                    .get(0);
 
             assertThat(firstCell.style().fillColor()).isEqualTo(ComponentColor.GREEN);
             assertThat(firstCell.style().padding()).isEqualTo(Padding.of(8));
@@ -203,7 +203,7 @@ class TableBuilderTest {
                     .getComponent(TableRowData.class)
                     .orElseThrow()
                     .cells()
-                    .getFirst();
+                    .get(0);
 
             assertThat(firstCell.lines()).containsExactly("Alpha");
         }
@@ -228,13 +228,13 @@ class TableBuilderTest {
                     .getComponent(TableRowData.class)
                     .orElseThrow()
                     .cells()
-                    .getFirst();
+                    .get(0);
 
             TableResolvedCell singleLineCell = child(longestLineTable, 0)
                     .getComponent(TableRowData.class)
                     .orElseThrow()
                     .cells()
-                    .getFirst();
+                    .get(0);
 
             double paddingVertical = TableCellLayoutStyle.DEFAULT.padding().vertical();
             double expectedMultilineHeight = (2 * (singleLineCell.height() - paddingVertical)) + paddingVertical;
@@ -271,12 +271,12 @@ class TableBuilderTest {
                     .getComponent(TableRowData.class)
                     .orElseThrow()
                     .cells()
-                    .getFirst();
+                    .get(0);
             TableResolvedCell singleLineCell = child(singleLineTable, 0)
                     .getComponent(TableRowData.class)
                     .orElseThrow()
                     .cells()
-                    .getFirst();
+                    .get(0);
 
             assertThat(multilineCell.height()).isEqualTo((2 * singleLineCell.height()) + 2.5);
         }
@@ -332,7 +332,7 @@ class TableBuilderTest {
                     .build();
 
             Entity row = child(table, 0);
-            TableResolvedCell cell = row.getComponent(TableRowData.class).orElseThrow().cells().getFirst();
+            TableResolvedCell cell = row.getComponent(TableRowData.class).orElseThrow().cells().get(0);
 
             assertThat(row.getComponent(EntityName.class)).hasValue(new EntityName("Orders__row_0"));
             assertThat(cell.name()).isEqualTo("Orders__row_0__cell_0");
@@ -353,7 +353,7 @@ class TableBuilderTest {
                     .getComponent(TableRowData.class)
                     .orElseThrow()
                     .cells()
-                    .getFirst();
+                    .get(0);
 
             TableResolvedCell firstRowSecondCell = child(table, 0)
                     .getComponent(TableRowData.class)
@@ -419,7 +419,7 @@ class TableBuilderTest {
                     .getComponent(TableRowData.class)
                     .orElseThrow()
                     .cells()
-                    .getFirst();
+                    .get(0);
 
             assertThat(secondRowCell.borderSides()).containsExactlyInAnyOrder(Side.TOP, Side.LEFT, Side.RIGHT, Side.BOTTOM);
             assertThat(secondRowCell.fillInsets().top()).isEqualTo(1.0);

--- a/src/test/java/com/demcha/testing/layout/LayoutSnapshotExtractorTest.java
+++ b/src/test/java/com/demcha/testing/layout/LayoutSnapshotExtractorTest.java
@@ -162,8 +162,8 @@ class LayoutSnapshotExtractorTest {
 
         assertThat(snapshot.totalPages()).isEqualTo(3);
         assertThat(snapshot.nodes()).hasSize(1);
-        assertThat(snapshot.nodes().getFirst().startPage()).isEqualTo(2);
-        assertThat(snapshot.nodes().getFirst().endPage()).isEqualTo(0);
+        assertThat(snapshot.nodes().get(0).startPage()).isEqualTo(2);
+        assertThat(snapshot.nodes().get(0).endPage()).isEqualTo(0);
     }
 
     @Test

--- a/src/test/java/com/demcha/testing/visual/TableRowSpanDemoTest.java
+++ b/src/test/java/com/demcha/testing/visual/TableRowSpanDemoTest.java
@@ -138,7 +138,7 @@ class TableRowSpanDemoTest {
             BufferedImage image = PdfVisualRegression.standard()
                     .renderScale(1.0f)
                     .renderPages(pdf)
-                    .getFirst();
+                    .get(0);
 
             List<PlacedFragment> rowFragments = graph.fragments().stream()
                     .filter(fragment -> fragment.payload() instanceof TableRowFragmentPayload)
@@ -146,7 +146,7 @@ class TableRowSpanDemoTest {
             PlacedFragment secondRow = rowFragments.get(1);
             TableRowFragmentPayload secondRowPayload =
                     (TableRowFragmentPayload) secondRow.payload();
-            TableResolvedCell leftCell = secondRowPayload.cells().getFirst();
+            TableResolvedCell leftCell = secondRowPayload.cells().get(0);
 
             double rowTop = secondRow.y() + secondRow.height();
             double leftCellRight = secondRow.x() + leftCell.x() + leftCell.width();
@@ -189,7 +189,7 @@ class TableRowSpanDemoTest {
             BufferedImage image = PdfVisualRegression.standard()
                     .renderScale(1.0f)
                     .renderPages(pdf)
-                    .getFirst();
+                    .get(0);
 
             List<PlacedFragment> rowFragments = graph.fragments().stream()
                     .filter(fragment -> fragment.payload() instanceof TableRowFragmentPayload)


### PR DESCRIPTION
## What this is

Maintenance + compatibility patch for **v1.6.1**. Drops the Java 21 source/target baseline to **Java 17+** so the library can ship into older enterprise stacks without a fork, and refreshes test/build dependencies (incl. CVE pass). **No public API change** — engine, DSL, themes, templates, and backend records all stay source-compatible with v1.6.0; existing callers compile and behave unchanged.

Co-developed with @jottinger via **#11** (deps refresh + ByteBuddy for Java 25 compat) and **#12** (engine source migration to Java 17). Their three commits are preserved at the bottom of this branch with original authorship; the top commits close the gaps those PRs left.

Closes #8 · supersedes #11 · supersedes #12.

> **Why v1.6.1, not v1.7.0?** SemVer-correct: no new public API, no breaking changes on the engine surface, no migration guide needed for users. Compatibility expansion + dependency hygiene fits the patch slot. Maven Central distribution ([#7](https://github.com/DemchaAV/GraphCompose/issues/7)) — the one true minor-level change — stays queued for v1.7.0 alongside JMH migration.

## What's in the branch (oldest → newest)

| Commit | Author | What |
|---|---|---|
| `5b7d6d4f` | @jottinger | Updates module dependencies (Jackson, Logback, Mockito, ByteBuddy, plugin bumps) |
| `2e32eb5d` | @jottinger | Updating benchmarks dependencies for CI/CD |
| `af1f82af` | @jottinger | Updates code to conform to java 17 (engine source migration) |
| `11d48d1f` | @DemchaAV | v1.7 prep: complete the Java 17 baseline migration (gaps closed below) |
| `2b1f64f1` | @DemchaAV | ci: trigger CI on PRs to any base + on develop pushes |
| `eda21695` | @DemchaAV | docs(changelog): reframe Java 17 baseline as v1.6.1 (patch), not v1.7 |

> The "v1.7 prep" wording in commit `11d48d1f` is left as-is to preserve history; the user-facing CHANGELOG entry has been reframed to **v1.6.1 — Planned** in `eda21695`.

## Gaps closed by my follow-up commits

- `examples/pom.xml` `<maven.compiler.release>` 21 → 17 (upstream only flipped root + benchmarks).
- `examples/.../WeeklyScheduleRenderer.java` — two switch-with-deconstruction blocks (`DayShift` / `Half`) and one `instanceof Half.StatusFill(ShiftStatus)` rewritten as Java 17 `instanceof` if-else chains.
- `benchmarks/.../BenchmarkMedianTool.java` — 9× `List.getFirst()` → `.get(0)` (JEP 431, Java 21).
- `benchmarks/.../ComparativeBenchmark.java` — 2× `Thread.currentThread().threadId()` → `.getId()` (threadId is Java 19+).
- `.github/workflows/ci.yml` — `actions/setup-java` `java-version: '21'` → `'17'` across all five jobs; trigger relaxed to run on PRs to any base branch + on develop pushes (otherwise feature-branch PRs wouldn't trigger CI).
- `README.md` — Java-21 badge → Java-17+.
- `CHANGELOG.md` — new `## v1.6.1 — Planned` entry detailing the Java 17 baseline + dependency refresh, with @jottinger credited upfront. Maven Central note moved to "queued for v1.7".

## Verification

| Check | Result |
|---|---|
| **CI on Temurin JDK 17** ([run 25596172760](https://github.com/DemchaAV/GraphCompose/actions/runs/25596172760)) | ✅ 4 / 4 active jobs green (Architecture+Documentation Guards, Build+test, Performance Smoke, Examples Generation) |
| **Test suite** (XML aggregation) | **819 / 0 / 0 / 0** — identical to main, zero regression |
| `./mvnw -B -ntp -f examples/pom.xml clean compile` | BUILD SUCCESS |
| `./mvnw -B -ntp -f benchmarks/pom.xml clean compile` | BUILD SUCCESS |
| Java 21 pattern scan (`getFirst`, `getLast`, `threadId`, switch-with-deconstruction) across `src/`, `examples/src/`, `benchmarks/src/` | clean |

> Note: local Maven runs on Java 21 with `-release 17`, which catches **compile-time** API drift but not runtime-only Java 21 dependencies. The CI run above on Temurin 17 is the truth source for the runtime side, and it's green.

## Release plan

`pwsh ./scripts/cut-release.ps1 -Version 1.6.1` after merge — script flips POMs to 1.6.1, dates the CHANGELOG entry, commits + tags v1.6.1, pushes.

## Status

🚧 **Draft.** Ready to flip to "Ready for review" once @DemchaAV eyeballs the diff and approves the merge plan.