### PR TITLE
build: add maven-enforcer-plugin with Java/Maven/plugin-version rules (E2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,19 @@ JitPack continue to resolve through the existing coordinates.
   excluded by convention (`InternalAnnotationCoverageTest` covers those).
   Method-level `@since` backfill for the ~380 public methods in these
   packages is intentionally out of scope here and tracked separately.
+- **`maven-enforcer-plugin` gate** (Track E2). Binds three rules to the
+  `validate` phase so the build refuses to start when a precondition is
+  broken: `requireJavaVersion` (≥ 17 — the declared baseline, catches
+  accidental JDK 11 / 15 attempts), `requireMavenVersion` (≥ 3.8.0 —
+  the oldest version the planned central-publishing pipeline supports),
+  and `requirePluginVersions` (every plugin must declare an explicit
+  non-`LATEST` / non-`RELEASE` / non-`SNAPSHOT` version — the
+  generalisation of the PR-7.1 exec-plugin drift lesson).
+  Default-lifecycle plugins (`clean` / `install` / `site` / `resources` /
+  `deploy`) are now pinned in a new `<pluginManagement>` block so
+  `requirePluginVersions` has nothing to flag. Minimums and versions
+  live in `<properties>` (`enforcer.requireMavenVersion`,
+  `enforcer.requireJavaVersion`, `maven.enforcer.plugin.version`).
 - **Parallel-session stress test** (Track I2). New
   `DocumentSessionParallelStressTest` drives 32 independent
   `DocumentSession` instances on a fixed-size thread pool through 4

--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,13 @@
 
         <!-- Build plugins -->
         <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
+        <maven.enforcer.plugin.version>3.5.0</maven.enforcer.plugin.version>
         <maven.javadoc.plugin.version>3.12.0</maven.javadoc.plugin.version>
         <maven.surefire.plugin.version>3.5.5</maven.surefire.plugin.version>
+
+        <!-- Minimum toolchain (enforced by maven-enforcer-plugin) -->
+        <enforcer.requireMavenVersion>3.8.0</enforcer.requireMavenVersion>
+        <enforcer.requireJavaVersion>17</enforcer.requireJavaVersion>
 
         <!-- Binary compatibility baseline (japicmp profile) -->
         <japicmp.version>0.23.1</japicmp.version>
@@ -262,6 +267,44 @@
     </dependencies>
 
     <build>
+        <!--
+            Pin the default-lifecycle plugins (clean / install / site /
+            resources / deploy) so requirePluginVersions in the enforcer
+            block below has nothing to flag. Versions match what Maven
+            3.9.x currently resolves out-of-the-box; the explicit pin
+            stops a future Maven upgrade from silently shifting the
+            plugin set we build against.
+        -->
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.4.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>3.1.4</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>3.21.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.3.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>3.1.4</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
         <plugins>
             <!-- Kotlin compatibility / mixed-source support -->
             <plugin>
@@ -295,6 +338,54 @@
                 <configuration>
                     <jvmTarget>${maven.compiler.release}</jvmTarget>
                 </configuration>
+            </plugin>
+
+            <!--
+                Build-time precondition enforcement. Three rules:
+                * requireJavaVersion: blocks builds on JDK < 17 (the
+                  declared baseline). Catches "works on my Java 21,
+                  silently breaks on the JDK 17 CI matrix" drift.
+                * requireMavenVersion: blocks Maven < 3.8.0 — the
+                  oldest version that fully supports the resolver
+                  features the central-publishing plugin (Track D3)
+                  needs to ship Maven Central artefacts.
+                * requirePluginVersions: every plugin must declare an
+                  explicit <version>. Stops the inherited "latest" or
+                  reactor-default drift that broke the v1.6.0 release
+                  (cf. PR-7.1 exec-plugin lesson). Tracked as 1.6.6 E2.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <version>${maven.enforcer.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>enforce-toolchain-and-plugin-versions</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireMavenVersion>
+                                    <version>[${enforcer.requireMavenVersion},)</version>
+                                    <message>GraphCompose requires Maven ${enforcer.requireMavenVersion} or newer.</message>
+                                </requireMavenVersion>
+                                <requireJavaVersion>
+                                    <version>[${enforcer.requireJavaVersion},)</version>
+                                    <message>GraphCompose requires JDK ${enforcer.requireJavaVersion} or newer.</message>
+                                </requireJavaVersion>
+                                <requirePluginVersions>
+                                    <banLatest>true</banLatest>
+                                    <banRelease>true</banRelease>
+                                    <banSnapshots>true</banSnapshots>
+                                    <message>Every plugin must declare an explicit non-LATEST/RELEASE version. See PR-7.1 (exec-plugin drift) for the lesson.</message>
+                                </requirePluginVersions>
+                            </rules>
+                            <fail>true</fail>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
             <!-- Java compilation -->


### PR DESCRIPTION
## Summary

Wires up Track **E2** from the v1.6.5→1.7 readiness taskboard. Binds three `maven-enforcer-plugin` rules to the `validate` phase so the build refuses to even start when a precondition is broken.

## The three rules

| Rule | Setting | What it catches |
|---|---|---|
| `requireJavaVersion` | `[17,)` | A maintainer who tries `mvn` under JDK 11 or 15 — "works on my Java 21" drift. |
| `requireMavenVersion` | `[3.8.0,)` | The oldest version the planned central-publishing pipeline (Track D3) supports — older Maven resolvers don't ship the relocation handling Central needs. |
| `requirePluginVersions` | `banLatest=true banRelease=true banSnapshots=true` | Every plugin must declare an explicit non-`LATEST` / non-`RELEASE` / non-`SNAPSHOT` version. **Generalisation of the PR-7.1 exec-plugin drift lesson** — any unpinned plugin is a future drift. |

All three values live in `<properties>` (`enforcer.requireMavenVersion`, `enforcer.requireJavaVersion`, `maven.enforcer.plugin.version`) so they sit at the top of the file and bump together.

## `<pluginManagement>` block

Maven's default lifecycle binds five plugins implicitly (`clean`, `install`, `site`, `resources`, `deploy`). `requirePluginVersions` would otherwise flag every one of them. Pinned in a new `<pluginManagement>` section to the versions Maven 3.9.x currently resolves out of the box:

| Plugin | Version |
|---|---|
| `maven-clean-plugin` | 3.4.0 |
| `maven-install-plugin` | 3.1.4 |
| `maven-site-plugin` | 3.21.0 |
| `maven-resources-plugin` | 3.3.1 |
| `maven-deploy-plugin` | 3.1.4 |

The explicit pin stops a future Maven upgrade from silently shifting the plugin set we build against.

## Verification

```
$ ./mvnw -B -ntp validate -pl .
[INFO] Rule 0: org.apache.maven.enforcer.rules.version.RequireMavenVersion passed
[INFO] Rule 1: org.apache.maven.enforcer.rules.version.RequireJavaVersion passed
[INFO] Rule 2: org.apache.maven.enforcer.rules.RequirePluginVersions passed
BUILD SUCCESS
```

Pre-pin, Rule 2 caught the five default plugins listed above — confirming the rule actually works. Post-pin, all three green.

Reactor validate green:
```
$ ./mvnw -B -ntp -f aggregator/pom.xml validate
[INFO] GraphCompose Examples ... SUCCESS
[INFO] GraphCompose Benchmarks ... SUCCESS
BUILD SUCCESS
```

Full suite re-run:
```
$ ./mvnw -B -ntp test -pl .
BUILD SUCCESS (~50s)
```

CHANGELOG entry added to `v1.6.6 — Planned` under `### Build`.

## Why this scope

- **Three rules, not five.** `dependencyConvergence` and `banDuplicateClasses` are commonly violated by transitive deps that don't impact runtime; they'd add noise without catching real bugs at this stage. Easy to add later if a specific drift incident motivates it.
- **`validate` phase, not `verify`.** Validate runs before compile, so a broken precondition fails fast — typically inside 1 second. No reason to wait for tests to discover that the JDK is wrong.
- **No subordinate-module activation.** The plugin is declared on the library root pom; `examples/pom.xml` and `benchmarks/pom.xml` inherit from the `graphcompose-build` aggregator, not the library root, so enforcer doesn't run twice. Intentional — only the library has the precondition contract.

## Test plan

- [x] `./mvnw validate -pl .` green
- [x] Reactor validate green
- [x] Full suite still green (~50s)
- [ ] CI green on PR (Guards / JDK 17/21/25 / Examples Smoke / binary-compat / no-poi-suite)
- [ ] Reviewer skim of the enforcer block (~30 LOC) and the `<pluginManagement>` block (~25 LOC) — the only load-bearing parts
- [ ] (Out of scope) follow-up: `dependencyConvergence` rule when (and if) a transitive-version drift surfaces in production