### PR TITLE
build(release): add sources/javadoc jars profile + canonicalise SCM block (D1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,24 @@ JitPack continue to resolve through the existing coordinates.
   `./mvnw -DskipTests -P japicmp verify -pl .`; HTML/MD/XML reports
   land in `target/japicmp/`. JitPack repository is scoped to the
   `japicmp` profile, so downstream consumers do not inherit it.
+- **`release` Maven profile with sources + javadoc jars** (Track D1).
+  Activated with `-P release`, attaches `*-sources.jar` and
+  `*-javadoc.jar` to the `package` phase via the standard
+  `maven-source-plugin` (3.3.1) and `maven-javadoc-plugin` (3.12.0)
+  configurations Maven Central requires. The Javadoc plugin runs with
+  `doclint=none` and `failOnError=false` so Lombok-generated members
+  and `@Internal` engine surface don't block a publish; warnings are
+  surfaced quietly. Default `mvnw verify` still does not pay the
+  ~30 s of extra packaging — the profile is off by default and turned
+  on by `cut-release.ps1` (once Track D3's central-publishing plugin
+  lands) and the publish workflow (Track D4).
+- **SCM block canonicalised** in `pom.xml` (Track D1 polish). The
+  Central metadata validator is strict about the `<scm>` block:
+  `<connection>` now uses `scm:git:https://…` (HTTPS, not the legacy
+  `git://` transport) and `<developerConnection>` now uses
+  `scm:git:ssh://git@github.com/…` (the canonical SSH URL with the
+  `git@` user, not the older `ssh://github.com:…` form). Matches the
+  shape every Central artefact's POM carries.
 - **New `benchmarks/README.md`** (Track B1). Honest framing for the
   manual benchmark layer ahead of the Maven Central debut: explicitly
   positions the harness as a smoke / diff / endurance tool — not a

--- a/pom.xml
+++ b/pom.xml
@@ -35,8 +35,8 @@
     </developers>
 
     <scm>
-        <connection>scm:git:git://github.com/DemchaAV/GraphCompose.git</connection>
-        <developerConnection>scm:git:ssh://github.com:DemchaAV/GraphCompose.git</developerConnection>
+        <connection>scm:git:https://github.com/DemchaAV/GraphCompose.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/DemchaAV/GraphCompose.git</developerConnection>
         <url>https://github.com/DemchaAV/GraphCompose/tree/main</url>
     </scm>
 
@@ -68,6 +68,7 @@
         <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
         <maven.enforcer.plugin.version>3.5.0</maven.enforcer.plugin.version>
         <maven.javadoc.plugin.version>3.12.0</maven.javadoc.plugin.version>
+        <maven.source.plugin.version>3.3.1</maven.source.plugin.version>
         <maven.surefire.plugin.version>3.5.5</maven.surefire.plugin.version>
 
         <!-- Minimum toolchain (enforced by maven-enforcer-plugin) -->
@@ -452,6 +453,65 @@
     </build>
 
     <profiles>
+        <!--
+            Maven Central / release-publishing artefacts. Activated
+            with `-P release`. Produces the `*-sources.jar` and
+            `*-javadoc.jar` Maven Central requires alongside the main
+            `.jar`. Activated by `cut-release.ps1` (when the
+            central-publishing plugin lands in Track D3) and by the
+            publish workflow (Track D4); never activated by the default
+            local build so a maintainer's everyday `mvnw verify` does
+            not pay the extra ~30 s of source / javadoc packaging.
+            Tracked in v1.6.6 stabilization (Track D1).
+        -->
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>${maven.source.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>${maven.javadoc.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <!--
+                                        Lombok-generated members and the
+                                        `@Internal` engine surface are not
+                                        part of the public Javadoc; skip
+                                        anything that would fail to resolve
+                                        rather than blocking the publish.
+                                    -->
+                                    <doclint>none</doclint>
+                                    <failOnError>false</failOnError>
+                                    <quiet>true</quiet>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
         <!--
             Optional-deps regression: runs the canonical suite with
             `poi-ooxml` (and its transitives) excluded from the test


### PR DESCRIPTION
## Summary

Wires up Track **D1** from the readiness taskboard — the first step of the Maven Central pipeline. Two changes, both prerequisites for Central upload:

### 1. New `release` Maven profile

Activated with `-P release`. Attaches the `*-sources.jar` and `*-javadoc.jar` that Central requires alongside the main `.jar`:

| Plugin | Goal | Phase | Configuration |
|---|---|---|---|
| `maven-source-plugin` 3.3.1 | `jar-no-fork` | `package` | default |
| `maven-javadoc-plugin` 3.12.0 | `jar` | `package` | `doclint=none`, `failOnError=false`, `quiet=true` |

The Javadoc plugin's `failOnError=false` is intentional — Lombok-generated members and the `@Internal` engine surface (e.g. `document.layout.*`) are not part of the public Javadoc contract, and a strict Javadoc pass would block the publish on things that aren't real problems. Warnings surface quietly so a maintainer running the profile by hand sees them, but they don't fail the build.

The profile is **off by default** so a maintainer's everyday `mvnw verify` does not pay the ~30 s of extra packaging. `cut-release.ps1` (after Track D3's `central-publishing-plugin` lands) and the publish workflow (Track D4) will activate it.

### 2. SCM block canonicalised

Central's metadata validator is strict about the `<scm>` block:

```diff
-<connection>scm:git:git://github.com/DemchaAV/GraphCompose.git</connection>
-<developerConnection>scm:git:ssh://github.com:DemchaAV/GraphCompose.git</developerConnection>
+<connection>scm:git:https://github.com/DemchaAV/GraphCompose.git</connection>
+<developerConnection>scm:git:ssh://git@github.com/DemchaAV/GraphCompose.git</developerConnection>
```

- `<connection>` flipped from the legacy `git://` (Git's anonymous transport, deprecated and blocked by many corporate networks) to `https://` — the universal anonymous-clone protocol.
- `<developerConnection>` flipped from `ssh://github.com:DemchaAV/…` (the older SCP-like form) to `ssh://git@github.com/…` (the canonical SSH URL with the `git@` user, the shape GitHub itself recommends).

Both lines now match the exact shape every Central artefact's POM carries — and the shape the audit notes pinned as a precondition for `central-publishing-plugin` validation.

## Verification

```
$ ./mvnw -B -ntp -DskipTests -P release package -pl .
[INFO] Building jar: .../target/graphcompose-1.6.5.jar
[INFO] Building jar: .../target/graphcompose-1.6.5-sources.jar
[INFO] Building jar: .../target/graphcompose-1.6.5-javadoc.jar
BUILD SUCCESS (36s)
```

Artefact sizes confirmed against the produced files:

| Jar | Size |
|---|---|
| `graphcompose-1.6.5.jar` | 19 MB |
| `graphcompose-1.6.5-sources.jar` | 18 MB |
| `graphcompose-1.6.5-javadoc.jar` | 4 MB |

Default `mvnw verify` (no profile) unchanged — sources / javadoc jars are not produced.

CHANGELOG entry added to `v1.6.6 — Planned` under `### Build`.

## What this _doesn't_ do

- **No GPG signing yet** — that's Track D2. Central will reject unsigned artefacts; D2 lands the `maven-gpg-plugin` and the `MAVEN_GPG_PRIVATE_KEY` + `MAVEN_GPG_PASSPHRASE` secrets.
- **No publishing wiring** — that's Track D3 (`central-publishing-maven-plugin` + namespace verification on Central Portal).
- **No publish workflow** — that's Track D4 (`.github/workflows/publish.yml`).

D2 / D3 / D4 will land sequentially; this PR is just the artefacts layer.

## Test plan

- [x] `mvnw -P release -DskipTests package -pl .` produces all three jars
- [x] Default `mvnw verify` unchanged (no profile activation)
- [x] SCM block matches the canonical Central shape
- [ ] CI green on PR (the enforcer added in [#93](https://github.com/DemchaAV/GraphCompose/pull/93) revalidates plugin versions on the `validate` phase before any of this runs)
- [ ] Reviewer skim — the `release` profile block (~45 LOC) and the two SCM-line replacements are the load-bearing pieces
- [ ] (Out of scope) follow-up: track D2 GPG signing