### PR TITLE
docs(cv-v2): fix two stale Javadoc references from migration review

### DIFF
--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/theme/CvSpacing.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/theme/CvSpacing.java
@@ -306,10 +306,11 @@ public record CvSpacing(
 
     /**
      * Spacing for the Monogram Sidebar preset: zero page-flow gap so
-     * the pale sidebar fill bleeds edge-to-edge against the
-     * RECOMMENDED_MARGIN=0 page bounds. Banner tokens are unused —
-     * the preset draws its visual chrome inline (monogram badge, rules,
-     * filler shape).
+     * the content sits flush against the RECOMMENDED_MARGIN=0 page
+     * bounds. The pale sidebar fill is painted edge-to-edge on every
+     * page by {@code DocumentSession.pageBackgrounds(...)}, not by this
+     * spacing; banner tokens are unused — the preset only draws the
+     * monogram badge and sidebar heading rules inline.
      */
     public static CvSpacing monogramSidebar() {
         return new CvSpacing(

--- a/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/PanelSmokeTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/PanelSmokeTest.java
@@ -20,7 +20,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Smoke test for the v2 Panel preset. Covers the header card with
  * optional job title + link row, plus the two-column row composition
  * fed through {@link com.demcha.compose.document.templates.cv.v2.components.SectionLookup}
- * and {@link com.demcha.compose.document.templates.cv.v2.components.SectionDispatcher}.
+ * and the preset-local body dispatcher (Panel renders its own
+ * row-free dispatch because each card sits inside {@code flow.addRow},
+ * which the engine forbids from containing nested rows — so it cannot
+ * delegate to the shared {@code SectionDispatcher}).
  */
 class PanelSmokeTest {
 


### PR DESCRIPTION
## Summary

Two doc-only fixes surfaced by the `graphcompose-cv-v2-migration-review` audit of the 6 migrated CV v2 presets. No behaviour or render change.

- **`CvSpacing.monogramSidebar()`** — Javadoc claimed the preset "draws its visual chrome inline (… filler shape)". Stale: MonogramSidebar now paints the sidebar fill via `DocumentSession.pageBackgrounds(...)` on every page and the filler shape was removed. Reworded to describe the pageBackgrounds chrome.
- **`PanelSmokeTest`** — Javadoc `@link`'d `SectionDispatcher`, but Panel renders a preset-local row-free dispatcher (its cards sit inside `flow.addRow`, which the engine forbids from containing nested rows). Updated to describe the preset-local dispatcher + reason.

## Review context

The full migration review (Executive / Panel / TimelineMinimal / EngineeringResume / MonogramSidebar / SidebarPortrait) came back **0 FAILs**. These were the only two actionable WARNs (both stale comments). Remaining WARNs are documented design trade-offs (atomic `flow.addRow` single-page constraint, TimelineMinimal fixed-height axis) and a deferred size optimisation (SidebarPortrait 945 lines).

## Test plan

- [x] `./mvnw test -Dtest=PanelSmokeTest,MonogramSidebarSmokeTest -pl .` — pass (compile + smoke)
- [ ] CI green