### PR TITLE
docs(showcase): repair broken v2 asset paths in index.html

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -113,19 +113,19 @@
             "@type": "ListItem",
             "position": 3,
             "name": "Modern Professional CV",
-            "url": "https://demchaav.github.io/GraphCompose/showcase/pdf/templates/cv/cv-modern-professional.pdf"
+            "url": "https://demchaav.github.io/GraphCompose/showcase/pdf/templates/cv/cv-modern-professional-v2.pdf"
           },
           {
             "@type": "ListItem",
             "position": 4,
             "name": "Sidebar Portrait CV",
-            "url": "https://demchaav.github.io/GraphCompose/showcase/pdf/templates/cv/cv-sidebar-portrait.pdf"
+            "url": "https://demchaav.github.io/GraphCompose/showcase/pdf/templates/cv/cv-sidebar-portrait-v2.pdf"
           },
           {
             "@type": "ListItem",
             "position": 5,
             "name": "Monogram Sidebar CV",
-            "url": "https://demchaav.github.io/GraphCompose/showcase/pdf/templates/cv/cv-monogram-sidebar.pdf"
+            "url": "https://demchaav.github.io/GraphCompose/showcase/pdf/templates/cv/cv-monogram-sidebar-v2.pdf"
           },
           {
             "@type": "ListItem",
@@ -183,7 +183,7 @@
         <div class="document-stack">
           <img class="doc-preview doc-preview-main" src="showcase/screenshots/templates/proposal/project-proposal-cinematic.png" alt="Cinematic project proposal preview">
           <img class="doc-preview doc-preview-side doc-preview-top" src="showcase/screenshots/templates/invoice/invoice-cinematic.png" alt="Cinematic invoice preview">
-          <img class="doc-preview doc-preview-side doc-preview-bottom" src="showcase/screenshots/templates/cv/cv-blue-banner.png" alt="Blue Banner CV preview">
+          <img class="doc-preview doc-preview-side doc-preview-bottom" src="showcase/screenshots/templates/cv/cv-blue-banner-v2.png" alt="Blue Banner CV preview">
         </div>
       </div>
     </section>
@@ -297,29 +297,29 @@ dependencies {
 
           <h4>CV (14 presets)</h4>
           <ul>
-            <li><a href="showcase/pdf/templates/cv/cv-modern-professional.pdf">Modern Professional CV</a></li>
-            <li><a href="showcase/pdf/templates/cv/cv-nordic-clean.pdf">Nordic Clean CV</a></li>
-            <li><a href="showcase/pdf/templates/cv/cv-classic-serif.pdf">Classic Serif CV</a></li>
-            <li><a href="showcase/pdf/templates/cv/cv-compact-mono.pdf">Compact Mono CV</a></li>
-            <li><a href="showcase/pdf/templates/cv/cv-executive.pdf">Executive CV</a></li>
-            <li><a href="showcase/pdf/templates/cv/cv-engineering-resume.pdf">Engineering Resume CV</a></li>
-            <li><a href="showcase/pdf/templates/cv/cv-timeline-minimal.pdf">Timeline Minimal CV</a></li>
-            <li><a href="showcase/pdf/templates/cv/cv-boxed-sections.pdf">Boxed Sections CV</a></li>
-            <li><a href="showcase/pdf/templates/cv/cv-centered-headline.pdf">Centered Headline CV</a></li>
-            <li><a href="showcase/pdf/templates/cv/cv-blue-banner.pdf">Blue Banner CV</a></li>
-            <li><a href="showcase/pdf/templates/cv/cv-editorial-blue.pdf">Editorial Blue CV</a></li>
-            <li><a href="showcase/pdf/templates/cv/cv-panel.pdf">Panel CV</a></li>
-            <li><a href="showcase/pdf/templates/cv/cv-sidebar-portrait.pdf">Sidebar Portrait CV</a></li>
-            <li><a href="showcase/pdf/templates/cv/cv-monogram-sidebar.pdf">Monogram Sidebar CV</a></li>
+            <li><a href="showcase/pdf/templates/cv/cv-modern-professional-v2.pdf">Modern Professional CV</a></li>
+            <li><a href="showcase/pdf/templates/cv/cv-nordic-clean-v2.pdf">Nordic Clean CV</a></li>
+            <li><a href="showcase/pdf/templates/cv/cv-classic-serif-v2.pdf">Classic Serif CV</a></li>
+            <li><a href="showcase/pdf/templates/cv/cv-compact-mono-v2.pdf">Compact Mono CV</a></li>
+            <li><a href="showcase/pdf/templates/cv/cv-executive-v2.pdf">Executive CV</a></li>
+            <li><a href="showcase/pdf/templates/cv/cv-engineering-resume-v2.pdf">Engineering Resume CV</a></li>
+            <li><a href="showcase/pdf/templates/cv/cv-timeline-minimal-v2.pdf">Timeline Minimal CV</a></li>
+            <li><a href="showcase/pdf/templates/cv/cv-boxed-sections-v2.pdf">Boxed Sections CV</a></li>
+            <li><a href="showcase/pdf/templates/cv/cv-centered-headline-v2.pdf">Centered Headline CV</a></li>
+            <li><a href="showcase/pdf/templates/cv/cv-blue-banner-v2.pdf">Blue Banner CV</a></li>
+            <li><a href="showcase/pdf/templates/cv/cv-editorial-blue-v2.pdf">Editorial Blue CV</a></li>
+            <li><a href="showcase/pdf/templates/cv/cv-panel-v2.pdf">Panel CV</a></li>
+            <li><a href="showcase/pdf/templates/cv/cv-sidebar-portrait-v2.pdf">Sidebar Portrait CV</a></li>
+            <li><a href="showcase/pdf/templates/cv/cv-monogram-sidebar-v2.pdf">Monogram Sidebar CV</a></li>
           </ul>
 
           <h4>Cover Letter (14 paired layouts)</h4>
           <ul>
-            <li><a href="showcase/pdf/templates/coverletter/cover-letter.pdf">Cover Letter (canonical)</a></li>
-            <li><a href="showcase/pdf/templates/coverletter/cover-letter-modern-professional.pdf">Modern Professional letter</a></li>
-            <li><a href="showcase/pdf/templates/coverletter/cover-letter-executive.pdf">Executive letter</a></li>
-            <li><a href="showcase/pdf/templates/coverletter/cover-letter-monogram-sidebar.pdf">Monogram Sidebar letter</a></li>
-            <li><a href="showcase/pdf/templates/coverletter/cover-letter-sidebar-portrait.pdf">Sidebar Portrait letter</a></li>
+            <li><a href="showcase/pdf/templates/coverletter/cover-letter-modern-professional-v2.pdf">Cover Letter (canonical)</a></li>
+            <li><a href="showcase/pdf/templates/coverletter/cover-letter-modern-professional-v2.pdf">Modern Professional letter</a></li>
+            <li><a href="showcase/pdf/templates/coverletter/cover-letter-executive-v2.pdf">Executive letter</a></li>
+            <li><a href="showcase/pdf/templates/coverletter/cover-letter-monogram-sidebar-v2.pdf">Monogram Sidebar letter</a></li>
+            <li><a href="showcase/pdf/templates/coverletter/cover-letter-sidebar-portrait-v2.pdf">Sidebar Portrait letter</a></li>
           </ul>
 
           <h4>Invoice / Proposal / Schedule</h4>


### PR DESCRIPTION
## Summary

External presentation audit ahead of the v1.6.6 Maven Central debut surfaced **20 of 27** showcase references in `docs/index.html` rendering as 404. After the CV v2 layered migration in 1.6.x, every preset's screenshot and PDF was renamed with a `-v2` suffix on disk, but the GitHub Pages site (`demchaav.github.io/GraphCompose/`) still referenced the pre-migration paths.

## Fix

| Pattern | Action | Count |
|---|---|---|
| `cv/cv-X.{pdf,png}` | → `cv/cv-X-v2.{pdf,png}` | 14 CV PDFs + 1 PNG |
| `coverletter/cover-letter-X.{pdf,png}` | → `coverletter/cover-letter-X-v2.{pdf,png}` | 4 specific cover letters |
| `coverletter/cover-letter.pdf` | → `coverletter/cover-letter-modern-professional-v2.pdf` | 1 generic landing link |
| Invoice / proposal / schedule | unchanged | already correct |

## Verification

```
$ for ref in $(grep -oE 'showcase/[a-z]+/templates/[a-z/]+[a-z-]+(-v2)?\.[a-z]+' docs/index.html | sort -u); do
    [ -f "docs/$ref" ] || echo "BROKEN: $ref"
  done
(empty — all 26 unique references resolve on disk)
```

## Why this is a release-blocker

The next Maven Central debut tag (v1.6.6) will route significantly more traffic at the Pages site. Broken-image-laden first impression for every new caller would have cost trust. Fixing this **before** cut is cheap; fixing after means days of broken homepage in the Central debut window.

This is Phase A of the pre-release polish plan; Phases B + C (hero PDF + README banner replacement) follow.

## Test plan

- [x] All 26 unique referenced paths resolve via `ls`
- [x] Diff is mechanical / structurally identical (`sed` substitution only)
- [ ] CI green on PR
- [ ] Visual verification on Pages once merged (homepage hero + CV gallery)