### PR TITLE
docs(templates-layered): comprehensive guide for v2 layered architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,8 +189,9 @@ document.pageFlow().addCanvas(523, 360, canvas -> canvas
 
 ## Documentation
 
-- [Template authoring cheatsheet](./docs/template-authoring.md) &mdash; read this once before writing your own template
-- [Templates v2 landing](./docs/templates-v2.md) &mdash; CV / cover-letter / invoice / proposal preset library
+- 🆕 [**Templates — layered architecture**](./docs/templates-layered/README.md) &mdash; the canonical going-forward pattern for new template families (CV v2 is the reference implementation). Personas: [quickstart](./docs/templates-layered/quickstart.md) · [using templates](./docs/templates-layered/using-templates.md) · [authoring presets](./docs/templates-layered/authoring-presets.md) · [contributing a new family](./docs/templates-layered/contributor-guide.md).
+- [Template authoring cheatsheet](./docs/template-authoring.md) &mdash; read this once before writing your own template (covers v1 template surface)
+- [Templates v2 landing](./docs/templates-v2.md) &mdash; CV / cover-letter / invoice / proposal preset library (v1 surface, still shipped)
 - [Examples gallery](./examples/README.md) &mdash; every runnable example with PDF preview
 - [Architecture](./docs/architecture.md) · [Lifecycle](./docs/lifecycle.md) · [Production rendering](./docs/production-rendering.md)
 - Recipes: [shape-as-container](./docs/recipes/shape-as-container.md) · [transforms](./docs/recipes/transforms.md) · [tables](./docs/recipes/tables.md) · [themes](./docs/recipes/themes.md) · [streaming](./docs/recipes/streaming.md) · [extending](./docs/recipes/extending.md)

--- a/docs/templates-layered/README.md
+++ b/docs/templates-layered/README.md
@@ -1,0 +1,118 @@
+# Templates — Layered Architecture
+
+The **canonical going-forward pattern** for building business documents
+on GraphCompose. CV is the reference implementation today
+(`com.demcha.compose.document.templates.cv.v2`); invoice, cover-letter,
+proposal, and any new template family will follow the same shape as
+they're migrated.
+
+This is the entry point. Pick the doc that matches your goal.
+
+---
+
+## Pick your path
+
+### 🆕 You're new to GraphCompose and templates
+Start with **[quickstart.md](quickstart.md)** — 5 minutes of orientation:
+what GraphCompose templates are, why they're layered, and a copy-paste
+example that renders a CV to a PDF.
+
+### 👤 You want to render a document with your own data
+You like an existing preset (Boxed Sections, Minimal Underlined,
+Modern Professional). Now you just want to feed it your name, your
+experience, your skills.
+
+→ **[using-templates.md](using-templates.md)**
+
+You'll learn the `CvDocument` builder API, the three section types
+(paragraph / rows / entries), how slots place sections into columns,
+and how to swap a theme (colours / fonts / glyphs) without forking a
+preset.
+
+### 🎨 You want a custom visual style on top of v2
+Existing presets aren't quite your design. You want a new look —
+different section title style, different alignment, different colour
+palette — but still using the v2 building blocks.
+
+→ **[authoring-presets.md](authoring-presets.md)**
+
+You'll learn the **widget cookbook** (`Headline`, `ContactLine`,
+`SectionHeader`), the 12-line `compose()` pattern, when to drop down to
+inline DSL, and how to ship a new preset as ~150 lines that anyone can
+read end-to-end.
+
+### 🛠 You're adding a new template family to the library
+You're a GraphCompose maintainer or contributor. You want to bring
+invoice-v2, cover-letter-v2, or a new document type onto the same
+5-layer pattern that CV uses.
+
+→ **[contributor-guide.md](contributor-guide.md)**
+
+You'll get the package convention (`<name>/v2/data` /
+`theme` / `components` / `widgets` / `presets`), naming rules, test
+expectations, doc expectations, and a worked checklist for a new
+template family from empty folder to merged PR.
+
+---
+
+## The 5-layer pattern at a glance
+
+```
+presets/      composition: data + theme + widgets → DocumentTemplate
+   │ compose from
+   ▼
+widgets/      LEGO bricks: Headline, ContactLine, SectionHeader, …
+   │ delegate to                                  read tokens from
+   ▼                                              ▼
+components/   internal renderers + primitives    theme/    palette
+                                                            typography
+                                                            spacing
+                                                            decoration
+   │ render
+   ▼
+data/         records describing what to render (no styling)
+```
+
+Every layer has **one job**. Layers below don't know about layers
+above. Adding a new theme variant, a new widget, a new section
+subtype, or a new preset each touches one layer and leaves the
+others alone.
+
+The detailed contract for each layer is in
+[contributor-guide.md](contributor-guide.md).
+
+---
+
+## What this pattern is *not*
+
+- ❌ **Not a migration mandate.** Existing v1 templates
+  (`cv/spec`, `cv/builder`, `cv/presets`) continue to work and
+  ship. The layered pattern is for **new** templates and major
+  rewrites.
+- ❌ **Not a framework with magic.** Every file is plain
+  Java records + static helpers. No reflection, no annotations,
+  no codegen.
+- ❌ **Not coupled to CV.** The pattern is domain-agnostic; CV is
+  just the first family migrated. Invoice or cover-letter would
+  use the same five folders with their own data shapes inside.
+- ❌ **Not a UI framework.** No state, no events, no lifecycle.
+  Templates render static PDFs from immutable data.
+
+---
+
+## See also
+
+- **Per-package JavaDocs**:
+  [`cv/v2/package-info.java`](../../src/main/java/com/demcha/compose/document/templates/cv/v2/package-info.java)
+  has the ASCII diagram and 4-step author walkthrough.
+- **AUTHORS.md**:
+  [`cv/v2/AUTHORS.md`](../../src/main/java/com/demcha/compose/document/templates/cv/v2/AUTHORS.md)
+  is the recipe cookbook — 7 hands-on recipes from "change a bullet
+  glyph" to "add a new section subtype".
+- **Examples**:
+  [`examples/cv/v2/`](../../examples/src/main/java/com/demcha/examples/templates/cv/v2)
+  has three runnable rendering examples — one per shipped preset.
+- **Legacy v1 surface**:
+  [`docs/templates-v2.md`](../templates-v2.md) describes the older
+  spec / preset / theme split used by the v1 templates. Still valid
+  for the v1 packages; superseded by this guide for v2 work.

--- a/docs/templates-layered/authoring-presets.md
+++ b/docs/templates-layered/authoring-presets.md
@@ -1,0 +1,350 @@
+# Authoring Presets — write your own visual style
+
+You like the layered architecture, but the three shipped presets
+(`BoxedSections`, `MinimalUnderlined`, `ModernProfessional`) don't
+match the design you want. This doc walks you through writing a
+new preset from scratch — **without subclassing, without duplicating
+rendering code**.
+
+If you haven't read [quickstart.md](quickstart.md) and
+[using-templates.md](using-templates.md), do those first.
+
+---
+
+## Table of contents
+
+1. [The core idea — compose, don't subclass](#the-core-idea)
+2. [The widget catalog](#the-widget-catalog)
+3. [Anatomy of a preset](#anatomy-of-a-preset)
+4. [Full worked example — `CardStyle` preset](#full-worked-example)
+5. [When the widget doesn't fit — go inline](#when-the-widget-doesnt-fit)
+6. [Three layers of widget customisation](#three-layers-of-widget-customisation)
+7. [Adding a new widget — the test of when](#adding-a-new-widget)
+8. [Tests + render parity](#tests--render-parity)
+
+---
+
+<a id="the-core-idea"></a>
+## The core idea — compose, don't subclass
+
+A preset is one `public final class` (no inheritance) with a
+`create()` factory that returns a `DocumentTemplate<CvDocument>`.
+Inside, `compose()` is the orchestration method: it sequences
+**widgets** in a page flow.
+
+```java
+@Override
+public void compose(DocumentSession document, CvDocument doc) {
+    document.dsl().pageFlow()
+        .name("MyPresetRoot")
+        .spacing(theme.spacing().pageFlowSpacing())
+        .addSection("Headline", s -> Headline.spacedCentered(s, doc.identity().name(), theme))
+        .addSection("Contact",  s -> ContactLine.centered(s, doc.identity(), theme));
+
+    for (CvSection sec : doc.sectionsIn(Slot.MAIN)) {
+        pageFlow
+            .addSection("Title", s -> SectionHeader.banner(s, sec.title(), theme))
+            .addSection("Body",  s -> SectionDispatcher.renderBody(s, sec, theme));
+    }
+    pageFlow.build();
+}
+```
+
+That's the **entire** rendering decision tree. ~12 lines. No DSL
+plumbing. No private `renderXxx` methods. Each line is a single
+visual decision you can read like a recipe.
+
+---
+
+<a id="the-widget-catalog"></a>
+## The widget catalog
+
+Today, three widget classes live in
+`com.demcha.compose.document.templates.cv.v2.widgets`. Each has 2-3
+named variants.
+
+### `Headline` — top-of-document name
+
+| Variant | Visual |
+|---|---|
+| `Headline.spacedCentered(host, name, theme)` | Centred letter-spaced uppercase (`J A N E   D O E`) |
+| `Headline.rightAligned(host, name, theme)` | Right-aligned plain bold (`Jane Doe`) |
+| `Headline.render(host, name, theme, align, spacedCaps)` | Low-level — any (alignment, transform) combo |
+
+### `ContactLine` — phone / email / address / links row
+
+| Variant | Visual |
+|---|---|
+| `ContactLine.centered(host, identity, theme)` | Centred, phone → email → address → links |
+| `ContactLine.rightAligned(host, identity, theme)` | Right-aligned, address → phone → email → links |
+| `ContactLine.render(host, identity, theme, align, order)` | Low-level — any alignment + field-order combo |
+
+### `SectionHeader` — title above each section body
+
+| Variant | Visual |
+|---|---|
+| `SectionHeader.banner(host, title, theme)` | Pale-grey panel + centred spaced-caps inside |
+| `SectionHeader.underlined(host, title, theme)` | Small left spaced-caps + thin rule below |
+| `SectionHeader.flat(host, title, color, theme)` | Large bold title in a given colour, no panel |
+
+The separator glyph used by `ContactLine`, the bullet glyph used by
+`RowRenderer`, and other character-level choices come from
+`theme.decoration()` — swap a `CvDecoration` to change them
+globally.
+
+---
+
+<a id="anatomy-of-a-preset"></a>
+## Anatomy of a preset
+
+Every preset is the same skeleton:
+
+```java
+public final class MyPreset {
+
+    public static final String ID            = "my-preset";
+    public static final String DISPLAY_NAME  = "My Preset";
+    public static final double RECOMMENDED_MARGIN = 28.0;
+
+    private MyPreset() { }
+
+    public static DocumentTemplate<CvDocument> create() {
+        return create(CvTheme.boxedClassic());
+    }
+
+    public static DocumentTemplate<CvDocument> create(CvTheme theme) {
+        Objects.requireNonNull(theme, "theme");
+        return new Template(theme);
+    }
+
+    private static final class Template implements DocumentTemplate<CvDocument> {
+        private final CvTheme theme;
+        Template(CvTheme theme) { this.theme = theme; }
+
+        @Override public String id()          { return ID; }
+        @Override public String displayName() { return DISPLAY_NAME; }
+
+        @Override
+        public void compose(DocumentSession document, CvDocument doc) {
+            // ← the only place that varies between presets
+        }
+    }
+}
+```
+
+Two factories (`create()` and `create(CvTheme)`), three constants
+(`ID`, `DISPLAY_NAME`, `RECOMMENDED_MARGIN`), one inner `Template`
+class implementing `DocumentTemplate<CvDocument>`. Stable.
+
+---
+
+<a id="full-worked-example"></a>
+## Full worked example — `CardStyle` preset
+
+Suppose you want a preset where each section is wrapped in a soft
+card with a coloured left accent stripe. Here's the full preset.
+
+```java
+public final class CardStyle {
+
+    public static final String ID            = "card-style";
+    public static final String DISPLAY_NAME  = "Card Style";
+    public static final double RECOMMENDED_MARGIN = 24.0;
+
+    private static final DocumentColor ACCENT = DocumentColor.rgb(33, 150, 243);
+
+    private CardStyle() { }
+
+    public static DocumentTemplate<CvDocument> create() {
+        return create(CvTheme.boxedClassic());
+    }
+
+    public static DocumentTemplate<CvDocument> create(CvTheme theme) {
+        Objects.requireNonNull(theme, "theme");
+        return new Template(theme);
+    }
+
+    private static final class Template implements DocumentTemplate<CvDocument> {
+
+        private final CvTheme theme;
+        Template(CvTheme theme) { this.theme = theme; }
+
+        @Override public String id()          { return ID; }
+        @Override public String displayName() { return DISPLAY_NAME; }
+
+        @Override
+        public void compose(DocumentSession document, CvDocument doc) {
+            PageFlowBuilder pageFlow = document.dsl().pageFlow()
+                .name("CardStyleRoot")
+                .spacing(8)
+                .addSection("Headline", s ->
+                    Headline.rightAligned(s, doc.identity().name(), theme))
+                .addSection("Contact", s ->
+                    ContactLine.rightAligned(s, doc.identity(), theme));
+
+            for (CvSection sec : doc.sectionsIn(Slot.MAIN)) {
+                pageFlow.addSection("Card", host -> {
+                    host.accentLeft(ACCENT, 3.0)             // ← the "card" stripe
+                        .padding(new DocumentInsets(8, 12, 8, 12));
+                    SectionHeader.flat(host, sec.title(), ACCENT, theme);
+                    SectionDispatcher.renderBody(host, sec, theme);
+                });
+            }
+            pageFlow.build();
+        }
+    }
+}
+```
+
+**Forty-five lines** including the boilerplate. Everything that
+makes it visually distinct is in `compose()`:
+
+- right-aligned headline (existing widget)
+- right-aligned contact (existing widget)
+- a custom "card" wrapper around each section (inline — uses DSL
+  `accentLeft` + `padding` directly)
+- flat coloured section title (existing widget, given `ACCENT`)
+- body rendered via the dispatcher (no custom rendering)
+
+You used **three widgets** (`Headline`, `ContactLine`,
+`SectionHeader`) plus **two inline DSL calls** (`accentLeft` and
+`padding`) to build the card shape. No private `renderXxx`. No
+duplicated rendering.
+
+---
+
+<a id="when-the-widget-doesnt-fit"></a>
+## When the widget doesn't fit — go inline
+
+Widgets are **optional helpers**, not required wrappers. If your
+preset needs something the catalog doesn't cover, **inline it**.
+
+Example: `ModernProfessional` uses preset-specific colours
+(slate-blue name, royal-blue link underlines) that no widget
+default knows about. Its `renderHeader` and `renderContact` stay
+inline — only `renderSectionTitle` uses a widget
+(`SectionHeader.flat(..., SECTION_TITLE_COLOR, theme)` because that
+widget takes a colour parameter).
+
+```java
+private void renderHeader(SectionBuilder section, CvIdentity identity) {
+    DocumentTextStyle nameStyle = DocumentTextStyle.builder()
+        .fontName(FontName.HELVETICA_BOLD)
+        .size(theme.typography().sizeHeadline())
+        .color(NAME_COLOR)
+        .build();
+
+    section.addParagraph(p -> p
+        .text(identity.name().full())
+        .textStyle(nameStyle)
+        .align(TextAlign.RIGHT)
+        .margin(DocumentInsets.zero()));
+}
+```
+
+This is fine. **Widgets coexist with inline DSL** in the same
+`compose()`. If you see the same inline rendering repeating across
+**2+ presets**, *then* extract a widget — not before.
+
+---
+
+<a id="three-layers-of-widget-customisation"></a>
+## Three layers of widget customisation
+
+Every widget exposes three layers, escalating from convenience to
+control:
+
+### Layer 1 — convenience factory (covers ~80% of cases)
+
+```java
+Headline.spacedCentered(host, name, theme);
+```
+
+One line. No params beyond `(host, content, theme)`.
+
+### Layer 2 — `.render(...)` with parameters (covers ~15%)
+
+```java
+Headline.render(host, name, theme, TextAlign.LEFT, /* spacedCaps */ false);
+```
+
+Same widget, fully parameterised. Use when the convenience method
+doesn't match your need but the widget shape is right.
+
+### Layer 3 — inline DSL (covers ~5%)
+
+```java
+section.addParagraph(p -> p
+    .text(name.full())
+    .textStyle(myCustomStyle)
+    .align(TextAlign.RIGHT));
+```
+
+Bypass the widget entirely. Use when no widget shape fits.
+
+**Don't fight the widget API.** If Layer 1 fits, use Layer 1. If
+not, try Layer 2. If still not, go inline. That's the design.
+
+---
+
+<a id="adding-a-new-widget"></a>
+## Adding a new widget — the test of when
+
+| Pattern repetition across presets | Action |
+|---|---|
+| 1 preset only | Inline. Don't extract. |
+| 2 presets | Add a new factory method to an existing widget, OR add a parameter to `.render(...)`. |
+| 3+ presets | It's its own widget — new class in `cv/v2/widgets/`. |
+
+Don't predict — extract. Premature widgets are noise; they add API
+surface that nobody calls.
+
+When you do add a new widget:
+
+1. **One file per widget** in `cv/v2/widgets/`.
+2. **`public final class`** with a private constructor.
+3. **2-3 named factories** + a lower-level `.render(...)`.
+4. **First parameter is always `SectionBuilder host`**.
+5. **Last parameter is always `CvTheme theme`**.
+6. **No instance state** — all static, all stateless.
+7. **JavaDoc the visual** — what does this look like? Who uses it?
+8. **Add to `WidgetSmokeTest`** with a basic "renders without
+   throwing" check.
+
+---
+
+<a id="tests--render-parity"></a>
+## Tests + render parity
+
+A new preset needs at least:
+
+1. **Smoke test** in `src/test/.../cv/v2/presets/MyPresetSmokeTest.java`:
+   - `exposes_stable_identity` — checks `id()` and `displayName()`
+   - `default_factory_renders` — calls `create().compose(...)` with
+     a full sample document, asserts `session.roots()` is non-empty
+   - `custom_theme_renders` — same but with `create(theme)`
+   - `renders_with_classic_theme_too` — proves the preset doesn't
+     depend on theme-specific tokens
+
+2. **Example runner** in
+   `examples/src/main/java/com/demcha/examples/templates/cv/v2/CvMyPresetExample.java`:
+   - Renders to `examples/target/generated-pdfs/templates/cv/cv-my-preset.pdf`
+   - Uses `ExampleDataFactory.sampleCvDocumentV2()` for content
+
+3. **Eyeball the rendered PDF** — does it match your design
+   intent? Are sections in the right slots? Is page break sensible?
+
+A future Phase will add PDF/PNG snapshot diffing so visual
+regressions break the build. Until then, render parity is by-hand.
+
+---
+
+## Next step
+
+→ Want to add a brand-new template family (invoice-v2,
+cover-letter-v2) following the same layered shape?
+[**contributor-guide.md**](contributor-guide.md)
+
+→ The full recipe cookbook (with code for every customisation
+combo):
+[`cv/v2/AUTHORS.md`](../../src/main/java/com/demcha/compose/document/templates/cv/v2/AUTHORS.md)

--- a/docs/templates-layered/contributor-guide.md
+++ b/docs/templates-layered/contributor-guide.md
@@ -1,0 +1,360 @@
+# Contributor Guide — add a new template family
+
+You're a GraphCompose contributor and you want to bring a brand-new
+document type onto the layered architecture — invoice-v2,
+cover-letter-v2, report-v2, anything that isn't CV. This doc is
+your checklist + convention reference.
+
+It assumes you've read [quickstart.md](quickstart.md) and
+[authoring-presets.md](authoring-presets.md) — those explain *why*
+the layered pattern looks the way it does.
+
+---
+
+## Table of contents
+
+1. [The 5-layer convention](#the-5-layer-convention)
+2. [Package map for a new family](#package-map-for-a-new-family)
+3. [Naming rules](#naming-rules)
+4. [Worked walkthrough — `invoice/v2`](#worked-walkthrough)
+5. [Required deliverables](#required-deliverables)
+6. [Test checklist](#test-checklist)
+7. [Doc checklist](#doc-checklist)
+8. [What you must NOT do](#what-you-must-not-do)
+9. [PR review expectations](#pr-review-expectations)
+
+---
+
+<a id="the-5-layer-convention"></a>
+## The 5-layer convention
+
+Every new template family lives under
+`com.demcha.compose.document.templates.<family>.v2` with **exactly
+five sub-packages**:
+
+```
+<family>/v2/
+├── data/         records describing what's on the page
+├── theme/        cosmetic tokens (palette, typography, spacing, decoration)
+├── components/   internal renderers + low-level primitives
+├── widgets/      reusable visual LEGO bricks
+└── presets/      composition: data + theme + widgets → DocumentTemplate
+```
+
+Each layer's contract:
+
+| Layer | Contract |
+|---|---|
+| `data/` | Pure records. Zero dependencies on rendering, theming, or DSL. Sealed hierarchy for section / block subtypes. |
+| `theme/` | Records + factories. No rendering logic. Aggregate root is `<Family>Theme(palette, typography, spacing, decoration)`. |
+| `components/` | Static helpers. Take `(host, data, theme)`. No statics holding state. No magic numbers — read tokens from theme. |
+| `widgets/` | Static helpers. Named factory methods per visual variant. Compose internally from `components/`. |
+| `presets/` | One `public final class` per visual style. Two factories: `create()` and `create(<Family>Theme)`. Inner `Template` implements `DocumentTemplate<<Family>Document>`. |
+
+**The convention is the same regardless of domain.** A cv has
+identity + sections; an invoice has parties + line items + totals; a
+proposal has scope + pricing + acceptance terms. The *shape* of the
+data differs; the *layering* is identical.
+
+---
+
+<a id="package-map-for-a-new-family"></a>
+## Package map for a new family
+
+Mirror the CV v2 layout. Concrete example for invoice:
+
+```
+src/main/java/com/demcha/compose/document/templates/invoice/v2/
+├── package-info.java                   ← ASCII diagram + 4-step walkthrough
+├── AUTHORS.md                          ← recipe cookbook
+├── data/
+│   ├── package-info.java
+│   ├── InvoiceDocument.java            ← root record
+│   ├── InvoiceParty.java               ← from / bill-to
+│   ├── InvoiceLine.java                ← line item record
+│   ├── InvoiceTotals.java              ← subtotal / tax / total
+│   ├── InvoiceSection.java             ← sealed interface
+│   ├── HeaderSection.java              ← concrete subtype
+│   ├── LineItemsSection.java           ← concrete subtype
+│   ├── TotalsSection.java              ← concrete subtype
+│   ├── NotesSection.java               ← concrete subtype
+│   └── Slot.java                       ← if multi-column variants needed
+├── theme/
+│   ├── package-info.java
+│   ├── InvoicePalette.java             ← ink / muted / rule / accent
+│   ├── InvoiceTypography.java          ← scale
+│   ├── InvoiceSpacing.java             ← margins, gaps
+│   ├── InvoiceDecoration.java          ← row separators, totals divider
+│   └── InvoiceTheme.java               ← aggregate + factories
+├── components/
+│   ├── package-info.java
+│   ├── ParagraphPrimitive.java         ← internal — package-private
+│   ├── LineRowRenderer.java            ← one line item row
+│   ├── TotalsBlockRenderer.java        ← right-aligned totals stack
+│   ├── PartyBlockRenderer.java         ← from / bill-to address block
+│   ├── SectionDispatcher.java          ← branches on sealed subtype
+│   └── … (other internal renderers)
+├── widgets/
+│   ├── package-info.java
+│   ├── Letterhead.java                 ← top-of-doc invoice header
+│   ├── PartyPair.java                  ← from + bill-to side-by-side
+│   ├── LineTable.java                  ← line items table
+│   └── TotalsCard.java                 ← totals summary
+└── presets/
+    ├── package-info.java
+    ├── ClassicInvoice.java             ← reference preset
+    └── (more as added)
+```
+
+The structure is **identical** to cv/v2 — only the records inside
+differ.
+
+---
+
+<a id="naming-rules"></a>
+## Naming rules
+
+- **Family prefix** on top-level records to avoid name collisions.
+  CV uses `CvName`, `CvContact`, `CvTheme`. Invoice should use
+  `InvoiceParty`, `InvoiceLine`, `InvoiceTheme`. Cover letter:
+  `CoverLetterRecipient`, `CoverLetterTheme`. Etc.
+- **`<Family>Document`** for the root record. (`CvDocument`,
+  `InvoiceDocument`, `CoverLetterDocument`.)
+- **`<Family>Section` (sealed)** for the body content hierarchy.
+- **`<Family>Theme(palette, typography, spacing, decoration)`** for
+  the aggregate theme record.
+- **Widgets** are domain-specific verbs / nouns describing the
+  visual: `Headline`, `ContactLine`, `SectionHeader` (CV);
+  `Letterhead`, `LineTable`, `TotalsCard` (invoice). Don't try to
+  share widget names across families — they capture different
+  visual ideas.
+- **Presets** are descriptive proper-noun names: `BoxedSections`,
+  `ModernProfessional`, `ClassicInvoice`, `MinimalLetter`. Avoid
+  generic names like `Default` or `Standard`.
+
+---
+
+<a id="worked-walkthrough"></a>
+## Worked walkthrough — `invoice/v2`
+
+Order to write things in:
+
+### 1. `data/` first (no rendering deps)
+
+```java
+public record InvoiceDocument(
+    InvoiceParty issuer,
+    InvoiceParty recipient,
+    String invoiceNumber,
+    String issueDate,
+    String dueDate,
+    List<InvoiceSection> sections) {
+    // builder, validation, accessors
+}
+
+public sealed interface InvoiceSection
+    permits HeaderSection, LineItemsSection, TotalsSection, NotesSection {
+    String title();
+}
+```
+
+Sealed `InvoiceSection` lists every body shape an invoice can have.
+Concrete subtypes (`LineItemsSection`, `TotalsSection`, …) are
+records carrying the section data.
+
+### 2. `theme/` second (no rendering, just tokens)
+
+```java
+public record InvoiceTheme(
+    InvoicePalette palette,
+    InvoiceTypography typography,
+    InvoiceSpacing spacing,
+    InvoiceDecoration decoration) {
+
+    public static InvoiceTheme classic() {
+        return new InvoiceTheme(
+            InvoicePalette.classic(),
+            InvoiceTypography.classic(),
+            InvoiceSpacing.classic(),
+            InvoiceDecoration.classic());
+    }
+}
+```
+
+### 3. `components/` third (low-level renderers consume data + theme)
+
+```java
+public final class LineRowRenderer {
+    private LineRowRenderer() {}
+
+    public static void render(SectionBuilder host, InvoiceLine line,
+                              InvoiceTheme theme) {
+        // … DSL calls reading theme tokens …
+    }
+}
+```
+
+Also: extract the shared paragraph DSL into a package-private
+`ParagraphPrimitive` (same idea as CV) so renderers don't duplicate
+configuration.
+
+### 4. `widgets/` fourth (named visual building blocks)
+
+```java
+public final class LineTable {
+    private LineTable() {}
+
+    public static void render(SectionBuilder host,
+                              List<InvoiceLine> lines, InvoiceTheme theme) {
+        for (InvoiceLine line : lines) {
+            LineRowRenderer.render(host, line, theme);
+        }
+    }
+}
+```
+
+Widgets wrap components into composable units that a preset can drop
+into its page flow.
+
+### 5. `presets/` last (orchestration)
+
+```java
+public final class ClassicInvoice {
+    public static final String ID = "classic-invoice";
+    public static final String DISPLAY_NAME = "Classic Invoice";
+    public static final double RECOMMENDED_MARGIN = 28.0;
+
+    private ClassicInvoice() {}
+
+    public static DocumentTemplate<InvoiceDocument> create() {
+        return create(InvoiceTheme.classic());
+    }
+
+    public static DocumentTemplate<InvoiceDocument> create(InvoiceTheme theme) {
+        return new Template(theme);
+    }
+
+    private static final class Template
+            implements DocumentTemplate<InvoiceDocument> {
+        // … compose() picks widgets in order …
+    }
+}
+```
+
+Mirror the CV preset shape exactly.
+
+---
+
+<a id="required-deliverables"></a>
+## Required deliverables
+
+A new template family PR ships with:
+
+- [ ] **5 packages** under `<family>/v2/` populated per convention
+- [ ] **At least 1 reference preset** that renders a sample document
+- [ ] **`AUTHORS.md`** in the family root (recipe cookbook — copy
+      the cv/v2 one as starting structure)
+- [ ] **`package-info.java`** at family root + each sub-package
+- [ ] **Sample fixture** in `ExampleDataFactory.sample<Family>DocumentV2()`
+- [ ] **Example runner** in `examples/.../templates/<family>/v2/`
+- [ ] **Smoke tests** per the checklist below
+- [ ] **No edits** to `engine/`, `dsl/`, or v1 `<family>/` surface
+
+---
+
+<a id="test-checklist"></a>
+## Test checklist
+
+Minimum test coverage matching CV v2:
+
+| Test class | What it asserts |
+|---|---|
+| `<Family>DocumentTest` | Builder rejects null / blank required fields; valid build succeeds |
+| `<Family>ThemeTest` | All factories produce valid themes; deprecated constructors (if any) wrap correctly |
+| `<Preset>SmokeTest` | `id()`, `displayName()`, default-factory render, custom-theme render |
+| `SectionDispatcherTest` *(optional)* | Each sealed subtype routes correctly |
+| `WidgetSmokeTest` | Each public widget variant renders without throwing |
+
+CI must be green before merge. Visual regression (PNG diff against
+a reference render) is encouraged but optional today.
+
+---
+
+<a id="doc-checklist"></a>
+## Doc checklist
+
+- [ ] `<family>/v2/package-info.java` — ASCII diagram of the 5
+      layers, plus a 4-step "how to author a document" walkthrough
+      (copy the cv/v2 one's structure).
+- [ ] `<family>/v2/AUTHORS.md` — recipe cookbook. At least:
+      change a glyph, change colours, add a new section subtype,
+      conditional sections.
+- [ ] `<family>/v2/<sub-package>/package-info.java` — each
+      sub-package gets a paragraph explaining its role.
+- [ ] **Update [`docs/templates-layered/README.md`](README.md)** to
+      list the new family in the "implementations" section.
+
+---
+
+<a id="what-you-must-not-do"></a>
+## What you must NOT do
+
+- ❌ **Don't edit the engine** (`document/api`, `document/dsl`,
+  `document/engine`, `document/node`, `document/style`). If your
+  family needs an engine feature that doesn't exist, that's a
+  separate prerequisite PR.
+- ❌ **Don't edit v1 surface** for the same family. They coexist.
+  Mark v1 `@Deprecated` only after the v2 surface is feature-complete
+  and shipped — that's a follow-up PR.
+- ❌ **Don't fork widgets across families.** If invoice needs a
+  `Headline`, write `templates/invoice/v2/widgets/Letterhead.java`
+  — an invoice letterhead has different needs from a CV name
+  headline. Don't try to share the same widget class across
+  domains.
+- ❌ **Don't use inheritance.** All records are sealed, all
+  components / widgets / presets are `final` with private
+  constructors. The intentional API shape.
+- ❌ **Don't add `instanceof` on the sealed section type outside
+  `SectionDispatcher`.** The dispatcher is the single dispatch
+  point.
+- ❌ **Don't hard-code colours / fonts / sizes in components or
+  widgets.** Every value reads from the theme. Preset-specific
+  accents (a single colour used only by one preset) may live as
+  `private static final` in that preset — but only when no other
+  preset needs them.
+
+---
+
+<a id="pr-review-expectations"></a>
+## PR review expectations
+
+A new template family PR is reviewed against:
+
+1. **Layer discipline** — do data / theme / components / widgets /
+   presets each obey their contract?
+2. **Test coverage** — smoke tests for every public surface;
+   builder validation tests; theme factory tests.
+3. **Doc completeness** — `package-info.java` everywhere,
+   `AUTHORS.md` with at least 4 recipes, root README updated.
+4. **Visual signature** — render the reference preset, attach the
+   PDF to the PR description, eyeball-validate it matches the
+   intent.
+5. **No engine / v1 edits** — additive only.
+
+Expected size: ~1500-2500 lines of new code for a fresh family.
+Compare to cv/v2 baseline (PR #45) which was 2082 lines including
+35 files.
+
+---
+
+## See also
+
+- The **CV v2** package
+  (`com.demcha.compose.document.templates.cv.v2`) is the reference
+  implementation. Read it end-to-end before starting a new family
+  — every convention listed here is visible there.
+- [authoring-presets.md](authoring-presets.md) — how preset authors
+  use widgets. Same conventions apply when designing widgets for a
+  new family.
+- [using-templates.md](using-templates.md) — what end users see.
+  Your new family's API should feel consistent with this.

--- a/docs/templates-layered/quickstart.md
+++ b/docs/templates-layered/quickstart.md
@@ -1,0 +1,142 @@
+# Quickstart — Templates Layered Architecture
+
+**5 minutes.** What it is, why it's structured this way, and a working
+example that renders a CV PDF.
+
+---
+
+## What you get
+
+GraphCompose's templates v2 (layered) gives you:
+
+- **Records describing content** — `CvDocument`, `CvIdentity`,
+  `CvSection`. No styling, no rendering, just structured data.
+- **Themes describing visuals** — `CvTheme` (palette + typography +
+  spacing + decoration). Swap a theme to change colours, fonts,
+  bullet glyphs without touching renderers.
+- **Widgets as visual LEGO bricks** — `Headline`, `ContactLine`,
+  `SectionHeader`. Each one is a named visual decision you can drop
+  into a preset.
+- **Presets as compositions** — a preset orchestrates widgets in a
+  page flow. `BoxedSections`, `MinimalUnderlined`, `ModernProfessional`
+  ship today; writing your own is ~150 lines.
+
+You hand a `CvDocument` to a preset, you get a PDF. The preset
+internally composes widgets that read theme tokens that ultimately
+emit DSL calls to the engine.
+
+---
+
+## Render your first CV
+
+```java
+import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.api.DocumentPageSize;
+import com.demcha.compose.document.api.DocumentSession;
+import com.demcha.compose.document.templates.api.DocumentTemplate;
+import com.demcha.compose.document.templates.cv.v2.data.*;
+import com.demcha.compose.document.templates.cv.v2.presets.BoxedSections;
+
+import java.nio.file.Path;
+
+CvDocument doc = CvDocument.builder()
+    .identity(CvIdentity.builder()
+        .name("Jane", "Doe")
+        .contact("+44 20 7946 0958", "jane@example.com", "London, UK")
+        .link("LinkedIn", "https://linkedin.com/in/jane-doe")
+        .build())
+    .section(new ParagraphSection("Professional Summary",
+        "Backend engineer with **5 years** of experience building "
+        + "high-throughput payment systems."))
+    .section(RowsSection.builder("Technical Skills", RowStyle.BULLETED)
+        .row("Languages", "Java 21, Kotlin, SQL")
+        .row("Frameworks", "Spring Boot, Quarkus")
+        .build())
+    .section(EntriesSection.builder("Experience")
+        .entry("Senior Engineer", "Acme Payments", "2022-Present",
+            "Owned the settlement service handling **2M+ tx/day**.")
+        .entry("Engineer", "Bright Bank", "2019-2022",
+            "Built the fraud-detection rule engine.")
+        .build())
+    .build();
+
+DocumentTemplate<CvDocument> template = BoxedSections.create();
+
+try (DocumentSession session = GraphCompose.document(Path.of("cv.pdf"))
+        .pageSize(DocumentPageSize.A4)
+        .margin(28, 28, 28, 28)
+        .create()) {
+    template.compose(session, doc);
+    session.buildPdf();
+}
+```
+
+Run it. You get `cv.pdf` rendered in the Boxed Sections visual style.
+Want it in the Modern Professional style instead? Change one line:
+
+```java
+DocumentTemplate<CvDocument> template = ModernProfessional.create();
+```
+
+Same data, different visual. That's the layering.
+
+---
+
+## The 5 layers
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  presets/   BoxedSections, MinimalUnderlined,               │
+│             ModernProfessional                              │
+│             — composition of widgets in a page flow         │
+└─────────────────────────────────────────────────────────────┘
+        │ compose from widgets
+        ▼
+┌─────────────────────────────────────────────────────────────┐
+│  widgets/   Headline, ContactLine, SectionHeader            │
+│             — named visual LEGO bricks                      │
+└─────────────────────────────────────────────────────────────┘
+        │ delegate to ↓    │ read tokens from ↓
+        ▼                  ▼
+┌─────────────────────┐  ┌──────────────────────────────────┐
+│  components/         │  │  theme/                          │
+│    SectionDispatcher │  │    CvPalette  (colours)          │
+│    EntryRenderer     │  │    CvTypography (fonts + sizes)  │
+│    RowRenderer       │  │    CvSpacing  (margins + gaps)   │
+│    ParagraphRenderer │  │    CvDecoration (bullet, sep)    │
+│    + primitives      │  │    CvTheme (bundle + factories)  │
+└─────────────────────┘  └──────────────────────────────────┘
+        │ renders into DSL
+        ▼
+┌─────────────────────────────────────────────────────────────┐
+│  data/      CvDocument, CvIdentity, CvSection (sealed),     │
+│             ParagraphSection / RowsSection / EntriesSection,│
+│             CvRow, CvEntry, Slot                            │
+│             — pure records, zero rendering deps             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**What each layer is for** (in plain English):
+
+| Layer | "Answers the question…" |
+|---|---|
+| `data/` | "What goes on the page?" — content, no styling. |
+| `theme/` | "How does it look?" — colours, fonts, glyphs. |
+| `components/` | "How is one element drawn?" — paragraph, row, entry primitives. |
+| `widgets/` | "Which visual building block do I want here?" — named LEGO bricks. |
+| `presets/` | "In what order, with which widgets, on which page flow?" — composition. |
+
+Lower layers don't know about higher ones. A theme change doesn't
+touch a renderer. A new widget doesn't touch the data model.
+
+---
+
+## Where to go next
+
+| You want to… | Read |
+|---|---|
+| Render your own CV with your data | [using-templates.md](using-templates.md) |
+| Make a new visual style | [authoring-presets.md](authoring-presets.md) |
+| Add a new template family to the library (invoice, cover-letter) | [contributor-guide.md](contributor-guide.md) |
+| See hands-on recipes (change a bullet, swap colours, …) | [`cv/v2/AUTHORS.md`](../../src/main/java/com/demcha/compose/document/templates/cv/v2/AUTHORS.md) |
+| Run the shipped examples | [`examples/cv/v2/`](../../examples/src/main/java/com/demcha/examples/templates/cv/v2) |

--- a/docs/templates-layered/using-templates.md
+++ b/docs/templates-layered/using-templates.md
@@ -1,0 +1,350 @@
+# Using Templates — author your own document
+
+You have a preset you like. You want to render **your** content
+(your name, your experience, your skills, your design tweaks). This
+doc walks the `CvDocument` builder, the section types, and the
+theme variants.
+
+If you haven't read [quickstart.md](quickstart.md), do that first —
+it sets up the conceptual model in 5 minutes.
+
+---
+
+## Table of contents
+
+1. [The three pieces you assemble](#the-three-pieces-you-assemble)
+2. [Identity — name, contact, optional links](#identity)
+3. [Section types — three shapes cover every case](#section-types)
+4. [Slots — main vs sidebar](#slots)
+5. [Picking a preset](#picking-a-preset)
+6. [Customising a theme](#customising-a-theme)
+7. [Rendering — pageSize, margins, output](#rendering)
+8. [Common patterns](#common-patterns)
+
+---
+
+## The three pieces you assemble
+
+```java
+CvDocument  doc      = …;                  // your content
+CvTheme     theme    = CvTheme.boxedClassic();   // optional override
+DocumentTemplate<CvDocument> tpl = BoxedSections.create(theme);
+
+try (DocumentSession s = GraphCompose.document(path).create()) {
+    tpl.compose(s, doc);
+    s.buildPdf();
+}
+```
+
+Three lines of "what":
+- **`CvDocument`** — your content. Built via builder.
+- **`CvTheme`** — visual style. Use a shipped factory or build your own.
+- **A preset** — orchestrates them into a page flow.
+
+---
+
+<a id="identity"></a>
+## Identity — name, contact, optional links
+
+Every CV starts with a `CvIdentity`. Two required pieces, links are
+optional.
+
+```java
+CvIdentity identity = CvIdentity.builder()
+    // Required: first + last (middle is optional)
+    .name("Jane", "Doe")
+    // .name("Jane", "Q.", "Doe")              // ← with middle name
+
+    // Required: phone + email + address (none can be blank)
+    .contact("+44 20 7946 0958",
+             "jane.doe@example.com",
+             "London, UK")
+
+    // Optional: any number of labelled links
+    .link("LinkedIn", "https://linkedin.com/in/jane-doe")
+    .link("GitHub",   "https://github.com/jane-doe")
+    .link("Portfolio","https://jane.dev")
+    .build();
+```
+
+**No `.link(...)` calls?** Header just renders the phone / email /
+address. Optional means truly optional.
+
+**Label is a free string.** `"Behance"`, `"Substack"`, `"Etsy"`, anything.
+The widget renders the label; the URL is the click target.
+
+---
+
+<a id="section-types"></a>
+## Section types — three shapes cover every case
+
+The `CvSection` sealed hierarchy has exactly **three** concrete
+shapes. Each captures a structurally different content pattern, not
+a visual flavour.
+
+### 1. `ParagraphSection` — one block of prose
+
+For Professional Summary, Profile, Objective, About Me.
+
+```java
+new ParagraphSection("Professional Summary",
+    "Backend engineer with **5 years** of experience...");
+```
+
+Inline markdown (`**bold**`, `*italic*`, `_italic_`) is honoured.
+
+### 2. `RowsSection` — list of label/body rows with a decoration style
+
+For Technical Skills, Languages, Awards, Additional Information,
+Projects, anything with "label: value" entries.
+
+```java
+RowsSection.builder("Technical Skills", RowStyle.BULLETED)
+    .row("Languages", "Java 21, Kotlin, SQL")
+    .row("Tools",     "Maven, Docker, GitHub Actions")
+    .build();
+```
+
+**Three decoration styles** — pick by what you want visually:
+
+```java
+RowStyle.PLAIN              // <b>Label:</b> body  (no bullet, single line)
+RowStyle.BULLETED           // • <b>Label:</b> body
+RowStyle.BULLETED_STACKED   // • <b>Label</b>
+                            //   body (on second line, indented)
+```
+
+The same `RowsSection` type covers Technical Skills, Additional
+Information, Projects — pick the style that matches the visual
+density you want.
+
+### 3. `EntriesSection` — timeline entries (title / subtitle / date / body)
+
+For Education, Professional Experience — anything where you have a
+list of items each with a title, subtitle, date, and description.
+
+```java
+EntriesSection.builder("Experience")
+    .entry("Senior Engineer",      // title (bold)
+           "Acme Payments",          // subtitle (italic, muted)
+           "2022-Present",           // date (right-aligned)
+           "Owned the settlement service...")    // body (paragraph)
+    .entry("Engineer",
+           "Bright Bank",
+           "2019-2022",
+           "Built the fraud-detection rule engine.")
+    .build();
+```
+
+Blank fields collapse — a blank `date` removes the right column, a
+blank `subtitle` drops the italic line, a blank `body` drops the
+paragraph beneath.
+
+---
+
+<a id="slots"></a>
+## Slots — main vs sidebar
+
+By default, every section is placed in `Slot.MAIN` — the main
+column. Multi-column presets read `Slot.SIDEBAR` separately.
+
+```java
+CvDocument doc = CvDocument.builder()
+    .identity(identity)
+    .section(summary)                              // → MAIN (default)
+    .section(Slot.MAIN, skills)                    // → MAIN (explicit)
+    .section(Slot.SIDEBAR, languagesSpoken)        // → SIDEBAR
+    .sections(Slot.MAIN, experience, education)    // varargs → MAIN
+    .build();
+```
+
+**Single-column presets** (`BoxedSections`, `MinimalUnderlined`,
+`ModernProfessional`) render only `Slot.MAIN`. Sidebar content is
+silently dropped — switch to a multi-column preset to render it.
+
+If you don't use slots at all, your sections go to `MAIN` and every
+preset renders them. The slot model is opt-in.
+
+---
+
+<a id="picking-a-preset"></a>
+## Picking a preset
+
+Three shipped today:
+
+| Preset | Visual signature |
+|---|---|
+| `BoxedSections.create()` | Centred letter-spaced name, pale-grey panel section banners, two-page friendly |
+| `MinimalUnderlined.create()` | Centred name with thin rule, small spaced-caps section titles with accent rule, single page |
+| `ModernProfessional.create()` | Right-aligned big slate-blue name, flat bright-blue bold section titles, dense single page |
+
+Each factory has a no-arg form (uses a sensible default theme) and
+a `create(CvTheme)` form (custom theme).
+
+```java
+BoxedSections.create()                          // default theme
+BoxedSections.create(CvTheme.boxedClassic())    // explicit
+BoxedSections.create(myCustomTheme)             // your own
+```
+
+---
+
+<a id="customising-a-theme"></a>
+## Customising a theme
+
+Themes are records made of four sub-records:
+
+| Sub-record | What it controls |
+|---|---|
+| `CvPalette` | Colours (`ink`, `muted`, `rule`, `banner`) |
+| `CvTypography` | Fonts + size scale (8 sizes + line spacing) |
+| `CvSpacing` | Margins, padding, weights, gaps |
+| `CvDecoration` | Bullet glyph, stacked indent, contact separator |
+
+**Swap one piece, keep the rest:**
+
+```java
+// Navy palette, classic everything else
+CvPalette navy = new CvPalette(
+    DocumentColor.rgb(15, 34, 80),     // ink — primary text
+    DocumentColor.rgb(90, 110, 150),   // muted — italic subtitles
+    DocumentColor.rgb(120, 140, 180),  // rule — separator lines
+    DocumentColor.rgb(220, 230, 240)); // banner — pale fill
+
+CvTheme navyTheme = new CvTheme(
+    navy,
+    CvTypography.classic(),
+    CvSpacing.classic(),
+    CvDecoration.classic());
+
+BoxedSections.create(navyTheme);
+```
+
+**Change a glyph** (bullet, separator):
+
+```java
+CvDecoration arrowDecoration = new CvDecoration(
+    "▶ ",       // bullet glyph
+    "  ",       // stacked-row second-line indent
+    "  ·  ");   // contact-line separator
+
+CvTheme theme = new CvTheme(
+    CvPalette.classic(),
+    CvTypography.classic(),
+    CvSpacing.classic(),
+    arrowDecoration);
+```
+
+**Change a font** (`Helvetica` instead of `PT Serif`):
+
+```java
+CvTypography sans = new CvTypography(
+    FontName.HELVETICA_BOLD, FontName.HELVETICA,
+    21.5, 8.5, 9.6, 9.2, 8.8, 8.4, 8.6, 1.4);  // sizes per role
+
+CvTheme theme = new CvTheme(
+    CvPalette.classic(), sans, CvSpacing.classic(), CvDecoration.classic());
+```
+
+For more recipes (compact spacing, alternative typography scales,
+etc.) see [`cv/v2/AUTHORS.md`](../../src/main/java/com/demcha/compose/document/templates/cv/v2/AUTHORS.md).
+
+---
+
+<a id="rendering"></a>
+## Rendering — pageSize, margins, output
+
+Standard session-first API. The preset has a `RECOMMENDED_MARGIN`
+constant that pairs visually with its design.
+
+```java
+float m = (float) BoxedSections.RECOMMENDED_MARGIN;  // 28pt for Boxed
+
+try (DocumentSession session = GraphCompose.document(Path.of("cv.pdf"))
+        .pageSize(DocumentPageSize.A4)
+        .margin(m, m, m, m)
+        .create()) {
+
+    template.compose(session, doc);
+    session.buildPdf();          // writes the file
+}
+```
+
+Other output forms:
+
+```java
+session.toPdfBytes();        // byte[]
+session.buildPdf(output);    // OutputStream
+```
+
+---
+
+<a id="common-patterns"></a>
+## Common patterns
+
+### Conditional section (omit if data is empty)
+
+```java
+CvDocument.Builder b = CvDocument.builder().identity(identity);
+b.section(summary);
+if (!certificates.isEmpty()) {
+    b.section(buildCertificationsSection(certificates));
+}
+CvDocument doc = b.build();
+```
+
+### Sidebar content
+
+```java
+CvDocument.builder()
+    .identity(identity)
+    .section(summary)                              // main
+    .sections(Slot.SIDEBAR, skills, languages)     // sidebar
+    .build();
+```
+
+Then render with a multi-column preset (when one ships) — sidebar
+content is dropped by single-column presets today.
+
+### Skip section title
+
+The section's `title` is rendered by the preset. To suppress a
+section title visually you'd need a preset that doesn't render it
+(or write your own — see [authoring-presets.md](authoring-presets.md)).
+
+### Persona-neutral content
+
+Nothing in the API assumes a developer audience. A teacher's CV
+looks the same — different strings, same builders:
+
+```java
+CvDocument.builder()
+    .identity(CvIdentity.builder()
+        .name("Maria", "Lopez")
+        .contact("+34 600 000 000", "maria@example.com", "Madrid, Spain")
+        // no .link() — Maria has no public profiles
+        .build())
+    .section(new ParagraphSection("About Me",
+        "Primary school teacher with 12 years' experience."))
+    .section(EntriesSection.builder("Teaching Experience")
+        .entry("Lead Teacher Y3", "Colegio Santa Ana", "2018-Present",
+               "Year-3 lead, mentored two NQTs.")
+        .build())
+    .section(RowsSection.builder("Languages", RowStyle.PLAIN)
+        .row("Spanish",   "Native")
+        .row("English",   "Fluent (CEFR C1)")
+        .build())
+    .build();
+```
+
+No GitHub, no Projects, no Tech Skills — and the API doesn't notice.
+
+---
+
+## Next step
+
+→ Want a custom visual style on top of the v2 building blocks?
+[**authoring-presets.md**](authoring-presets.md)
+
+→ Reference for every recipe (change bullet, swap colours, …)
+[`cv/v2/AUTHORS.md`](../../src/main/java/com/demcha/compose/document/templates/cv/v2/AUTHORS.md)


### PR DESCRIPTION
## Summary

Adds the documentation pack that closes the «как авторам разрабатывать
шаблоны, что переиспользовать, как написать свой» story for the new
layered template architecture (`cv/v2`).

Until now, information was scattered between in-package JavaDoc
(`package-info.java`) and an in-package `AUTHORS.md`. New
contributors had nowhere to land for a coherent walkthrough.

> ⚠️ **Stacked on #47 / #48 / #49.** After all four merge, this PR's
> diff shrinks to just the docs files.

## What's new — `docs/templates-layered/`

Five focused docs, one per reader persona. Each has a TOC and
cross-links to the others.

| File | Persona | Lines |
|---|---|---|
| `README.md` | landing — pick your path | 118 |
| `quickstart.md` | new evaluator (5-min orientation + working example) | 142 |
| `using-templates.md` | user with own data — builder API, section types, slots, theme variants | 350 |
| `authoring-presets.md` | preset author — widget cookbook + full CardStyle example | 350 |
| `contributor-guide.md` | library contributor adding new template family | 360 |
| **Total** | | **1320** |

### Coverage by persona

- 🆕 **New user**: "what is GraphCompose templates v2?" → quickstart
- 👤 **Document author**: "render my CV with my data" → using-templates
- 🎨 **Preset author**: "make my own visual style on top of widgets" → authoring-presets
- 🛠 **Library contributor**: "add invoice-v2 / cover-letter-v2 family" → contributor-guide

## Highlights

- **5-layer diagram** in quickstart explains data / theme /
  components / widgets / presets at a glance.
- **Persona-neutral example** in using-templates: full Maria Lopez
  (teacher) CV showing the API isn't dev-biased.
- **Worked CardStyle preset** in authoring-presets: 45-line full
  preset using existing widgets + 2 inline DSL calls. Demonstrates
  "compose, don't subclass".
- **Worked invoice-v2 walkthrough** in contributor-guide: step-by-step
  package layout, naming rules, test + doc + PR review checklist.

## What changes elsewhere

- `README.md` gains a new "Documentation" entry pointing to
  `docs/templates-layered/README.md` plus four persona-specific
  links.
- Existing `docs/template-authoring.md` and `docs/templates-v2.md`
  are flagged as covering the legacy v1 surface (still valid for
  v1 packages).

## What's NOT changed

- **No engine edits.**
- **No source / test changes** (pure documentation PR).
- **No edits to existing template-authoring or templates-v2 docs**
  — they describe the v1 surface and remain accurate for that.

## Test plan

- [x] All 5 docs render correctly on GitHub markdown preview
      (relative links resolve, code blocks highlight, tables
      align)
- [x] Each cross-reference (link to AUTHORS.md, examples/, package
      paths) resolves to a real file in the repo
- [x] README.md links resolve
- [ ] CI green (docs-only — should be trivially green)