### PR TITLE
chore(build): inherit module versions via aggregator reactor

### DIFF
--- a/aggregator/pom.xml
+++ b/aggregator/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.github.demchaav</groupId>
+    <artifactId>graphcompose-build</artifactId>
+    <version>1.6.4</version>
+    <packaging>pom</packaging>
+
+    <name>GraphCompose Build Aggregator</name>
+    <description>
+        Non-published reactor aggregator. Builds the library plus the examples
+        and benchmarks modules in one pass and gives a single entry point for
+        `versions:set`, so a version bump propagates to every module at once.
+        This is NOT a Maven parent and is NOT published to JitPack: the library
+        root pom.xml stays standalone so consumer coordinates never change.
+
+        Usage:
+          mvn -f aggregator/pom.xml -DskipTests install        # build everything
+          mvn -f aggregator/pom.xml versions:set -DnewVersion=X # bump all modules
+    </description>
+
+    <modules>
+        <module>..</module>
+        <module>../examples</module>
+        <module>../benchmarks</module>
+    </modules>
+</project>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -4,9 +4,14 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.github.demchaav</groupId>
+    <parent>
+        <groupId>io.github.demchaav</groupId>
+        <artifactId>graphcompose-build</artifactId>
+        <version>1.6.4</version>
+        <relativePath>../aggregator/pom.xml</relativePath>
+    </parent>
+
     <artifactId>graphcompose-benchmarks</artifactId>
-    <version>1.6.4</version>
     <name>GraphCompose Benchmarks</name>
     <description>
         Performance benchmarks, stress tests, and endurance harnesses for
@@ -16,7 +21,7 @@
     </description>
 
     <properties>
-        <graphcompose.version>1.6.4</graphcompose.version>
+        <graphcompose.version>${project.version}</graphcompose.version>
         <maven.compiler.release>17</maven.compiler.release>
 
         <junit.bom.version>6.1.0</junit.bom.version>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -4,9 +4,14 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.github.demchaav</groupId>
+    <parent>
+        <groupId>io.github.demchaav</groupId>
+        <artifactId>graphcompose-build</artifactId>
+        <version>1.6.4</version>
+        <relativePath>../aggregator/pom.xml</relativePath>
+    </parent>
+
     <artifactId>graphcompose-examples</artifactId>
-    <version>1.6.4</version>
 
     <name>GraphCompose Examples</name>
     <description>Runnable file-render examples for GraphCompose templates.</description>


### PR DESCRIPTION
## Summary
- `examples` and `benchmarks` now inherit their version from a new, non-published `graphcompose-build` aggregator (`aggregator/pom.xml`, `packaging=pom`) instead of pinning a literal.
- Removes the hardcoded `<graphcompose.version>` in `benchmarks/pom.xml` that caused version drift after a bump — the benchmark dependency now tracks `${project.version}`.
- The library root `pom.xml` is **unchanged**, so JitPack coordinates and consumers are unaffected.
- A single `mvn -f aggregator/pom.xml versions:set -DnewVersion=X` now bumps every module atomically.

## Why
After a version bump, `benchmarks` kept building against the *previous* GraphCompose release because its version was an independent literal. Maven forbids a `jar`-packaging POM as a `<parent>`, so the parent is the aggregator (`packaging=pom`); the library stays a standalone module in the reactor (`..`).

## Test plan
- [x] `mvnw -DskipTests install` (JitPack-faithful, root unchanged) — BUILD SUCCESS
- [x] `mvnw -f aggregator/pom.xml -DskipTests install` — library + examples + benchmarks build with inherited versions
- [x] `mvnw -f aggregator/pom.xml versions:set -DnewVersion=1.6.5-TEST` propagated to all 4 POMs, 0 stale (reverted)
- [x] `mvnw clean verify -pl .` — 990 tests green
- [x] All 26 examples regenerate, no layout errors