### PR TITLE
refactor(engine): extract RowSlots helper for weights/children guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,20 @@ JitPack continue to resolve through the existing coordinates.
   land in `target/japicmp/`. JitPack repository is scoped to the
   `japicmp` profile, so downstream consumers do not inherit it.
 
+### Engine internals (no behaviour change)
+
+- **`RowSlots` helper extracted** from `LayoutCompiler` and
+  `NodeDefinitionSupport`. The defence-in-depth `IllegalArgumentException`
+  guard added in v1.6.5 (PR-7.3) for the row weights / children size
+  mismatch lived as duplicated inline code at both engine call sites
+  with no direct test — a future refactor could have silently deleted
+  either copy. The validation now lives in
+  `com.demcha.compose.document.layout.RowSlots#validateWeightsMatchChildren`
+  (package-private), with `RowSlotsTest` driving it directly. Error
+  message is unchanged. `GraphCompose.DocumentBuilder#pageBackgrounds(...)`
+  Javadoc now spells out the empty-list-clears semantics in prose, not
+  only in the `@param` line.
+
 ## v1.6.5 — 2026-05-30
 
 ### Templates v2

--- a/src/main/java/com/demcha/compose/GraphCompose.java
+++ b/src/main/java/com/demcha/compose/GraphCompose.java
@@ -251,6 +251,11 @@ public final class GraphCompose {
          * {@link com.demcha.compose.document.api.DocumentSession#pageBackgrounds}
          * for the full semantics.
          *
+         * <p>Calling this method with an empty list is an <b>explicit clear</b>:
+         * it overrides any earlier {@link #pageBackground(com.demcha.compose.document.style.DocumentColor)}
+         * call on the same builder and emits no page-background fragments.
+         * Passing {@code null} has the same effect.</p>
+         *
          * @param fills ordered fills, or {@code null}/empty to clear
          * @return this builder
          */
@@ -381,9 +386,8 @@ public final class GraphCompose {
                     markdown,
                     guideLines);
             if (pageBackgrounds != null) {
-                // Explicit pageBackgrounds() call wins — even an empty
-                // list is an intentional clear that should override any
-                // earlier pageBackground(color) on the same builder.
+                // Explicit pageBackgrounds() call wins over a prior
+                // pageBackground(color). Empty list = clear; see builder Javadoc.
                 session.pageBackgrounds(pageBackgrounds);
             } else if (pageBackground != null) {
                 session.pageBackground(pageBackground);

--- a/src/main/java/com/demcha/compose/document/layout/LayoutCompiler.java
+++ b/src/main/java/com/demcha/compose/document/layout/LayoutCompiler.java
@@ -746,11 +746,7 @@ public final class LayoutCompiler {
             }
             return slots;
         }
-        if (weights.size() != n) {
-            throw new IllegalArgumentException(
-                    "Row weights size (" + weights.size() + ") must match children size (" + n
-                            + "). Pass exactly " + n + " weight(s) or leave weights empty for an even split.");
-        }
+        RowSlots.validateWeightsMatchChildren(weights, n);
         double total = 0.0;
         for (double w : weights) {
             total += w;

--- a/src/main/java/com/demcha/compose/document/layout/NodeDefinitionSupport.java
+++ b/src/main/java/com/demcha/compose/document/layout/NodeDefinitionSupport.java
@@ -324,11 +324,7 @@ public final class NodeDefinitionSupport {
                 slotWidths[i] = share;
             }
         } else {
-            if (node.weights().size() != n) {
-                throw new IllegalArgumentException(
-                        "Row weights size (" + node.weights().size() + ") must match children size (" + n
-                                + "). Pass exactly " + n + " weight(s) or leave weights empty for an even split.");
-            }
+            RowSlots.validateWeightsMatchChildren(node.weights(), n);
             double total = 0.0;
             for (Double w : node.weights()) {
                 total += w;

--- a/src/main/java/com/demcha/compose/document/layout/RowSlots.java
+++ b/src/main/java/com/demcha/compose/document/layout/RowSlots.java
@@ -1,0 +1,44 @@
+package com.demcha.compose.document.layout;
+
+import java.util.List;
+
+/**
+ * Shared validation helpers for row weight / children distribution code.
+ *
+ * <p>Centralises the {@link IllegalArgumentException} contract used by both
+ * {@link LayoutCompiler#distributeRowSlotWidths(List, List, double, double) compile-phase}
+ * and {@link NodeDefinitionSupport#measureRow measure-phase} row distribution.
+ * The {@code RowNode} canonical constructor already rejects a mismatched
+ * weights list at construction time; these helpers are defence-in-depth
+ * for any path that bypasses the constructor (reflection-based
+ * deserialization, framework proxies, etc.) and arrives at the engine
+ * with an inconsistent {@code (weights, children)} pair.</p>
+ *
+ * <p>Package-private intentionally — engine surface, not public API.</p>
+ *
+ * @author Artem Demchyshyn
+ */
+final class RowSlots {
+
+    private RowSlots() {
+        // Utility class, no instantiation.
+    }
+
+    /**
+     * Asserts that an explicit {@code weights} list matches the row's
+     * children count. Callers must skip this check when {@code weights}
+     * is null or empty — the even-split fallback applies there instead.
+     *
+     * @param weights non-null, non-empty weights list
+     * @param childCount number of row children
+     * @throws IllegalArgumentException if {@code weights.size() != childCount}
+     */
+    static void validateWeightsMatchChildren(List<Double> weights, int childCount) {
+        if (weights.size() != childCount) {
+            throw new IllegalArgumentException(
+                    "Row weights size (" + weights.size() + ") must match children size ("
+                            + childCount + "). Pass exactly " + childCount
+                            + " weight(s) or leave weights empty for an even split.");
+        }
+    }
+}

--- a/src/test/java/com/demcha/compose/document/layout/RowSlotsTest.java
+++ b/src/test/java/com/demcha/compose/document/layout/RowSlotsTest.java
@@ -1,0 +1,61 @@
+package com.demcha.compose.document.layout;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Engine-level contract for the row weights / children-count guard
+ * shared by {@link LayoutCompiler} and {@link NodeDefinitionSupport}.
+ *
+ * <p>The {@code RowNode} canonical constructor already rejects the
+ * mismatched state via {@link RowBuilder}, so under normal authoring the
+ * helper is unreachable. The helper exists for defence-in-depth paths
+ * that bypass the constructor (reflection-based deserialization, etc.);
+ * these tests pin the contract so a future refactor cannot silently
+ * delete the guard at either call site.</p>
+ */
+class RowSlotsTest {
+
+    @Test
+    void matchingSizesPassWithoutThrowing() {
+        assertThatCode(() -> RowSlots.validateWeightsMatchChildren(List.of(1.0, 2.0, 3.0), 3))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void moreWeightsThanChildrenIsRejectedWithBothSizesNamed() {
+        assertThatThrownBy(() -> RowSlots.validateWeightsMatchChildren(List.of(1.0, 2.0, 3.0), 2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("weights")
+                .hasMessageContaining("children")
+                .hasMessageContaining("(3)")
+                .hasMessageContaining("(2)");
+    }
+
+    @Test
+    void fewerWeightsThanChildrenIsRejectedWithBothSizesNamed() {
+        assertThatThrownBy(() -> RowSlots.validateWeightsMatchChildren(List.of(1.0, 2.0), 5))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("(2)")
+                .hasMessageContaining("(5)");
+    }
+
+    @Test
+    void errorMessageHintsAtTheFix() {
+        // The senior-review bar for engine exception messages: name the
+        // values AND tell the caller how to fix it. Asserting the verb
+        // is enough — the exact wording is implementation detail.
+        assertThatThrownBy(() -> RowSlots.validateWeightsMatchChildren(List.of(1.0), 4))
+                .isInstanceOf(IllegalArgumentException.class)
+                .extracting(Throwable::getMessage)
+                .satisfies(msg -> {
+                    String s = (String) msg;
+                    assertThat(s).containsAnyOf("Pass", "Provide", "Use");
+                });
+    }
+}


### PR DESCRIPTION
## Summary

Polish pass surfaced by retrospective senior review of [PR-7.3](https://github.com/DemchaAV/GraphCompose/pull/81) (`f868499b`) through the new ``graphcompose-senior-review`` skill. PR-7.3 added a defence-in-depth ``IllegalArgumentException`` guard for the row weights / children size mismatch at two engine call sites — and shipped no test that drives those guards directly, because the path is unreachable through the public API (``RowNode``'s canonical constructor blocks the mismatched state at construction time).

Unreachable code without coverage rots: the next engine refactor can silently delete either guard with no test going red. This PR locks the contract behind a covered surface.

## Changes

- **New `RowSlots`** (`src/main/java/com/demcha/compose/document/layout/RowSlots.java`, package-private) with a single helper, ``validateWeightsMatchChildren(weights, n)``. Package-private intentionally — engine surface, not public API. Error message **unchanged** from PR-7.3.
- **Both call sites collapsed:** ``LayoutCompiler#distributeRowSlotWidths`` (was lines 746-750) and ``NodeDefinitionSupport#measureRow`` (was lines 324-328) now delegate to ``RowSlots.validateWeightsMatchChildren(...)``.
- **New `RowSlotsTest`** (`src/test/java/com/demcha/compose/document/layout/RowSlotsTest.java`) with 4 tests:
  - Happy path: matching sizes pass without throwing.
  - More weights than children → IAE with both sizes named.
  - Fewer weights than children → IAE with both sizes named.
  - Message-quality check: the error tells the caller how to fix it (``containsAnyOf("Pass","Provide","Use")``) without locking the exact wording.
- **Javadoc polish on `GraphCompose.DocumentBuilder#pageBackgrounds(...)`** — empty-list-clears semantics now spelled out in a ``<p>`` block instead of only the ``@param`` line. Inner comment in ``DocumentBuilder.create()`` shortened — rationale moved up to the public Javadoc where it belongs.
- **CHANGELOG** gets a new ``### Engine internals (no behaviour change)`` subsection under ``## v1.6.6 — Planned``.

## Why this PR, not a comment on PR-7.3

PR-7.3 shipped in v1.6.5. The guard was correct and the public-API surface is right — what was missing is the **test-the-helper** scaffolding that survives a future refactor. Fixing it forward as a small isolated PR (zero behaviour change, ``japicmp`` clean) is cheaper than retroactively reopening a closed release.

The retrospective senior review also flagged the duplicated error message as a future-drift risk (PR-7.1 lesson generalised: any literal in two files is a drift waiting to happen). The helper kills the duplication in one move.

## Verification

```
$ ./mvnw test -pl . -Dtest=RowSlotsTest,RowBuilderTest,PageBackgroundTest
Tests run: 33, Failures: 0, Errors: 0, Skipped: 0

$ ./mvnw test -pl .
Tests run: 1023, Failures: 0, Errors: 0, Skipped: 0  (+4 from RowSlotsTest)
```

The new ``binary-compat`` CI job (PR-84) will check ``japicmp`` against ``v1.6.5`` — expecting ``No changes`` since the helper is package-private and the public-API contract is identical.

## Test plan

- [x] Full canonical suite green locally (1023 / 0 / 0)
- [x] ``RowSlotsTest`` covers happy + both negative directions + message quality
- [ ] CI green (Guards / JDK 17/21/25 / Examples Smoke / **binary-compat**)
- [ ] japicmp diff: ``No changes`` (package-private extraction = no public-surface delta)
- [ ] Reviewer skim of helper class (45 LOC) — package-private gate held, contract documented in Javadoc

## Senior review findings addressed

| Severity | Finding | Resolution |
|---|---|---|
| Major | Engine guards have zero test coverage | New `RowSlots` + 4-test `RowSlotsTest` covers it directly |
| Minor | Duplicated error message string in two engine call sites | Single source in `RowSlots`; both sites delegate |
| Minor | `GraphCompose.java` inner comment + builder Javadoc don't surface the empty-list-clear contract in prose | `<p>` block added to builder Javadoc; inner comment shortened |