### PR TITLE
docs(examples): reorganise gallery by maturity tier (G2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,20 @@ JitPack continue to resolve through the existing coordinates.
   `GraphCompose.pdf(...)`, `PdfComposer`, etc. don't trip the
   legacy-token scan (same allowlist class as the v1.5 → v1.6 migration
   log already in there).
+- **`examples/README.md` reorganised by maturity** (Track G2). The
+  gallery section was grouped by the GraphCompose release that
+  introduced each example (Built-in templates / Cinematic v1.5 /
+  v1.5 feature showcases / v1.6 feature showcases / Public-API
+  surface / Production patterns / Operational documents) — useful
+  history for maintainers, less useful for someone landing on the
+  examples folder for the first time. The gallery now categorises
+  by maturity / intent: **🚀 Start here**, **🧱 Core DSL**,
+  **📋 Templates recommended**, **🔧 Advanced SPI**, **🗄️ Legacy**.
+  All 26 examples retained their anchor IDs, so existing deep links
+  continue to resolve; only the gallery index is restructured. A
+  maturity legend introduces the five tiers and links to
+  `docs/templates/which-template-system.md` for the V1 → V2 path that
+  the **Legacy** tier points at.
 
 ## v1.6.5 — 2026-05-30
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -32,68 +32,69 @@ Then run all 26 examples in one shot:
 Generated PDFs land in `examples/target/generated-pdfs/`. The same
 `mvnw.cmd` form works on Windows PowerShell with backslash paths.
 
-## Gallery
+## Gallery — pick by your goal
 
-### Built-in document templates
+Examples are categorised by **maturity / intent**, not by the GraphCompose
+release that introduced them. Pick the row that matches how far along you
+are with the canonical DSL, then jump to its detailed section below.
+
+> **Maturity legend.**
+> 🚀 **Start here** — minimum-friction entry points; pick one if you've never used the canonical DSL before.
+> 🧱 **Core DSL** — features you'll author against every day once the basics click.
+> 📋 **Templates recommended** — the v2 / layered template surfaces and how to drive them; pick when you want a one-line CV / invoice / proposal / cover-letter.
+> 🔧 **Advanced SPI** — production-deployment patterns, specialty SPIs (shapes, transforms, barcodes), engine-level tools (snapshots).
+> 🗄️ **Legacy** — pre-rebuild examples kept for downstream callers still on V1; do not start new code here. See [`docs/templates/which-template-system.md`](../docs/templates/which-template-system.md) for the V1 → V2 migration path.
+
+### 🚀 Start here
 
 | Example | What it shows | Preview · Source |
 |---|---|---|
-| [Cover Letter](#cover-letter) | One-page `BusinessTheme.modern()` cover letter with section presets | [PDF](../assets/readme/examples/cover-letter.pdf) · [Source](src/main/java/com/demcha/examples/templates/coverletter/CoverLetterFileExample.java) |
-| [Invoice (V1)](#invoice-v1) | `InvoiceTemplateV1` driven from `InvoiceDocumentSpec` | [PDF](../assets/readme/examples/invoice.pdf) · [Source](src/main/java/com/demcha/examples/templates/invoice/InvoiceFileExample.java) |
-| [Proposal (V1)](#proposal-v1) | `ProposalTemplateV1` driven from `ProposalDocumentSpec` | [PDF](../assets/readme/examples/proposal.pdf) · [Source](src/main/java/com/demcha/examples/templates/proposal/ProposalFileExample.java) |
-| [Module-first Profile](#module-first-profile) | Authoring directly against `DocumentSession.module(...).paragraph(...)` | [PDF](../assets/readme/examples/module-first-profile.pdf) · [Source](src/main/java/com/demcha/examples/flagships/ModuleFirstFileExample.java) |
 | [CV — single template](#cv-single-template) | One CV via `ModernProfessional.create(BusinessTheme.modern())` (Templates v2) | [PDF](../assets/readme/examples/cv-modern-professional.pdf) · [Source](src/main/java/com/demcha/examples/templates/cv/CvFileExample.java) |
+| [Invoice — cinematic V2](#invoice-cinematic-v2) | `InvoiceTemplateV2 + BusinessTheme.modern()` — the recommended invoice path | [PDF](../assets/readme/examples/invoice-cinematic.pdf) · [Source](src/main/java/com/demcha/examples/templates/invoice/InvoiceCinematicFileExample.java) |
+| [Cover Letter](#cover-letter) | One-page `BusinessTheme.modern()` cover letter with section presets | [PDF](../assets/readme/examples/cover-letter.pdf) · [Source](src/main/java/com/demcha/examples/templates/coverletter/CoverLetterFileExample.java) |
+| [Module-first Profile](#module-first-profile) | Authoring directly against `DocumentSession.module(...).paragraph(...)` — DSL-direct, no template | [PDF](../assets/readme/examples/module-first-profile.pdf) · [Source](src/main/java/com/demcha/examples/flagships/ModuleFirstFileExample.java) |
+
+### 🧱 Core DSL
+
+| Example | What it shows | Preview · Source |
+|---|---|---|
+| [Rich text](#rich-text) | Every `RichText` method (bold / italic / underline / link / colour / accent / size / append) | [PDF](../assets/readme/examples/rich-text-showcase.pdf) · [Source](src/main/java/com/demcha/examples/features/text/RichTextShowcaseExample.java) |
+| [Section presets](#section-presets) | `pageBackground`, `band`, `softPanel`, `accentLeft / Right / Top / Bottom`, per-corner `DocumentCornerRadius` | [PDF](../assets/readme/examples/section-presets.pdf) · [Source](src/main/java/com/demcha/examples/features/text/SectionPresetsExample.java) |
+| [Nested lists](#nested-lists-v16) | `ListBuilder.addItem(label, Consumer)` — depth cascade, per-depth markers, mixed flat / nested authoring | [PDF](../assets/readme/examples/nested-list-showcase.pdf) · [Source](src/main/java/com/demcha/examples/features/lists/NestedListExample.java) |
+| [Composed table cells](#composed-table-cells-v16) | `DocumentTableCell.node(DocumentNode)` — paragraphs, lists, sub-tables inside cells with two-pass measurement | [PDF](../assets/readme/examples/composed-table-cell-showcase.pdf) · [Source](src/main/java/com/demcha/examples/features/tables/ComposedTableCellExample.java) |
+| [Canvas layer (free placement)](#canvas-layer-v16) | `CanvasLayerNode` — pixel-precise `(x, y)` placement of children inside a fixed bounding box, with `ClipPolicy` clipping | [PDF](../assets/readme/examples/canvas-layer-showcase.pdf) · [Source](src/main/java/com/demcha/examples/features/canvas/CanvasLayerExample.java) |
+| [Transforms](#transforms) | `rotate`, `scale`, and per-layer `zIndex` swap | [PDF](../assets/readme/examples/transforms.pdf) · [Source](src/main/java/com/demcha/examples/features/transforms/TransformsExample.java) |
+
+### 📋 Templates recommended
+
+| Example | What it shows | Preview · Source |
+|---|---|---|
 | [CV — template gallery](#cv-template-gallery) | All 14 v2 CV presets in one orchestrated run | [Source](src/main/java/com/demcha/examples/templates/cv/CvTemplateGalleryFileExample.java) |
 | [Cover letter — template gallery](#cover-letter-template-gallery) | All 14 paired v2 cover-letter presets in one orchestrated run | [Source](src/main/java/com/demcha/examples/templates/coverletter/CoverLetterTemplateGalleryFileExample.java) |
-
-### Cinematic templates (v1.5)
-
-| Example | What it shows | Preview · Source |
-|---|---|---|
-| [Invoice — cinematic V2](#invoice-cinematic-v2) | `InvoiceTemplateV2 + BusinessTheme.modern()` | [PDF](../assets/readme/examples/invoice-cinematic.pdf) · [Source](src/main/java/com/demcha/examples/templates/invoice/InvoiceCinematicFileExample.java) |
 | [Proposal — cinematic V2](#proposal-cinematic-v2) | `ProposalTemplateV2 + BusinessTheme.modern()` | [PDF](../assets/readme/examples/proposal-cinematic.pdf) · [Source](src/main/java/com/demcha/examples/templates/proposal/ProposalCinematicFileExample.java) |
-| [Handcrafted Proposal](#handcrafted-proposal) | v1.4-style cinematic proposal composed by hand | [PDF](../assets/readme/examples/project-proposal-cinematic.pdf) · [Source](src/main/java/com/demcha/examples/templates/proposal/CinematicProposalFileExample.java) |
+| [Custom Business Theme](#custom-business-theme) | Hand-built `BusinessTheme` driving `InvoiceTemplateV2` — theme-token customisation entry point | [PDF](../assets/readme/examples/invoice-custom-theme.pdf) · [Source](src/main/java/com/demcha/examples/features/themes/CustomBusinessThemeExample.java) |
 
-### v1.5 feature showcases
+### 🔧 Advanced SPI
 
 | Example | What it shows | Preview · Source |
 |---|---|---|
 | [Shape containers](#shape-containers) | Circles, ellipses, rounded cards with `ClipPolicy.CLIP_PATH` | [PDF](../assets/readme/examples/shape-container.pdf) · [Source](src/main/java/com/demcha/examples/features/shapes/ShapeContainerExample.java) |
-| [Transforms](#transforms) | `rotate`, `scale`, and per-layer `zIndex` swap | [PDF](../assets/readme/examples/transforms.pdf) · [Source](src/main/java/com/demcha/examples/features/transforms/TransformsExample.java) |
 | [Advanced tables](#advanced-tables) | Row span, zebra rows, totals, repeating header on page break | [PDF](../assets/readme/examples/table-advanced.pdf) · [Source](src/main/java/com/demcha/examples/features/tables/TableAdvancedExample.java) |
-| [Custom Business Theme](#custom-business-theme) | Hand-built `BusinessTheme` driving `InvoiceTemplateV2` | [PDF](../assets/readme/examples/invoice-custom-theme.pdf) · [Source](src/main/java/com/demcha/examples/features/themes/CustomBusinessThemeExample.java) |
-
-### v1.6 feature showcases
-
-| Example | What it shows | Preview · Source |
-|---|---|---|
-| [Nested lists](#nested-lists-v16) | `ListBuilder.addItem(label, Consumer)` — depth cascade, per-depth markers, mixed flat / nested authoring | [PDF](../assets/readme/examples/nested-list-showcase.pdf) · [Source](src/main/java/com/demcha/examples/features/lists/NestedListExample.java) |
-| [Composed table cells](#composed-table-cells-v16) | `DocumentTableCell.node(DocumentNode)` — paragraphs, lists, sub-tables inside cells with two-pass measurement | [PDF](../assets/readme/examples/composed-table-cell-showcase.pdf) · [Source](src/main/java/com/demcha/examples/features/tables/ComposedTableCellExample.java) |
-| [Canvas layer (free placement)](#canvas-layer-v16) | `CanvasLayerNode` — pixel-precise `(x, y)` placement of children inside a fixed bounding box, with `ClipPolicy` clipping | [PDF](../assets/readme/examples/canvas-layer-showcase.pdf) · [Source](src/main/java/com/demcha/examples/features/canvas/CanvasLayerExample.java) |
-
-### Public-API surface
-
-| Example | What it shows | Preview · Source |
-|---|---|---|
-| [Rich text](#rich-text) | Every `RichText` method (bold / italic / underline / link / colour / accent / size / link / append) | [PDF](../assets/readme/examples/rich-text-showcase.pdf) · [Source](src/main/java/com/demcha/examples/features/text/RichTextShowcaseExample.java) |
-| [Section presets](#section-presets) | `pageBackground`, `band`, `softPanel`, `accentLeft / Right / Top / Bottom`, per-corner `DocumentCornerRadius` | [PDF](../assets/readme/examples/section-presets.pdf) · [Source](src/main/java/com/demcha/examples/features/text/SectionPresetsExample.java) |
 | [Barcodes](#barcodes) | QR, Code 128, Code 39, EAN-13, EAN-8, branded QR with theme colours | [PDF](../assets/readme/examples/barcode-showcase.pdf) · [Source](src/main/java/com/demcha/examples/features/barcodes/BarcodeShowcaseExample.java) |
 | [PDF chrome](#pdf-chrome) | `DocumentMetadata`, `DocumentWatermark`, `DocumentHeaderFooter`, `DocumentBookmarkOptions` | [PDF](../assets/readme/examples/pdf-chrome.pdf) · [Source](src/main/java/com/demcha/examples/features/chrome/PdfChromeExample.java) |
-
-### Production patterns
-
-| Example | What it shows | Preview · Source |
-|---|---|---|
 | [HTTP streaming](#http-streaming) | `writePdf(OutputStream)` for Servlet / S3 / GCS — caller's stream is not closed | [PDF](../assets/readme/examples/invoice-http-stream.pdf) · [Source](src/main/java/com/demcha/examples/features/streaming/HttpStreamingExample.java) |
-| [Layout snapshot regression](#layout-snapshot-regression) | Deterministic `layoutSnapshot()` workflow with baseline + drift report | [PDF](../assets/readme/examples/invoice-snapshot-regression.pdf) · [Source](src/main/java/com/demcha/examples/features/snapshots/LayoutSnapshotRegressionExample.java) |
-
-### Operational documents
-
-| Example | What it shows | Preview · Source |
-|---|---|---|
-| [Weekly schedule](#weekly-schedule) | Bar / restaurant shift schedule via reusable `WeeklyScheduleRenderer` with typed `DayShift` API | [PDF](../assets/readme/examples/weekly-schedule.pdf) · [Source](src/main/java/com/demcha/examples/templates/schedule/WeeklyScheduleFileExample.java) |
+| [Layout snapshot regression](#layout-snapshot-regression) | Deterministic `layoutSnapshot()` workflow with baseline + drift report — production regression-testing pattern | [PDF](../assets/readme/examples/invoice-snapshot-regression.pdf) · [Source](src/main/java/com/demcha/examples/features/snapshots/LayoutSnapshotRegressionExample.java) |
 | [Business report cover](#business-report-cover) | Single-page Q1 investor brief — hero image, KPI cards, bar chart, metrics table | [PDF](../assets/readme/examples/business-report.pdf) · [Source](src/main/java/com/demcha/examples/flagships/BusinessReportExample.java) |
 | [Master showcase](#master-showcase) | Kitchen-sink "Q2 sample report" combining the canonical surface end-to-end | [PDF](../assets/readme/examples/master-showcase.pdf) · [Source](src/main/java/com/demcha/examples/flagships/MasterShowcaseExample.java) |
+
+### 🗄️ Legacy
+
+| Example | What it shows | Preview · Source |
+|---|---|---|
+| [Invoice (V1)](#invoice-v1) | `InvoiceTemplateV1` driven from `InvoiceDocumentSpec` — pre-rebuild surface, supported only | [PDF](../assets/readme/examples/invoice.pdf) · [Source](src/main/java/com/demcha/examples/templates/invoice/InvoiceFileExample.java) |
+| [Proposal (V1)](#proposal-v1) | `ProposalTemplateV1` driven from `ProposalDocumentSpec` — pre-rebuild surface, supported only | [PDF](../assets/readme/examples/proposal.pdf) · [Source](src/main/java/com/demcha/examples/templates/proposal/ProposalFileExample.java) |
+| [Handcrafted Proposal](#handcrafted-proposal) | v1.4-style cinematic proposal composed by hand — pre-template authoring; kept for parity reference | [PDF](../assets/readme/examples/project-proposal-cinematic.pdf) · [Source](src/main/java/com/demcha/examples/templates/proposal/CinematicProposalFileExample.java) |
+| [Weekly schedule](#weekly-schedule) | Bar / restaurant shift schedule via `WeeklyScheduleRenderer` (`WeeklyScheduleTemplateV1` — no V2 yet; will be re-shaped before 2.0) | [PDF](../assets/readme/examples/weekly-schedule.pdf) · [Source](src/main/java/com/demcha/examples/templates/schedule/WeeklyScheduleFileExample.java) |
 
 ---
 


### PR DESCRIPTION
## Summary

Wires up Track **G2 (`docs/examples-maturity-index`)** from the 1.6.5→1.7 readiness taskboard — the second of three onboarding-clarity PRs for the 1.6.6 Maven Central debut (after [G1 #86](https://github.com/DemchaAV/GraphCompose/pull/86)).

`examples/README.md` previously grouped the 26 examples by the release that introduced each one (*Built-in templates / Cinematic v1.5 / v1.5 feature showcases / v1.6 feature showcases / Public-API surface / Production patterns / Operational documents*). Useful as a release history; less useful for someone landing on the folder for the first time who needs to know *"which one do I read first?"* or *"is this still recommended for new code?"*.

## What changes

The gallery now categorises by **maturity / intent**, in five tiers introduced by a legend block at the section header:

| Tier | Count | Use it for |
|---|---|---|
| 🚀 **Start here** | 4 | Minimum-friction entry points |
| 🧱 **Core DSL** | 6 | Daily-driver features |
| 📋 **Templates recommended** | 4 | v2 / layered template surfaces |
| 🔧 **Advanced SPI** | 8 | Production patterns + specialty SPIs (shapes, transforms, barcodes, snapshots, streaming) |
| 🗄️ **Legacy** | 4 | Pre-rebuild surface; do not start new code here |

Total = **26 examples** (unchanged — no examples added or removed). Tier counts double-check the migration is complete.

All anchor IDs (``#cv-single-template``, ``#invoice-cinematic-v2``, etc.) are preserved verbatim, so existing deep links from the canonical README, ADRs, and external sources continue to resolve. Only the gallery index is restructured; the detailed sections below the gallery are untouched.

The 🗄️ **Legacy** tier description links to [`docs/templates/which-template-system.md`](../docs/templates/which-template-system.md) (from G1) for the V1 → V2 migration path, so the two onboarding-clarity PRs cross-link naturally.

## Notable categorisation calls

- **`Invoice — cinematic V2`** moved into 🚀 Start here (it's the recommended invoice path; the previous "Cinematic templates v1.5" tier was misleading — "cinematic" is the theme, not the maturity).
- **`Module-first Profile`** stays in 🚀 Start here — it's the DSL-direct authoring entry point, not a template, and beginners benefit from seeing both the template and DSL paths early.
- **`Transforms`** sits in 🧱 Core DSL rather than 🔧 Advanced SPI — `rotate`/`scale`/`zIndex` are part of the daily-driver DSL surface, not specialty SPI. Shape clipping and barcodes are SPI; transforms aren't.
- **`Custom Business Theme`** sits in 📋 Templates recommended — it's the theme-customisation entry point for V2 built-in templates, naturally adjacent to the gallery examples.
- **`WeeklyScheduleTemplateV1`** sits in 🗄️ Legacy — there's no V2 yet and the V1 API will be re-shaped before 2.0 (called out in the row description, mirrored from the G1 doc).

## Verification

```
$ ./mvnw -B -ntp test -pl . \
    -Dtest='CanonicalSurfaceGuardTest,DocumentationCoverageTest,DocumentationExamplesTest,VersionConsistencyGuardTest'
Tests run: 30, Failures: 0, Errors: 0, Skipped: 0
```

```
$ ./mvnw -B -ntp -f examples/pom.xml clean compile
BUILD SUCCESS (5.2s)
```

The taskboard G2 gate is `doc-guard + smoke compile`; both green.

CHANGELOG entry added to ``v1.6.6 — Planned`` under the existing ``### Documentation`` subsection alongside the G1 entry.

## Test plan

- [x] Doc guards green (no legacy-token leak, no broken `CanonicalSurfaceGuardTest`)
- [x] Examples module compiles cleanly (smoke gate from taskboard)
- [x] All 26 anchor IDs preserved (reviewer can spot-check by clicking the row links from the rendered diff)
- [ ] CI green on PR (Guards / JDK 17/21/25 / Examples Smoke / binary-compat)
- [ ] (Out of scope) follow-up: cross-link the maturity legend from `docs/templates/which-template-system.md` so the two onboarding pages reference each other in both directions