### PR TITLE
test(build): add no-poi Maven profile to validate poi-ooxml stays optional (I1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,34 @@ jobs:
           path: examples/target/generated-pdfs/**
           if-no-files-found: error
 
+  no-poi-suite:
+    name: Test suite without poi-ooxml (optional-deps regression)
+    if: github.event_name == 'pull_request'
+    needs: architecture-and-documentation-guards
+    runs-on: ubuntu-latest
+    env:
+      JAVA_TOOL_OPTIONS: -Djava.awt.headless=true
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Temurin JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Run suite under -P no-poi
+        # poi-ooxml is declared <optional>true</optional>; this job
+        # validates that callers who don't render DOCX still get a
+        # green suite without the POI footprint. Tests that require
+        # poi (DocxSemanticBackend output) carry
+        # @DisabledIfSystemProperty(named = "no.poi", matches = "true")
+        # and skip cleanly. See Track I1 in the readiness taskboard.
+        run: ./mvnw -B -ntp test -pl . -P no-poi
+
   binary-compat:
     name: Binary Compatibility (japicmp vs v1.6.5)
     if: github.event_name == 'pull_request'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,18 @@ JitPack continue to resolve through the existing coordinates.
   excluded by convention (`InternalAnnotationCoverageTest` covers those).
   Method-level `@since` backfill for the ~380 public methods in these
   packages is intentionally out of scope here and tracked separately.
+- **`no-poi` Maven profile + CI job** (Track I1). The `poi-ooxml`
+  dependency is declared `<optional>true</optional>` so callers that
+  render only PDFs don't pay the ~10 MB POI footprint; this PR adds a
+  regression gate that proves it. Running `./mvnw -P no-poi test -pl .`
+  excludes `poi-ooxml` (and its `poi` / `poi-ooxml-lite` transitives)
+  from the surefire test classpath and sets the system property
+  `no.poi=true`. DOCX-specific tests (`DocxSemanticBackendTest` and the
+  one DOCX export in `DocumentSessionTest`) now carry
+  `@DisabledIfSystemProperty(named = "no.poi", matches = "true")` and
+  skip cleanly. The rest of the canonical suite (1029 tests, 4 skipped
+  under `-P no-poi`) runs green without POI on the classpath. A new
+  `no-poi-suite` CI job exercises the profile on every pull request.
 
 ### Public API
 

--- a/pom.xml
+++ b/pom.xml
@@ -362,6 +362,39 @@
 
     <profiles>
         <!--
+            Optional-deps regression: runs the canonical suite with
+            `poi-ooxml` (and its transitives) excluded from the test
+            classpath, so callers that don't render DOCX validate that
+            our DocxSemanticBackend is genuinely optional. Tests that
+            require POI carry @DisabledIfSystemProperty(named = "no.poi",
+            matches = "true") and skip cleanly under this profile.
+            Activate with `-P no-poi`. Tracked in v1.6.6 stabilization
+            (Track I1).
+        -->
+        <profile>
+            <id>no-poi</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <version>${maven.surefire.plugin.version}</version>
+                        <configuration>
+                            <classpathDependencyExcludes>
+                                <classpathDependencyExclude>org.apache.poi:poi-ooxml</classpathDependencyExclude>
+                                <classpathDependencyExclude>org.apache.poi:poi</classpathDependencyExclude>
+                                <classpathDependencyExclude>org.apache.poi:poi-ooxml-lite</classpathDependencyExclude>
+                            </classpathDependencyExcludes>
+                            <systemPropertyVariables>
+                                <no.poi>true</no.poi>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <!--
             Binary-compatibility baseline against the last published
             release. Activated with `-P japicmp`. Resolves the baseline
             artifact from JitPack (kept profile-local so consumers do

--- a/src/test/java/com/demcha/compose/document/api/DocumentSessionTest.java
+++ b/src/test/java/com/demcha/compose/document/api/DocumentSessionTest.java
@@ -73,6 +73,7 @@ import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.apache.pdfbox.rendering.PDFRenderer;
 import org.apache.pdfbox.text.PDFTextStripper;
 
@@ -681,6 +682,8 @@ class DocumentSessionTest {
     }
 
     @Test
+    @DisabledIfSystemProperty(named = "no.poi", matches = "true",
+            disabledReason = "Exercises DocxSemanticBackend; skipped under the no-poi profile that excludes poi-ooxml from the test classpath")
     void semanticBackendsShouldExportManifestsFromDocumentGraph() throws Exception {
         try (DocumentSession session = GraphCompose.document()
                 .pageSize(200, 200)

--- a/src/test/java/com/demcha/compose/document/backend/semantic/DocxSemanticBackendTest.java
+++ b/src/test/java/com/demcha/compose/document/backend/semantic/DocxSemanticBackendTest.java
@@ -14,12 +14,22 @@ import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.apache.poi.xwpf.usermodel.XWPFParagraph;
 import org.apache.poi.xwpf.usermodel.XWPFTable;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import java.io.ByteArrayInputStream;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * DOCX semantic backend output. Skipped under the {@code -P no-poi}
+ * profile, where {@code poi-ooxml} is intentionally absent from the
+ * test classpath to validate that consumers who don't render DOCX can
+ * still build and run the canonical suite without the optional POI
+ * footprint (Track I1).
+ */
+@DisabledIfSystemProperty(named = "no.poi", matches = "true",
+        disabledReason = "DocxSemanticBackend requires poi-ooxml; the no-poi profile validates the rest of the suite without it")
 class DocxSemanticBackendTest {
 
     @Test


### PR DESCRIPTION
## Summary

Wires up Track **I1** from the v1.6.5→1.7 readiness taskboard. `poi-ooxml` is declared `<optional>true</optional>` in `pom.xml` so callers that render only PDFs don't pay the ~10 MB POI footprint; this PR ships the regression gate that proves the rest of the canonical suite runs without it.

## What changes

### `no-poi` profile in `pom.xml`

```
$ ./mvnw -P no-poi test -pl .
```

Activates a profile that does two things via `maven-surefire-plugin`:

- **Excludes POI from the test classpath** via `<classpathDependencyExcludes>`: `org.apache.poi:poi-ooxml`, `org.apache.poi:poi`, `org.apache.poi:poi-ooxml-lite`. No POI on the classpath at test runtime — any unconditional reference becomes `NoClassDefFoundError`.
- **Sets `no.poi=true` system property** so DOCX-specific tests can self-skip.

### Two tests carry `@DisabledIfSystemProperty(named = "no.poi", matches = "true")`

| Test | Why |
|---|---|
| `DocxSemanticBackendTest` (whole class) | Every test imports `org.apache.poi.xwpf.usermodel.*` and exercises `DocxSemanticBackend` end-to-end. |
| `DocumentSessionTest#semanticBackendsShouldExportManifestsFromDocumentGraph` | Single test that asserts `session.export(new DocxSemanticBackend())` produces a ZIP-shaped DOCX byte stream. |

Both skip cleanly under `-P no-poi`. All other tests — including the rest of `DocumentSessionTest` — run green without POI on the classpath.

### New CI job — `no-poi-suite`

PR-only, runs after the architecture guards job, executes `./mvnw -B -ntp test -pl . -P no-poi`. Adds the regression gate to every PR so a future change that quietly introduces an unconditional POI reference fails the job rather than silently re-coupling the optional dependency.

## Verification

```
$ ./mvnw -B -ntp test -pl . -P no-poi
Tests run: 1029, Failures: 0, Errors: 0, Skipped: 4
BUILD SUCCESS (~65s)
```

4 skipped == `DocxSemanticBackendTest` (3 tests) + 1 method in `DocumentSessionTest` — exactly the methods I annotated. The other 1025 tests ran without POI on the classpath, validating the `<optional>` declaration.

CHANGELOG entry added to `v1.6.6 — Planned` under the `### Build` subsection.

## Why this scope

- **Profile-level exclusion, not pom-level removal** — `poi-ooxml` stays a declared dependency so consumers that *do* need DOCX still resolve it transitively; the profile is for *us* to test the no-POI footprint.
- **Skip annotation, not test removal** — the DOCX backend is still production code under active use; the tests stay green by default and only skip when the profile says "validate without POI".
- **No production-code changes** — `DocxSemanticBackend.java` itself is untouched. The taskboard says *"DOCX backend disabled gracefully"*; gracefully here means "the suite around it doesn't fall over when POI is absent", which is what this validates.

## Test plan

- [x] `-P no-poi` profile green locally (1029 / 0 / 0 / 4 skipped)
- [x] Default suite (no profile) still green
- [x] `binary-compat` profile unchanged (still in the same `<profiles>` block)
- [ ] CI green on PR, including the new `no-poi-suite` job
- [ ] Reviewer skim — the profile config (15 LOC in pom.xml) and the two `@DisabledIfSystemProperty` placements are the load-bearing pieces
- [ ] (Out of scope) follow-up: a real consumer-side smoke test in a downstream repo that depends on `graphcompose` without explicitly adding `poi-ooxml` — tracked as v1.6.6 release-prep checklist item