### PR TITLE
fix(docs): showcase lightbox View Code button + v1.6.1 flip

### DIFF
--- a/docs/examples.js
+++ b/docs/examples.js
@@ -275,6 +275,7 @@
   function renderHighlight(ex, categoryId) {
     const screenshot = ex.screenshot || '';
     const pdf = ex.pdf || '';
+    const code = ex.code || '#';
     const badge = CATEGORY_BADGE[categoryId] || '';
     return [
       '<article class="highlight-tile" data-id="' + escAttr(ex.id || '') + '" role="listitem">',
@@ -282,6 +283,7 @@
       '          data-action="lightbox"',
       '          data-screenshot="' + escAttr(screenshot) + '"',
       '          data-pdf="' + escAttr(pdf) + '"',
+      '          data-code="' + escAttr(code) + '"',
       '          data-title="' + escAttr(ex.title || ex.id || '') + '"',
       '          aria-label="Open preview for ' + escAttr(ex.title || ex.id || '') + '">',
       screenshot
@@ -359,6 +361,7 @@
       '          data-action="lightbox"',
       '          data-screenshot="' + escAttr(screenshot) + '"',
       '          data-pdf="' + escAttr(pdf) + '"',
+      '          data-code="' + escAttr(code) + '"',
       '          data-title="' + escAttr(ex.title || ex.id || '') + '"',
       '          aria-label="Open preview for ' + escAttr(ex.title || ex.id || '') + '">',
       screenshot
@@ -412,7 +415,8 @@
       '  <header class="lightbox-header">',
       '    <h4 class="lightbox-title"></h4>',
       '    <div class="lightbox-actions">',
-      '      <a class="example-action lightbox-pdf-link" target="_blank" rel="noopener">Open PDF</a>',
+      '      <a class="example-action lightbox-pdf-link" target="_blank" rel="noopener" aria-label="Open PDF">Open PDF</a>',
+      '      <a class="example-action example-action-ghost lightbox-code-link" target="_blank" rel="noopener" aria-label="Open source on GitHub">View Code</a>',
       '      <button class="lightbox-close" type="button" aria-label="Close" data-close>&times;</button>',
       '    </div>',
       '  </header>',
@@ -434,12 +438,19 @@
     });
     return lightbox;
   }
-  function openLightbox(screenshot, pdf, title) {
+  function openLightbox(screenshot, pdf, code, title) {
     const lb = ensureLightbox();
     lb.querySelector('.lightbox-image').src = screenshot;
     lb.querySelector('.lightbox-image').alt = title + ' preview';
     lb.querySelector('.lightbox-title').textContent = title;
     lb.querySelector('.lightbox-pdf-link').href = pdf;
+    const codeLink = lb.querySelector('.lightbox-code-link');
+    if (code && code !== '#') {
+      codeLink.href = code;
+      codeLink.style.display = '';
+    } else {
+      codeLink.style.display = 'none';
+    }
     lb.classList.add('is-open');
     lb.setAttribute('aria-hidden', 'false');
     document.body.classList.add('lightbox-open');
@@ -470,9 +481,10 @@
     e.preventDefault();
     const screenshot = trigger.dataset.screenshot;
     const pdf = trigger.dataset.pdf;
+    const code = trigger.dataset.code;
     const title = trigger.dataset.title;
     if (screenshot) {
-      openLightbox(screenshot, pdf, title);
+      openLightbox(screenshot, pdf, code, title);
     } else if (pdf) {
       window.open(pdf, '_blank');
     }

--- a/docs/index.html
+++ b/docs/index.html
@@ -44,9 +44,9 @@
         "applicationSubCategory": "Library",
         "operatingSystem": "Cross-platform (JVM 21+)",
         "programmingLanguage": "Java",
-        "softwareVersion": "1.6.0",
+        "softwareVersion": "1.6.1",
         "url": "https://demchaav.github.io/GraphCompose/",
-        "downloadUrl": "https://jitpack.io/#DemchaAV/GraphCompose/v1.6.0",
+        "downloadUrl": "https://jitpack.io/#DemchaAV/GraphCompose/v1.6.1",
         "image": "https://demchaav.github.io/GraphCompose/assets/logo/graphcompose-logo.png",
         "license": "https://github.com/DemchaAV/GraphCompose/blob/main/LICENSE",
         "author": {
@@ -151,7 +151,7 @@
   <main id="top">
     <section class="hero section-shell" aria-labelledby="hero-title">
       <div class="hero-copy">
-        <p class="eyebrow">Java &middot; v1.6 &middot; MIT</p>
+        <p class="eyebrow">Java &middot; v1.6.1 &middot; MIT</p>
         <h1 id="hero-title">Java PDF layout engine for structured business documents.</h1>
         <p class="hero-lead">Describe documents. Render polished PDFs. A semantic layout engine for Java services that need <b>structured, paginated, theme-driven</b> output &mdash; CVs, invoices, proposals, reports.</p>
         <p class="hero-text">No drawing API. No pixel arithmetic. You compose <code>ParagraphNode</code>, <code>TableNode</code>, <code>SectionNode</code>; GraphCompose handles measurement, pagination, fonts, and PDFBox rendering.</p>
@@ -208,7 +208,7 @@
 &lt;dependency&gt;
   &lt;groupId&gt;com.github.DemchaAV&lt;/groupId&gt;
   &lt;artifactId&gt;GraphCompose&lt;/artifactId&gt;
-  &lt;version&gt;v1.6.0&lt;/version&gt;
+  &lt;version&gt;v1.6.1&lt;/version&gt;
 &lt;/dependency&gt;</code></pre>
         </div>
         <div class="install-block">
@@ -219,7 +219,7 @@
 
 dependencies {
   implementation(
-    'com.github.DemchaAV:GraphCompose:v1.6.0'
+    'com.github.DemchaAV:GraphCompose:v1.6.1'
   )
 }</code></pre>
         </div>


### PR DESCRIPTION
## Bugs

1. **Lightbox missing "View Code" button.** Click a Featured tile → modal opens with screenshot + "Open PDF" only. Reading the source on GitHub from a featured example requires closing the lightbox and scrolling to find the same example in the gallery below.
2. **`docs/index.html` still references v1.6.0** in `softwareVersion` (JSON-LD), `downloadUrl`, install snippets (Maven + Gradle), and the hero eyebrow tag — even though v1.6.1 is the live JitPack version.

## Fix

### `docs/examples.js`
- Threaded `code` through `renderHighlight` (`data-code` on the highlight preview button).
- Added the same `data-code` to `renderCard` (it was already in scope but never wired to the lightbox).
- Added a `.lightbox-code-link` anchor in `ensureLightbox` next to the existing `.lightbox-pdf-link`.
- Extended `openLightbox(screenshot, pdf, code, title)` to set the new link's `href`. If `code` is `'#'` or empty, the link hides itself (e.g. examples without source).
- Click handler now reads `dataset.code` alongside `dataset.screenshot/pdf/title` and passes it to `openLightbox`.

### `docs/index.html`
- `softwareVersion` JSON-LD: `1.6.0` → `1.6.1`
- `downloadUrl`: `…/v1.6.0` → `…/v1.6.1`
- Maven snippet: `<version>v1.6.0</version>` → `v1.6.1`
- Gradle snippet: `:GraphCompose:v1.6.0` → `:v1.6.1`
- Hero eyebrow: `Java · v1.6 · MIT` → `Java · v1.6.1 · MIT`

## Verification

Docs-only change. CI guards (`Architecture and Documentation Guards`) pass since none of the touched files are scanned by Java tests. Visual check on Launch preview panel confirms eyebrow + lightbox layout look right.