### PR TITLE
build(api): add japicmp binary-compatibility gate vs v1.6.5 (E1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,41 @@ jobs:
           path: examples/target/generated-pdfs/**
           if-no-files-found: error
 
+  binary-compat:
+    name: Binary Compatibility (japicmp vs v1.6.5)
+    if: github.event_name == 'pull_request'
+    needs: architecture-and-documentation-guards
+    runs-on: ubuntu-latest
+    env:
+      JAVA_TOOL_OPTIONS: -Djava.awt.headless=true
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Temurin JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Compare public API against baseline
+        # The `japicmp` profile pulls the v1.6.5 jar from JitPack and
+        # diffs it against the freshly-built artifact. Fails the job on
+        # any binary-incompatible modification to the public surface.
+        # Source-incompatible changes are reported only (phased policy).
+        # See Track E1 in the v1.6.5→1.7 readiness taskboard.
+        run: ./mvnw -B -ntp -DskipTests -P japicmp verify -pl .
+
+      - name: Upload japicmp report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: japicmp-report-${{ github.run_id }}
+          path: target/japicmp/**
+          if-no-files-found: ignore
+
   perf-smoke:
     name: Performance Smoke Check
     if: github.event_name == 'pull_request'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 All notable changes to GraphCompose are documented here. Versions
 follow semantic versioning; release dates are ISO 8601.
 
+## v1.6.6 — Planned
+
+First Maven Central release. Adds publishable sources/javadoc jars,
+GPG-signed artifacts, a binary-compatibility gate against v1.6.5, and
+the metadata Maven Central requires. Zero breaking changes; users on
+JitPack continue to resolve through the existing coordinates.
+
+### Build
+
+- **Binary-compatibility gate against v1.6.5** (`japicmp` profile,
+  Track E1). The new `binary-compat` CI job builds the artifact on every
+  pull request and diffs it against `com.github.DemchaAV:GraphCompose:v1.6.5`
+  pulled from JitPack. Binary-incompatible modifications to the public
+  surface fail the build; source-incompatible changes are reported only
+  (phased policy, will tighten after the 1.6.6 cut). Run locally with
+  `./mvnw -DskipTests -P japicmp verify -pl .`; HTML/MD/XML reports
+  land in `target/japicmp/`. JitPack repository is scoped to the
+  `japicmp` profile, so downstream consumers do not inherit it.
+
 ## v1.6.5 — 2026-05-30
 
 ### Templates v2

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,10 @@
         <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
         <maven.javadoc.plugin.version>3.12.0</maven.javadoc.plugin.version>
         <maven.surefire.plugin.version>3.5.5</maven.surefire.plugin.version>
+
+        <!-- Binary compatibility baseline (japicmp profile) -->
+        <japicmp.version>0.23.1</japicmp.version>
+        <japicmp.baseline>v1.6.5</japicmp.baseline>
     </properties>
 
     <dependencyManagement>
@@ -355,4 +359,66 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <!--
+            Binary-compatibility baseline against the last published
+            release. Activated with `-P japicmp`. Resolves the baseline
+            artifact from JitPack (kept profile-local so consumers do
+            NOT inherit a JitPack repository). Fails the build on any
+            binary-incompatible modification to the public surface;
+            source-incompatible changes are reported but do not fail
+            (yet) so the team can phase the policy in. Tracked in the
+            v1.6.6 stabilization (Track E1).
+        -->
+        <profile>
+            <id>japicmp</id>
+            <repositories>
+                <repository>
+                    <id>jitpack.io</id>
+                    <url>https://jitpack.io</url>
+                </repository>
+            </repositories>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.siom79.japicmp</groupId>
+                        <artifactId>japicmp-maven-plugin</artifactId>
+                        <version>${japicmp.version}</version>
+                        <executions>
+                            <execution>
+                                <id>japicmp-against-baseline</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>cmp</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <oldVersion>
+                                <dependency>
+                                    <groupId>com.github.DemchaAV</groupId>
+                                    <artifactId>GraphCompose</artifactId>
+                                    <version>${japicmp.baseline}</version>
+                                </dependency>
+                            </oldVersion>
+                            <newVersion>
+                                <file>
+                                    <path>${project.build.directory}/${project.build.finalName}.jar</path>
+                                </file>
+                            </newVersion>
+                            <parameter>
+                                <onlyModified>true</onlyModified>
+                                <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
+                                <breakBuildOnSourceIncompatibleModifications>false</breakBuildOnSourceIncompatibleModifications>
+                                <includeSynthetic>false</includeSynthetic>
+                                <reportOnlyFilename>true</reportOnlyFilename>
+                                <skipPomModules>true</skipPomModules>
+                            </parameter>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
## Summary

Wires up Track **E1 (japicmp baseline=v1.6.5)** from the 1.6.5→1.7 readiness taskboard — the foundation 1.6.6's Maven Central debut and 1.6.7's dependency cleanup depend on.

- **`pom.xml`** — new ``japicmp`` profile carrying ``japicmp-maven-plugin`` and a profile-local JitPack ``<repositories>`` (downstream consumers do **not** inherit it). Versions pinned in properties: ``japicmp.version=0.23.1``, ``japicmp.baseline=v1.6.5``. Plugin binds its ``cmp`` goal to the ``verify`` phase.
- **`.github/workflows/ci.yml`** — new ``binary-compat`` job, PR-only, runs after the guards job. Uploads the report directory as an artifact for inspection on red runs.
- **`CHANGELOG.md`** — opens ``## v1.6.6 — Planned`` with a ``Build`` subsection.

## Why

Without a structural binary-compatibility gate we cannot promise *zero breaking* — which is the whole point of the v1.6.6 Maven Central debut. JitPack consumers tolerate accidental breaks (you bump and find out); Central consumers do not, and `japicmp-maven-plugin` against a published baseline is the standard fix.

Pinning the baseline at v1.6.5 specifically: it's the freshest published artifact, ships through JitPack today, and is the canonical "what users currently see" surface. Each subsequent patch release will keep `<japicmp.baseline>` pointed at the previous public tag.

## Policy

| Knob | Setting | Reasoning |
|---|---|---|
| ``breakBuildOnBinaryIncompatibleModifications`` | **true** | An unintended binary break = hard fail. This is the gate's whole job. |
| ``breakBuildOnSourceIncompatibleModifications`` | false | Phased — we'll tighten after 1.6.6 cut. Avoids tripping on Javadoc-only or signature-clarification churn while the policy beds in. |
| ``onlyModified`` | true | Don't re-emit unchanged classes in the report. |
| ``includeSynthetic`` | false | Compiler-generated bridge methods aren't part of the contract. |

Reports land in ``target/japicmp/`` as HTML / MD / XML / diff. The CI artifact upload is the audit trail for any red run.

## Verification

Local run against current develop:

```
$ ./mvnw -B -ntp -DskipTests -P japicmp verify -pl .
[INFO] --- japicmp:0.23.1:cmp (japicmp-against-baseline) @ graphcompose ---
[INFO] Written file '.../target/japicmp/japicmp-against-baseline.diff'.
...
[INFO] BUILD SUCCESS
```

Report contents:

```
Comparing source compatibility of graphcompose-1.6.5.jar against GraphCompose-v1.6.5.jar
No changes.
Semantic versioning suggestion: 0.0.1
```

(Expected — develop is bit-identical to v1.6.5 at the jar level fresh after the release; the cut-release-script fix-up PR-83 only touched ``scripts/`` and ``docs/``.) The next PR that touches the public surface will exercise the gate end-to-end.

Guards re-run after pom changes:

```
$ ./mvnw -B -ntp test -Dtest=VersionConsistencyGuardTest,CanonicalSurfaceGuardTest,DocumentationCoverageTest -pl .
[INFO] Tests run: 18, Failures: 0, Errors: 0, Skipped: 0
```

## Test plan

- [x] ``mvn -P japicmp verify`` zelёный locally
- [x] Guards (Version/CanonicalSurface/DocumentationCoverage) unchanged
- [ ] PR CI green — the new ``binary-compat`` job is the live gate
- [ ] Reviewer skim of the profile config (JitPack repo scoping, plugin policy)
- [ ] Next public-surface PR exercises the gate end-to-end (out of scope here)