### PR TITLE
build(release): add GPG signing plugin to release profile (D2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ JitPack continue to resolve through the existing coordinates.
   `./mvnw -DskipTests -P japicmp verify -pl .`; HTML/MD/XML reports
   land in `target/japicmp/`. JitPack repository is scoped to the
   `japicmp` profile, so downstream consumers do not inherit it.
+- **GPG signing in the `release` profile** (Track D2). Adds
+  `maven-gpg-plugin` 3.2.7 to the existing `release` profile, binding
+  to the `verify` phase to sign main / sources / javadoc / pom
+  artefacts — Maven Central rejects unsigned uploads. **Off by
+  default**: a new property `<gpg.skip>true</gpg.skip>` keeps local
+  `mvn -P release package` runs working without a configured GPG key.
+  The publish workflow (Track D4) flips it explicitly with
+  `-Dgpg.skip=false` once the `MAVEN_GPG_PRIVATE_KEY` and
+  `MAVEN_GPG_PASSPHRASE` secrets are wired. `gpgArguments` declares
+  `--pinentry-mode loopback` so non-interactive CI runs accept the
+  passphrase from `-Dgpg.passphrase` / `MAVEN_GPG_PASSPHRASE` without
+  needing a TTY for `gpg-agent`.
 - **`release` Maven profile with sources + javadoc jars** (Track D1).
   Activated with `-P release`, attaches `*-sources.jar` and
   `*-javadoc.jar` to the `package` phase via the standard

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
         <!-- Build plugins -->
         <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
         <maven.enforcer.plugin.version>3.5.0</maven.enforcer.plugin.version>
+        <maven.gpg.plugin.version>3.2.7</maven.gpg.plugin.version>
         <maven.javadoc.plugin.version>3.12.0</maven.javadoc.plugin.version>
         <maven.source.plugin.version>3.3.1</maven.source.plugin.version>
         <maven.surefire.plugin.version>3.5.5</maven.surefire.plugin.version>
@@ -78,6 +79,14 @@
         <!-- Binary compatibility baseline (japicmp profile) -->
         <japicmp.version>0.23.1</japicmp.version>
         <japicmp.baseline>v1.6.5</japicmp.baseline>
+
+        <!--
+            GPG signing — opted in via -Dgpg.skip=false (the publish
+            workflow does this on tag pushes). Default true so a
+            maintainer running `mvn -P release package` locally does
+            not need a configured GPG key.
+        -->
+        <gpg.skip>true</gpg.skip>
     </properties>
 
     <dependencyManagement>
@@ -504,6 +513,44 @@
                                     <doclint>none</doclint>
                                     <failOnError>false</failOnError>
                                     <quiet>true</quiet>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!--
+                        GPG signing of the four published artefacts
+                        (main jar + sources + javadoc + pom). Maven
+                        Central rejects unsigned uploads.
+
+                        Local default: `<gpg.skip>true</gpg.skip>` (set
+                        in <properties>) so `mvn -P release package`
+                        works without a configured GPG key. The publish
+                        workflow (Track D4) flips it with
+                        -Dgpg.skip=false.
+
+                        The `gpgArguments` pinentry-mode=loopback is
+                        required for non-interactive runs (CI), where
+                        the passphrase arrives via
+                        MAVEN_GPG_PASSPHRASE / -Dgpg.passphrase and
+                        there is no TTY for gpg-agent to prompt on.
+                    -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${maven.gpg.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${gpg.skip}</skip>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
## Summary

Wires up Track **D2** — Maven Central rejects unsigned uploads; this PR adds `maven-gpg-plugin` 3.2.7 to the existing `release` profile so the main / sources / javadoc / pom artefacts are signed during the `verify` phase.

## Off by default

| Surface | Behaviour |
|---|---|
| `mvn -P release package` (local) | Signing skipped — no GPG key required. New `<gpg.skip>true</gpg.skip>` property in `<properties>` keeps every local invocation working. |
| `mvn -P release -Dgpg.skip=false verify` (manual) | Plugin attempts to sign. Without a configured key, expected GPG exit code 2. |
| Publish workflow (Track D4) | Flips `-Dgpg.skip=false` explicitly and provides `MAVEN_GPG_PRIVATE_KEY` + `MAVEN_GPG_PASSPHRASE` from repo secrets. |

`gpgArguments` declares `--pinentry-mode loopback` so non-interactive CI runs accept the passphrase from `-Dgpg.passphrase` / `MAVEN_GPG_PASSPHRASE` without needing a TTY for `gpg-agent`.

## Verification

Default (skip=true):
```
$ ./mvnw -B -ntp -DskipTests -P release verify -pl .
[INFO] --- gpg:3.2.7:sign (sign-artifacts) @ graphcompose ---
[INFO] BUILD SUCCESS
```
Sign step engaged but silently skipped via `<skip>${gpg.skip}</skip>`.

Forced (skip=false), no key:
```
$ ./mvnw -B -ntp -DskipTests -P release -Dgpg.skip=false verify -pl .
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-gpg-plugin:3.2.7:sign: Exit code: 2
```
Expected — confirms the plugin would actually attempt signing when the workflow flips the switch.

CHANGELOG entry added to `v1.6.6 — Planned` under `### Build`.

## What this _doesn't_ do

- **Does not wire up secrets.** `MAVEN_GPG_PRIVATE_KEY` and `MAVEN_GPG_PASSPHRASE` are GitHub repo secrets the maintainer must create after generating the GPG key and uploading the public key to the keyserver pool. Until then, this PR is dormant — no publish workflow yet (Track D4), and the local default keeps everything green.
- **Does not pick a key**. The GPG plugin signs with whatever key the agent / `gpg --homedir` resolves; that policy lives outside the pom.

## Pipeline state after this PR

| Step | State |
|---|---|
| D1 — sources / javadoc jars + SCM | ✅ shipped |
| D2 — GPG signing | 🟢 **this PR** |
| D3 — central-publishing plugin | next |
| D4 — publish workflow | after D3 |

Maintainer GPG key generation and GitHub secret wiring is the human prerequisite before D4's workflow will actually publish anything; the plugin / workflow side will be ready and waiting.

## Test plan

- [x] Default `mvn -P release verify` green locally
- [x] `mvn -P release -Dgpg.skip=false verify` correctly attempts signing (expected failure without key)
- [x] No regression on default `mvnw verify` (no profile activation)
- [ ] CI green on PR (enforcer / japicmp / no-poi / guards / JDK matrix)
- [ ] Reviewer skim — the GPG plugin block (~30 LOC) and the `<gpg.skip>true</gpg.skip>` property are the load-bearing pieces