### PR TITLE
docs(release): prep v1.6.6 — Central install snippet + release status + community links (PR-1.6.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,25 @@ follow semantic versioning; release dates are ISO 8601.
 
 ## v1.6.6 — Planned
 
-First Maven Central release. Adds publishable sources/javadoc jars,
-GPG-signed artifacts, a binary-compatibility gate against v1.6.5, and
-the metadata Maven Central requires. Zero breaking changes; users on
-JitPack continue to resolve through the existing coordinates.
+**First Maven Central release.** GraphCompose now ships under
+`io.github.demchaav:graphcompose:1.6.6` alongside the existing
+JitPack distribution. The release adds publishable sources/javadoc
+jars, GPG-signed artefacts, a binary-compatibility gate against
+v1.6.5, the metadata Maven Central requires, and a substantial
+documentation polish for the maturity / stability / migration story.
+
+**Zero breaking changes from v1.6.5.** Existing JitPack callers continue
+to resolve through the same coordinates; existing API surface compiles
+and runs unchanged (validated by the new `japicmp` gate against the
+v1.6.5 baseline). New: the `@Beta` annotation marker, the `@since 1.0.0`
+class-level Javadoc on entry-point packages, and a curated docs pass
+(decision guide for the two template surfaces, examples maturity index,
+explicit API stability policy).
+
+**Migration from v1.6.5:** no code changes required. Optionally swap
+the JitPack `<dependency>` for the Maven Central equivalent
+(`io.github.demchaav:graphcompose:1.6.6`); both publish paths continue
+to ship the same artefact.
 
 ### Build
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,18 @@
 <p align="center">
   <a href="https://github.com/DemchaAV/GraphCompose/actions/workflows/ci.yml?query=branch%3Amain"><img src="https://img.shields.io/github/actions/workflow/status/DemchaAV/GraphCompose/ci.yml?branch=main&style=for-the-badge&label=CI" alt="CI"/></a>
   <a href="https://github.com/DemchaAV/GraphCompose/releases/latest"><img src="https://img.shields.io/github/v/release/DemchaAV/GraphCompose?style=for-the-badge&label=Release" alt="Latest release"/></a>
+  <a href="https://central.sonatype.com/artifact/io.github.demchaav/graphcompose"><img src="https://img.shields.io/maven-central/v/io.github.demchaav/graphcompose?style=for-the-badge&label=Maven%20Central" alt="Maven Central"/></a>
   <a href="https://jitpack.io/#DemchaAV/GraphCompose"><img src="https://img.shields.io/jitpack/v/github/DemchaAV/GraphCompose?style=for-the-badge&label=JitPack" alt="JitPack"/></a>
   <img src="https://img.shields.io/badge/Java-17%2B-orange?style=for-the-badge&logo=openjdk" alt="Java 17+"/>
   <img src="https://img.shields.io/badge/PDFBox-3.0-red?style=for-the-badge" alt="PDFBox 3.0"/>
   <img src="https://img.shields.io/badge/License-MIT-blue?style=for-the-badge" alt="MIT License"/>
 </p>
+
+> **Release status** &mdash;
+> 🟢 **Latest stable**: [v1.6.5](https://github.com/DemchaAV/GraphCompose/releases/tag/v1.6.5) (JitPack)
+> &nbsp;·&nbsp; 🟡 **In develop**: v1.6.6 (Maven Central debut; zero breaking from v1.6.5)
+> &nbsp;·&nbsp; ⚪ **Planned next**: v1.6.7 (dependency cleanup), v1.7.0 (new canonical DSL primitives)
+> &nbsp;·&nbsp; See [API stability policy](./docs/api-stability.md) for tier definitions.
 
 <p align="center">
   <a href="https://demchaav.github.io/GraphCompose/"><b>Live Showcase</b></a>
@@ -86,6 +93,22 @@ GraphCompose uses PDFBox under the hood as the rendering backend &mdash; the com
 | Regression-test generated layouts | Layout snapshots | `DocumentSession#layoutSnapshot()` &mdash; see [snapshot testing](./docs/operations/layout-snapshot-testing.md) |
 
 ## Installation
+
+### Maven Central (primary, from v1.6.6)
+
+```xml
+<dependency>
+    <groupId>io.github.demchaav</groupId>
+    <artifactId>graphcompose</artifactId>
+    <version>1.6.6</version>
+</dependency>
+```
+
+```kotlin
+dependencies { implementation("io.github.demchaav:graphcompose:1.6.6") }
+```
+
+### JitPack (fallback / pre-v1.6.6)
 
 ```xml
 <repositories>
@@ -206,7 +229,8 @@ document.pageFlow().addCanvas(523, 360, canvas -> canvas
 - [Examples gallery](./examples/README.md) &mdash; every runnable example with PDF preview
 
 ### Contributing & releases
-- [Migration v1.5 → v1.6](./docs/roadmaps/migration-v1-5-to-v1-6.md) · [Release process](./docs/contributing/release-process.md) · [Contributing](./CONTRIBUTING.md)
+- [Contributing](./CONTRIBUTING.md) · [Code of conduct](./CODE_OF_CONDUCT.md) · [Security policy](./SECURITY.md) · [Release process](./docs/contributing/release-process.md)
+- [API stability policy](./docs/api-stability.md) · [Which template system?](./docs/templates/which-template-system.md) · [Migration v1.5 → v1.6](./docs/roadmaps/migration-v1-5-to-v1-6.md)
 
 ## Companion projects
 


### PR DESCRIPTION
## Summary

Final pre-cut PR from the readiness taskboard. Brings README + CHANGELOG up to the shape v1.6.6 will ship in. After this merges, `graphcompose-release-engineer` cuts v1.6.6.

## What changes

### README

| Where | What |
|---|---|
| **Hero badges** | New `Maven Central` badge alongside `JitPack`. |
| **New "Release status" block** | `🟢 Latest stable v1.6.5 (JitPack) · 🟡 In develop v1.6.6 (Maven Central debut; zero breaking) · ⚪ Planned next v1.6.7 (dep cleanup), v1.7.0 (new DSL primitives)`. Links to [`docs/api-stability.md`](docs/api-stability.md) for tier definitions. |
| **Install section** | Maven Central (`io.github.demchaav:graphcompose:1.6.6`) listed first as the primary path. JitPack snippet stays as fallback / pre-v1.6.6 alternative. |
| **Footer "Contributing & releases"** | New links to `CODE_OF_CONDUCT.md`, `SECURITY.md`, `docs/api-stability.md`, `docs/templates/which-template-system.md` — files that were committed long ago but never linked from the README. |

### CHANGELOG

`v1.6.6 — Planned` summary expanded to three paragraphs:
- **What shipped** — Central, sources/javadoc jars, GPG, japicmp gate, docs polish.
- **Zero breaking changes from v1.6.5** — existing API surface unchanged (validated by `japicmp` against v1.6.5 baseline).
- **Migration from v1.6.5** — "no code changes required; optionally swap to the Central coordinates."

## Version-pinning intent

| Snippet | Pinned at | Why |
|---|---|---|
| JitPack `<dependency>` | `v1.6.5` (current pom) | `cut-release.ps1` flips this to `v1.6.6` at release time, matching the `VersionConsistencyGuardTest` invariant (README JitPack snippet == pom version). |
| Central `<dependency>` | `1.6.6` (explicit) | v1.6.5 was never on Central, so pinning to current pom would advertise a non-existent artefact. `VersionConsistencyGuardTest` only scans the JitPack snippet (matches `<artifactId>GraphCompose</artifactId>` — capital G; Central uses lowercase `graphcompose`), so the Central pin is exempt from the guard. Maintainer manually bumps this in each subsequent release-prep PR. |

## Verification

```
$ ./mvnw -B -ntp test -pl . -Dtest='CanonicalSurfaceGuardTest,DocumentationCoverageTest,VersionConsistencyGuardTest,DocumentationExamplesTest'
Tests run: 25, Failures: 0, Errors: 0, Skipped: 0
```

```
$ ./mvnw -B -ntp test -pl .
Tests run: 1033, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS (~91s)
```

Doc guards green, full suite green.

## What's _next_ (post-merge)

1. Maintainer wires the four GitHub repo secrets (`MAVEN_GPG_PRIVATE_KEY`, `MAVEN_GPG_PASSPHRASE`, `CENTRAL_USERNAME`, `CENTRAL_TOKEN`) per `docs/contributing/release-process.md` § 2.C — one-time setup.
2. Cut v1.6.6 via `graphcompose-release-engineer` skill: `cut-release.ps1` bumps the four pom version sites + the JitPack snippet to `1.6.6`, dates the CHANGELOG, runs `verify`, commits, tags `v1.6.6`, pushes.
3. Three workflows fire on the tag push, in parallel:
   - `release.yml` — creates the GitHub Release with the CHANGELOG section as the body.
   - `publish.yml` — signs + uploads to Maven Central; the maintainer flips the "release" switch on `central.sonatype.com` after Central's validator confirms.
   - JitPack picks up the tag on first request.
4. `javadoc.io/doc/io.github.demchaav/graphcompose/1.6.6` becomes available within minutes of the Central publish.

## Test plan

- [x] All doc guards green
- [x] Full suite green
- [x] `VersionConsistencyGuardTest` passes (JitPack snippet matches pom; Central snippet exempt by artifactId difference)
- [ ] CI green on PR (Guards / JDK 17/21/25 / Examples Smoke / no-poi-suite / binary-compat)
- [ ] Reviewer skim — README install + release-status block + CHANGELOG summary are the load-bearing changes
- [ ] (Out of scope but called out) follow-up: extend `VersionConsistencyGuardTest` to also enforce the Central snippet's `1.6.6` matches the pom — once Central versioning has shipped a few times and we know the bump cadence we want