### PR TITLE
v2: extension points + author docs + demo preset

### DIFF
--- a/examples/src/main/java/com/demcha/examples/templates/cv/v2/CvMinimalUnderlinedExample.java
+++ b/examples/src/main/java/com/demcha/examples/templates/cv/v2/CvMinimalUnderlinedExample.java
@@ -1,0 +1,48 @@
+package com.demcha.examples.templates.cv.v2;
+
+import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.api.DocumentPageSize;
+import com.demcha.compose.document.api.DocumentSession;
+import com.demcha.compose.document.templates.api.DocumentTemplate;
+import com.demcha.compose.document.templates.cv.v2.data.CvDocument;
+import com.demcha.compose.document.templates.cv.v2.presets.MinimalUnderlined;
+import com.demcha.examples.support.ExampleDataFactory;
+import com.demcha.examples.support.ExampleOutputPaths;
+
+import java.nio.file.Path;
+
+/**
+ * Renders the v2 Minimal Underlined preset against the same Jordan
+ * Rivera sample data used by {@link CvBoxedV2Example}. Demonstrates
+ * that switching from one preset to another is a one-line change at
+ * the call site — same data, different visual composition.
+ *
+ * <p>Output:
+ * {@code examples/target/generated-pdfs/templates/cv/cv-minimal-underlined.pdf}.</p>
+ */
+public final class CvMinimalUnderlinedExample {
+
+    private CvMinimalUnderlinedExample() {
+    }
+
+    public static Path generate() throws Exception {
+        Path outputFile = ExampleOutputPaths.prepare(
+                "templates/cv", "cv-minimal-underlined.pdf");
+        CvDocument doc = ExampleDataFactory.sampleCvDocumentV2();
+        DocumentTemplate<CvDocument> template = MinimalUnderlined.create();
+
+        float m = (float) MinimalUnderlined.RECOMMENDED_MARGIN;
+        try (DocumentSession document = GraphCompose.document(outputFile)
+                .pageSize(DocumentPageSize.A4)
+                .margin(m, m, m, m)
+                .create()) {
+            template.compose(document, doc);
+            document.buildPdf();
+        }
+        return outputFile;
+    }
+
+    public static void main(String[] args) throws Exception {
+        System.out.println("Generated: " + generate());
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/AUTHORS.md
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/AUTHORS.md
@@ -1,0 +1,285 @@
+# CV Templates v2 — author guide
+
+This document is for developers who want to **build their own CV template**
+on top of the v2 surface. It complements the JavaDoc in
+`package-info.java` with longer, copy-pasteable recipes.
+
+If you have never used this package before, read
+[the package overview](./package-info.java) first. The four layers
+(`data/` · `theme/` · `components/` · `presets/`) and what each is for
+are explained there.
+
+This guide answers the **"how do I…"** questions.
+
+---
+
+## Recipe 1 — change a bullet glyph
+
+You want `▶` instead of `•`, or numbered bullets, or em-dashes.
+
+This is a **theme** change, not a renderer change. Build a custom
+`CvDecoration` and hand it to a fresh `CvTheme`:
+
+```java
+CvTheme theme = new CvTheme(
+        CvPalette.classic(),
+        CvTypography.classic(),
+        CvSpacing.classic(),
+        new CvDecoration(
+                "▶ ",      // bullet glyph
+                "  ",      // stacked-row second-line indent (same visual width as bullet)
+                "  ·  "    // contact-line separator
+        ));
+
+DocumentTemplate<CvDocument> template = BoxedSections.create(theme);
+```
+
+That's it. No renderer code changes. `RowRenderer` and
+`ContactRenderer` read these strings from `theme.decoration()` on every
+call.
+
+**Why the second-line indent is its own token:** when a stacked row
+(Projects style) wraps to a second line, the body text must align under
+the **bold name**, not under the bullet. The indent string must have
+the same visual width as the bullet glyph + trailing space, so if you
+pick a wider bullet you'll likely want a wider stacked-indent too.
+
+---
+
+## Recipe 2 — change colours only
+
+You want the same Boxed Sections look but in navy instead of grey.
+
+```java
+CvPalette navy = new CvPalette(
+        DocumentColor.rgb(15, 34, 80),     // ink — primary text
+        DocumentColor.rgb(90, 110, 150),   // muted — italic subtitles
+        DocumentColor.rgb(120, 140, 180),  // rule — separator lines
+        DocumentColor.rgb(220, 230, 240)); // banner — pale fill behind titles
+
+CvTheme navyTheme = new CvTheme(
+        navy,
+        CvTypography.classic(),
+        CvSpacing.classic(),
+        CvDecoration.classic());
+
+DocumentTemplate<CvDocument> template = BoxedSections.create(navyTheme);
+```
+
+Same shape — sub-record swap, keep the rest of the theme.
+
+---
+
+## Recipe 3 — change fonts and sizes
+
+You want a sans-serif body or a tighter scale.
+
+```java
+CvTypography compact = new CvTypography(
+        FontName.INTER, FontName.INTER,
+        18.0,    // headline (was 21.5)
+        7.8,     // contact
+        8.6,     // banner
+        8.4,     // entry title
+        8.0,     // entry date
+        7.6,     // entry subtitle
+        7.8,     // body
+        1.3);    // line spacing (was 1.4)
+
+CvTheme compactTheme = new CvTheme(
+        CvPalette.classic(),
+        compact,
+        CvSpacing.classic(),
+        CvDecoration.classic());
+```
+
+---
+
+## Recipe 4 — write a new preset (reuse existing renderers)
+
+You want a different page layout — no banner panels, section titles
+underlined instead. Same data, same components, different composition.
+
+See `presets/MinimalUnderlined.java` for a worked example. The pattern:
+
+```java
+public final class MyPreset {
+
+    public static DocumentTemplate<CvDocument> create() {
+        return create(CvTheme.boxedClassic());
+    }
+
+    public static DocumentTemplate<CvDocument> create(CvTheme theme) {
+        Objects.requireNonNull(theme, "theme");
+        return new Template(theme);
+    }
+
+    private static final class Template implements DocumentTemplate<CvDocument> {
+        private final CvTheme theme;
+        Template(CvTheme theme) { this.theme = theme; }
+
+        @Override public String id() { return "my-preset"; }
+        @Override public String displayName() { return "My Preset"; }
+
+        @Override
+        public void compose(DocumentSession document, CvDocument doc) {
+            PageFlowBuilder pageFlow = document.dsl().pageFlow()
+                    .name("MyRoot")
+                    .spacing(theme.spacing().pageFlowSpacing())
+                    .addSection("Headline", s ->
+                            HeadlineRenderer.render(s, doc.identity().name(), theme))
+                    .addSection("Contact", s ->
+                            ContactRenderer.render(s, doc.identity(), theme));
+
+            for (int i = 0; i < doc.sections().size(); i++) {
+                final CvSection sec = doc.sections().get(i);
+                final int idx = i;
+
+                // Replace BannerRenderer with whatever title style you want.
+                pageFlow.addSection("Title_" + idx, host -> {
+                    /* custom title rendering */
+                });
+                pageFlow.addSection("Body_" + idx, host ->
+                        SectionDispatcher.renderBody(host, sec, theme));
+            }
+
+            pageFlow.build();
+        }
+    }
+}
+```
+
+The renderers in `components/` are all `static` — your preset just
+calls them. No inheritance, no instance state to manage.
+
+---
+
+## Recipe 5 — add a brand-new section subtype
+
+You need something the existing three section types can't express —
+say, a skill-bar chart, a quote block, or a contact-references list.
+
+Three places to touch (compile-checked path):
+
+**a)** Add a record to `data/`:
+
+```java
+public record QuoteSection(String title, String quote, String attribution)
+        implements CvSection {
+    public QuoteSection {
+        Objects.requireNonNull(title, "title");
+        Objects.requireNonNull(quote, "quote");
+        Objects.requireNonNull(attribution, "attribution");
+        if (title.isBlank()) throw new IllegalArgumentException("title must not be blank");
+    }
+}
+```
+
+**b)** Add it to the sealed permits in `CvSection.java`:
+
+```java
+public sealed interface CvSection
+        permits ParagraphSection, RowsSection, EntriesSection, QuoteSection {
+    String title();
+}
+```
+
+**c)** Write a renderer in `components/`:
+
+```java
+public final class QuoteRenderer {
+    private QuoteRenderer() {}
+    public static void render(SectionBuilder section, QuoteSection q, CvTheme theme) {
+        // …compose the visual using ParagraphPrimitive + theme tokens…
+    }
+}
+```
+
+**d)** Add a branch in `SectionDispatcher.renderBody`:
+
+```java
+} else if (section instanceof QuoteSection q) {
+    QuoteRenderer.render(host, q, theme);
+}
+```
+
+The final `else` of the dispatcher throws — if you forget (d) the
+runtime will say so loudly the first time someone uses your new
+subtype. (On Java 21 this would be a compile-time exhaustiveness
+check via pattern-match switch; we target Java 17 so it's a runtime
+guard.)
+
+---
+
+## Recipe 6 — conditional sections (data-driven)
+
+Real CVs often hide a section when there's nothing to put in it:
+
+```java
+CvDocument.Builder builder = CvDocument.builder()
+        .identity(identity)
+        .section(summary);
+
+if (!skillCategories.isEmpty()) {
+    builder.section(buildSkillsSection(skillCategories));
+}
+if (latestCertification != null) {
+    builder.section(buildEducationSection());
+}
+
+CvDocument doc = builder.build();
+```
+
+The plain `if` is fine. There's no built-in `.sectionIf(...)` yet — if
+this pattern becomes pervasive in your code, file an issue.
+
+---
+
+## Style guide for authors
+
+When writing your own classes in this package, follow these conventions
+so future readers can navigate the same way:
+
+- **Records over classes** for data. Records carry no behavior.
+- **`final` classes with private constructors** for static renderers
+  and helpers. Mark them `package-private` if they aren't meant to be
+  called by user code (like `ParagraphPrimitive`).
+- **Theme as parameter**, not as a static or instance field. Renderers
+  must work for any theme passed to them.
+- **No magic numbers** in renderer code. Every literal that affects
+  visuals goes into `CvSpacing`, `CvTypography`, or `CvDecoration`.
+- **No instanceof on the data** outside `SectionDispatcher`. That class
+  is the single dispatch point.
+- **JavaDoc the public surface.** Sub-records and section types get a
+  paragraph describing what they model and where they're rendered.
+
+---
+
+## What <em>not</em> to do
+
+- ❌ Subclass renderers. They're `final`. If you need different
+     behavior, write a new preset that composes them differently, or
+     add a new theme token if it's cosmetic.
+- ❌ Read raw `DocumentColor.rgb(...)` literals in renderer code. Add
+     them to `CvPalette` so a theme can swap them.
+- ❌ Use `instanceof` on `CvSection` outside `SectionDispatcher`.
+     The dispatcher is the only place that knows about variants.
+- ❌ Add behavior to data records. Records are inert.
+- ❌ Break the public v2 API. If you must change a signature, add the
+     new one and mark the old `@Deprecated` — see `CvTheme`'s 3-arg
+     constructor for the pattern.
+
+---
+
+## When to write a new preset vs. a new theme vs. a new section type
+
+| You want to change… | Add a new… |
+|---|---|
+| Colour / font / size | `CvPalette` / `CvTypography` (theme) |
+| Bullet / separator glyph | `CvDecoration` (theme) |
+| Layout / page-flow / which renderers run | **preset** |
+| The data shape itself (new section type) | `CvSection` permits + renderer + dispatch branch |
+
+When in doubt: try a theme change first. If that doesn't fit, write a
+preset. Adding new data shapes is the last resort and the most
+invasive — but the compiler will guide you (sealed + dispatch).

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/ContactRenderer.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/ContactRenderer.java
@@ -49,7 +49,8 @@ public final class ContactRenderer {
                                     rich.style(part.text(), textStyle);
                                 }
                                 if (i < parts.size() - 1) {
-                                    rich.style("   |   ", separatorStyle);
+                                    rich.style(theme.decoration().contactSeparator(),
+                                            separatorStyle);
                                 }
                             }
                         }));

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/EntryRenderer.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/EntryRenderer.java
@@ -19,10 +19,11 @@ import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
  *
  * <p>Blank fields collapse — a blank date drops the right column,
  * a blank subtitle drops the italic line, a blank body drops the
- * paragraph beneath. The same renderer fits both flavours because
- * the visual is identical; if a preset wants to style Education
- * differently it does so by passing a different theme, not by
- * forking this code.</p>
+ * paragraph beneath.</p>
+ *
+ * <p>The subtitle and body paragraphs go through
+ * {@link ParagraphPrimitive} so they share alignment, margin, and
+ * markdown handling with every other renderer in this package.</p>
  */
 public final class EntryRenderer {
 
@@ -36,6 +37,9 @@ public final class EntryRenderer {
         DocumentTextStyle bodyStyle = theme.bodyStyle();
 
         // -- title + date row -------------------------------------------
+        // The two-column header is a row layout, not a paragraph, so it
+        // does not go through ParagraphPrimitive — its DSL shape is
+        // genuinely different.
         section.addRow("CvV2EntryHeader", row -> row
                 .spacing(theme.spacing().entryHeaderRowSpacing())
                 .weights(theme.spacing().entryTitleWeight(),
@@ -57,23 +61,12 @@ public final class EntryRenderer {
 
         // -- italic subtitle --------------------------------------------
         if (!entry.subtitle().isBlank()) {
-            section.addParagraph(p -> p
-                    .textStyle(subtitleStyle)
-                    .align(TextAlign.LEFT)
-                    .margin(DocumentInsets.zero())
-                    .rich(rich -> MarkdownInline.append(rich,
-                            entry.subtitle(), subtitleStyle)));
+            ParagraphPrimitive.writeSubtitle(section, entry.subtitle(), subtitleStyle);
         }
 
         // -- body paragraph ---------------------------------------------
         if (!entry.body().isBlank()) {
-            section.addParagraph(p -> p
-                    .textStyle(bodyStyle)
-                    .lineSpacing(theme.typography().bodyLineSpacing())
-                    .align(TextAlign.LEFT)
-                    .margin(DocumentInsets.top((float) theme.spacing().paragraphMarginTop()))
-                    .rich(rich -> MarkdownInline.append(rich,
-                            entry.body(), bodyStyle)));
+            ParagraphPrimitive.writeBody(section, entry.body(), bodyStyle, theme);
         }
     }
 }

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/ParagraphPrimitive.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/ParagraphPrimitive.java
@@ -1,0 +1,102 @@
+package com.demcha.compose.document.templates.cv.v2.components;
+
+import com.demcha.compose.document.dsl.SectionBuilder;
+import com.demcha.compose.document.node.TextAlign;
+import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.document.style.DocumentTextIndent;
+import com.demcha.compose.document.style.DocumentTextStyle;
+import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+
+/**
+ * Internal primitive that owns the shared
+ * {@code section.addParagraph(p -> p.textStyle(...).lineSpacing(...).align(LEFT).margin(...).rich(...))}
+ * skeleton used by every body / row / entry renderer in this package.
+ *
+ * <p>Higher-level renderers
+ * ({@link ParagraphRenderer}, {@link RowRenderer},
+ * {@link EntryRenderer}) compose their output by calling one of the
+ * three short methods below — no one re-writes the paragraph DSL
+ * configuration by hand, no two renderers can disagree about the
+ * default alignment, and changing the markdown helper or the default
+ * text alignment is a one-line edit.</p>
+ *
+ * <p>Not part of the public v2 API — package-private deliberately.
+ * Renderers that consume {@link ParagraphPrimitive} are the public
+ * surface; this class is their plumbing.</p>
+ */
+final class ParagraphPrimitive {
+
+    private ParagraphPrimitive() {
+    }
+
+    /**
+     * Body-style paragraph with the theme's default top margin, body
+     * line spacing, no bullet. Used for prose paragraphs, entry body
+     * lines, and plain rows.
+     */
+    static void writeBody(SectionBuilder host, String text,
+                          DocumentTextStyle style, CvTheme theme) {
+        write(host, text, style,
+                DocumentInsets.top((float) theme.spacing().paragraphMarginTop()),
+                theme.typography().bodyLineSpacing(),
+                null);
+    }
+
+    /**
+     * Body-style paragraph plus a bullet glyph + hanging indent. The
+     * glyph is supplied by the caller (typically
+     * {@code theme.decoration().bulletGlyph()} or
+     * {@code theme.decoration().stackedIndent()} for the stacked
+     * second line).
+     */
+    static void writeBulleted(SectionBuilder host, String text,
+                              DocumentTextStyle style,
+                              String bulletGlyph,
+                              DocumentInsets margin,
+                              CvTheme theme) {
+        write(host, text, style,
+                margin,
+                theme.typography().bodyLineSpacing(),
+                bulletGlyph);
+    }
+
+    /**
+     * Subtitle-style paragraph — caller-supplied margin, no
+     * lineSpacing override, no bullet. Used for the italic
+     * employer/institution line under an entry title.
+     */
+    static void writeSubtitle(SectionBuilder host, String text,
+                              DocumentTextStyle style) {
+        write(host, text, style, DocumentInsets.zero(), null, null);
+    }
+
+    /**
+     * Full-control variant — every knob exposed. Reserved for callers
+     * that need a one-off combination not covered by the convenience
+     * methods above.
+     *
+     * @param margin       paragraph margin
+     * @param lineSpacing  optional lineSpacing override; null = use
+     *                     engine default
+     * @param bulletGlyph  optional bullet prefix; null = no bullet
+     */
+    static void write(SectionBuilder host, String text,
+                      DocumentTextStyle style,
+                      DocumentInsets margin,
+                      Double lineSpacing,
+                      String bulletGlyph) {
+        host.addParagraph(p -> {
+            p.textStyle(style)
+                    .align(TextAlign.LEFT)
+                    .margin(margin)
+                    .rich(rich -> MarkdownInline.append(rich, text, style));
+            if (lineSpacing != null) {
+                p.lineSpacing(lineSpacing);
+            }
+            if (bulletGlyph != null) {
+                p.bulletOffset(bulletGlyph)
+                        .indentStrategy(DocumentTextIndent.ALL_LINES);
+            }
+        });
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/ParagraphRenderer.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/ParagraphRenderer.java
@@ -1,15 +1,16 @@
 package com.demcha.compose.document.templates.cv.v2.components;
 
 import com.demcha.compose.document.dsl.SectionBuilder;
-import com.demcha.compose.document.node.TextAlign;
-import com.demcha.compose.document.style.DocumentInsets;
-import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
 
 /**
  * Draws one prose paragraph (markdown-aware) in body style. Used by
- * {@code ParagraphSection} bodies and as a shared primitive by other
- * renderers (e.g. the description line under an entry).
+ * {@code ParagraphSection} bodies.
+ *
+ * <p>Implementation is a one-liner delegation to
+ * {@link ParagraphPrimitive} — the actual addParagraph DSL plumbing
+ * lives there so every body / row / entry renderer agrees on
+ * alignment, margin, line spacing, and markdown handling.</p>
  */
 public final class ParagraphRenderer {
 
@@ -25,12 +26,6 @@ public final class ParagraphRenderer {
         if (text == null || text.isBlank()) {
             return;
         }
-        DocumentTextStyle base = theme.bodyStyle();
-        section.addParagraph(p -> p
-                .textStyle(base)
-                .lineSpacing(theme.typography().bodyLineSpacing())
-                .align(TextAlign.LEFT)
-                .margin(DocumentInsets.top((float) theme.spacing().paragraphMarginTop()))
-                .rich(rich -> MarkdownInline.append(rich, text.trim(), base)));
+        ParagraphPrimitive.writeBody(section, text.trim(), theme.bodyStyle(), theme);
     }
 }

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/RowRenderer.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/RowRenderer.java
@@ -1,9 +1,7 @@
 package com.demcha.compose.document.templates.cv.v2.components;
 
 import com.demcha.compose.document.dsl.SectionBuilder;
-import com.demcha.compose.document.node.TextAlign;
 import com.demcha.compose.document.style.DocumentInsets;
-import com.demcha.compose.document.style.DocumentTextIndent;
 import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.cv.v2.data.CvRow;
 import com.demcha.compose.document.templates.cv.v2.data.RowStyle;
@@ -12,19 +10,14 @@ import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
 /**
  * Unified renderer for a {@link CvRow} under any {@link RowStyle}.
  *
- * <p>One entry point — {@link #render(SectionBuilder, CvRow, RowStyle, CvTheme)} —
- * branches by style into three private helpers that share their
- * paragraph configuration. There is no copy-paste of {@code
- * .textStyle(...).lineSpacing(...).align(...)} across four near-identical
- * methods like the first v2 iteration had — the only thing that varies
- * per style is the bullet glyph and whether the row stacks onto a
- * second line.</p>
+ * <p>One public entry point dispatches on the style enum. All actual
+ * paragraph drawing is delegated to {@link ParagraphPrimitive} so no
+ * paragraph configuration is duplicated between this class and the
+ * other renderers. Bullet glyphs and stacked-indent strings come
+ * from {@code theme.decoration()} — changing them is a theme-level
+ * decision, not a code change.</p>
  */
 public final class RowRenderer {
-
-    private static final String BULLET_GLYPH = "• ";
-    /** Two-space prefix so wrapped stacked-body text sits under the name. */
-    private static final String STACK_INDENT = "  ";
 
     private RowRenderer() {
     }
@@ -35,13 +28,14 @@ public final class RowRenderer {
      * @param section host
      * @param row     content (label + body)
      * @param style   decoration toggle
-     * @param theme   active theme
+     * @param theme   active theme — supplies typography, palette,
+     *                bullet glyph, and stacked indent
      */
     public static void render(SectionBuilder section, CvRow row,
                               RowStyle style, CvTheme theme) {
         switch (style) {
             case PLAIN -> inline(section, row, null, theme);
-            case BULLETED -> inline(section, row, BULLET_GLYPH, theme);
+            case BULLETED -> inline(section, row, theme.decoration().bulletGlyph(), theme);
             case BULLETED_STACKED -> stacked(section, row, theme);
         }
     }
@@ -56,57 +50,44 @@ public final class RowRenderer {
                                String bulletGlyph, CvTheme theme) {
         DocumentTextStyle base = theme.bodyStyle();
         String source = labelColonValue(row);
-        section.addParagraph(p -> {
-            p.textStyle(base)
-                    .lineSpacing(theme.typography().bodyLineSpacing())
-                    .align(TextAlign.LEFT)
-                    .margin(DocumentInsets.top((float) theme.spacing().paragraphMarginTop()))
-                    .rich(rich -> MarkdownInline.append(rich, source, base));
-            if (bulletGlyph != null) {
-                p.bulletOffset(bulletGlyph)
-                        .indentStrategy(DocumentTextIndent.ALL_LINES);
-            }
-        });
+        DocumentInsets margin = DocumentInsets.top(
+                (float) theme.spacing().paragraphMarginTop());
+        if (bulletGlyph == null) {
+            ParagraphPrimitive.writeBody(section, source, base, theme);
+        } else {
+            ParagraphPrimitive.writeBulleted(section, source, base,
+                    bulletGlyph, margin, theme);
+        }
     }
 
     /**
-     * Renders the row as two stacked paragraphs:
-     * {@code • <b>label</b>} on line 1, body indented under the label
-     * on line 2.
+     * Renders the row as two stacked paragraphs: bullet + bold label
+     * on line 1, body indented under the label on line 2. Both
+     * paragraphs draw through {@link ParagraphPrimitive#writeBulleted}
+     * so only the bullet glyph / margin differs.
      */
     private static void stacked(SectionBuilder section, CvRow row, CvTheme theme) {
         DocumentTextStyle base = theme.bodyStyle();
         DocumentTextStyle nameStyle = theme.bodyBoldStyle();
+        DocumentInsets topMargin = DocumentInsets.top(
+                (float) theme.spacing().paragraphMarginTop());
 
-        // Line 1 — bullet + bold name (markdown still honoured).
-        section.addParagraph(p -> p
-                .textStyle(base)
-                .lineSpacing(theme.typography().bodyLineSpacing())
-                .align(TextAlign.LEFT)
-                .margin(DocumentInsets.top((float) theme.spacing().paragraphMarginTop()))
-                .bulletOffset(BULLET_GLYPH)
-                .indentStrategy(DocumentTextIndent.ALL_LINES)
-                .rich(rich -> MarkdownInline.append(rich, row.label(), nameStyle)));
+        // Line 1 — bullet + bold name.
+        ParagraphPrimitive.writeBulleted(section, row.label(), nameStyle,
+                theme.decoration().bulletGlyph(), topMargin, theme);
 
         if (row.body().isBlank()) {
             return;
         }
         // Line 2 — body indented under name (not under bullet).
-        section.addParagraph(p -> p
-                .textStyle(base)
-                .lineSpacing(theme.typography().bodyLineSpacing())
-                .align(TextAlign.LEFT)
-                .margin(DocumentInsets.zero())
-                .bulletOffset(STACK_INDENT)
-                .indentStrategy(DocumentTextIndent.ALL_LINES)
-                .rich(rich -> MarkdownInline.append(rich, row.body(), base)));
+        ParagraphPrimitive.writeBulleted(section, row.body(), base,
+                theme.decoration().stackedIndent(), DocumentInsets.zero(), theme);
     }
 
     /**
      * Wraps the label in markdown bold markers + trailing colon so the
-     * existing inline-markdown parser emits one bold run for the label
-     * and a regular run for the body without any extra typography
-     * plumbing.
+     * shared markdown helper emits one bold run for the label and a
+     * regular run for the body without any extra typography plumbing.
      */
     private static String labelColonValue(CvRow row) {
         StringBuilder source = new StringBuilder(

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/package-info.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/package-info.java
@@ -1,0 +1,146 @@
+/**
+ * CV Templates v2 — author-facing API.
+ *
+ * <p>This package is the canonical pattern for building CV-style
+ * documents on top of GraphCompose. Below is the conceptual model
+ * every author should hold in their head before writing a template.</p>
+ *
+ * <h2>Four layers, one responsibility each</h2>
+ *
+ * <pre>
+ *   ┌─────────────────────────────────────────────────────────────┐
+ *   │  presets/                                                   │
+ *   │    BoxedSections      ← composition: data + theme + render  │
+ *   │    MinimalUnderlined  ← another composition, same pieces    │
+ *   └─────────────────────────────────────────────────────────────┘
+ *           │ uses                              │ uses
+ *           ▼                                   ▼
+ *   ┌──────────────────────┐         ┌──────────────────────────┐
+ *   │  components/         │         │  theme/                  │
+ *   │    HeadlineRenderer  │ reads   │    CvPalette  (colours)  │
+ *   │    ContactRenderer   │◀────────│    CvTypography (fonts)  │
+ *   │    BannerRenderer    │         │    CvSpacing  (margins)  │
+ *   │    RowRenderer       │         │    CvDecoration (glyphs) │
+ *   │    EntryRenderer     │         │    CvTheme    (bundle)   │
+ *   │    SectionDispatcher │         └──────────────────────────┘
+ *   └──────────────────────┘
+ *           │ renders
+ *           ▼
+ *   ┌─────────────────────────────────────────────────────────────┐
+ *   │  data/                                                      │
+ *   │    CvIdentity   ← name, contact, optional links             │
+ *   │    CvSection    ← sealed: Paragraph | Rows | Entries        │
+ *   │    CvDocument   ← identity + ordered sections               │
+ *   └─────────────────────────────────────────────────────────────┘
+ * </pre>
+ *
+ * <h2>What goes where — when you write your own template</h2>
+ *
+ * <dl>
+ *   <dt><b>{@code data/}</b></dt>
+ *   <dd>The author's content. <em>"What is on the CV?"</em>
+ *       No colours, no fonts, no sizes. Pure records. If you're
+ *       describing a person's job history, this is where you live.</dd>
+ *
+ *   <dt><b>{@code theme/}</b></dt>
+ *   <dd>The cosmetic decisions. <em>"How does it look?"</em>
+ *       Colours, fonts, sizes, margins, glyphs. Swap-able without
+ *       touching renderers. If you want a navy theme or a different
+ *       bullet character, this is where you live.</dd>
+ *
+ *   <dt><b>{@code components/}</b></dt>
+ *   <dd>The reusable drawing primitives. <em>"How is a section
+ *       row laid out?"</em> Each renderer takes a host
+ *       {@code SectionBuilder}, a data record, and a {@code CvTheme}.
+ *       You rarely write a new one — usually you compose the
+ *       existing ones in a new preset.</dd>
+ *
+ *   <dt><b>{@code presets/}</b></dt>
+ *   <dd>The compositions. <em>"In what order, what page flow?"</em>
+ *       A preset picks a theme and orchestrates renderers. Writing
+ *       a new visual style usually means writing a new preset —
+ *       not a new renderer.</dd>
+ * </dl>
+ *
+ * <h2>How to write your own template — 4 steps</h2>
+ *
+ * <h3>Step 1. Build the data</h3>
+ *
+ * <pre>{@code
+ * CvDocument doc = CvDocument.builder()
+ *     .identity(CvIdentity.builder()
+ *         .name("Jane", "Doe")                       // required: first + last
+ *         // .name("Jane", "Quinn", "Doe")            // optional middle
+ *         .contact("+44 0", "j@d.com", "London, UK") // required triple
+ *         .link("LinkedIn", "https://...")            // optional
+ *         .link("GitHub",   "https://...")            // optional
+ *         .build())
+ *     .section(new ParagraphSection("Professional Summary",
+ *         "Backend engineer with **5 years** of..."))
+ *     .section(RowsSection.builder("Technical Skills", RowStyle.BULLETED)
+ *         .row("Languages", "Java 21, Kotlin")
+ *         .row("Testing",   "JUnit 5, AssertJ")
+ *         .build())
+ *     .section(EntriesSection.builder("Experience")
+ *         .entry("Senior Engineer", "Acme Inc", "2022-Present", "Built ...")
+ *         .build())
+ *     .build();
+ * }</pre>
+ *
+ * <h3>Step 2. Pick or build a theme</h3>
+ *
+ * <pre>{@code
+ * // Take the classic look
+ * CvTheme theme = CvTheme.boxedClassic();
+ *
+ * // ... or customise one piece, keep the rest
+ * CvTheme custom = new CvTheme(
+ *     CvPalette.classic(),
+ *     CvTypography.classic(),
+ *     CvSpacing.classic(),
+ *     new CvDecoration("▶ ", "  ", "  ·  "));   // ▶ bullets, mid-dot separators
+ * }</pre>
+ *
+ * <h3>Step 3. Hand to a preset</h3>
+ *
+ * <pre>{@code
+ * DocumentTemplate<CvDocument> template = BoxedSections.create(custom);
+ * }</pre>
+ *
+ * <h3>Step 4. Render</h3>
+ *
+ * <pre>{@code
+ * try (DocumentSession session = GraphCompose.document(outputPath)
+ *         .pageSize(DocumentPageSize.A4)
+ *         .margin(28, 28, 28, 28)
+ *         .create()) {
+ *     template.compose(session, doc);
+ *     session.buildPdf();
+ * }
+ * }</pre>
+ *
+ * <h2>Going further — extension recipes</h2>
+ *
+ * <p>See {@code AUTHORS.md} alongside this package for longer
+ * recipes:</p>
+ * <ul>
+ *   <li>Swap bullet glyph / contact separator / stacked indent</li>
+ *   <li>Build a new theme variant (navy / compact / serif)</li>
+ *   <li>Write a brand-new preset that reuses existing renderers</li>
+ *   <li>Add a brand-new section subtype (compile-checked dispatch)</li>
+ * </ul>
+ *
+ * <h2>What this package is <em>not</em></h2>
+ *
+ * <ul>
+ *   <li>An inheritance hierarchy. Records here are sealed; renderers
+ *       are utility classes. <strong>Compose, don't subclass.</strong></li>
+ *   <li>A free-form layout engine. The engine lives in
+ *       {@code com.demcha.compose.document.engine.*}; this package
+ *       is a thin author-facing layer on top of its public DSL.</li>
+ *   <li>A replacement for v1 yet. The legacy
+ *       {@code com.demcha.compose.document.templates.cv.*} surface is
+ *       untouched; both pipelines coexist while v2 stabilises.</li>
+ * </ul>
+ */
+package com.demcha.compose.document.templates.cv.v2;

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/MinimalUnderlined.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/MinimalUnderlined.java
@@ -1,0 +1,143 @@
+package com.demcha.compose.document.templates.cv.v2.presets;
+
+import com.demcha.compose.document.api.DocumentSession;
+import com.demcha.compose.document.dsl.PageFlowBuilder;
+import com.demcha.compose.document.node.TextAlign;
+import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.document.style.DocumentTextStyle;
+import com.demcha.compose.document.templates.api.DocumentTemplate;
+import com.demcha.compose.document.templates.cv.v2.components.ContactRenderer;
+import com.demcha.compose.document.templates.cv.v2.components.HeadlineRenderer;
+import com.demcha.compose.document.templates.cv.v2.components.SectionDispatcher;
+import com.demcha.compose.document.templates.cv.v2.components.TextOrnaments;
+import com.demcha.compose.document.templates.cv.v2.data.CvDocument;
+import com.demcha.compose.document.templates.cv.v2.data.CvSection;
+import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * v2 demonstration preset — Minimal Underlined.
+ *
+ * <p>Same data model ({@link CvDocument}), same theme tokens
+ * ({@link CvTheme}), same body renderers — but the section header
+ * is drawn as a small left-aligned uppercase title with an
+ * underline rule instead of a centred banner panel.</p>
+ *
+ * <p><strong>Purpose:</strong> show that writing a new preset is a
+ * compositional exercise. The pieces that change:</p>
+ *
+ * <ul>
+ *   <li>{@link com.demcha.compose.document.templates.cv.v2.components.BannerRenderer}
+ *       is <em>not</em> used.</li>
+ *   <li>A small inline paragraph + an {@code accentBottom} draws the
+ *       section title.</li>
+ * </ul>
+ *
+ * <p>Everything else — identity rendering, contact line, section
+ * body dispatch — is the same call into the same components as
+ * {@link BoxedSections}. No code is duplicated, only composed
+ * differently.</p>
+ *
+ * <p>Compare {@code BoxedSections.compose()} and
+ * {@code MinimalUnderlined.compose()} side by side: they are
+ * structurally identical except for the section-title rendering.</p>
+ */
+public final class MinimalUnderlined {
+
+    /** Stable template identifier. */
+    public static final String ID = "minimal-underlined";
+
+    /** Human-readable display name. */
+    public static final String DISPLAY_NAME = "Minimal Underlined";
+
+    /** Recommended page margin (in points). */
+    public static final double RECOMMENDED_MARGIN = 32.0;
+
+    private MinimalUnderlined() {
+    }
+
+    /**
+     * Builds the preset with the classic theme.
+     */
+    public static DocumentTemplate<CvDocument> create() {
+        return create(CvTheme.boxedClassic());
+    }
+
+    /**
+     * Builds the preset with a caller-supplied theme.
+     */
+    public static DocumentTemplate<CvDocument> create(CvTheme theme) {
+        Objects.requireNonNull(theme, "theme");
+        return new Template(theme);
+    }
+
+    private static final class Template implements DocumentTemplate<CvDocument> {
+
+        private final CvTheme theme;
+
+        Template(CvTheme theme) {
+            this.theme = theme;
+        }
+
+        @Override
+        public String id() {
+            return ID;
+        }
+
+        @Override
+        public String displayName() {
+            return DISPLAY_NAME;
+        }
+
+        @Override
+        public void compose(DocumentSession document, CvDocument doc) {
+            Objects.requireNonNull(document, "document");
+            Objects.requireNonNull(doc, "doc");
+
+            PageFlowBuilder pageFlow = document.dsl()
+                    .pageFlow()
+                    .name("CvV2MinimalRoot")
+                    .spacing(theme.spacing().pageFlowSpacing())
+                    .addSection("Headline", section ->
+                            HeadlineRenderer.render(section, doc.identity().name(), theme))
+                    .addSection("Contact", section -> {
+                        section.accentBottom(theme.palette().rule(),
+                                theme.spacing().accentRuleWidth());
+                        ContactRenderer.render(section, doc.identity(), theme);
+                    });
+
+            List<CvSection> sections = doc.sections();
+            for (int i = 0; i < sections.size(); i++) {
+                final CvSection sec = sections.get(i);
+                final int idx = i;
+                pageFlow.addSection("Title_" + idx, host ->
+                        renderUnderlinedTitle(host, sec.title()));
+                pageFlow.addSection("Body_" + idx, host ->
+                        SectionDispatcher.renderBody(host, sec, theme));
+            }
+
+            pageFlow.build();
+        }
+
+        /**
+         * The one piece that differs from {@link BoxedSections}: a
+         * small left-aligned uppercase title with a thin underline,
+         * in place of the centred banner panel.
+         */
+        private void renderUnderlinedTitle(
+                com.demcha.compose.document.dsl.SectionBuilder host,
+                String title) {
+            DocumentTextStyle titleStyle = theme.entryTitleStyle();
+            host.accentBottom(theme.palette().rule(),
+                            theme.spacing().accentRuleWidth())
+                    .padding(new DocumentInsets(8, 0, 2, 0))
+                    .addParagraph(p -> p
+                            .text(TextOrnaments.spacedUpper(title))
+                            .textStyle(titleStyle)
+                            .align(TextAlign.LEFT)
+                            .margin(DocumentInsets.zero()));
+        }
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/theme/CvDecoration.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/theme/CvDecoration.java
@@ -1,0 +1,50 @@
+package com.demcha.compose.document.templates.cv.v2.theme;
+
+import java.util.Objects;
+
+/**
+ * Glyph / separator tokens for a {@link CvTheme} — the small "what
+ * character renders here" decisions that vary per visual flavour but
+ * never depend on the layout or the data.
+ *
+ * <p>This is the answer to "I want to swap the bullet from {@code •}
+ * to {@code ▶}", "I want to use {@code  · } as the contact-line
+ * separator instead of pipes", or "I want stacked-body lines to align
+ * with a 3-space indent instead of 2". None of these need a custom
+ * renderer — pass a different {@code CvDecoration} into your theme.</p>
+ *
+ * <p>Decorations live in the {@code theme} layer because they are
+ * cosmetic. They are <strong>not</strong> renderer constants:
+ * components like {@code RowRenderer} and {@code ContactRenderer}
+ * read these strings from the active theme on every call.</p>
+ *
+ * @param bulletGlyph      glyph + trailing space used by row styles
+ *                         that draw a bullet
+ *                         (e.g. {@code "• "}, {@code "▶ "})
+ * @param stackedIndent    string prefix used for the second line of a
+ *                         {@code BULLETED_STACKED} row — must visually
+ *                         occupy the same width as
+ *                         {@link #bulletGlyph} so wrapped body text
+ *                         aligns with the bold name above
+ * @param contactSeparator string used between phone / email /
+ *                         address / links on the contact row
+ *                         (e.g. {@code "   |   "}, {@code "  ·  "})
+ */
+public record CvDecoration(String bulletGlyph,
+                           String stackedIndent,
+                           String contactSeparator) {
+
+    public CvDecoration {
+        Objects.requireNonNull(bulletGlyph, "bulletGlyph");
+        Objects.requireNonNull(stackedIndent, "stackedIndent");
+        Objects.requireNonNull(contactSeparator, "contactSeparator");
+    }
+
+    /**
+     * The classic decoration: round bullet, two-space stacked indent,
+     * pipe contact separator. Used by {@link CvTheme#boxedClassic()}.
+     */
+    public static CvDecoration classic() {
+        return new CvDecoration("• ", "  ", "   |   ");
+    }
+}

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/theme/CvTheme.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/theme/CvTheme.java
@@ -26,26 +26,46 @@ import java.util.Objects;
  */
 public record CvTheme(CvPalette palette,
                       CvTypography typography,
-                      CvSpacing spacing) {
+                      CvSpacing spacing,
+                      CvDecoration decoration) {
 
     public CvTheme {
         Objects.requireNonNull(palette, "palette");
         Objects.requireNonNull(typography, "typography");
         Objects.requireNonNull(spacing, "spacing");
+        Objects.requireNonNull(decoration, "decoration");
+    }
+
+    /**
+     * Backward-compatible 3-arg constructor that fills the
+     * {@link CvDecoration} slot with {@link CvDecoration#classic()}.
+     * Retained so callers built before the decoration token landed
+     * keep compiling and behaving identically.
+     *
+     * @deprecated since the introduction of {@link CvDecoration} —
+     *             pass an explicit decoration so callers can choose
+     *             a different bullet glyph or contact separator
+     *             without forking the renderer.
+     */
+    @Deprecated
+    public CvTheme(CvPalette palette, CvTypography typography, CvSpacing spacing) {
+        this(palette, typography, spacing, CvDecoration.classic());
     }
 
     // -- canonical factories ---------------------------------------------
 
     /**
      * The "Boxed Sections" classic look — PT-Serif, near-black ink,
-     * pale-grey section banners. Visual signature of the original
+     * pale-grey section banners, round bullets, pipe contact
+     * separators. Visual signature of the original
      * {@code cv-boxed-sections.pdf} reference output.
      */
     public static CvTheme boxedClassic() {
         return new CvTheme(
                 CvPalette.classic(),
                 CvTypography.classic(),
-                CvSpacing.classic());
+                CvSpacing.classic(),
+                CvDecoration.classic());
     }
 
     // -- pre-built text-style helpers ------------------------------------

--- a/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/MinimalUnderlinedSmokeTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/MinimalUnderlinedSmokeTest.java
@@ -1,0 +1,71 @@
+package com.demcha.compose.document.templates.cv.v2.presets;
+
+import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.api.DocumentSession;
+import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.document.templates.api.DocumentTemplate;
+import com.demcha.compose.document.templates.cv.v2.data.CvDocument;
+import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
+import com.demcha.compose.document.templates.cv.v2.data.EntriesSection;
+import com.demcha.compose.document.templates.cv.v2.data.ParagraphSection;
+import com.demcha.compose.document.templates.cv.v2.data.RowStyle;
+import com.demcha.compose.document.templates.cv.v2.data.RowsSection;
+import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Smoke test for the v2 MinimalUnderlined preset. Demonstrates that
+ * the same {@link CvDocument} renders cleanly through a different
+ * composition of the existing components.
+ */
+class MinimalUnderlinedSmokeTest {
+
+    @Test
+    void exposes_stable_identity() {
+        DocumentTemplate<CvDocument> template = MinimalUnderlined.create();
+        assertThat(template.id()).isEqualTo("minimal-underlined");
+        assertThat(template.displayName()).isEqualTo("Minimal Underlined");
+    }
+
+    @Test
+    void default_factory_renders_full_document() throws Exception {
+        DocumentTemplate<CvDocument> template = MinimalUnderlined.create();
+        try (DocumentSession session = GraphCompose.document()
+                .pageSize(420, 595)
+                .margin(DocumentInsets.of(24))
+                .create()) {
+            template.compose(session, fullDocument());
+            assertThat(session.roots()).isNotEmpty();
+        }
+    }
+
+    @Test
+    void custom_theme_factory_renders() throws Exception {
+        DocumentTemplate<CvDocument> template =
+                MinimalUnderlined.create(CvTheme.boxedClassic());
+        try (DocumentSession session = GraphCompose.document()
+                .pageSize(420, 595)
+                .margin(DocumentInsets.of(24))
+                .create()) {
+            template.compose(session, fullDocument());
+            assertThat(session.roots()).isNotEmpty();
+        }
+    }
+
+    private static CvDocument fullDocument() {
+        return CvDocument.builder()
+                .identity(CvIdentity.builder()
+                        .name("Jane", "Doe")
+                        .contact("+44 0", "j@d.com", "London")
+                        .build())
+                .sections(
+                        new ParagraphSection("Summary", "body"),
+                        RowsSection.builder("Skills", RowStyle.BULLETED)
+                                .row("Languages", "Java").build(),
+                        EntriesSection.builder("Experience")
+                                .entry("Engineer", "Acme", "2020", "did stuff").build())
+                .build();
+    }
+}

--- a/src/test/java/com/demcha/compose/document/templates/cv/v2/theme/CvDecorationTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/v2/theme/CvDecorationTest.java
@@ -1,0 +1,62 @@
+package com.demcha.compose.document.templates.cv.v2.theme;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CvDecorationTest {
+
+    @Test
+    void classic_carries_the_canonical_glyphs() {
+        CvDecoration d = CvDecoration.classic();
+        assertThat(d.bulletGlyph()).isEqualTo("• ");
+        assertThat(d.stackedIndent()).isEqualTo("  ");
+        assertThat(d.contactSeparator()).isEqualTo("   |   ");
+    }
+
+    @Test
+    void rejects_null_field() {
+        assertThatThrownBy(() -> new CvDecoration(null, "  ", " | "))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("bulletGlyph");
+    }
+
+    @Test
+    void custom_decoration_is_carried_verbatim() {
+        CvDecoration d = new CvDecoration("▶ ", "   ", "  ·  ");
+        assertThat(d.bulletGlyph()).isEqualTo("▶ ");
+        assertThat(d.stackedIndent()).isEqualTo("   ");
+        assertThat(d.contactSeparator()).isEqualTo("  ·  ");
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void deprecated_three_arg_theme_constructor_supplies_classic_decoration() {
+        // The pre-decoration call shape must keep working and yield
+        // the classic decoration, so older callers keep rendering
+        // pixel-identical output.
+        CvTheme theme = new CvTheme(
+                CvPalette.classic(),
+                CvTypography.classic(),
+                CvSpacing.classic());
+        assertThat(theme.decoration()).isEqualTo(CvDecoration.classic());
+    }
+
+    @Test
+    void canonical_four_arg_theme_constructor_carries_custom_decoration() {
+        CvDecoration custom = new CvDecoration("· ", "  ", "  /  ");
+        CvTheme theme = new CvTheme(
+                CvPalette.classic(),
+                CvTypography.classic(),
+                CvSpacing.classic(),
+                custom);
+        assertThat(theme.decoration()).isSameAs(custom);
+    }
+
+    @Test
+    void boxedClassic_carries_classic_decoration() {
+        assertThat(CvTheme.boxedClassic().decoration())
+                .isEqualTo(CvDecoration.classic());
+    }
+}


### PR DESCRIPTION
## Summary

Builds on top of #45. Three additions that preserve the existing v2
public API while making the package easier to extend and easier to
learn from.

> ⚠️ **Merge order: this PR depends on #45.** GitHub will reduce the
> diff to the polish-only commit once #45 is merged.

## 1. `CvDecoration` theme sub-record

New `CvDecoration(bulletGlyph, stackedIndent, contactSeparator)`
captures the glyph-level cosmetic choices that used to be hard-coded
inside `RowRenderer` / `ContactRenderer`.

- `CvTheme` gains a 4-arg canonical constructor + a `@Deprecated` 3-arg
  constructor that fills `CvDecoration.classic()` — so callers from #45
  keep compiling and rendering identically.
- Swapping `•` → `▶` is now a theme change, no renderer fork.

## 2. `ParagraphPrimitive` (package-private helper)

Consolidates the `addParagraph(p -> p.textStyle().lineSpacing().align()
.margin().rich(...))` skeleton that was duplicated across
`ParagraphRenderer`, `RowRenderer` (both branches), and `EntryRenderer`
(subtitle + body). Exposes three convenience methods (`writeBody`,
`writeBulleted`, `writeSubtitle`) plus a full-control `write()`.

**Public signatures of the renderers are unchanged.**

## 3. `MinimalUnderlined` demo preset + author docs

- `presets/MinimalUnderlined.java` — second preset using the **same**
  data, **same** theme tokens, **same** component renderers as
  `BoxedSections` but a different page-flow composition. Proves
  components are reusable across presets.
- Expanded `cv/v2/package-info.java` with the 4-step author workflow.
- New `cv/v2/AUTHORS.md` with 7 recipes: change bullet, change
  colours, build a new preset, add a new section subtype, conditional
  sections, style guide, do's and don'ts.

## Test plan

- [x] `CvDecorationTest` (6 tests)
- [x] `MinimalUnderlinedSmokeTest` (3 tests)
- [x] Total v2 tests: **24/24 pass** (15 from #45 + 9 new)
- [x] `cv-boxed-sections-v2.pdf` still pixel-identical to legacy reference
- [x] `cv-minimal-underlined.pdf` renders cleanly
- [ ] CI green