### PR TITLE
docs(showcase): add Layered Architecture callout under hero

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -171,6 +171,19 @@
       </div>
     </section>
 
+    <section class="layered-callout section-shell" aria-labelledby="layered-title">
+      <div class="layered-card">
+        <span class="layered-badge">NEW</span>
+        <h2 id="layered-title">Building your own templates?</h2>
+        <p>The <strong>layered architecture</strong> guide walks you through the five-folder pattern &mdash; <code>data</code> / <code>theme</code> / <code>components</code> / <code>widgets</code> / <code>presets</code> &mdash; with a worked CV example, widget cookbook, and step-by-step contributor checklist. New templates and major rewrites follow this shape.</p>
+        <div class="layered-actions">
+          <a class="button button-primary" href="https://github.com/DemchaAV/GraphCompose/tree/develop/docs/templates/v2-layered">Quickstart (5 min)</a>
+          <a class="button button-secondary" href="https://github.com/DemchaAV/GraphCompose/blob/develop/docs/templates/v2-layered/authoring-presets.md">Author a preset</a>
+          <a class="button button-ghost" href="https://github.com/DemchaAV/GraphCompose/blob/develop/docs/templates/v2-layered/contributor-guide.md">Add a template family</a>
+        </div>
+      </div>
+    </section>
+
     <section class="value-prop section-shell" aria-labelledby="value-title">
       <div class="value-grid">
         <div>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -799,6 +799,63 @@ h2 {
   font-size: 0.94em;
 }
 
+/* Layered architecture callout */
+.layered-callout {
+  padding-top: 32px;
+  padding-bottom: 32px;
+}
+
+.layered-card {
+  position: relative;
+  padding: 28px 32px;
+  border-radius: 14px;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.10), rgba(99, 102, 241, 0.10));
+  border: 1px solid rgba(129, 140, 248, 0.35);
+}
+
+.layered-badge {
+  display: inline-block;
+  padding: 4px 10px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 1.5px;
+  color: #0f172a;
+  background: linear-gradient(135deg, #38bdf8, #818cf8);
+  border-radius: 4px;
+  margin-bottom: 12px;
+}
+
+.layered-card h2 {
+  margin: 0 0 8px 0;
+  font-size: 22px;
+  color: #f8fafc;
+}
+
+.layered-card p {
+  margin: 0 0 18px 0;
+  max-width: 720px;
+  color: #cbd5e1;
+  line-height: 1.55;
+}
+
+.layered-card strong {
+  color: #e2e8f0;
+}
+
+.layered-card code {
+  background: rgba(148, 163, 184, 0.18);
+  color: #f1f5f9;
+  padding: 1px 6px;
+  border-radius: 3px;
+  font-size: 12px;
+}
+
+.layered-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
 /* Value prop strip */
 .value-prop {
   padding-top: 56px;


### PR DESCRIPTION
## Summary

Right now the GitHub Pages showcase is a gallery of generated PDFs — useful, but it doesn't surface the new **v2 layered template architecture** or its documentation. Visitors arrive, browse the 14 v1 CV presets, and have no obvious path to *"I want to build my own template."*

This PR drops a small callout block between the hero and the value-prop strip that points at the v2 layered docs.

## What changed

`docs/index.html`
- New `<section class="layered-callout">` between hero and value-prop strip:
  - `NEW` pill badge (tinted gradient, matches existing accent palette)
  - Title: *Building your own templates?*
  - One-sentence intro describing the 5-folder pattern (`data` / `theme` / `components` / `widgets` / `presets`)
  - 3 buttons:
    - **Quickstart (5 min)** → `docs/templates/v2-layered/README.md`
    - **Author a preset** → `docs/templates/v2-layered/authoring-presets.md`
    - **Add a template family** → `docs/templates/v2-layered/contributor-guide.md`

`docs/styles.css`
- New `.layered-callout` / `.layered-card` / `.layered-badge` / `.layered-actions` rules.
- Dark-theme tokens (slate-50 / slate-200 / slate-300) consistent with the rest of the page. First iteration accidentally used dark text on the dark background — fixed.

## Screenshot

> _Drag `docs/private/showcase-callout-fullpage.png` into this description box to embed._

The callout sits directly under the hero, above the **30 lines → one invoice / Atomic pagination / 14 CV presets / Tested at every layer** grid. NEW badge, three buttons with distinct visual weights (primary cyan → secondary outline → ghost gold).

## What this is NOT

A **placeholder discoverability fix**, not a showcase rework. A proper *Level 1* overhaul (hero with persona buttons, v2 preset cards with doc-links, 5-layer SVG diagram, v1 collapsed by default) is deferred until v2 stabilises across 3+ ported presets or the first non-CV template family ships. Full plan is recorded in `docs/private/cv-v2-roadmap.md` for when that moment arrives.

## Scope

- No engine changes.
- No source / test changes.
- HTML + CSS only — affects the GitHub Pages site, nothing else.

## Test plan

- [ ] Verify the callout renders correctly on the deployed GitHub Pages site after merge.
- [ ] Click each of the 3 buttons — all 3 should land on the correct doc page.
- [ ] Confirm text contrast is readable on the dark theme (already verified locally).