### PR TITLE
build: drop Kotlin runtime + JetBrains annotations (F2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@ filled in as work lands on `develop`. No breaking changes are
 planned; the next minor with new canonical DSL primitives is
 **v1.7.0** (see [ROADMAP.md](ROADMAP.md)).
 
+### Build
+
+- Dropped the `kotlin-stdlib-jdk8` compile dependency, the
+  `kotlin-test` test dependency, and the `kotlin-maven-plugin`
+  build extension. GraphCompose is Java-first; no production
+  Kotlin sources exist, and the runtime now no longer carries
+  the Kotlin standard library transitively. Consumers that
+  relied on `kotlin-stdlib` flowing through GraphCompose must
+  declare it explicitly.
+
+### Internal
+
+- Replaced eight residual `org.jetbrains.annotations.NotNull` /
+  `@Nullable` usages with `lombok.NonNull` (where the surrounding
+  file already used Lombok) or removed them entirely (private
+  methods and test fixtures). `org.jetbrains:annotations` is no
+  longer on the runtime classpath after the Kotlin removal.
+
 ## v1.6.6 — 2026-05-31
 
 **First Maven Central release.** GraphCompose now ships under

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,6 @@
         <!-- Runtime / library dependencies -->
         <flexmark.version>0.64.8</flexmark.version>
         <jackson.bom.version>2.21.3</jackson.bom.version>
-        <kotlin.version>2.3.21</kotlin.version>
         <logback.version>1.5.32</logback.version>
         <lombok.version>1.18.46</lombok.version>
         <pdfbox.version>3.0.7</pdfbox.version>
@@ -198,13 +197,6 @@
             <version>${zxing.version}</version>
         </dependency>
 
-        <!-- Kotlin compatibility -->
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
-            <version>${kotlin.version}</version>
-        </dependency>
-
         <!-- Test dependencies -->
         <dependency>
             <groupId>ch.qos.logback</groupId>
@@ -246,12 +238,6 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <version>${mockito.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test</artifactId>
-            <version>${kotlin.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -317,40 +303,6 @@
         </pluginManagement>
 
         <plugins>
-            <!-- Kotlin compatibility / mixed-source support -->
-            <plugin>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-maven-plugin</artifactId>
-                <version>${kotlin.version}</version>
-                <executions>
-                    <execution>
-                        <id>compile</id>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                        <configuration>
-                            <sourceDirs>
-                                <sourceDir>${project.basedir}/src/main/java</sourceDir>
-                            </sourceDirs>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>test-compile</id>
-                        <goals>
-                            <goal>test-compile</goal>
-                        </goals>
-                        <configuration>
-                            <sourceDirs>
-                                <sourceDir>${project.basedir}/src/test/java</sourceDir>
-                            </sourceDirs>
-                        </configuration>
-                    </execution>
-                </executions>
-                <configuration>
-                    <jvmTarget>${maven.compiler.release}</jvmTarget>
-                </configuration>
-            </plugin>
-
             <!--
                 Build-time precondition enforcement. Three rules:
                 * requireJavaVersion: blocks builds on JDK < 17 (the

--- a/src/main/java/com/demcha/compose/engine/components/content/text/TextDataBody.java
+++ b/src/main/java/com/demcha/compose/engine/components/content/text/TextDataBody.java
@@ -1,7 +1,6 @@
 package com.demcha.compose.engine.components.content.text;
 
 import com.demcha.compose.engine.font.Font;
-import org.jetbrains.annotations.NotNull;
 
 public record TextDataBody(String text, TextStyle textStyle) {
     public  TextDataBody(String text, TextStyle textStyle){
@@ -9,7 +8,7 @@ public record TextDataBody(String text, TextStyle textStyle) {
         this.text = text;
         this.textStyle = textStyle;
     }
-    public double width(@NotNull Font<?> font) {
+    public double width(Font<?> font) {
         return font.getTextWidth(textStyle, text);
     }
 }

--- a/src/main/java/com/demcha/compose/engine/components/core/Entity.java
+++ b/src/main/java/com/demcha/compose/engine/components/core/Entity.java
@@ -10,7 +10,6 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 
@@ -146,7 +145,7 @@ public final class Entity {
         return this;
     }
 
-    private <T extends Component> void debugPutMethod(@NotNull T c, Component prev, String methodName) {
+    private <T extends Component> void debugPutMethod(T c, Component prev, String methodName) {
         if (log.isDebugEnabled()) {
             if (prev == null) {
                 log.debug("Added component {} to {} through method {}", c, this, methodName);

--- a/src/main/java/com/demcha/compose/engine/pagination/TextBlockProcessor.java
+++ b/src/main/java/com/demcha/compose/engine/pagination/TextBlockProcessor.java
@@ -18,7 +18,6 @@ import com.demcha.compose.engine.exceptions.BigSizeElementException;
 import com.demcha.compose.engine.measurement.TextMeasurementSystem;
 import lombok.NonNull;
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -164,7 +163,7 @@ public class TextBlockProcessor {
 
     private void finalizePageBreakingAndDefinition(Entity entity,
                                                    BlockTextData blockTextData,
-                                                   @NotNull Offset yOffset,
+                                                   Offset yOffset,
                                                    List<LineTextData> assignPositionTextData,
                                                    Offset entityYOffset) {
         BlockTextData newBlockTextData = blockTextData.withLines(assignPositionTextData);

--- a/src/main/java/com/demcha/compose/engine/render/guides/GuideCoordinate.java
+++ b/src/main/java/com/demcha/compose/engine/render/guides/GuideCoordinate.java
@@ -7,7 +7,6 @@ import com.demcha.compose.engine.exceptions.RenderGuideLinesException;
 import com.demcha.compose.engine.render.RenderPassSession;
 import com.demcha.compose.engine.render.RenderingSystemECS;
 import lombok.NonNull;
-import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.util.Set;
@@ -81,7 +80,7 @@ public interface GuideCoordinate<T extends AutoCloseable> {
         return renderingSystem().renderBorder(stream, coordinateContext, lineDash, sides);
     }
 
-    default void startMarkers(@NotNull RenderCoordinateContext context, @NotNull T stream) throws IOException {
+    default void startMarkers(@NonNull RenderCoordinateContext context, @NonNull T stream) throws IOException {
         final float radius = renderingSystem().guidLineSettings().MARKER_RADIUS();
         float cx = (float) context.x();
         float cy = (float) context.y();
@@ -116,7 +115,7 @@ public interface GuideCoordinate<T extends AutoCloseable> {
         return true;
     }
 
-    default void endMarkers(@NotNull RenderCoordinateContext context, @NotNull T stream) throws IOException {
+    default void endMarkers(@NonNull RenderCoordinateContext context, @NonNull T stream) throws IOException {
         final float radius = renderingSystem().guidLineSettings().MARKER_RADIUS();
         float cx = (float) context.x();
         float cy = (float) context.y();

--- a/src/main/java/com/demcha/compose/engine/render/guides/GuidesRenderer.java
+++ b/src/main/java/com/demcha/compose/engine/render/guides/GuidesRenderer.java
@@ -16,7 +16,6 @@ import lombok.NonNull;
 import lombok.ToString;
 import lombok.experimental.Accessors;
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
 
 import java.awt.Color;
 import java.io.IOException;
@@ -48,7 +47,6 @@ public abstract class GuidesRenderer<S extends AutoCloseable> {
     @ToString.Exclude
     protected final PaddingRender<S> padding;
 
-    @NotNull
     private static RenderCoordinateContext update(RenderCoordinateContext source, double y, double height, int page) {
         return new RenderCoordinateContext(
                 source.x(),
@@ -262,7 +260,6 @@ public abstract class GuidesRenderer<S extends AutoCloseable> {
         }
     }
 
-    @NotNull
     private RenderCoordinateContext boxCoordinate(Entity entity) {
         Stroke stroke = renderingSystem().guidLineSettings().BOX_STROKE();
         Color color = renderingSystem().guidLineSettings().BOX_COLOR();

--- a/src/main/java/com/demcha/compose/engine/render/pdf/PdfFont.java
+++ b/src/main/java/com/demcha/compose/engine/render/pdf/PdfFont.java
@@ -8,7 +8,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.fontbox.util.BoundingBox;
 import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.pdfbox.pdmodel.font.PDFontDescriptor;
-import org.jetbrains.annotations.NotNull;
 
 import java.awt.*;
 import java.awt.geom.AffineTransform;
@@ -179,7 +178,7 @@ public class PdfFont extends FontBase<PDFont> {
         }
     }
 
-    private @NotNull String textSanitizer(String text) {
+    private String textSanitizer(String text) {
         // v1.6.3: preserve author-supplied whitespace verbatim. The
         // previous implementation collapsed any run of resulting spaces
         // (original + converted) into one, but downstream geometry

--- a/src/test/java/com/demcha/compose/testsupport/EngineComposerHarness.java
+++ b/src/test/java/com/demcha/compose/testsupport/EngineComposerHarness.java
@@ -28,7 +28,6 @@ import org.apache.pdfbox.pdmodel.PDDocumentInformation;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.apache.pdfbox.pdmodel.encryption.AccessPermission;
 import org.apache.pdfbox.pdmodel.encryption.StandardProtectionPolicy;
-import org.jetbrains.annotations.Nullable;
 
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
@@ -51,16 +50,11 @@ public final class EngineComposerHarness implements Closeable {
     private final Canvas canvas;
     private final LayoutSystem<PdfRenderingSystemECS> layoutSystem;
     private final PdfRenderingSystemECS renderingSystem;
-    @Nullable
     private final Path outputFile;
-    @Nullable
     private final PdfFileManagerSystem fileManagerSystem;
     private final List<HeaderFooterConfig> headerFooterConfigs = new ArrayList<>();
-    @Nullable
     private WatermarkConfig watermarkConfig;
-    @Nullable
     private DocumentMetadata documentMetadata;
-    @Nullable
     private PdfProtectionConfig protectionConfig;
     private boolean postProcessed;
     private boolean layoutResolved;

--- a/src/test/java/com/demcha/compose/testsupport/engine/assembly/BlockTextBuilder.java
+++ b/src/test/java/com/demcha/compose/testsupport/engine/assembly/BlockTextBuilder.java
@@ -25,7 +25,6 @@ import com.demcha.compose.engine.text.markdown.MarkDownParser;
 import lombok.NonNull;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
-import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
 
@@ -583,13 +582,13 @@ public class BlockTextBuilder extends EmptyBox<BlockTextBuilder> {
         return "([{".indexOf(last) >= 0;
     }
 
-    private @NotNull TextMeasurementSystem textMeasurementSystem() {
+    private TextMeasurementSystem textMeasurementSystem() {
         return entityManager.getSystems()
                 .getSystem(TextMeasurementSystem.class)
                 .orElseThrow(() -> new IllegalStateException("TextMeasurementSystem is required to build block text."));
     }
 
-    private @NotNull TextStyle measurementStyle() {
+    private TextStyle measurementStyle() {
         if (baseComponents != null) {
             TextStyle style = (TextStyle) baseComponents.get(TextStyle.class);
             if (style != null) {


### PR DESCRIPTION
## Summary

Opens the **v1.6.7 dependency-cleanup cycle**. Implements track **F2** from the
[v1.6.5-1.7 readiness taskboard](https://github.com/DemchaAV/GraphCompose/blob/develop/CHANGELOG.md) using the
[F1 audit](https://github.com/DemchaAV/GraphCompose/pull/85) as input:

- Drops `kotlin-stdlib-jdk8`, `kotlin-test`, and the `kotlin-maven-plugin`
  build extension from `pom.xml` (plus the now-orphan `kotlin.version`
  property). GraphCompose is Java-first; no production Kotlin sources
  exist, so the runtime no longer carries `kotlin-stdlib` transitively.
- Strips eight residual `org.jetbrains.annotations.NotNull` / `@Nullable`
  usages — these only resolved because they came in transitively via
  `kotlin-stdlib`. In `GuideCoordinate` they become `@lombok.NonNull`
  (the sibling default methods already use it); elsewhere they were
  annotation-only hints on private methods, return types, or test
  fixtures and are dropped.

**Consumer impact**: callers that depended on `kotlin-stdlib` flowing
through GraphCompose must now declare it explicitly. The public API
is unchanged.

## Test plan

- [x] `./mvnw test -pl .` — **1031 tests, 0 failures, 0 errors**
- [x] `./mvnw dependency:tree -pl .` — **0 `org.jetbrains` / `kotlin`** in
      the tree
- [x] `./mvnw verify -pl . -P japicmp` — **semver OK, no incompatible
      changes** vs v1.6.6 baseline