### PR TITLE
ci(workflow): drop hardcoded exec-maven-plugin:3.5.0 (PR-7.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Run coarse performance smoke benchmark
         run: |
           ./mvnw -B -ntp -f benchmarks/pom.xml -DskipTests \
-            "org.codehaus.mojo:exec-maven-plugin:3.5.0:java" \
+            exec:java \
             "-Dexec.mainClass=com.demcha.compose.CurrentSpeedBenchmark" \
             "-Dgraphcompose.benchmark.profile=smoke"
 
@@ -194,7 +194,7 @@ jobs:
       - name: Run full benchmark suite
         run: |
           ./mvnw -B -ntp -f benchmarks/pom.xml -DskipTests \
-            "org.codehaus.mojo:exec-maven-plugin:3.5.0:java" \
+            exec:java \
             "-Dexec.mainClass=com.demcha.compose.CurrentSpeedBenchmark" \
             "-Dgraphcompose.benchmark.profile=full" \
             "-Dgraphcompose.benchmark.enforceGate=false"
@@ -212,7 +212,7 @@ jobs:
         if: steps.benchmark-runs.outputs.count != '0' && steps.benchmark-runs.outputs.count != '1'
         run: |
           ./mvnw -B -ntp -f benchmarks/pom.xml -DskipTests \
-            "org.codehaus.mojo:exec-maven-plugin:3.5.0:java" \
+            exec:java \
             "-Dexec.mainClass=com.demcha.compose.BenchmarkDiffTool" \
             "-Dexec.args=current-speed"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,15 @@ follow semantic versioning; release dates are ISO 8601.
   though no production code references it. Setting `<scope>test</scope>`
   keeps the version pin but keeps `byte-buddy` out of consumers' runtime
   classpath (`mvn dependency:tree` shows it only as `:test`).
+- **CI `exec-maven-plugin` version drift removed.** The CI workflow's
+  three benchmark steps invoked
+  `org.codehaus.mojo:exec-maven-plugin:3.5.0:java` directly, while
+  `benchmarks/pom.xml` already declared `exec-maven-plugin` at `3.6.3`
+  for local runs — a silent version split between CI and local invocations
+  that grew the surface area to keep aligned. CI now calls the configured
+  plugin via `exec:java`, picking up the pinned `3.6.3` from
+  `benchmarks/pom.xml`. No behaviour change; one fewer hardcoded version
+  to bump.
 
 ## v1.6.4 — 2026-05-22
 


### PR DESCRIPTION
## Summary

- Replace three hardcoded `org.codehaus.mojo:exec-maven-plugin:3.5.0:java` invocations in [.github/workflows/ci.yml](.github/workflows/ci.yml) with `exec:java`, so the CI workflow resolves the plugin through `benchmarks/pom.xml`'s `build/plugins` declaration (`3.6.3`).
- Add a **Build** entry to the in-progress `v1.6.5 — Planned` CHANGELOG section.

## Why

`benchmarks/pom.xml:134-138` already pins `exec-maven-plugin:3.6.3` for
local benchmark runs, but CI bypassed that pin and invoked `3.5.0`
directly — a silent version split between CI and local invocations
that grew the surface area to keep aligned. Using `exec:java` lets
Maven resolve the plugin through the module POM, so there is only one
version to bump going forward.

This is the third of three short branches unblocking the v1.6.5 cut
(alongside PR-7.2 #79 `chore/byte-buddy-test-scope` and PR-7.3
`fix/pagebackgrounds-empty-and-row-weights`). Tracked in the private
release-readiness taskboard.

## Verification

The exact CI command was reproduced locally on JDK 17:

```
./mvnw -B -ntp -f benchmarks/pom.xml -DskipTests exec:java \
  -Dexec.mainClass=com.demcha.compose.CurrentSpeedBenchmark \
  -Dgraphcompose.benchmark.profile=smoke
```

→ ``Performance gate passed for profile smoke`` · BUILD SUCCESS · ~15 s.

The full and diff invocations follow the same pattern (only the
mainClass / profile / `enforceGate` flags differ), so plugin resolution
is identical.

## Test plan

- [x] Smoke benchmark reproduced locally with the new ``exec:java`` invocation
- [ ] CI perf-smoke green on PR
- [ ] Required CI checks (Guards / JDK 17/21/25 / Examples Smoke) green on PR
- [ ] Weekly benchmark-diff cron exercise — verified by maintainer post-merge (cron-only, not on PR)