### PR TITLE
build: narrow flexmark-all to targeted modules + jcl-over-slf4j bridge (F3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ planned; the next minor with new canonical DSL primitives is
   the Kotlin standard library transitively. Consumers that
   relied on `kotlin-stdlib` flowing through GraphCompose must
   declare it explicitly.
+- Replaced the `flexmark-all` aggregator dependency with the three
+  modules actually referenced by `MarkDownParser`: `flexmark`
+  (core parser + AST), `flexmark-util-ast` (Node / NodeVisitor /
+  VisitHandler), and `flexmark-util-data` (MutableDataSet). No
+  extension modules (tables, footnotes, gfm-strikethrough, etc.)
+  are used by GraphCompose. Consumers that relied on extensions
+  flowing through GraphCompose must depend on the relevant
+  `flexmark-ext-*` modules explicitly.
+- Added `jcl-over-slf4j` as an explicit compile dependency. PDFBox
+  3.0.7's `PDDocument.<clinit>` calls `org.apache.commons.logging.
+  LogFactory` directly; we exclude PDFBox's own `commons-logging`
+  artifact to keep one logging facade, and the bridge routes those
+  calls through SLF4J. Previously the bridge was provided
+  transitively via `flexmark-all`; making it explicit keeps the
+  classpath reproducible after the flexmark narrowing above.
 
 ### Internal
 

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,21 @@
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
         </dependency>
+        <!--
+            commons-logging → SLF4J bridge. PDFBox's static initializer
+            (`PDDocument.<clinit>`) still calls `org.apache.commons.logging.
+            LogFactory` directly. We exclude PDFBox's own `commons-logging`
+            artefact to keep a single logging facade and route those calls
+            through SLF4J via this drop-in replacement. Previously this
+            class was on the classpath transitively via `flexmark-all` —
+            F3 (v1.6.7) narrowed flexmark to its core modules and made
+            the bridge explicit so the build is reproducible.
+        -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jcl-over-slf4j</artifactId>
+            <version>${slf4j.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
@@ -135,9 +150,29 @@
             </exclusions>
         </dependency>
 
+        <!--
+            Flexmark markdown parser. F3 (v1.6.7) narrowed `flexmark-all`
+            down to the modules actually referenced by
+            `com.demcha.compose.engine.text.markdown.MarkDownParser`:
+            - `flexmark`           — Parser + `com.vladsch.flexmark.ast.*`
+                                     (Heading, ListItem, Emphasis, etc.)
+            - `flexmark-util-ast`  — Node, NodeVisitor, VisitHandler
+            - `flexmark-util-data` — MutableDataSet
+            No extension modules (tables, footnotes, gfm) are used.
+        -->
         <dependency>
             <groupId>com.vladsch.flexmark</groupId>
-            <artifactId>flexmark-all</artifactId>
+            <artifactId>flexmark</artifactId>
+            <version>${flexmark.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vladsch.flexmark</groupId>
+            <artifactId>flexmark-util-ast</artifactId>
+            <version>${flexmark.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.vladsch.flexmark</groupId>
+            <artifactId>flexmark-util-data</artifactId>
             <version>${flexmark.version}</version>
         </dependency>
 


### PR DESCRIPTION
## Summary

Continues the **v1.6.7 dependency-cleanup cycle**. Implements track
**F3** from the readiness taskboard using the
[F1 audit](docs/private/dependency-analyze-2026-05-31.md) as input.

### What changed

- **flexmark-all → targeted modules.** GraphCompose's only
  flexmark consumer is `com.demcha.compose.engine.text.markdown.MarkDownParser`,
  which references core parser + AST classes, `util.ast.Node`/
  `NodeVisitor`/`VisitHandler`, and `util.data.MutableDataSet`.
  The aggregator pulled ~40 jars (extensions, formatters,
  converters) the codebase never touches. Replaced with
  `flexmark` (core), `flexmark-util-ast`, `flexmark-util-data`.
- **`jcl-over-slf4j` added explicitly.** Fixing F3 surfaced a
  latent gap: PDFBox 3.0.7's `PDDocument.<clinit>` still calls
  `org.apache.commons.logging.LogFactory` directly. We
  intentionally exclude PDFBox's own `commons-logging` artefact
  (single logging facade — SLF4J), but the bridge was provided
  transitively via `flexmark-all`. Without it, every
  PDDocument-touching test now fails with `NoClassDefFoundError`
  at clinit. The standard SLF4J bridge fixes it cleanly.

### Consumer impact

Callers that depended on flexmark extensions (`flexmark-ext-tables`,
gfm-strikethrough, footnotes, …) flowing transitively through
GraphCompose must depend on those modules explicitly. Logging
behaviour is unchanged for consumers — SLF4J was already the
project's logging facade.

## Test plan

- [x] `./mvnw test -pl .` — **1031 tests, 0 failures, 0 errors**
- [x] `./mvnw dependency:tree -pl .` — `flexmark-all` removed; 3
      direct flexmark modules + 8 transitive `util-*` (vs ~40 from
      the aggregator); `jcl-over-slf4j` present; PDFBox's
      `commons-logging` excluded as before.
- [x] `./mvnw verify -pl . -P japicmp` — semver OK vs v1.6.6.