### PR TITLE
v2: introduce cv/v2 master pattern (data/theme/components/presets)

### DIFF
--- a/examples/src/main/java/com/demcha/examples/support/ExampleDataFactory.java
+++ b/examples/src/main/java/com/demcha/examples/support/ExampleDataFactory.java
@@ -12,6 +12,12 @@ import com.demcha.compose.document.templates.coverletter.spec.CoverLetterSpec;
 import com.demcha.compose.document.templates.cv.spec.CvHeader;
 import com.demcha.compose.document.templates.cv.spec.CvModule;
 import com.demcha.compose.document.templates.cv.spec.CvSpec;
+import com.demcha.compose.document.templates.cv.v2.data.CvDocument;
+import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
+import com.demcha.compose.document.templates.cv.v2.data.EntriesSection;
+import com.demcha.compose.document.templates.cv.v2.data.ParagraphSection;
+import com.demcha.compose.document.templates.cv.v2.data.RowStyle;
+import com.demcha.compose.document.templates.cv.v2.data.RowsSection;
 import com.demcha.compose.document.templates.data.common.EmailYaml;
 import com.demcha.compose.document.templates.data.common.Header;
 import com.demcha.compose.document.templates.data.coverletter.CoverLetterDocumentSpec;
@@ -439,6 +445,144 @@ public final class ExampleDataFactory {
                 .email("jordan.rivera@example.com")
                 .link("LinkedIn", "https://linkedin.com/in/jordan-rivera-demo")
                 .link("GitHub", "https://github.com/jrivera-demo")
+                .build();
+    }
+
+    // -- Templates v2 (cv/v2) sample data ------------------------------
+
+    /**
+     * Returns a sample {@code CvDocument} for the v2 CV pipeline —
+     * the canonical Jordan Rivera content expressed in the new
+     * 3-section sealed hierarchy
+     * ({@link com.demcha.compose.document.templates.cv.v2.data.ParagraphSection},
+     * {@link RowsSection},
+     * {@link EntriesSection}).
+     *
+     * <p>Each section explicitly picks its visual decoration —
+     * Technical Skills uses {@link RowStyle#BULLETED}, Projects uses
+     * {@link RowStyle#BULLETED_STACKED}, Additional Information uses
+     * {@link RowStyle#PLAIN}. Education and Experience are the same
+     * {@link EntriesSection} record, distinguished only by title.</p>
+     *
+     * @return sample v2 CV document
+     */
+    public static CvDocument sampleCvDocumentV2() {
+        CvIdentity identity = CvIdentity.builder()
+                .name("Jordan", "Rivera")
+                .contact("+44 20 5555 1000",
+                        "jordan.rivera@example.com",
+                        "London, UK")
+                .link("LinkedIn", "https://linkedin.com/in/jordan-rivera-demo")
+                .link("GitHub", "https://github.com/jrivera-demo")
+                .build();
+
+        ParagraphSection summary = new ParagraphSection(
+                "Professional Summary",
+                "Platform engineer with **10+ years** building resilient "
+                        + "document-generation pipelines, layout engines, and "
+                        + "developer-facing template systems. Specialised in "
+                        + "high-throughput PDF rendering, semantic authoring "
+                        + "DSLs, and turning brittle production-ops scripts "
+                        + "into typed, snapshot-tested libraries that scale.");
+
+        RowsSection skills = RowsSection
+                .builder("Technical Skills", RowStyle.BULLETED)
+                .row("Languages", "Java 21, Kotlin, Groovy, Python, SQL")
+                .row("Document & Print", "PDFBox, Apache POI (DOCX/XLSX), iText, "
+                        + "PostScript, ICC colour profiles, font metrics")
+                .row("Layout engines", "Custom DSL design, semantic layout trees, "
+                        + "pagination, snapshot testing, visual regression")
+                .row("Build & infrastructure", "Maven, Gradle, GitHub Actions, "
+                        + "JitPack, Docker, JMH benchmarking")
+                .row("Testing", "JUnit 5, AssertJ, PDFBox-based PNG diff, "
+                        + "layout-graph snapshots, mutation testing (Pitest)")
+                .row("Distribution", "Maven Central, Sonatype OSSRH, GPG signing, "
+                        + "JitPack, semantic versioning discipline")
+                .build();
+
+        EntriesSection education = EntriesSection
+                .builder("Education & Certifications")
+                .entry("MSc Computer Science",
+                        "University of Manchester",
+                        "2021",
+                        "Distinction. Thesis: *Composable layout primitives "
+                                + "for deterministic document rendering*.")
+                .entry("BSc Software Engineering",
+                        "Imperial College London",
+                        "2019",
+                        "First-class honours. Specialisation in compilers and "
+                                + "static analysis.")
+                .entry("Oracle Java Certification",
+                        "Professional track",
+                        "2023",
+                        "Java 17 platform deep-dive: records, sealed types, "
+                                + "pattern matching, virtual threads.")
+                .build();
+
+        RowsSection projects = RowsSection
+                .builder("Projects", RowStyle.BULLETED_STACKED)
+                .row("GraphCompose (Java 21, PDFBox, Maven, JMH)",
+                        "Declarative Java PDF layout engine. Semantic DSL, "
+                                + "slot-based templates, snapshot testing. Powers "
+                                + "production CV / invoice / proposal pipelines for "
+                                + "hiring tools and billing systems. *(Open source)*")
+                .row("Template Studio (Kotlin, Compose Desktop, PDFBox PNG diff)",
+                        "Internal tool for evaluating CV, proposal, and "
+                                + "invoice output across 14 design presets. PNG "
+                                + "diffing, side-by-side layout, baseline freezing.")
+                .row("LayoutLint (Java 21, JavaParser, Spoon)",
+                        "Static analyser that flags fragile authoring patterns "
+                                + "(deeply nested rows, untyped offsets, implicit "
+                                + "page breaks) before they ship to production.")
+                .row("ChromeForge (Java, GraphCompose, Pandoc bridge)",
+                        "Editorial-magazine document toolkit built on "
+                                + "GraphCompose: cinematic covers, pull quotes, "
+                                + "multi-column flow, sidebar callouts.")
+                .build();
+
+        EntriesSection experience = EntriesSection
+                .builder("Professional Experience")
+                .entry("Senior Platform Engineer",
+                        "Northwind Systems",
+                        "2024-Present",
+                        "Led the reusable document-generation platform serving "
+                                + "billing, hiring, and reporting flows across "
+                                + "**8 product teams**. Reduced template maintenance "
+                                + "time by **70%** by retiring per-team PDF scripts "
+                                + "in favour of one canonical engine.")
+                .entry("Software Engineer",
+                        "BrightLeaf Labs",
+                        "2021-2024",
+                        "Built backend services and production document rendering "
+                                + "pipelines processing **2M+ documents per month**. "
+                                + "Drove the migration from iText to a custom layout "
+                                + "engine, eliminating licensing risk and cutting "
+                                + "p99 render latency from 1.4s to 380ms.")
+                .entry("Backend Engineer",
+                        "Helix Print Co",
+                        "2019-2021",
+                        "Maintained a high-volume invoice-printing service "
+                                + "(15M PDFs/year) and authored the compliance test "
+                                + "harness that gated every template change.")
+                .build();
+
+        RowsSection additional = RowsSection
+                .builder("Additional Information", RowStyle.PLAIN)
+                .row("Languages",
+                        "English (Fluent), German (Intermediate), Spanish (Basic)")
+                .row("Work Eligibility",
+                        "Eligible to work in the UK and the EU")
+                .row("Open Source",
+                        "Maintainer of GraphCompose. Regular contributor to "
+                                + "PDFBox issue triage.")
+                .row("Speaking",
+                        "JVM Summit 2024, Devoxx UK 2025 — both on declarative "
+                                + "document layout.")
+                .build();
+
+        return CvDocument.builder()
+                .identity(identity)
+                .sections(summary, skills, education, projects, experience, additional)
                 .build();
     }
 }

--- a/examples/src/main/java/com/demcha/examples/templates/cv/v2/CvBoxedV2Example.java
+++ b/examples/src/main/java/com/demcha/examples/templates/cv/v2/CvBoxedV2Example.java
@@ -1,0 +1,59 @@
+package com.demcha.examples.templates.cv.v2;
+
+import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.api.DocumentPageSize;
+import com.demcha.compose.document.api.DocumentSession;
+import com.demcha.compose.document.templates.api.DocumentTemplate;
+import com.demcha.compose.document.templates.cv.v2.data.CvDocument;
+import com.demcha.compose.document.templates.cv.v2.presets.BoxedSections;
+import com.demcha.examples.support.ExampleDataFactory;
+import com.demcha.examples.support.ExampleOutputPaths;
+
+import java.nio.file.Path;
+
+/**
+ * Renders the v2 Boxed Sections CV preset against the structured
+ * {@code CvDocument} sample data using the default
+ * {@code CvTheme.boxedClassic()} theme.
+ *
+ * <p>Output:
+ * {@code examples/target/generated-pdfs/templates/cv/cv-boxed-sections-v2.pdf}.</p>
+ *
+ * <p>This is the canonical "hello world" for the v2 CV pipeline:
+ * fetch sample data, ask the preset for a template, render it. No
+ * custom theme, no manual section ordering, no parsing.</p>
+ */
+public final class CvBoxedV2Example {
+
+    private CvBoxedV2Example() {
+    }
+
+    /**
+     * @return absolute path of the rendered PDF
+     * @throws Exception if rendering fails
+     */
+    public static Path generate() throws Exception {
+        Path outputFile = ExampleOutputPaths.prepare(
+                "templates/cv", "cv-boxed-sections-v2.pdf");
+        CvDocument doc = ExampleDataFactory.sampleCvDocumentV2();
+        DocumentTemplate<CvDocument> template = BoxedSections.create();
+
+        float m = (float) BoxedSections.RECOMMENDED_MARGIN;
+        try (DocumentSession document = GraphCompose.document(outputFile)
+                .pageSize(DocumentPageSize.A4)
+                .margin(m, m, m, m)
+                .create()) {
+            template.compose(document, doc);
+            document.buildPdf();
+        }
+        return outputFile;
+    }
+
+    /**
+     * @param args ignored
+     * @throws Exception if rendering fails
+     */
+    public static void main(String[] args) throws Exception {
+        System.out.println("Generated: " + generate());
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/BannerRenderer.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/BannerRenderer.java
@@ -1,0 +1,32 @@
+package com.demcha.compose.document.templates.cv.v2.components;
+
+import com.demcha.compose.document.dsl.SectionBuilder;
+import com.demcha.compose.document.node.TextAlign;
+import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+
+/**
+ * Draws the pale-grey banner row holding a centred, letter-spaced
+ * uppercase section title (e.g. {@code P R O J E C T S}).
+ *
+ * <p>The host {@link SectionBuilder} becomes the banner panel —
+ * theme tokens drive the fill colour, corner radius, inner padding,
+ * and surrounding margin.</p>
+ */
+public final class BannerRenderer {
+
+    private BannerRenderer() {
+    }
+
+    public static void render(SectionBuilder section, String title, CvTheme theme) {
+        section.softPanel(theme.palette().banner(),
+                        theme.spacing().bannerCornerRadius(),
+                        theme.spacing().bannerInnerPadding())
+                .margin(theme.spacing().bannerMargin())
+                .addParagraph(p -> p
+                        .text(TextOrnaments.spacedUpper(title))
+                        .textStyle(theme.bannerStyle())
+                        .align(TextAlign.CENTER)
+                        .margin(DocumentInsets.zero()));
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/ContactRenderer.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/ContactRenderer.java
@@ -1,0 +1,73 @@
+package com.demcha.compose.document.templates.cv.v2.components;
+
+import com.demcha.compose.document.dsl.SectionBuilder;
+import com.demcha.compose.document.node.DocumentLinkOptions;
+import com.demcha.compose.document.node.TextAlign;
+import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.document.style.DocumentTextStyle;
+import com.demcha.compose.document.templates.cv.v2.data.CvContact;
+import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
+import com.demcha.compose.document.templates.cv.v2.data.CvLink;
+import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Draws the centred pipe-separated contact row under the headline:
+ * phone → email (clickable mailto) → address → optional labelled
+ * links in source order, each rendered as an active hyperlink.
+ *
+ * <p>Required contact fields are guaranteed non-blank by
+ * {@link CvContact} so the helper never needs to skip-on-empty for
+ * them. Optional {@link CvLink} entries are rendered if present and
+ * silently omitted if not — that's the whole point of the
+ * {@code .link(...)} builder method.</p>
+ */
+public final class ContactRenderer {
+
+    private ContactRenderer() {
+    }
+
+    public static void render(SectionBuilder section, CvIdentity identity, CvTheme theme) {
+        List<Part> parts = parts(identity);
+        DocumentTextStyle textStyle = theme.contactStyle();
+        DocumentTextStyle separatorStyle = theme.contactSeparatorStyle();
+
+        section.spacing(0)
+                .padding(theme.spacing().contactPadding())
+                .addParagraph(p -> p
+                        .textStyle(textStyle)
+                        .align(TextAlign.CENTER)
+                        .margin(DocumentInsets.zero())
+                        .rich(rich -> {
+                            for (int i = 0; i < parts.size(); i++) {
+                                Part part = parts.get(i);
+                                if (part.link() != null) {
+                                    rich.link(part.text(), part.link());
+                                } else {
+                                    rich.style(part.text(), textStyle);
+                                }
+                                if (i < parts.size() - 1) {
+                                    rich.style("   |   ", separatorStyle);
+                                }
+                            }
+                        }));
+    }
+
+    private static List<Part> parts(CvIdentity identity) {
+        CvContact contact = identity.contact();
+        List<Part> parts = new ArrayList<>(4 + identity.links().size());
+        parts.add(new Part(contact.phone(), null));
+        parts.add(new Part(contact.email(),
+                new DocumentLinkOptions("mailto:" + contact.email())));
+        parts.add(new Part(contact.address(), null));
+        for (CvLink link : identity.links()) {
+            parts.add(new Part(link.label(), new DocumentLinkOptions(link.url())));
+        }
+        return parts;
+    }
+
+    private record Part(String text, DocumentLinkOptions link) {
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/EntryRenderer.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/EntryRenderer.java
@@ -1,0 +1,79 @@
+package com.demcha.compose.document.templates.cv.v2.components;
+
+import com.demcha.compose.document.dsl.SectionBuilder;
+import com.demcha.compose.document.node.TextAlign;
+import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.document.style.DocumentTextStyle;
+import com.demcha.compose.document.templates.cv.v2.data.CvEntry;
+import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+
+/**
+ * Renders one {@link CvEntry} as the canonical four-zone timeline
+ * row used by both Education and Professional Experience:
+ *
+ * <pre>
+ *  &lt;Title bold, left&gt;                      &lt;Date, right&gt;
+ *  &lt;Subtitle, italic, muted&gt;
+ *  &lt;Body, full-width paragraph&gt;
+ * </pre>
+ *
+ * <p>Blank fields collapse — a blank date drops the right column,
+ * a blank subtitle drops the italic line, a blank body drops the
+ * paragraph beneath. The same renderer fits both flavours because
+ * the visual is identical; if a preset wants to style Education
+ * differently it does so by passing a different theme, not by
+ * forking this code.</p>
+ */
+public final class EntryRenderer {
+
+    private EntryRenderer() {
+    }
+
+    public static void render(SectionBuilder section, CvEntry entry, CvTheme theme) {
+        DocumentTextStyle titleStyle = theme.entryTitleStyle();
+        DocumentTextStyle dateStyle = theme.entryDateStyle();
+        DocumentTextStyle subtitleStyle = theme.entrySubtitleStyle();
+        DocumentTextStyle bodyStyle = theme.bodyStyle();
+
+        // -- title + date row -------------------------------------------
+        section.addRow("CvV2EntryHeader", row -> row
+                .spacing(theme.spacing().entryHeaderRowSpacing())
+                .weights(theme.spacing().entryTitleWeight(),
+                        theme.spacing().entryDateWeight())
+                .addSection("Title", titleColumn -> titleColumn
+                        .padding(DocumentInsets.zero())
+                        .addParagraph(p -> p
+                                .text(entry.title())
+                                .textStyle(titleStyle)
+                                .align(TextAlign.LEFT)
+                                .margin(DocumentInsets.zero())))
+                .addSection("Date", dateColumn -> dateColumn
+                        .padding(DocumentInsets.zero())
+                        .addParagraph(p -> p
+                                .text(entry.date())
+                                .textStyle(dateStyle)
+                                .align(TextAlign.RIGHT)
+                                .margin(DocumentInsets.zero()))));
+
+        // -- italic subtitle --------------------------------------------
+        if (!entry.subtitle().isBlank()) {
+            section.addParagraph(p -> p
+                    .textStyle(subtitleStyle)
+                    .align(TextAlign.LEFT)
+                    .margin(DocumentInsets.zero())
+                    .rich(rich -> MarkdownInline.append(rich,
+                            entry.subtitle(), subtitleStyle)));
+        }
+
+        // -- body paragraph ---------------------------------------------
+        if (!entry.body().isBlank()) {
+            section.addParagraph(p -> p
+                    .textStyle(bodyStyle)
+                    .lineSpacing(theme.typography().bodyLineSpacing())
+                    .align(TextAlign.LEFT)
+                    .margin(DocumentInsets.top((float) theme.spacing().paragraphMarginTop()))
+                    .rich(rich -> MarkdownInline.append(rich,
+                            entry.body(), bodyStyle)));
+        }
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/HeadlineRenderer.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/HeadlineRenderer.java
@@ -1,0 +1,32 @@
+package com.demcha.compose.document.templates.cv.v2.components;
+
+import com.demcha.compose.document.dsl.SectionBuilder;
+import com.demcha.compose.document.node.TextAlign;
+import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.document.templates.cv.v2.data.CvName;
+import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+
+/**
+ * Draws the centred letter-spaced uppercase name headline at the very
+ * top of a CV — the first thing a reader sees.
+ */
+public final class HeadlineRenderer {
+
+    private HeadlineRenderer() {
+    }
+
+    /**
+     * @param section host section that will host the headline paragraph
+     * @param name    full name to render
+     * @param theme   active theme
+     */
+    public static void render(SectionBuilder section, CvName name, CvTheme theme) {
+        section.spacing(2)
+                .padding(theme.spacing().headlinePadding())
+                .addParagraph(p -> p
+                        .text(TextOrnaments.spacedUpper(name.full()))
+                        .textStyle(theme.headlineStyle())
+                        .align(TextAlign.CENTER)
+                        .margin(DocumentInsets.zero()));
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/MarkdownInline.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/MarkdownInline.java
@@ -1,0 +1,45 @@
+package com.demcha.compose.document.templates.cv.v2.components;
+
+import com.demcha.compose.document.dsl.RichText;
+import com.demcha.compose.document.node.InlineRun;
+import com.demcha.compose.document.node.InlineTextRun;
+import com.demcha.compose.document.style.DocumentTextStyle;
+import com.demcha.compose.document.templates.components.MarkdownText;
+
+/**
+ * Tiny adapter that pushes inline-markdown-parsed runs of {@code text}
+ * into a {@link RichText} builder using {@code baseStyle} for plain
+ * (non-emphasised) segments.
+ *
+ * <p>Honours {@code **bold**}, {@code *italic*}, {@code _italic_} via
+ * the shared {@link MarkdownText} parser. Lives in the components
+ * layer because every body / row / entry renderer calls it.</p>
+ */
+public final class MarkdownInline {
+
+    private MarkdownInline() {
+    }
+
+    /**
+     * Appends {@code text} to {@code rich}, expanding inline markdown.
+     *
+     * @param rich      target rich-text builder
+     * @param text      source string; null treated as empty
+     * @param baseStyle style applied to plain runs
+     */
+    public static void append(RichText rich, String text,
+                              DocumentTextStyle baseStyle) {
+        if (text == null || text.isEmpty()) {
+            return;
+        }
+        for (InlineRun run : MarkdownText.parse(text, baseStyle)) {
+            if (!(run instanceof InlineTextRun textRun)) {
+                continue;
+            }
+            DocumentTextStyle runStyle = textRun.textStyle() == null
+                    ? baseStyle
+                    : textRun.textStyle();
+            rich.style(textRun.text(), runStyle);
+        }
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/ParagraphRenderer.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/ParagraphRenderer.java
@@ -1,0 +1,36 @@
+package com.demcha.compose.document.templates.cv.v2.components;
+
+import com.demcha.compose.document.dsl.SectionBuilder;
+import com.demcha.compose.document.node.TextAlign;
+import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.document.style.DocumentTextStyle;
+import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+
+/**
+ * Draws one prose paragraph (markdown-aware) in body style. Used by
+ * {@code ParagraphSection} bodies and as a shared primitive by other
+ * renderers (e.g. the description line under an entry).
+ */
+public final class ParagraphRenderer {
+
+    private ParagraphRenderer() {
+    }
+
+    /**
+     * @param section host
+     * @param text    paragraph text; blank inputs are silently skipped
+     * @param theme   active theme
+     */
+    public static void render(SectionBuilder section, String text, CvTheme theme) {
+        if (text == null || text.isBlank()) {
+            return;
+        }
+        DocumentTextStyle base = theme.bodyStyle();
+        section.addParagraph(p -> p
+                .textStyle(base)
+                .lineSpacing(theme.typography().bodyLineSpacing())
+                .align(TextAlign.LEFT)
+                .margin(DocumentInsets.top((float) theme.spacing().paragraphMarginTop()))
+                .rich(rich -> MarkdownInline.append(rich, text.trim(), base)));
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/RowRenderer.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/RowRenderer.java
@@ -1,0 +1,120 @@
+package com.demcha.compose.document.templates.cv.v2.components;
+
+import com.demcha.compose.document.dsl.SectionBuilder;
+import com.demcha.compose.document.node.TextAlign;
+import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.document.style.DocumentTextIndent;
+import com.demcha.compose.document.style.DocumentTextStyle;
+import com.demcha.compose.document.templates.cv.v2.data.CvRow;
+import com.demcha.compose.document.templates.cv.v2.data.RowStyle;
+import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+
+/**
+ * Unified renderer for a {@link CvRow} under any {@link RowStyle}.
+ *
+ * <p>One entry point — {@link #render(SectionBuilder, CvRow, RowStyle, CvTheme)} —
+ * branches by style into three private helpers that share their
+ * paragraph configuration. There is no copy-paste of {@code
+ * .textStyle(...).lineSpacing(...).align(...)} across four near-identical
+ * methods like the first v2 iteration had — the only thing that varies
+ * per style is the bullet glyph and whether the row stacks onto a
+ * second line.</p>
+ */
+public final class RowRenderer {
+
+    private static final String BULLET_GLYPH = "• ";
+    /** Two-space prefix so wrapped stacked-body text sits under the name. */
+    private static final String STACK_INDENT = "  ";
+
+    private RowRenderer() {
+    }
+
+    /**
+     * Draws one row with the given decoration.
+     *
+     * @param section host
+     * @param row     content (label + body)
+     * @param style   decoration toggle
+     * @param theme   active theme
+     */
+    public static void render(SectionBuilder section, CvRow row,
+                              RowStyle style, CvTheme theme) {
+        switch (style) {
+            case PLAIN -> inline(section, row, null, theme);
+            case BULLETED -> inline(section, row, BULLET_GLYPH, theme);
+            case BULLETED_STACKED -> stacked(section, row, theme);
+        }
+    }
+
+    /**
+     * Renders the row as a single paragraph
+     * {@code [bullet?] <b>label:</b> body}.
+     *
+     * @param bulletGlyph bullet glyph to attach, or null for plain
+     */
+    private static void inline(SectionBuilder section, CvRow row,
+                               String bulletGlyph, CvTheme theme) {
+        DocumentTextStyle base = theme.bodyStyle();
+        String source = labelColonValue(row);
+        section.addParagraph(p -> {
+            p.textStyle(base)
+                    .lineSpacing(theme.typography().bodyLineSpacing())
+                    .align(TextAlign.LEFT)
+                    .margin(DocumentInsets.top((float) theme.spacing().paragraphMarginTop()))
+                    .rich(rich -> MarkdownInline.append(rich, source, base));
+            if (bulletGlyph != null) {
+                p.bulletOffset(bulletGlyph)
+                        .indentStrategy(DocumentTextIndent.ALL_LINES);
+            }
+        });
+    }
+
+    /**
+     * Renders the row as two stacked paragraphs:
+     * {@code • <b>label</b>} on line 1, body indented under the label
+     * on line 2.
+     */
+    private static void stacked(SectionBuilder section, CvRow row, CvTheme theme) {
+        DocumentTextStyle base = theme.bodyStyle();
+        DocumentTextStyle nameStyle = theme.bodyBoldStyle();
+
+        // Line 1 — bullet + bold name (markdown still honoured).
+        section.addParagraph(p -> p
+                .textStyle(base)
+                .lineSpacing(theme.typography().bodyLineSpacing())
+                .align(TextAlign.LEFT)
+                .margin(DocumentInsets.top((float) theme.spacing().paragraphMarginTop()))
+                .bulletOffset(BULLET_GLYPH)
+                .indentStrategy(DocumentTextIndent.ALL_LINES)
+                .rich(rich -> MarkdownInline.append(rich, row.label(), nameStyle)));
+
+        if (row.body().isBlank()) {
+            return;
+        }
+        // Line 2 — body indented under name (not under bullet).
+        section.addParagraph(p -> p
+                .textStyle(base)
+                .lineSpacing(theme.typography().bodyLineSpacing())
+                .align(TextAlign.LEFT)
+                .margin(DocumentInsets.zero())
+                .bulletOffset(STACK_INDENT)
+                .indentStrategy(DocumentTextIndent.ALL_LINES)
+                .rich(rich -> MarkdownInline.append(rich, row.body(), base)));
+    }
+
+    /**
+     * Wraps the label in markdown bold markers + trailing colon so the
+     * existing inline-markdown parser emits one bold run for the label
+     * and a regular run for the body without any extra typography
+     * plumbing.
+     */
+    private static String labelColonValue(CvRow row) {
+        StringBuilder source = new StringBuilder(
+                row.label().length() + row.body().length() + 5);
+        source.append("**").append(row.label()).append(":**");
+        if (!row.body().isBlank()) {
+            source.append(' ').append(row.body());
+        }
+        return source.toString();
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/SectionDispatcher.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/SectionDispatcher.java
@@ -1,0 +1,51 @@
+package com.demcha.compose.document.templates.cv.v2.components;
+
+import com.demcha.compose.document.dsl.SectionBuilder;
+import com.demcha.compose.document.templates.cv.v2.data.CvEntry;
+import com.demcha.compose.document.templates.cv.v2.data.CvRow;
+import com.demcha.compose.document.templates.cv.v2.data.CvSection;
+import com.demcha.compose.document.templates.cv.v2.data.EntriesSection;
+import com.demcha.compose.document.templates.cv.v2.data.ParagraphSection;
+import com.demcha.compose.document.templates.cv.v2.data.RowsSection;
+import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+
+/**
+ * Single entry point that renders any {@link CvSection} body into a
+ * host {@link SectionBuilder}, dispatching on the sealed subtype.
+ *
+ * <p>Adding a new {@code CvSection} variant means adding a branch
+ * here — the final {@code else} throws so that an unhandled subtype
+ * fails loudly at runtime. On Java 21+ this becomes a pattern-match
+ * switch with compiler-enforced exhaustiveness; we target Java 17 so
+ * the if/else cascade is the cleanest form available.</p>
+ *
+ * <p>Presets call this from their page-flow loop — that is the
+ * <em>only</em> place a preset reasons about section subtypes. Every
+ * other rendering decision (palette, typography, layout weights) is
+ * settled by the theme.</p>
+ */
+public final class SectionDispatcher {
+
+    private SectionDispatcher() {
+    }
+
+    public static void renderBody(SectionBuilder host, CvSection section, CvTheme theme) {
+        host.spacing(theme.spacing().sectionBodySpacing())
+                .padding(theme.spacing().sectionBodyPadding());
+
+        if (section instanceof ParagraphSection p) {
+            ParagraphRenderer.render(host, p.body(), theme);
+        } else if (section instanceof RowsSection r) {
+            for (CvRow row : r.rows()) {
+                RowRenderer.render(host, row, r.style(), theme);
+            }
+        } else if (section instanceof EntriesSection e) {
+            for (CvEntry entry : e.entries()) {
+                EntryRenderer.render(host, entry, theme);
+            }
+        } else {
+            throw new IllegalStateException(
+                    "Unknown CvSection subtype: " + section.getClass().getName());
+        }
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/TextOrnaments.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/TextOrnaments.java
@@ -1,0 +1,46 @@
+package com.demcha.compose.document.templates.cv.v2.components;
+
+import java.util.Locale;
+
+/**
+ * Pure text-transform helpers used by the v2 components. Currently
+ * one entry: letter-spaced uppercase rendering for the document
+ * headline and section banners.
+ *
+ * <p>These are <strong>algorithmic</strong>, not cosmetic — they do
+ * not belong in {@code theme}. The visual effect of "space letters
+ * apart" is structural: even if a theme picked a different banner
+ * colour, the letters would still need the same spacing logic.</p>
+ */
+public final class TextOrnaments {
+
+    private TextOrnaments() {
+    }
+
+    /**
+     * Letter-spaced uppercase rendering (e.g.
+     * {@code spacedUpper("Jane Doe") -> "J A N E   D O E"}).
+     *
+     * @param value source text (null tolerated, returned as empty)
+     * @return spaced-caps representation
+     */
+    public static String spacedUpper(String value) {
+        if (value == null) {
+            return "";
+        }
+        String upper = value.toUpperCase(Locale.ROOT);
+        StringBuilder out = new StringBuilder(upper.length() * 2);
+        for (int i = 0; i < upper.length(); i++) {
+            char current = upper.charAt(i);
+            out.append(current);
+            if (Character.isLetterOrDigit(current)
+                    && i + 1 < upper.length()
+                    && Character.isLetterOrDigit(upper.charAt(i + 1))) {
+                out.append(' ');
+            } else if (Character.isWhitespace(current)) {
+                out.append("  ");
+            }
+        }
+        return out.toString();
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/package-info.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/package-info.java
@@ -1,0 +1,26 @@
+/**
+ * <h2>Layer 2 — reusable renderers</h2>
+ *
+ * <p>Every class here is a static helper that takes a host
+ * {@link com.demcha.compose.document.dsl.SectionBuilder}, a
+ * {@code cv/v2/data} record, and a
+ * {@link com.demcha.compose.document.templates.cv.v2.theme.CvTheme},
+ * and draws the data into the host using the theme's tokens.</p>
+ *
+ * <p>Components <strong>never</strong>:</p>
+ * <ul>
+ *   <li>store theme as a static field — theme is always an argument,
+ *       so the same component renders any theme without reflection
+ *       or singletons;</li>
+ *   <li>parse data — that is the spec's job;</li>
+ *   <li>read magic numbers — every value reads from the theme.</li>
+ * </ul>
+ *
+ * <p>The dispatch hub is
+ * {@link com.demcha.compose.document.templates.cv.v2.components.SectionDispatcher}
+ * — it pattern-matches on the sealed
+ * {@link com.demcha.compose.document.templates.cv.v2.data.CvSection}
+ * subtype and delegates to one of the row / entry / paragraph
+ * renderers.</p>
+ */
+package com.demcha.compose.document.templates.cv.v2.components;

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/data/CvContact.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/data/CvContact.java
@@ -1,0 +1,32 @@
+package com.demcha.compose.document.templates.cv.v2.data;
+
+import java.util.Objects;
+
+/**
+ * Required contact triple — phone, email, address — that every CV in
+ * the v2 model carries.
+ *
+ * <p>All three fields are non-blank by construction so renderers
+ * never have to skip-on-empty for the canonical contact row.</p>
+ *
+ * @param phone   non-blank phone number, formatted by the author
+ * @param email   non-blank email (rendered as a clickable mailto link)
+ * @param address non-blank location / postal address line
+ */
+public record CvContact(String phone, String email, String address) {
+
+    public CvContact {
+        Objects.requireNonNull(phone, "phone");
+        Objects.requireNonNull(email, "email");
+        Objects.requireNonNull(address, "address");
+        if (phone.isBlank()) {
+            throw new IllegalArgumentException("phone must not be blank");
+        }
+        if (email.isBlank()) {
+            throw new IllegalArgumentException("email must not be blank");
+        }
+        if (address.isBlank()) {
+            throw new IllegalArgumentException("address must not be blank");
+        }
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/data/CvDocument.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/data/CvDocument.java
@@ -1,0 +1,86 @@
+package com.demcha.compose.document.templates.cv.v2.data;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Root of the v2 CV data model — required {@link CvIdentity} block
+ * plus an ordered list of {@link CvSection} entries that render in
+ * source order beneath the header.
+ *
+ * <p>This record carries no styling or rendering decision. Pair it
+ * with a
+ * {@link com.demcha.compose.document.templates.cv.v2.theme.CvTheme}
+ * and a preset from
+ * {@code com.demcha.compose.document.templates.cv.v2.presets} to
+ * produce a PDF.</p>
+ *
+ * @param identity required identity / contact block
+ * @param sections ordered sections; rendered in source order
+ */
+public record CvDocument(CvIdentity identity, List<CvSection> sections) {
+
+    public CvDocument {
+        Objects.requireNonNull(identity, "identity");
+        Objects.requireNonNull(sections, "sections");
+        sections = List.copyOf(sections);
+    }
+
+    /**
+     * @return new fluent builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Mutable builder. Section order in the builder is preserved 1:1
+     * in the built document.
+     */
+    public static final class Builder {
+        private CvIdentity identity;
+        private final List<CvSection> sections = new ArrayList<>();
+
+        private Builder() {
+        }
+
+        public Builder identity(CvIdentity value) {
+            this.identity = value;
+            return this;
+        }
+
+        public Builder section(CvSection section) {
+            this.sections.add(Objects.requireNonNull(section, "section"));
+            return this;
+        }
+
+        /**
+         * Varargs convenience for the common case where every section
+         * is constructed up-front. Equivalent to chained
+         * {@link #section(CvSection)} calls.
+         *
+         * @param values one or more sections in render order
+         * @return this builder
+         */
+        public Builder sections(CvSection... values) {
+            Objects.requireNonNull(values, "values");
+            for (CvSection s : values) {
+                section(s);
+            }
+            return this;
+        }
+
+        public Builder sections(List<CvSection> values) {
+            Objects.requireNonNull(values, "values");
+            for (CvSection s : values) {
+                section(s);
+            }
+            return this;
+        }
+
+        public CvDocument build() {
+            return new CvDocument(identity, sections);
+        }
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/data/CvEntry.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/data/CvEntry.java
@@ -1,0 +1,34 @@
+package com.demcha.compose.document.templates.cv.v2.data;
+
+import java.util.Objects;
+
+/**
+ * Timeline-style entry used inside an {@link EntriesSection}. Covers
+ * both Education and Professional Experience — they share the same
+ * four fields so authors don't have to learn two record types.
+ *
+ * <p>Blank fields are honoured: a blank {@code date} omits the date
+ * column, a blank {@code subtitle} drops the italic line, a blank
+ * {@code body} drops the description paragraph.</p>
+ *
+ * @param title    bold heading on the left (job title, degree)
+ * @param subtitle italic subtitle on the line below (employer,
+ *                 institution); blank collapses the subtitle line
+ * @param date     right-aligned date column next to title
+ *                 (e.g. {@code "2024-Present"}, {@code "2021"});
+ *                 blank removes the date column
+ * @param body     full-width prose paragraph beneath the subtitle;
+ *                 may contain inline markdown
+ */
+public record CvEntry(String title, String subtitle, String date, String body) {
+
+    public CvEntry {
+        Objects.requireNonNull(title, "title");
+        Objects.requireNonNull(subtitle, "subtitle");
+        Objects.requireNonNull(date, "date");
+        Objects.requireNonNull(body, "body");
+        if (title.isBlank()) {
+            throw new IllegalArgumentException("title must not be blank");
+        }
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/data/CvIdentity.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/data/CvIdentity.java
@@ -1,0 +1,86 @@
+package com.demcha.compose.document.templates.cv.v2.data;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Top-of-document identity block — name, required contact triple, and
+ * an optional ordered list of labelled outbound links.
+ *
+ * <p>Required pieces have their own types ({@link CvName},
+ * {@link CvContact}); optional links are accumulated through the
+ * builder's {@code link(...)} method — added when the author wants
+ * them, simply omitted otherwise.</p>
+ *
+ * @param name    structured name with first / last required and an
+ *                optional middle component
+ * @param contact phone / email / address — all three required
+ * @param links   ordered list of optional outbound links; never null
+ */
+public record CvIdentity(CvName name, CvContact contact, List<CvLink> links) {
+
+    public CvIdentity {
+        Objects.requireNonNull(name, "name");
+        Objects.requireNonNull(contact, "contact");
+        links = links == null ? List.of() : List.copyOf(links);
+    }
+
+    /**
+     * @return new fluent builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Mutable builder for {@link CvIdentity}.
+     */
+    public static final class Builder {
+        private CvName name;
+        private CvContact contact;
+        private final List<CvLink> links = new ArrayList<>();
+
+        private Builder() {
+        }
+
+        public Builder name(CvName value) {
+            this.name = value;
+            return this;
+        }
+
+        public Builder name(String first, String last) {
+            this.name = CvName.of(first, last);
+            return this;
+        }
+
+        public Builder name(String first, String middle, String last) {
+            this.name = new CvName(first, middle, last);
+            return this;
+        }
+
+        public Builder contact(CvContact value) {
+            this.contact = value;
+            return this;
+        }
+
+        public Builder contact(String phone, String email, String address) {
+            this.contact = new CvContact(phone, email, address);
+            return this;
+        }
+
+        public Builder link(CvLink link) {
+            this.links.add(Objects.requireNonNull(link, "link"));
+            return this;
+        }
+
+        public Builder link(String label, String url) {
+            this.links.add(new CvLink(label, url));
+            return this;
+        }
+
+        public CvIdentity build() {
+            return new CvIdentity(name, contact, links);
+        }
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/data/CvLink.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/data/CvLink.java
@@ -1,0 +1,32 @@
+package com.demcha.compose.document.templates.cv.v2.data;
+
+import java.util.Objects;
+
+/**
+ * Optional labelled hyperlink in the CV header — LinkedIn, GitHub,
+ * portfolio, personal site, etc.
+ *
+ * @param label visible link text (required, non-blank)
+ * @param url   click target (required, non-blank)
+ */
+public record CvLink(String label, String url) {
+
+    public CvLink {
+        Objects.requireNonNull(label, "label");
+        Objects.requireNonNull(url, "url");
+        if (label.isBlank()) {
+            throw new IllegalArgumentException("label must not be blank");
+        }
+        if (url.isBlank()) {
+            throw new IllegalArgumentException("url must not be blank");
+        }
+    }
+
+    /**
+     * Convenience factory mirroring {@code CvLink.of("LinkedIn",
+     * "https://...")} call sites.
+     */
+    public static CvLink of(String label, String url) {
+        return new CvLink(label, url);
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/data/CvName.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/data/CvName.java
@@ -1,0 +1,56 @@
+package com.demcha.compose.document.templates.cv.v2.data;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Subject's legal name, split into first / last (required) and an
+ * optional middle component.
+ *
+ * <p>Held as separate fields so consumers can render initials,
+ * monogrammes, or alphabetical sort keys without re-parsing a joined
+ * full-name string.</p>
+ *
+ * @param first  first name (required, non-blank)
+ * @param middle optional middle name; never null, may be empty
+ * @param last   family name (required, non-blank)
+ */
+public record CvName(String first, String middle, String last) {
+
+    public CvName {
+        Objects.requireNonNull(first, "first");
+        Objects.requireNonNull(last, "last");
+        middle = middle == null ? "" : middle;
+        if (first.isBlank()) {
+            throw new IllegalArgumentException("first must not be blank");
+        }
+        if (last.isBlank()) {
+            throw new IllegalArgumentException("last must not be blank");
+        }
+    }
+
+    /**
+     * Convenience constructor for the common first + last case.
+     */
+    public static CvName of(String first, String last) {
+        return new CvName(first, "", last);
+    }
+
+    /**
+     * @return middle wrapped in {@link Optional#empty()} when blank,
+     *         otherwise the middle name
+     */
+    public Optional<String> middleName() {
+        return middle.isBlank() ? Optional.empty() : Optional.of(middle);
+    }
+
+    /**
+     * Concatenates the present parts with single spaces in
+     * first / middle / last order.
+     */
+    public String full() {
+        return middle.isBlank()
+                ? first + " " + last
+                : first + " " + middle + " " + last;
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/data/CvRow.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/data/CvRow.java
@@ -1,0 +1,31 @@
+package com.demcha.compose.document.templates.cv.v2.data;
+
+import java.util.Objects;
+
+/**
+ * Generic two-field row used inside a {@link RowsSection}.
+ *
+ * <p>The {@code label} is the bold "key" rendered at the start of
+ * the row (e.g. {@code "Languages"}, {@code "GraphCompose (Java 21,
+ * PDFBox)"}). The {@code body} is the regular-weight value, may
+ * contain inline markdown.</p>
+ *
+ * <p>How the pair is presented visually (inline {@code "Label:
+ * body"}, two-line "bold label / body below", bullet glyph or not)
+ * is decided by the parent {@link RowsSection}'s {@link RowStyle}
+ * setting — not by the row itself.</p>
+ *
+ * @param label bold key (required, non-blank)
+ * @param body  free-form text; may contain inline markdown
+ *              ({@code **bold**}, {@code *italic*})
+ */
+public record CvRow(String label, String body) {
+
+    public CvRow {
+        Objects.requireNonNull(label, "label");
+        Objects.requireNonNull(body, "body");
+        if (label.isBlank()) {
+            throw new IllegalArgumentException("label must not be blank");
+        }
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/data/CvSection.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/data/CvSection.java
@@ -1,0 +1,31 @@
+package com.demcha.compose.document.templates.cv.v2.data;
+
+/**
+ * Sealed top of the v2 CV section hierarchy. Each concrete subtype
+ * captures a <strong>structurally distinct</strong> body shape — not
+ * a visual flavour. Visual flavours like "bulleted vs plain" are
+ * style toggles inside the section, not separate types.
+ *
+ * <p>Three subtypes cover every canonical resume layout:</p>
+ *
+ * <ul>
+ *   <li>{@link ParagraphSection} — one block of prose. One field.</li>
+ *   <li>{@link RowsSection} — list of two-field {@link CvRow} items
+ *       plus a {@link RowStyle} decoration enum (plain / bulleted /
+ *       bulleted-stacked).</li>
+ *   <li>{@link EntriesSection} — list of timeline {@link CvEntry}
+ *       items with four fields (title, subtitle, date, body).</li>
+ * </ul>
+ *
+ * <p>Every implementation carries a {@code title} — the banner text
+ * the renderer wraps in a styled panel above the section body.</p>
+ */
+public sealed interface CvSection
+        permits ParagraphSection, RowsSection, EntriesSection {
+
+    /**
+     * @return banner heading shown above the body (non-blank by
+     *         construction)
+     */
+    String title();
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/data/EntriesSection.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/data/EntriesSection.java
@@ -1,0 +1,67 @@
+package com.demcha.compose.document.templates.cv.v2.data;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Section whose body is a list of timeline {@link CvEntry}s.
+ *
+ * <p>Used for both Education and Professional Experience — they
+ * share the same four-field shape and the same canonical render, so
+ * we don't pay for a separate type per semantic flavour. If a
+ * preset wants to style Education differently from Experience it can
+ * branch on the section title at the preset level — the data model
+ * stays minimal.</p>
+ *
+ * @param title   non-blank banner heading
+ * @param entries ordered entries (oldest-last by convention)
+ */
+public record EntriesSection(String title, List<CvEntry> entries)
+        implements CvSection {
+
+    public EntriesSection {
+        Objects.requireNonNull(title, "title");
+        Objects.requireNonNull(entries, "entries");
+        if (title.isBlank()) {
+            throw new IllegalArgumentException("title must not be blank");
+        }
+        entries = List.copyOf(entries);
+    }
+
+    /**
+     * Fluent builder.
+     *
+     * @param title non-blank section heading
+     * @return new builder
+     */
+    public static Builder builder(String title) {
+        return new Builder(title);
+    }
+
+    /**
+     * Mutable builder.
+     */
+    public static final class Builder {
+        private final String title;
+        private final List<CvEntry> entries = new ArrayList<>();
+
+        private Builder(String title) {
+            this.title = title;
+        }
+
+        public Builder entry(String title, String subtitle, String date, String body) {
+            this.entries.add(new CvEntry(title, subtitle, date, body));
+            return this;
+        }
+
+        public Builder entry(CvEntry entry) {
+            this.entries.add(Objects.requireNonNull(entry, "entry"));
+            return this;
+        }
+
+        public EntriesSection build() {
+            return new EntriesSection(title, entries);
+        }
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/data/ParagraphSection.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/data/ParagraphSection.java
@@ -1,0 +1,25 @@
+package com.demcha.compose.document.templates.cv.v2.data;
+
+import java.util.Objects;
+
+/**
+ * Section whose body is a single block of free prose — used for
+ * Professional Summary, Profile, Objective, and similar one-paragraph
+ * headings.
+ *
+ * <p>Inline markdown markers ({@code **bold**}, {@code *italic*},
+ * {@code _italic_}) are honoured by the renderer.</p>
+ *
+ * @param title non-blank banner heading (e.g. "Professional Summary")
+ * @param body  prose; may contain inline markdown
+ */
+public record ParagraphSection(String title, String body) implements CvSection {
+
+    public ParagraphSection {
+        Objects.requireNonNull(title, "title");
+        Objects.requireNonNull(body, "body");
+        if (title.isBlank()) {
+            throw new IllegalArgumentException("title must not be blank");
+        }
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/data/RowStyle.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/data/RowStyle.java
@@ -1,0 +1,38 @@
+package com.demcha.compose.document.templates.cv.v2.data;
+
+/**
+ * Visual decoration toggle for a {@link RowsSection}. Selects how
+ * each {@link CvRow} is laid out — bullet on/off, inline vs stacked.
+ *
+ * <p>This is the orthogonal "decoration" axis the v2 model factors
+ * out of section types so that bulleted-skills, plain Additional
+ * Information, and stacked Projects all share one {@link RowsSection}
+ * record.</p>
+ */
+public enum RowStyle {
+
+    /**
+     * No bullet glyph. The label renders bold inline with a trailing
+     * colon, followed by the body on the same line: <br>
+     * {@code <b>Languages:</b> English (Fluent), German}.
+     * Used by Additional Information style content.
+     */
+    PLAIN,
+
+    /**
+     * Bullet glyph + bold label + colon + body, inline: <br>
+     * {@code • <b>Languages:</b> Java 21, Kotlin}.
+     * Used by Technical Skills.
+     */
+    BULLETED,
+
+    /**
+     * Bullet glyph + bold label on line one, body indented on line
+     * two: <br>
+     * {@code • <b>Project name (tech stack)</b>} <br>
+     * {@code   Description text wrapping under the project name}.
+     * Used by Projects-style sections where the description is too
+     * long to fit inline.
+     */
+    BULLETED_STACKED
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/data/RowsSection.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/data/RowsSection.java
@@ -1,0 +1,79 @@
+package com.demcha.compose.document.templates.cv.v2.data;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Section whose body is a list of {@link CvRow}s rendered with a
+ * uniform {@link RowStyle} decoration.
+ *
+ * <p>One record covers three common shapes:</p>
+ *
+ * <ul>
+ *   <li>Technical Skills: {@code style = BULLETED}.</li>
+ *   <li>Projects: {@code style = BULLETED_STACKED}.</li>
+ *   <li>Additional Information: {@code style = PLAIN}.</li>
+ * </ul>
+ *
+ * <p>If a future shape needs a different decoration (numbered list,
+ * coloured chips, etc.) the only change is a new constant in
+ * {@link RowStyle} plus a branch in
+ * {@code components.RowRenderer} — the data model stays untouched.</p>
+ *
+ * @param title non-blank banner heading
+ * @param rows  ordered list of two-field rows
+ * @param style decoration applied uniformly to every row
+ */
+public record RowsSection(String title, List<CvRow> rows, RowStyle style)
+        implements CvSection {
+
+    public RowsSection {
+        Objects.requireNonNull(title, "title");
+        Objects.requireNonNull(rows, "rows");
+        Objects.requireNonNull(style, "style");
+        if (title.isBlank()) {
+            throw new IllegalArgumentException("title must not be blank");
+        }
+        rows = List.copyOf(rows);
+    }
+
+    /**
+     * Fluent builder seeded with the row decoration.
+     *
+     * @param title non-blank section heading
+     * @param style decoration applied to every row
+     * @return new builder
+     */
+    public static Builder builder(String title, RowStyle style) {
+        return new Builder(title, style);
+    }
+
+    /**
+     * Mutable builder.
+     */
+    public static final class Builder {
+        private final String title;
+        private final RowStyle style;
+        private final List<CvRow> rows = new ArrayList<>();
+
+        private Builder(String title, RowStyle style) {
+            this.title = title;
+            this.style = style;
+        }
+
+        public Builder row(String label, String body) {
+            this.rows.add(new CvRow(label, body));
+            return this;
+        }
+
+        public Builder row(CvRow row) {
+            this.rows.add(Objects.requireNonNull(row, "row"));
+            return this;
+        }
+
+        public RowsSection build() {
+            return new RowsSection(title, rows, style);
+        }
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/data/package-info.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/data/package-info.java
@@ -1,0 +1,54 @@
+/**
+ * <h2>Layer 1 — pure CV data</h2>
+ *
+ * <p>This package holds the <strong>data model</strong> of a CV in the
+ * v2 architecture. Records here:</p>
+ * <ul>
+ *   <li>describe the author's content — name, contact, sections;</li>
+ *   <li>carry <strong>no</strong> styling, colour, font, or layout
+ *       decisions;</li>
+ *   <li>never reference {@code DocumentNode}, {@code DocumentColor},
+ *       {@code DocumentTextStyle}, or anything from the rendering
+ *       runtime.</li>
+ * </ul>
+ *
+ * <p>The point: a CV's <em>content</em> is portable across themes and
+ * presets. Rendering decisions live in {@code components} and
+ * {@code theme} packages, not here.</p>
+ *
+ * <h3>Section catalog</h3>
+ *
+ * <p>The sealed {@link com.demcha.compose.document.templates.cv.v2.data.CvSection}
+ * hierarchy intentionally has <strong>only three</strong> concrete
+ * shapes — one per genuinely-different structural pattern, not one
+ * per visual flavour:</p>
+ *
+ * <ul>
+ *   <li>{@link com.demcha.compose.document.templates.cv.v2.data.ParagraphSection}
+ *       — single block of prose (Professional Summary, Objective).</li>
+ *   <li>{@link com.demcha.compose.document.templates.cv.v2.data.RowsSection}
+ *       — list of two-field {@link com.demcha.compose.document.templates.cv.v2.data.CvRow}
+ *       items. Visual decoration is picked via the
+ *       {@link com.demcha.compose.document.templates.cv.v2.data.RowStyle}
+ *       enum so Technical Skills (bulleted), Additional Information
+ *       (plain), and Projects (bulleted, two-line) share one
+ *       record.</li>
+ *   <li>{@link com.demcha.compose.document.templates.cv.v2.data.EntriesSection}
+ *       — list of timeline {@link com.demcha.compose.document.templates.cv.v2.data.CvEntry}
+ *       items with title / subtitle / date / body. Used for Education
+ *       and Professional Experience interchangeably.</li>
+ * </ul>
+ *
+ * <h3>Adding a new section type</h3>
+ *
+ * <ol>
+ *   <li>Add a new record implementing
+ *       {@link com.demcha.compose.document.templates.cv.v2.data.CvSection}.</li>
+ *   <li>Add it to the {@code permits} list on {@code CvSection}.</li>
+ *   <li>Add a case in
+ *       {@code com.demcha.compose.document.templates.cv.v2.components.SectionDispatcher} —
+ *       Java 17 makes this an {@code if/else if} branch; the final
+ *       else throws so the omission fails loudly.</li>
+ * </ol>
+ */
+package com.demcha.compose.document.templates.cv.v2.data;

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/BoxedSections.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/BoxedSections.java
@@ -1,0 +1,130 @@
+package com.demcha.compose.document.templates.cv.v2.presets;
+
+import com.demcha.compose.document.api.DocumentSession;
+import com.demcha.compose.document.dsl.PageFlowBuilder;
+import com.demcha.compose.document.templates.api.DocumentTemplate;
+import com.demcha.compose.document.templates.cv.v2.components.BannerRenderer;
+import com.demcha.compose.document.templates.cv.v2.components.ContactRenderer;
+import com.demcha.compose.document.templates.cv.v2.components.HeadlineRenderer;
+import com.demcha.compose.document.templates.cv.v2.components.SectionDispatcher;
+import com.demcha.compose.document.templates.cv.v2.data.CvDocument;
+import com.demcha.compose.document.templates.cv.v2.data.CvSection;
+import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * v2 reference preset — Boxed Sections.
+ *
+ * <p>Centred letter-spaced headline, thin rules above and below the
+ * contact line, one pale-grey banner per section. Visual signature
+ * of the canonical {@code cv-boxed-sections.pdf} reference output.</p>
+ *
+ * <p>The preset owns three responsibilities and no more:</p>
+ *
+ * <ol>
+ *   <li>Define its identity ({@link #ID}, {@link #DISPLAY_NAME},
+ *       {@link #RECOMMENDED_MARGIN}).</li>
+ *   <li>Pick a default theme — {@link CvTheme#boxedClassic()} — that
+ *       callers can override via the
+ *       {@link #create(CvTheme)} overload.</li>
+ *   <li>Walk {@link CvDocument#sections()} top-to-bottom, emitting a
+ *       banner + body pair per section. All actual drawing is
+ *       delegated to {@code cv/v2/components}.</li>
+ * </ol>
+ *
+ * <p>Compare to the 700-line legacy preset that parsed dates,
+ * sniffed module titles, and embedded RGB literals — this class is
+ * the canonical example of what a v2 preset should look like.</p>
+ */
+public final class BoxedSections {
+
+    /** Stable template identifier. */
+    public static final String ID = "boxed-sections";
+
+    /** Human-readable display name. */
+    public static final String DISPLAY_NAME = "Boxed Sections";
+
+    /** Recommended page margin (in points). */
+    public static final double RECOMMENDED_MARGIN = 28.0;
+
+    private BoxedSections() {
+        // utility class — not instantiable
+    }
+
+    /**
+     * Builds the preset with the classic Boxed Sections theme.
+     *
+     * @return ready-to-use template
+     */
+    public static DocumentTemplate<CvDocument> create() {
+        return create(CvTheme.boxedClassic());
+    }
+
+    /**
+     * Builds the preset with a caller-supplied theme. Allows callers
+     * to ship an alternate palette / typography / spacing without
+     * touching this class.
+     *
+     * @param theme active theme
+     * @return ready-to-use template
+     * @throws NullPointerException if {@code theme} is null
+     */
+    public static DocumentTemplate<CvDocument> create(CvTheme theme) {
+        Objects.requireNonNull(theme, "theme");
+        return new Template(theme);
+    }
+
+    private static final class Template implements DocumentTemplate<CvDocument> {
+
+        private final CvTheme theme;
+
+        Template(CvTheme theme) {
+            this.theme = theme;
+        }
+
+        @Override
+        public String id() {
+            return ID;
+        }
+
+        @Override
+        public String displayName() {
+            return DISPLAY_NAME;
+        }
+
+        @Override
+        public void compose(DocumentSession document, CvDocument doc) {
+            Objects.requireNonNull(document, "document");
+            Objects.requireNonNull(doc, "doc");
+
+            PageFlowBuilder pageFlow = document.dsl()
+                    .pageFlow()
+                    .name("CvV2Root")
+                    .spacing(theme.spacing().pageFlowSpacing())
+                    .addSection("CvV2Headline", section -> {
+                        section.accentBottom(theme.palette().rule(),
+                                theme.spacing().accentRuleWidth());
+                        HeadlineRenderer.render(section, doc.identity().name(), theme);
+                    })
+                    .addSection("CvV2Contact", section -> {
+                        section.accentBottom(theme.palette().rule(),
+                                theme.spacing().accentRuleWidth());
+                        ContactRenderer.render(section, doc.identity(), theme);
+                    });
+
+            List<CvSection> sections = doc.sections();
+            for (int i = 0; i < sections.size(); i++) {
+                final CvSection sec = sections.get(i);
+                final int idx = i;
+                pageFlow.addSection("CvV2Banner_" + idx,
+                        host -> BannerRenderer.render(host, sec.title(), theme));
+                pageFlow.addSection("CvV2Body_" + idx,
+                        host -> SectionDispatcher.renderBody(host, sec, theme));
+            }
+
+            pageFlow.build();
+        }
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/package-info.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/package-info.java
@@ -1,0 +1,23 @@
+/**
+ * <h2>Layer 4 — preset composition</h2>
+ *
+ * <p>A <strong>preset</strong> in v2 is just three things glued
+ * together:</p>
+ *
+ * <ol>
+ *   <li>A {@link com.demcha.compose.document.templates.cv.v2.data.CvDocument}
+ *       supplied by the caller (the data).</li>
+ *   <li>A {@link com.demcha.compose.document.templates.cv.v2.theme.CvTheme}
+ *       picked at construction (the cosmetics).</li>
+ *   <li>A loop over the document's sections that calls renderers
+ *       from {@code cv/v2/components}.</li>
+ * </ol>
+ *
+ * <p>That's it. No parsing, no palette literals, no per-section
+ * branching outside the dispatcher. A new visual flavour is a new
+ * theme factory in {@code cv/v2/theme}; a new structural section is
+ * a new sealed subtype in {@code cv/v2/data} plus a renderer in
+ * {@code cv/v2/components}; a new preset is this file copied and
+ * fed a different theme.</p>
+ */
+package com.demcha.compose.document.templates.cv.v2.presets;

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/theme/CvPalette.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/theme/CvPalette.java
@@ -1,0 +1,39 @@
+package com.demcha.compose.document.templates.cv.v2.theme;
+
+import com.demcha.compose.document.style.DocumentColor;
+
+import java.util.Objects;
+
+/**
+ * Colour tokens for a {@link CvTheme}.
+ *
+ * @param ink    primary text colour — headlines, body, entry titles
+ * @param muted  secondary text colour — italic subtitles (employer,
+ *               institution)
+ * @param rule   thin horizontal rules + the contact-line pipe glyph
+ * @param banner pale fill behind section title banners
+ */
+public record CvPalette(DocumentColor ink,
+                        DocumentColor muted,
+                        DocumentColor rule,
+                        DocumentColor banner) {
+
+    public CvPalette {
+        Objects.requireNonNull(ink, "ink");
+        Objects.requireNonNull(muted, "muted");
+        Objects.requireNonNull(rule, "rule");
+        Objects.requireNonNull(banner, "banner");
+    }
+
+    /**
+     * The classic dark-grey / pale-grey palette used by the original
+     * Boxed Sections preset.
+     */
+    public static CvPalette classic() {
+        return new CvPalette(
+                DocumentColor.rgb(34, 34, 34),
+                DocumentColor.rgb(120, 120, 120),
+                DocumentColor.rgb(170, 170, 170),
+                DocumentColor.rgb(220, 226, 230));
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/theme/CvSpacing.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/theme/CvSpacing.java
@@ -1,0 +1,75 @@
+package com.demcha.compose.document.templates.cv.v2.theme;
+
+import com.demcha.compose.document.style.DocumentInsets;
+
+import java.util.Objects;
+
+/**
+ * Layout / spacing tokens for a {@link CvTheme}.
+ *
+ * <p>Every magic numeric literal that used to live inside a renderer
+ * (padding, margin, gap, weight, accent width) now lives here, so a
+ * "compact" or "spacious" variant of the same visual is a new
+ * {@code CvSpacing} record — not a forked renderer.</p>
+ *
+ * @param pageFlowSpacing       gap between top-level page-flow rows
+ * @param sectionBodySpacing    gap between paragraphs inside a
+ *                              section body
+ * @param sectionBodyPadding    inset around section body content
+ * @param headlinePadding       inset around the top headline
+ * @param contactPadding        inset around the contact line
+ * @param bannerCornerRadius    corner radius of the section-title
+ *                              banner panel
+ * @param bannerInnerPadding    padding inside the banner panel
+ * @param bannerMargin          margin around the banner panel
+ * @param accentRuleWidth       stroke width of the thin horizontal
+ *                              rules under headline / contact
+ * @param paragraphMarginTop    top margin applied to body paragraphs
+ *                              and rows so consecutive items breathe
+ * @param entryHeaderRowSpacing horizontal gap between an entry's
+ *                              title column and date column
+ * @param entryTitleWeight      flex weight of the entry title column
+ * @param entryDateWeight       flex weight of the entry date column
+ */
+public record CvSpacing(
+        double pageFlowSpacing,
+        double sectionBodySpacing,
+        DocumentInsets sectionBodyPadding,
+        DocumentInsets headlinePadding,
+        DocumentInsets contactPadding,
+        double bannerCornerRadius,
+        double bannerInnerPadding,
+        DocumentInsets bannerMargin,
+        double accentRuleWidth,
+        double paragraphMarginTop,
+        double entryHeaderRowSpacing,
+        double entryTitleWeight,
+        double entryDateWeight) {
+
+    public CvSpacing {
+        Objects.requireNonNull(sectionBodyPadding, "sectionBodyPadding");
+        Objects.requireNonNull(headlinePadding, "headlinePadding");
+        Objects.requireNonNull(contactPadding, "contactPadding");
+        Objects.requireNonNull(bannerMargin, "bannerMargin");
+    }
+
+    /**
+     * The classic spacing used by the original Boxed Sections preset.
+     */
+    public static CvSpacing classic() {
+        return new CvSpacing(
+                7,                                       // pageFlowSpacing
+                4,                                       // sectionBodySpacing
+                new DocumentInsets(4, 4, 0, 4),          // sectionBodyPadding
+                new DocumentInsets(0, 0, 4, 0),          // headlinePadding
+                new DocumentInsets(4, 0, 4, 0),          // contactPadding
+                0.0,                                     // bannerCornerRadius
+                5.0,                                     // bannerInnerPadding
+                DocumentInsets.top(4),                   // bannerMargin
+                0.7,                                     // accentRuleWidth
+                2.0,                                     // paragraphMarginTop
+                8.0,                                     // entryHeaderRowSpacing
+                1.0,                                     // entryTitleWeight
+                0.45);                                   // entryDateWeight
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/theme/CvTheme.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/theme/CvTheme.java
@@ -1,0 +1,112 @@
+package com.demcha.compose.document.templates.cv.v2.theme;
+
+import com.demcha.compose.document.style.DocumentColor;
+import com.demcha.compose.document.style.DocumentTextDecoration;
+import com.demcha.compose.document.style.DocumentTextStyle;
+import com.demcha.compose.font.FontName;
+
+import java.util.Objects;
+
+/**
+ * Aggregate cosmetic theme — palette + typography + spacing — passed
+ * to every component renderer in {@code cv/v2/components}.
+ *
+ * <p>This is the <strong>only</strong> place a CV preset reads colour,
+ * font, size, or spacing values from. Renderers never inline literal
+ * RGB tuples, font names, or magic numbers.</p>
+ *
+ * <p>To define a new visual flavour: add a static factory here
+ * returning a fresh {@code CvTheme} with custom sub-records. The
+ * existing preset code keeps working — only the theme handed to
+ * {@code BoxedSections.create(theme)} changes.</p>
+ *
+ * @param palette    colour tokens
+ * @param typography font + size scale
+ * @param spacing    paddings / margins / weights
+ */
+public record CvTheme(CvPalette palette,
+                      CvTypography typography,
+                      CvSpacing spacing) {
+
+    public CvTheme {
+        Objects.requireNonNull(palette, "palette");
+        Objects.requireNonNull(typography, "typography");
+        Objects.requireNonNull(spacing, "spacing");
+    }
+
+    // -- canonical factories ---------------------------------------------
+
+    /**
+     * The "Boxed Sections" classic look — PT-Serif, near-black ink,
+     * pale-grey section banners. Visual signature of the original
+     * {@code cv-boxed-sections.pdf} reference output.
+     */
+    public static CvTheme boxedClassic() {
+        return new CvTheme(
+                CvPalette.classic(),
+                CvTypography.classic(),
+                CvSpacing.classic());
+    }
+
+    // -- pre-built text-style helpers ------------------------------------
+    // Renderers ask the theme for an already-composed DocumentTextStyle
+    // instead of re-assembling font + size + decoration + colour every
+    // call site. This is the only "computed" code in the theme — every
+    // value reads from the underlying records.
+
+    public DocumentTextStyle headlineStyle() {
+        return style(typography.headlineFont(), typography.sizeHeadline(),
+                DocumentTextDecoration.DEFAULT, palette.ink());
+    }
+
+    public DocumentTextStyle bannerStyle() {
+        return style(typography.headlineFont(), typography.sizeBanner(),
+                DocumentTextDecoration.BOLD, palette.ink());
+    }
+
+    public DocumentTextStyle contactStyle() {
+        return style(typography.bodyFont(), typography.sizeContact(),
+                DocumentTextDecoration.DEFAULT, palette.ink());
+    }
+
+    public DocumentTextStyle contactSeparatorStyle() {
+        return style(typography.bodyFont(), typography.sizeContact(),
+                DocumentTextDecoration.DEFAULT, palette.rule());
+    }
+
+    public DocumentTextStyle bodyStyle() {
+        return style(typography.bodyFont(), typography.sizeBody(),
+                DocumentTextDecoration.DEFAULT, palette.ink());
+    }
+
+    public DocumentTextStyle bodyBoldStyle() {
+        return style(typography.bodyFont(), typography.sizeBody(),
+                DocumentTextDecoration.BOLD, palette.ink());
+    }
+
+    public DocumentTextStyle entryTitleStyle() {
+        return style(typography.bodyFont(), typography.sizeEntryTitle(),
+                DocumentTextDecoration.BOLD, palette.ink());
+    }
+
+    public DocumentTextStyle entryDateStyle() {
+        return style(typography.bodyFont(), typography.sizeEntryDate(),
+                DocumentTextDecoration.DEFAULT, palette.ink());
+    }
+
+    public DocumentTextStyle entrySubtitleStyle() {
+        return style(typography.bodyFont(), typography.sizeEntrySubtitle(),
+                DocumentTextDecoration.ITALIC, palette.muted());
+    }
+
+    private static DocumentTextStyle style(FontName font, double size,
+                                           DocumentTextDecoration decoration,
+                                           DocumentColor color) {
+        return DocumentTextStyle.builder()
+                .fontName(font)
+                .size(size)
+                .decoration(decoration)
+                .color(color)
+                .build();
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/theme/CvTypography.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/theme/CvTypography.java
@@ -1,0 +1,64 @@
+package com.demcha.compose.document.templates.cv.v2.theme;
+
+import com.demcha.compose.font.FontName;
+
+import java.util.Objects;
+
+/**
+ * Font + size scale tokens for a {@link CvTheme}.
+ *
+ * <p>Each field names <strong>what</strong> renders at that size, not
+ * an abstract "small / medium / large" — that way the call site
+ * ({@code theme.typography().sizeEntryDate()}) reads as the renderer's
+ * intent and a future scale-rebalance affects only the values, never
+ * the field names.</p>
+ *
+ * @param headlineFont      font for the top-of-document spaced-caps
+ *                          name
+ * @param bodyFont          font for everything else (body prose,
+ *                          subtitles, banner labels, …)
+ * @param sizeHeadline      top-of-document name size
+ * @param sizeContact       contact-line size (phone / email / links)
+ * @param sizeBanner        spaced-caps section banner label size
+ * @param sizeEntryTitle    bold entry title (job title, degree) size
+ * @param sizeEntryDate     right-aligned date column size
+ * @param sizeEntrySubtitle italic subtitle (employer, institution)
+ *                          size
+ * @param sizeBody          paragraph / bullet / key-value body size
+ * @param bodyLineSpacing   line-spacing multiplier for body
+ *                          paragraphs (typically 1.4)
+ */
+public record CvTypography(
+        FontName headlineFont,
+        FontName bodyFont,
+        double sizeHeadline,
+        double sizeContact,
+        double sizeBanner,
+        double sizeEntryTitle,
+        double sizeEntryDate,
+        double sizeEntrySubtitle,
+        double sizeBody,
+        double bodyLineSpacing) {
+
+    public CvTypography {
+        Objects.requireNonNull(headlineFont, "headlineFont");
+        Objects.requireNonNull(bodyFont, "bodyFont");
+    }
+
+    /**
+     * The classic PT-Serif scale used by the original Boxed Sections
+     * preset.
+     */
+    public static CvTypography classic() {
+        return new CvTypography(
+                FontName.PT_SERIF, FontName.PT_SERIF,
+                21.5,    // headline
+                8.5,     // contact
+                9.6,     // banner
+                9.2,     // entry title
+                8.8,     // entry date
+                8.4,     // entry subtitle
+                8.6,     // body
+                1.4);    // line spacing
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/theme/package-info.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/theme/package-info.java
@@ -1,0 +1,29 @@
+/**
+ * <h2>Layer 3 — cosmetic tokens (theme)</h2>
+ *
+ * <p>The <strong>shift-able</strong> layer. Every colour, font, size,
+ * padding, corner radius, accent width — everything purely visual —
+ * lives in {@link com.demcha.compose.document.templates.cv.v2.theme.CvTheme}
+ * and its three sub-records:</p>
+ *
+ * <ul>
+ *   <li>{@link com.demcha.compose.document.templates.cv.v2.theme.CvPalette}
+ *       — colours.</li>
+ *   <li>{@link com.demcha.compose.document.templates.cv.v2.theme.CvTypography}
+ *       — fonts, sizes, line spacing.</li>
+ *   <li>{@link com.demcha.compose.document.templates.cv.v2.theme.CvSpacing}
+ *       — paddings, margins, banner radius, accent widths, row
+ *       weights.</li>
+ * </ul>
+ *
+ * <p>Renderers in {@code cv/v2/components} accept a {@code CvTheme}
+ * argument and never read constants directly — so a new visual flavour
+ * is just a new {@code CvTheme} factory, no renderer changes
+ * required.</p>
+ *
+ * <p>Why split into three sub-records: it lets you mix-and-match — a
+ * preset can build {@code new CvTheme(palette, defaultTypography,
+ * tighterSpacing)} for a compact variant without redeclaring every
+ * field.</p>
+ */
+package com.demcha.compose.document.templates.cv.v2.theme;

--- a/src/test/java/com/demcha/compose/document/templates/cv/v2/data/CvContactTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/v2/data/CvContactTest.java
@@ -1,0 +1,44 @@
+package com.demcha.compose.document.templates.cv.v2.data;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CvContactTest {
+
+    @Test
+    void rejects_blank_phone() {
+        assertThatThrownBy(() -> new CvContact("", "j@d.com", "London"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("phone");
+    }
+
+    @Test
+    void rejects_blank_email() {
+        assertThatThrownBy(() -> new CvContact("+44 0", "  ", "London"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("email");
+    }
+
+    @Test
+    void rejects_blank_address() {
+        assertThatThrownBy(() -> new CvContact("+44 0", "j@d.com", ""))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("address");
+    }
+
+    @Test
+    void rejects_null_field() {
+        assertThatThrownBy(() -> new CvContact(null, "j@d.com", "London"))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void happy_path_keeps_fields() {
+        CvContact c = new CvContact("+44 1234", "j@d.com", "London, UK");
+        assertThat(c.phone()).isEqualTo("+44 1234");
+        assertThat(c.email()).isEqualTo("j@d.com");
+        assertThat(c.address()).isEqualTo("London, UK");
+    }
+}

--- a/src/test/java/com/demcha/compose/document/templates/cv/v2/data/CvNameTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/v2/data/CvNameTest.java
@@ -1,0 +1,51 @@
+package com.demcha.compose.document.templates.cv.v2.data;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CvNameTest {
+
+    @Test
+    void rejects_blank_first() {
+        assertThatThrownBy(() -> new CvName("", "", "Doe"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("first");
+    }
+
+    @Test
+    void rejects_blank_last() {
+        assertThatThrownBy(() -> new CvName("Jane", "", "  "))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("last");
+    }
+
+    @Test
+    void rejects_null_first() {
+        assertThatThrownBy(() -> new CvName(null, "", "Doe"))
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void null_middle_becomes_empty() {
+        CvName name = new CvName("Jane", null, "Doe");
+        assertThat(name.middle()).isEqualTo("");
+        assertThat(name.middleName()).isEmpty();
+        assertThat(name.full()).isEqualTo("Jane Doe");
+    }
+
+    @Test
+    void full_joins_with_middle() {
+        CvName name = new CvName("Jane", "Q", "Doe");
+        assertThat(name.full()).isEqualTo("Jane Q Doe");
+        assertThat(name.middleName()).contains("Q");
+    }
+
+    @Test
+    void of_factory_builds_two_part_name() {
+        CvName name = CvName.of("Jane", "Doe");
+        assertThat(name.full()).isEqualTo("Jane Doe");
+        assertThat(name.middle()).isEqualTo("");
+    }
+}

--- a/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/BoxedSectionsSmokeTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/BoxedSectionsSmokeTest.java
@@ -1,0 +1,121 @@
+package com.demcha.compose.document.templates.cv.v2.presets;
+
+import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.api.DocumentSession;
+import com.demcha.compose.document.node.DocumentNode;
+import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.document.templates.api.DocumentTemplate;
+import com.demcha.compose.document.templates.cv.v2.data.CvDocument;
+import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
+import com.demcha.compose.document.templates.cv.v2.data.EntriesSection;
+import com.demcha.compose.document.templates.cv.v2.data.ParagraphSection;
+import com.demcha.compose.document.templates.cv.v2.data.RowStyle;
+import com.demcha.compose.document.templates.cv.v2.data.RowsSection;
+import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Smoke test for the v2 BoxedSections preset. Builds a document with
+ * <strong>every</strong> sealed section subtype and verifies compose
+ * runs cleanly — catches dispatcher omissions and renderer
+ * regressions before they hit the example PDFs.
+ */
+class BoxedSectionsSmokeTest {
+
+    @Test
+    void exposes_stable_identity() {
+        DocumentTemplate<CvDocument> template = BoxedSections.create();
+        assertThat(template.id()).isEqualTo("boxed-sections");
+        assertThat(template.displayName()).isEqualTo("Boxed Sections");
+    }
+
+    @Test
+    void default_factory_uses_classic_theme_and_renders() throws Exception {
+        DocumentTemplate<CvDocument> template = BoxedSections.create();
+        renderAndAssertNonEmpty(template, fullDocument());
+    }
+
+    @Test
+    void custom_theme_factory_renders() throws Exception {
+        DocumentTemplate<CvDocument> template =
+                BoxedSections.create(CvTheme.boxedClassic());
+        renderAndAssertNonEmpty(template, fullDocument());
+    }
+
+    @Test
+    void every_section_subtype_dispatches_cleanly() throws Exception {
+        // Documents that exercise each subtype in isolation — catches
+        // any dispatcher branch that throws on a specific row style
+        // or empty-list shape.
+        DocumentTemplate<CvDocument> template = BoxedSections.create();
+
+        renderAndAssertNonEmpty(template, documentWith(
+                new ParagraphSection("Summary", "body text")));
+        renderAndAssertNonEmpty(template, documentWith(
+                RowsSection.builder("Skills", RowStyle.BULLETED)
+                        .row("Languages", "Java, Kotlin")
+                        .build()));
+        renderAndAssertNonEmpty(template, documentWith(
+                RowsSection.builder("Info", RowStyle.PLAIN)
+                        .row("Languages", "English")
+                        .build()));
+        renderAndAssertNonEmpty(template, documentWith(
+                RowsSection.builder("Projects", RowStyle.BULLETED_STACKED)
+                        .row("Project X", "what it does")
+                        .build()));
+        renderAndAssertNonEmpty(template, documentWith(
+                EntriesSection.builder("Experience")
+                        .entry("Engineer", "Acme", "2020-2024", "did stuff")
+                        .build()));
+    }
+
+    private static void renderAndAssertNonEmpty(
+            DocumentTemplate<CvDocument> template, CvDocument doc) throws Exception {
+        try (DocumentSession session = GraphCompose.document()
+                .pageSize(420, 595)
+                .margin(DocumentInsets.of(24))
+                .create()) {
+
+            template.compose(session, doc);
+
+            List<DocumentNode> roots = session.roots();
+            assertThat(roots).isNotEmpty();
+        }
+    }
+
+    private static CvDocument documentWith(
+            com.demcha.compose.document.templates.cv.v2.data.CvSection section) {
+        return CvDocument.builder()
+                .identity(identity())
+                .section(section)
+                .build();
+    }
+
+    private static CvDocument fullDocument() {
+        return CvDocument.builder()
+                .identity(identity())
+                .sections(
+                        new ParagraphSection("Summary", "body"),
+                        RowsSection.builder("Skills", RowStyle.BULLETED)
+                                .row("Languages", "Java").build(),
+                        EntriesSection.builder("Experience")
+                                .entry("Engineer", "Acme", "2020", "did stuff").build(),
+                        RowsSection.builder("Projects", RowStyle.BULLETED_STACKED)
+                                .row("X", "desc").build(),
+                        RowsSection.builder("Info", RowStyle.PLAIN)
+                                .row("Languages", "English").build())
+                .build();
+    }
+
+    private static CvIdentity identity() {
+        return CvIdentity.builder()
+                .name("Jane", "Doe")
+                .contact("+44 0", "j@d.com", "London")
+                .link("GitHub", "https://github.com/jane-doe")
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary

Introduces a side-by-side rewrite of the CV template surface under
`com.demcha.compose.document.templates.cv.v2` organised as four strict
layers:

- **`data/`** — pure CV records: `CvName`, `CvContact`, `CvLink`,
  `CvIdentity` + sealed `CvSection` (`ParagraphSection`,
  `RowsSection` with `RowStyle`, `EntriesSection`). No rendering deps.
- **`theme/`** — cosmetic tokens: `CvPalette`, `CvTypography`,
  `CvSpacing` aggregated as `CvTheme` with a `boxedClassic()` factory.
- **`components/`** — reusable renderers (`HeadlineRenderer`,
  `ContactRenderer`, `BannerRenderer`, `ParagraphRenderer`,
  `RowRenderer`, `EntryRenderer`, `SectionDispatcher`) that take theme
  as a parameter — no statics, no parsing.
- **`presets/`** — `BoxedSections` composition example.

## What's included

- 28 new source files under `cv/v2/` (~1500 lines)
- Sample fixture `ExampleDataFactory.sampleCvDocumentV2()`
- Runner `CvBoxedV2Example` rendering pixel-identical output to the
  legacy `cv-boxed-sections.pdf` reference
- 15 passing tests (`CvNameTest`, `CvContactTest`,
  `BoxedSectionsSmokeTest`)

## What's NOT changed

- **Engine** (`document/api`, `document/dsl`, `document/engine`,
  `document/node`, `document/style`) — zero edits
- **v1 CV surface** (`cv/spec`, `cv/builder`, `cv/layouts`,
  `cv/presets`) — zero edits. All 14 v1 presets continue to work.

## Follow-ups (separate PRs)

- `feature/cv-v2-extensible` — `CvDecoration` token, `ParagraphPrimitive`
  helper, author docs, second demo preset
- Phase 1 — slot mapping for multi-column presets
- Phase 2-5 — port priority v1 presets, visual regression test,
  migration doc, eventual v1 deprecation

## Test plan

- [x] `mvn test` — 15/15 v2 tests pass
- [x] `mvn compile` — main + examples + tests clean
- [x] Render `cv-boxed-sections-v2.pdf` — visual parity vs legacy
- [ ] CI green