### PR TITLE
build(release): add central-publishing-maven-plugin to release profile (D3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,21 @@ JitPack continue to resolve through the existing coordinates.
   `./mvnw -DskipTests -P japicmp verify -pl .`; HTML/MD/XML reports
   land in `target/japicmp/`. JitPack repository is scoped to the
   `japicmp` profile, so downstream consumers do not inherit it.
+- **`central-publishing-maven-plugin` in the `release` profile**
+  (Track D3). Adds Sonatype's `central-publishing-maven-plugin` 0.7.0
+  to the existing `release` profile as a packaging extension. Replaces
+  the legacy `nexus-staging-maven-plugin` + manual staging-repository
+  workflow with a single `deploy` call. Configuration:
+  `publishingServerId=central` (matches the `<server id="central">`
+  entry the publish workflow writes from `CENTRAL_USERNAME` /
+  `CENTRAL_TOKEN` secrets), `autoPublish=false` (validation gate before
+  the artefact goes live — flips to `true` once we're confident
+  post-D4), `waitUntil=validated` (the build waits for Sonatype's
+  validator so any rejection surfaces in the workflow run, not a
+  silent stuck upload). Requires the `io.github.demchaav` namespace to
+  be verified on `central.sonatype.com` (one-time human step via
+  GitHub auth or DNS TXT record). The plugin loads inert until D4's
+  workflow provides the credentials.
 - **GPG signing in the `release` profile** (Track D2). Adds
   `maven-gpg-plugin` 3.2.7 to the existing `release` profile, binding
   to the `verify` phase to sign main / sources / javadoc / pom

--- a/pom.xml
+++ b/pom.xml
@@ -65,6 +65,7 @@
         <byteBuddy.version>1.18.8</byteBuddy.version>
 
         <!-- Build plugins -->
+        <central.publishing.plugin.version>0.7.0</central.publishing.plugin.version>
         <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
         <maven.enforcer.plugin.version>3.5.0</maven.enforcer.plugin.version>
         <maven.gpg.plugin.version>3.2.7</maven.gpg.plugin.version>
@@ -554,6 +555,54 @@
                                 </configuration>
                             </execution>
                         </executions>
+                    </plugin>
+                    <!--
+                        Sonatype central-publishing-maven-plugin: the
+                        modern replacement for the old `nexus-staging-maven-plugin`
+                        + manual staging-repository flow. Uploads the
+                        signed artefacts (main + sources + javadoc + pom)
+                        to the namespace verified at central.sonatype.com.
+
+                        Configuration:
+                          publishingServerId=central — matches the
+                            <server id="central"> entry the publish
+                            workflow (Track D4) writes into
+                            ~/.m2/settings.xml from the CENTRAL_USERNAME
+                            / CENTRAL_TOKEN repo secrets.
+                          autoPublish=false — uploads to the validation
+                            queue but does NOT auto-release. The
+                            maintainer flips the switch on
+                            central.sonatype.com after a sanity check
+                            on the first publish; subsequent releases
+                            can flip this to true in the workflow when
+                            we are confident.
+                          waitUntil=validated — block the Maven build
+                            until Sonatype's validator confirms the
+                            upload meets the Central requirements
+                            (signed artefacts, sources/javadoc jars,
+                            valid POM metadata, etc.). Surfaces errors
+                            inside the workflow run rather than
+                            silently leaving a stuck upload.
+                          <extensions>true</extensions> — required so
+                            the plugin participates in the build
+                            lifecycle as a packaging extension.
+
+                        Requires (configured by Track D4 workflow):
+                          - CENTRAL_USERNAME / CENTRAL_TOKEN secrets
+                          - namespace `io.github.demchaav` verified on
+                            central.sonatype.com (one-time, via GitHub
+                            auth or DNS TXT record).
+                    -->
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${central.publishing.plugin.version}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>false</autoPublish>
+                            <waitUntil>validated</waitUntil>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
## Summary

Wires up Track **D3** — third step of the Maven Central pipeline. Adds Sonatype's `central-publishing-maven-plugin` 0.7.0 to the existing `release` profile as a packaging extension, replacing the legacy `nexus-staging-maven-plugin` + manual staging-repository flow with a single `deploy` call.

> **Stacked on D2** ([#96](https://github.com/DemchaAV/GraphCompose/pull/96)). The diff includes the D2 GPG signing block; after D2 merges, this PR's diff will fast-forward to just the D3 additions. Reviewing in either order is fine — the two profiles are independent except both live under `<id>release</id>`.

## Plugin configuration

| Setting | Value | Why |
|---|---|---|
| `publishingServerId` | `central` | Matches the `<server id="central">` entry the publish workflow (Track D4) writes into `~/.m2/settings.xml` from `CENTRAL_USERNAME` / `CENTRAL_TOKEN` secrets. |
| `autoPublish` | `false` | Validation gate before the artefact goes live. The maintainer sanity-checks the first publish on `central.sonatype.com` and flips this to `true` once we're confident. |
| `waitUntil` | `validated` | The build blocks until Sonatype's validator confirms the upload meets Central requirements (signed artefacts, sources/javadoc jars, valid POM metadata). Surfaces errors in the workflow run rather than silently leaving a stuck upload. |
| `<extensions>true</extensions>` | required | Plugin must participate in the build lifecycle as a packaging extension. |

## Verification

```
$ ./mvnw -B -ntp -DskipTests -P release package -pl .
BUILD SUCCESS
```

Deploy step not exercised locally — no credentials configured, no namespace verified yet. That's Track D4's setup phase.

CHANGELOG entry added to `v1.6.6 — Planned` under `### Build`.

## What this _doesn't_ do

- **Does not deploy anything.** The plugin is inert until `deploy` runs with credentials in `~/.m2/settings.xml`.
- **Does not verify the namespace.** The maintainer must verify `io.github.demchaav` on [`central.sonatype.com`](https://central.sonatype.com) (one-time, via GitHub auth or DNS TXT record).
- **Does not wire secrets.** `CENTRAL_USERNAME` + `CENTRAL_TOKEN` GitHub repo secrets are the human prerequisite. The publish workflow (D4) will read them.

## Pipeline state after this PR

| Step | State |
|---|---|
| D1 — sources / javadoc jars + SCM | ✅ shipped |
| D2 — GPG signing | 🟡 [#96](https://github.com/DemchaAV/GraphCompose/pull/96) (this PR's parent) |
| D3 — central-publishing plugin | 🟢 **this PR** |
| D4 — publish workflow | next |

## Human prerequisites for actual publishing

1. Generate GPG key locally, upload public key to keyserver pool.
2. Generate Sonatype Central token at `central.sonatype.com → Account → Generate User Token`.
3. Verify `io.github.demchaav` namespace.
4. Add four GitHub repo secrets: `MAVEN_GPG_PRIVATE_KEY`, `MAVEN_GPG_PASSPHRASE`, `CENTRAL_USERNAME`, `CENTRAL_TOKEN`.

All of which I'll capture in the release-process doc alongside the D4 PR.

## Test plan

- [x] `mvn -P release -DskipTests package -pl .` green
- [x] Default `mvnw verify` (no profile) unchanged
- [ ] CI green on PR
- [ ] After D2 merge — rebase onto develop and re-run CI; should be near-trivial fast-forward
- [ ] Reviewer skim — the `central-publishing-maven-plugin` block (~55 LOC including the explanatory comment) is the load-bearing piece