### PR TITLE
chore(build): scope byte-buddy as test (PR-7.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,16 @@ follow semantic versioning; release dates are ISO 8601.
   full-height column fills are unchanged. Adds top-/bottom-/mid-band
   regression tests.
 
+### Build
+
+- **`byte-buddy` is now `<scope>test</scope>`.** Mockito already excludes
+  its transitive `byte-buddy` and the project pins a single version in a
+  standalone dependency; that dependency was missing a scope, so the
+  published POM advertised `byte-buddy` as a compile dependency even
+  though no production code references it. Setting `<scope>test</scope>`
+  keeps the version pin but keeps `byte-buddy` out of consumers' runtime
+  classpath (`mvn dependency:tree` shows it only as `:test`).
+
 ## v1.6.4 — 2026-05-22
 
 Bug fix + structured-block patch. Adds two new public Block types —

--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,7 @@
             <groupId>net.bytebuddy</groupId>
             <artifactId>byte-buddy</artifactId>
             <version>${byteBuddy.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
## Summary

- Set `<scope>test</scope>` on the standalone `byte-buddy` dependency in [pom.xml](pom.xml).
- Add a **Build** subsection to the in-progress `v1.6.5 — Planned` CHANGELOG entry documenting the publish-hygiene fix.

## Why

`byte-buddy` is used only by Mockito at test time. Mockito already
excludes its transitive `byte-buddy` (so the project can pin a single
version) but the standalone pinning dependency was missing a scope —
the published POM therefore advertised `byte-buddy` as a compile
dependency even though no production code references it.

With `<scope>test</scope>` the version pin stays, but consumers no
longer inherit `byte-buddy` on their runtime classpath.

This is the second of three PRs unblocking the v1.6.5 cut (after
PR-7.1 `ci/exec-plugin-drift-fix` and before PR-7.3
`fix/pagebackgrounds-empty-and-row-weights`). Tracked in the private
release-readiness taskboard.

## Verification

- ``./mvnw -pl . dependency:tree`` — both ``net.bytebuddy:byte-buddy:jar:1.18.8`` and the transitive ``byte-buddy-agent:jar:1.17.7`` now show ``:test`` only; no runtime branch references either.
- ``./mvnw test -pl .`` — **1016 tests, 0 failures, 0 errors** (~54 s).

## Test plan

- [x] ``dependency:tree`` shows no runtime ``byte-buddy``
- [x] Full canonical suite green locally
- [ ] CI green on PR