### PR TITLE
docs(release): point distribution status at Maven Central + javadoc.io (H3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,16 @@ JitPack continue to resolve through the existing coordinates.
   secrets, and the release-candidate dry-run strategy. § 2.B
   post-release checklist gains a new step 9 for the Central publish
   alongside the existing JitPack step.
+- **Hosted Javadocs via `javadoc.io`** (Track H3). README's
+  distribution-status note now points callers at
+  [javadoc.io/doc/io.github.demchaav/graphcompose](https://javadoc.io/doc/io.github.demchaav/graphcompose),
+  which auto-mirrors any artefact published to Maven Central within
+  minutes — no separate hosting infrastructure required. The note
+  also pins Maven Central as the going-forward primary distribution
+  starting v1.6.6 (JitPack stays available alongside for existing
+  callers). The full Central install snippet ("Central as primary,
+  JitPack as fallback") lands in the v1.6.6 release-prep PR after the
+  first Central publish proves the pipeline end-to-end.
 - **`central-publishing-maven-plugin` in the `release` profile**
   (Track D3). Adds Sonatype's `central-publishing-maven-plugin` 0.7.0
   to the existing `release` profile as a packaging extension. Replaces

--- a/README.md
+++ b/README.md
@@ -104,7 +104,10 @@ repositories { maven("https://jitpack.io") }
 dependencies { implementation("com.github.demchaav:GraphCompose:v1.6.5") }
 ```
 
-> **Distribution status** &mdash; currently **JitPack**. Maven Central is planned for v1.7 ([tracking issue](https://github.com/DemchaAV/GraphCompose/issues/7)).
+> **Distribution status** &mdash; currently **JitPack**. **Maven Central**
+> ships from **v1.6.6** under coordinates `io.github.demchaav:graphcompose:<version>`;
+> hosted Javadocs auto-publish to [javadoc.io/doc/io.github.demchaav/graphcompose](https://javadoc.io/doc/io.github.demchaav/graphcompose) shortly after each Central release.
+> JitPack stays available alongside Central for existing callers.
 
 > **Upgrading from v1.5?** Core document authoring stays source-compatible &mdash; engine, DSL, themes, and backend-neutral records carry v1.5 callers unchanged. **Templates v2** replaces the legacy CV / cover-letter template classes; legacy classes were **deleted**, not deprecated. Read the [migration guide](./docs/roadmaps/migration-v1-5-to-v1-6.md) before upgrading template-heavy code.
 


### PR DESCRIPTION
## Summary

Wires up Track **H3** — hosted Javadocs. [javadoc.io](https://javadoc.io) auto-mirrors any artefact published to Maven Central within minutes, so no separate hosting infrastructure is required. This PR is just the README documentation step pointing callers at the URL.

## README distribution-status note

```diff
-> **Distribution status** — currently **JitPack**. Maven Central is planned for v1.7 ([tracking issue](https://github.com/DemchaAV/GraphCompose/issues/7)).
+> **Distribution status** — currently **JitPack**. **Maven Central**
+> ships from **v1.6.6** under coordinates `io.github.demchaav:graphcompose:<version>`;
+> hosted Javadocs auto-publish to [javadoc.io/doc/io.github.demchaav/graphcompose](https://javadoc.io/doc/io.github.demchaav/graphcompose) shortly after each Central release.
+> JitPack stays available alongside Central for existing callers.
```

The old line claimed Central was planned for v1.7 — outdated once the D-track ([#95](https://github.com/DemchaAV/GraphCompose/pull/95) / [#96](https://github.com/DemchaAV/GraphCompose/pull/96) / [#97](https://github.com/DemchaAV/GraphCompose/pull/97) / [#98](https://github.com/DemchaAV/GraphCompose/pull/98)) shipped the v1.6.6 publish pipeline.

## What this _doesn't_ do

- **Does not change the JitPack install snippet.** That stays as-is — `cut-release.ps1` rewrites it to `v1.6.6` at release time, and `VersionConsistencyGuardTest` validates the post-bump state. Adding a Central snippet now would require either pinning a future version (snippet pointing at a tag that doesn't exist breaks JitPack-style copy-paste) or duplicating the guard logic; both are friction without payoff yet.
- **Does not add a "Central as primary, JitPack as fallback" snippet.** That's the v1.6.6 release-prep PR's job — explicitly listed in the readiness taskboard — after the first Central publish proves the pipeline end-to-end. This PR is the lightweight documentation step that's safe to ship _now_.

## Verification

```
$ ./mvnw -B -ntp test -pl . -Dtest='CanonicalSurfaceGuardTest,DocumentationCoverageTest,VersionConsistencyGuardTest'
Tests run: 13, Failures: 0, Errors: 0, Skipped: 0
```

CHANGELOG entry added to `v1.6.6 — Planned` under `### Build`.

## Test plan

- [x] Doc guards green locally
- [ ] CI green on PR
- [ ] Reviewer skim — single sentence change in README + matching CHANGELOG entry