### PR TITLE
chore(api): add class-level @since to public entry points + coverage guard (H1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ JitPack continue to resolve through the existing coordinates.
   `./mvnw -DskipTests -P japicmp verify -pl .`; HTML/MD/XML reports
   land in `target/japicmp/`. JitPack repository is scoped to the
   `japicmp` profile, so downstream consumers do not inherit it.
+- **Class-level `@since 1.0.0` Javadoc on the public entry-point
+  surface** (Track H1). 26 public types in the canonical user-reached
+  packages (`com.demcha.compose.GraphCompose`, `com.demcha.compose.document.api.{DocumentSession, DocumentPageSize, PageBackgroundFill}`,
+  `com.demcha.compose.document.dsl.{DocumentDsl, RichText, Transformable}` plus all 19 DSL builders)
+  now carry class-level `@since 1.0.0` Javadoc tags so callers can see
+  the introduction version at IDE quick-doc / generated Javadoc time
+  without trawling CHANGELOG history. New guard test
+  `PublicApiSinceTagCoverageTest` source-scans the three entry-point
+  roots and fails the build if a new public top-level type lands
+  without a class-level `@since` tag; `internal/` sub-packages are
+  excluded by convention (`InternalAnnotationCoverageTest` covers those).
+  Method-level `@since` backfill for the ~380 public methods in these
+  packages is intentionally out of scope here and tracked separately.
 
 ### Engine internals (no behaviour change)
 

--- a/src/main/java/com/demcha/compose/GraphCompose.java
+++ b/src/main/java/com/demcha/compose/GraphCompose.java
@@ -31,6 +31,7 @@ import java.util.Objects;
  * </ol>
  *
  * @author Artem Demchyshyn
+ * @since 1.0.0
  *
  * <h3>Build a PDF file with the canonical DSL</h3>
  * <pre>

--- a/src/main/java/com/demcha/compose/document/api/DocumentPageSize.java
+++ b/src/main/java/com/demcha/compose/document/api/DocumentPageSize.java
@@ -8,6 +8,7 @@ package com.demcha.compose.document.api;
  *
  * @param width page width in points
  * @param height page height in points
+ * @since 1.0.0
  */
 public record DocumentPageSize(double width, double height) {
     /**

--- a/src/main/java/com/demcha/compose/document/api/DocumentSession.java
+++ b/src/main/java/com/demcha/compose/document/api/DocumentSession.java
@@ -59,6 +59,7 @@ import java.util.function.Consumer;
  * <p><b>Thread-safety:</b> this type is mutable and not thread-safe.</p>
  *
  * @author Artem Demchyshyn
+ * @since 1.0.0
  */
 public final class DocumentSession implements AutoCloseable {
     private static final Logger LIFECYCLE_LOG = LoggerFactory.getLogger("com.demcha.compose.document.lifecycle");

--- a/src/main/java/com/demcha/compose/document/api/PageBackgroundFill.java
+++ b/src/main/java/com/demcha/compose/document/api/PageBackgroundFill.java
@@ -44,6 +44,7 @@ import java.util.Objects;
  *                    Keep {@code yRatio + heightRatio <= 1.0} so the fill
  *                    stays within the page.
  * @param color       fill color (required)
+ * @since 1.0.0
  */
 public record PageBackgroundFill(double xRatio,
                                  double yRatio,

--- a/src/main/java/com/demcha/compose/document/dsl/AbstractFlowBuilder.java
+++ b/src/main/java/com/demcha/compose/document/dsl/AbstractFlowBuilder.java
@@ -23,6 +23,7 @@ import java.util.function.Consumer;
  *
  * @param <T> concrete builder type
  * @param <N> concrete node type
+ * @since 1.0.0
  */
 public abstract class AbstractFlowBuilder<T extends AbstractFlowBuilder<T, N>, N extends DocumentNode> {
     private String name = "";

--- a/src/main/java/com/demcha/compose/document/dsl/BarcodeBuilder.java
+++ b/src/main/java/com/demcha/compose/document/dsl/BarcodeBuilder.java
@@ -42,6 +42,7 @@ import java.util.function.Consumer;
 
 /**
  * Builder for semantic barcode and QR-code nodes.
+ * @since 1.0.0
  */
 public final class BarcodeBuilder implements Transformable<BarcodeBuilder> {
     private String name = "";

--- a/src/main/java/com/demcha/compose/document/dsl/CanvasLayerBuilder.java
+++ b/src/main/java/com/demcha/compose/document/dsl/CanvasLayerBuilder.java
@@ -20,6 +20,7 @@ import java.util.Objects;
  * positive {@code y} is down.</p>
  *
  * @author Artem Demchyshyn
+ * @since 1.0.0
  */
 public final class CanvasLayerBuilder {
 

--- a/src/main/java/com/demcha/compose/document/dsl/DividerBuilder.java
+++ b/src/main/java/com/demcha/compose/document/dsl/DividerBuilder.java
@@ -41,6 +41,7 @@ import java.util.function.Consumer;
 
 /**
  * Builder for thin horizontal divider nodes.
+ * @since 1.0.0
  */
 public final class DividerBuilder extends ShapeBuilder {
     DividerBuilder() {

--- a/src/main/java/com/demcha/compose/document/dsl/DocumentDsl.java
+++ b/src/main/java/com/demcha/compose/document/dsl/DocumentDsl.java
@@ -24,6 +24,7 @@ import java.util.function.Consumer;
  * }</pre>
  *
  * @author Artem Demchyshyn
+ * @since 1.0.0
  */
 public final class DocumentDsl {
     private final DocumentSession session;

--- a/src/main/java/com/demcha/compose/document/dsl/EllipseBuilder.java
+++ b/src/main/java/com/demcha/compose/document/dsl/EllipseBuilder.java
@@ -14,6 +14,7 @@ import java.awt.Color;
  * Builder for semantic circle and ellipse nodes.
  *
  * @author Artem Demchyshyn
+ * @since 1.0.0
  */
 public final class EllipseBuilder implements Transformable<EllipseBuilder> {
     private String name = "";

--- a/src/main/java/com/demcha/compose/document/dsl/ImageBuilder.java
+++ b/src/main/java/com/demcha/compose/document/dsl/ImageBuilder.java
@@ -15,6 +15,7 @@ import java.util.Objects;
  * Builder for semantic image nodes.
  *
  * @author Artem Demchyshyn
+ * @since 1.0.0
  */
 public final class ImageBuilder implements Transformable<ImageBuilder> {
     private String name = "";

--- a/src/main/java/com/demcha/compose/document/dsl/LayerStackBuilder.java
+++ b/src/main/java/com/demcha/compose/document/dsl/LayerStackBuilder.java
@@ -19,6 +19,7 @@ import java.util.Objects;
  * block by the canonical paginator.</p>
  *
  * @author Artem Demchyshyn
+ * @since 1.0.0
  */
 public final class LayerStackBuilder {
     private String name = "";

--- a/src/main/java/com/demcha/compose/document/dsl/LineBuilder.java
+++ b/src/main/java/com/demcha/compose/document/dsl/LineBuilder.java
@@ -12,6 +12,7 @@ import com.demcha.compose.document.style.DocumentTransform;
  * Builder for fixed-size semantic line nodes.
  *
  * @author Artem Demchyshyn
+ * @since 1.0.0
  */
 public final class LineBuilder implements Transformable<LineBuilder> {
     private String name = "";

--- a/src/main/java/com/demcha/compose/document/dsl/ListBuilder.java
+++ b/src/main/java/com/demcha/compose/document/dsl/ListBuilder.java
@@ -42,6 +42,7 @@ import java.util.function.Consumer;
 
 /**
  * Builder for semantic list nodes with marker and spacing controls.
+ * @since 1.0.0
  */
 public final class ListBuilder {
     private String name = "";

--- a/src/main/java/com/demcha/compose/document/dsl/ModuleBuilder.java
+++ b/src/main/java/com/demcha/compose/document/dsl/ModuleBuilder.java
@@ -43,6 +43,7 @@ import java.util.function.Consumer;
  * Builder for named semantic modules with optional title content.
  *
  * @author Artem Demchyshyn
+ * @since 1.0.0
  */
 public final class ModuleBuilder extends AbstractFlowBuilder<ModuleBuilder, SectionNode> {
     private String title = "";

--- a/src/main/java/com/demcha/compose/document/dsl/PageBreakBuilder.java
+++ b/src/main/java/com/demcha/compose/document/dsl/PageBreakBuilder.java
@@ -41,6 +41,7 @@ import java.util.function.Consumer;
 
 /**
  * Builder for explicit page-break control nodes.
+ * @since 1.0.0
  */
 public final class PageBreakBuilder {
     private String name = "";

--- a/src/main/java/com/demcha/compose/document/dsl/PageFlowBuilder.java
+++ b/src/main/java/com/demcha/compose/document/dsl/PageFlowBuilder.java
@@ -43,6 +43,7 @@ import java.util.function.Consumer;
  * Builder for root page-flow containers that attach to a document session.
  *
  * @author Artem Demchyshyn
+ * @since 1.0.0
  */
 public final class PageFlowBuilder extends AbstractFlowBuilder<PageFlowBuilder, ContainerNode> {
     private final DocumentSession session;

--- a/src/main/java/com/demcha/compose/document/dsl/ParagraphBuilder.java
+++ b/src/main/java/com/demcha/compose/document/dsl/ParagraphBuilder.java
@@ -21,6 +21,7 @@ import java.util.function.Consumer;
 
 /**
  * Builder for semantic paragraph nodes and inline text runs.
+ * @since 1.0.0
  */
 public final class ParagraphBuilder {
     private String name = "";

--- a/src/main/java/com/demcha/compose/document/dsl/RichText.java
+++ b/src/main/java/com/demcha/compose/document/dsl/RichText.java
@@ -35,6 +35,7 @@ import java.util.Objects;
  * }</pre>
  *
  * @author Artem Demchyshyn
+ * @since 1.0.0
  */
 public final class RichText {
     private final List<InlineRun> runs = new ArrayList<>();

--- a/src/main/java/com/demcha/compose/document/dsl/RowBuilder.java
+++ b/src/main/java/com/demcha/compose/document/dsl/RowBuilder.java
@@ -44,6 +44,7 @@ import java.util.function.Consumer;
  * atomic pagination.</p>
  *
  * @author Artem Demchyshyn
+ * @since 1.0.0
  */
 public final class RowBuilder {
     private String name = "";

--- a/src/main/java/com/demcha/compose/document/dsl/SectionBuilder.java
+++ b/src/main/java/com/demcha/compose/document/dsl/SectionBuilder.java
@@ -43,6 +43,7 @@ import java.util.function.Consumer;
  * Builder for semantic sections inside document flows.
  *
  * @author Artem Demchyshyn
+ * @since 1.0.0
  */
 public final class SectionBuilder extends AbstractFlowBuilder<SectionBuilder, SectionNode> {
     /**

--- a/src/main/java/com/demcha/compose/document/dsl/ShapeBuilder.java
+++ b/src/main/java/com/demcha/compose/document/dsl/ShapeBuilder.java
@@ -45,6 +45,7 @@ import java.util.function.Consumer;
  * Builder for rectangle-like semantic shape nodes.
  *
  * @author Artem Demchyshyn
+ * @since 1.0.0
  */
 public class ShapeBuilder implements Transformable<ShapeBuilder> {
     protected String name = "";

--- a/src/main/java/com/demcha/compose/document/dsl/ShapeContainerBuilder.java
+++ b/src/main/java/com/demcha/compose/document/dsl/ShapeContainerBuilder.java
@@ -27,6 +27,7 @@ import java.util.Objects;
  * nine {@link LayerAlign} anchors plus optional on-screen offset.</p>
  *
  * @author Artem Demchyshyn
+ * @since 1.0.0
  */
 public final class ShapeContainerBuilder implements Transformable<ShapeContainerBuilder> {
     private String name = "";

--- a/src/main/java/com/demcha/compose/document/dsl/SpacerBuilder.java
+++ b/src/main/java/com/demcha/compose/document/dsl/SpacerBuilder.java
@@ -7,6 +7,7 @@ import com.demcha.compose.document.style.DocumentInsets;
  * Builder for invisible fixed-size spacer nodes.
  *
  * @author Artem Demchyshyn
+ * @since 1.0.0
  */
 public final class SpacerBuilder {
     private String name = "";

--- a/src/main/java/com/demcha/compose/document/dsl/TableBuilder.java
+++ b/src/main/java/com/demcha/compose/document/dsl/TableBuilder.java
@@ -24,6 +24,7 @@ import java.util.function.Consumer;
 
 /**
  * Builder for semantic table nodes.
+ * @since 1.0.0
  */
 public final class TableBuilder {
     private String name = "";

--- a/src/main/java/com/demcha/compose/document/dsl/Transformable.java
+++ b/src/main/java/com/demcha/compose/document/dsl/Transformable.java
@@ -22,6 +22,7 @@ import com.demcha.compose.document.style.DocumentTransform;
  *            can chain naturally
  *
  * @author Artem Demchyshyn
+ * @since 1.0.0
  */
 public interface Transformable<T extends Transformable<T>> {
 

--- a/src/test/java/com/demcha/documentation/PublicApiSinceTagCoverageTest.java
+++ b/src/test/java/com/demcha/documentation/PublicApiSinceTagCoverageTest.java
@@ -1,0 +1,126 @@
+package com.demcha.documentation;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Asserts every {@code public} type in the canonical authoring entry-point
+ * packages carries a class-level {@code @since} Javadoc tag. The guard is
+ * intentionally narrow — it covers only the surfaces a user first reaches
+ * for ({@link com.demcha.compose.GraphCompose} factory, the
+ * {@code document.api} session / builder seam, and the {@code document.dsl}
+ * authoring builders) — not the whole public surface. A broader sweep
+ * across {@code document.node}, {@code document.style}, and the template
+ * packages is tracked separately.
+ *
+ * <p>The check is source-level rather than reflective because
+ * {@code @since} is a Javadoc tag, not a runtime annotation. The guard
+ * scans each {@code *.java} file and verifies that an {@code @since}
+ * token appears somewhere before the first {@code public class},
+ * {@code public final class}, {@code public sealed class}, {@code public
+ * abstract class}, {@code public interface}, {@code public sealed
+ * interface}, {@code public record}, {@code public final record}, or
+ * {@code public enum} declaration.</p>
+ *
+ * <p>Files with no public top-level type ({@code package-info.java} and
+ * the like) are skipped.</p>
+ */
+class PublicApiSinceTagCoverageTest {
+
+    private static final Path PROJECT_ROOT = Paths.get(".").toAbsolutePath().normalize();
+
+    /**
+     * The narrow set of "entry-point" sources this guard scans. New
+     * packages should be added here only when they qualify as primary
+     * user-reached surface; otherwise leave them for the broader sweep
+     * tracked under the v1.6.6 H-track.
+     */
+    private static final List<Path> ROOTS = List.of(
+            PROJECT_ROOT.resolve("src/main/java/com/demcha/compose/GraphCompose.java"),
+            PROJECT_ROOT.resolve("src/main/java/com/demcha/compose/document/api"),
+            PROJECT_ROOT.resolve("src/main/java/com/demcha/compose/document/dsl")
+    );
+
+    /**
+     * Files explicitly excused from the {@code @since} requirement.
+     * Add an entry here only when the file truly does not declare a
+     * public top-level type that callers can reach — e.g. an internal
+     * helper that ended up in an entry-point package by accident and
+     * is on its way out.
+     */
+    private static final Set<String> ALLOWLIST = Set.of();
+
+    private static final Pattern FIRST_PUBLIC_TYPE = Pattern.compile(
+            "(?m)^public\\s+(?:final\\s+|abstract\\s+|sealed\\s+|non-sealed\\s+)*"
+                    + "(?:class|interface|record|enum|@interface)\\b");
+
+    @Test
+    void publicEntryPointFilesCarryClassLevelSinceTag() throws IOException {
+        List<String> missing = new ArrayList<>();
+        for (Path root : ROOTS) {
+            scan(root, missing);
+        }
+        assertThat(missing)
+                .as("public entry-point files missing class-level @since tag")
+                .isEmpty();
+    }
+
+    private void scan(Path root, List<String> missing) throws IOException {
+        if (!Files.exists(root)) {
+            // Source layout change — let the test fail loudly so the
+            // maintainer notices the dropped root rather than silently
+            // skipping coverage.
+            throw new IllegalStateException("Guard root does not exist: " + root);
+        }
+        if (Files.isRegularFile(root)) {
+            checkFile(root, missing);
+            return;
+        }
+        try (Stream<Path> paths = Files.walk(root)) {
+            paths.filter(Files::isRegularFile)
+                    .filter(p -> p.getFileName().toString().endsWith(".java"))
+                    .filter(p -> !p.getFileName().toString().equals("package-info.java"))
+                    // Files inside a `.internal` subpackage are internal by
+                    // package-naming convention; treat the same way as the
+                    // package-level @Internal annotation in `document.layout`.
+                    // Coverage on those packages is enforced separately by
+                    // InternalAnnotationCoverageTest.
+                    .filter(p -> !p.toString().replace('\\', '/').contains("/internal/"))
+                    .forEach(p -> checkFile(p, missing));
+        }
+    }
+
+    private void checkFile(Path file, List<String> missing) {
+        String relative = PROJECT_ROOT.relativize(file).toString().replace('\\', '/');
+        if (ALLOWLIST.contains(relative)) {
+            return;
+        }
+        String content;
+        try {
+            content = Files.readString(file);
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read " + file, e);
+        }
+        Matcher m = FIRST_PUBLIC_TYPE.matcher(content);
+        if (!m.find()) {
+            // Source file has no public top-level type — skip silently.
+            return;
+        }
+        String beforeFirstPublicType = content.substring(0, m.start());
+        if (!beforeFirstPublicType.contains("@since")) {
+            missing.add(relative);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Wires up Track **H1** from the v1.6.5→1.7 readiness taskboard. The G3 stability policy ([#88](https://github.com/DemchaAV/GraphCompose/pull/88)) pins what `@since` is supposed to mean; this PR makes it true on the canonical entry-point surface.

**26 public types** in the canonical user-reached packages now carry **class-level `@since 1.0.0`** Javadoc tags so callers see the introduction version at IDE quick-doc / generated Javadoc time without trawling CHANGELOG history. A new architecture guard fails the build if a future public top-level type lands in these packages without a class-level `@since`.

## What changes

### `@since 1.0.0` added (class-level Javadoc)

| Package | Types tagged |
|---|---|
| `com.demcha.compose` | `GraphCompose` |
| `com.demcha.compose.document.api` | `DocumentSession`, `DocumentPageSize`, `PageBackgroundFill` |
| `com.demcha.compose.document.dsl` | `DocumentDsl`, `RichText`, `Transformable` + **19 builders** (`AbstractFlowBuilder`, `BarcodeBuilder`, `CanvasLayerBuilder`, `DividerBuilder`, `EllipseBuilder`, `ImageBuilder`, `LayerStackBuilder`, `LineBuilder`, `ListBuilder`, `ModuleBuilder`, `PageBreakBuilder`, `PageFlowBuilder`, `ParagraphBuilder`, `RowBuilder`, `SectionBuilder`, `ShapeBuilder`, `ShapeContainerBuilder`, `SpacerBuilder`, `TableBuilder`) |

**Total: 26 files.**

### Baseline choice — why `@since 1.0.0`

These are foundational types that have shipped since the first GraphCompose release and predate the CHANGELOG history that could pin a more specific version. The pragmatic baseline communicates "this is in the API from the beginning"; new public types added in subsequent PRs use the upcoming release version (e.g. `@since 1.6.6`).

### New guard — `PublicApiSinceTagCoverageTest`

Source-scans three entry-point roots:

- `src/main/java/com/demcha/compose/GraphCompose.java`
- `src/main/java/com/demcha/compose/document/api/`
- `src/main/java/com/demcha/compose/document/dsl/`

Fails the build if a `.java` file declares a public top-level type (class / interface / record / enum / annotation) and `@since` does not appear in the source above the first such declaration. `package-info.java` and files in `internal/` sub-packages are excluded by convention — `InternalAnnotationCoverageTest` already covers `@Internal` packages and the same naming rule applies to `internal/` sub-packages.

## Why this scope, not a full sweep

- **Method-level backfill** for the ~380 public methods in these packages is intentionally out of scope. Method `@since` is now policy for **all new** public methods (the `graphcompose-senior-review` skill enforces it in Lane 5's Javadoc checklist) but retrofitting the existing surface is its own task — and one that benefits from per-method git archaeology that an automated sed pass can't safely do.
- **Other public packages** (`document.node`, `document.style`, the template surfaces) are not scanned. The taskboard scopes H1 to the entry-point surface — `GraphCompose` factory, the `document.api` session / builder seam, and the `document.dsl` authoring builders. A broader sweep follows the same pattern when it lands.

## Verification

```
$ ./mvnw -B -ntp test -pl . -Dtest=PublicApiSinceTagCoverageTest
Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```

Mentally reverting any single `@since` line goes red — confirmed by sed-removing one tag in `RowBuilder.java` and re-running the guard (then restoring it).

```
$ ./mvnw -B -ntp test -pl .
Tests run: 1024 (+1 from PublicApiSinceTagCoverageTest), Failures: 0, Errors: 0
```

Full suite green confirms the bulk Javadoc edits didn't break Javadoc parsing or unrelated tests.

CHANGELOG entry added to ``v1.6.6 — Planned`` under the existing ``### Build`` subsection.

## Test plan

- [x] New guard green against current state
- [x] Full suite green (1024 / 0 / 0)
- [x] All 19 builders + 7 non-builder entry points carry class-level `@since 1.0.0`
- [ ] CI green on PR
- [ ] Reviewer skim — most edits are mechanical (the sed-generated `@since 1.0.0` line); the guard test itself (~95 LOC) is where the human review pays off
- [ ] (Out of scope) follow-up: method-level `@since` backfill — separate PR, separate cadence; the guard does not enforce method-level today