### PR TITLE
ci(jitpack): pin JDK 17 and scope install to the library module

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,4 +1,14 @@
+# JitPack builds the published library artifact
+# (com.github.DemchaAV:GraphCompose) from the standalone root pom.xml.
+#
+# JDK is pinned to 17 — the project's compile baseline
+# (maven.compiler.release=17) and the JDK the release verify/javadoc gate
+# runs on — so the jar consumers download is built on the same JDK CI
+# validates, not a drifting newer one.
+#
+# install is scoped to the root module (-pl .) so JitPack builds only the
+# library, never the examples/benchmarks reactor siblings.
 jdk:
-  - openjdk21
+  - openjdk17
 install:
-  - ./mvnw -DskipTests install
+  - ./mvnw -DskipTests install -pl .


### PR DESCRIPTION
## Summary
- `jitpack.yml`: `openjdk21` → `openjdk17`, and `install` scoped to `-pl .`.

## Why
JitPack built the published jar on openjdk21 while the release verify/javadoc gate runs on JDK 17 (the project's `maven.compiler.release` baseline) — the artifact consumers download was built on a JDK CI doesn't validate. Pinning to 17 removes that drift. Scoping install to `-pl .` builds only the library, never the examples/benchmarks reactor siblings.

## Test plan
- [x] `jitpack.yml` parses (jdk: [openjdk17], install: [`...-pl .`])
- [x] JitPack-faithful smoke `./mvnw -B -ntp -DskipTests install -pl .` → BUILD SUCCESS, installs only graphcompose (library + tests jar), no siblings
- [ ] JitPack build.log verified at the v1.6.5 tag (Task #8 post-release smoke)