### PR TITLE
build: jackson-yaml optional, drop unused jsonSchema + direct snakeyaml (F4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,26 @@ planned; the next minor with new canonical DSL primitives is
   calls through SLF4J. Previously the bridge was provided
   transitively via `flexmark-all`; making it explicit keeps the
   classpath reproducible after the flexmark narrowing above.
+- Marked `jackson-dataformat-yaml` as `<optional>true</optional>`,
+  mirroring the existing `poi-ooxml` pattern. The only consumer is
+  `ConfigLoader.loadConfigWithEnv(...)` when the caller passes a
+  `.yaml` / `.yml` resource; library consumers that load JSON
+  configs (or skip `ConfigLoader` altogether) no longer pull in the
+  ~1.7 MB SnakeYAML transitive footprint. Applications that load
+  YAML configs through this helper must now declare
+  `jackson-dataformat-yaml` in their own build.
+- Removed the unused `jackson-module-jsonSchema` dependency — no
+  code path references it.
+- Removed the explicit `snakeyaml` dependency declaration and the
+  `snakeyaml.version` property. SnakeYAML is now resolved
+  transitively (and `optional`) through `jackson-dataformat-yaml`,
+  which version-aligns it with Jackson's BOM.
+
+### Documentation
+
+- `ConfigLoader.loadConfigWithEnv` Javadoc now states the YAML
+  path requires `jackson-dataformat-yaml` on the classpath and
+  throws `NoClassDefFoundError` when the optional dep is absent.
 
 ### Internal
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,6 @@
         <poi.version>5.5.1</poi.version>
         <javafx.version>21.0.2</javafx.version>
         <slf4j.version>2.0.18</slf4j.version>
-        <snakeyaml.version>2.6</snakeyaml.version>
         <zxing.version>3.5.4</zxing.version>
 
         <!-- Test dependencies -->
@@ -204,20 +203,22 @@
             <artifactId>jackson-databind</artifactId>
         </dependency>
 
+        <!--
+            jackson-dataformat-yaml is consumed only by `ConfigLoader.
+            loadConfigWithEnv(...)` when the caller passes a *.yaml /
+            *.yml resource. Library consumers that load JSON configs
+            (or do not use ConfigLoader at all) should not pay the
+            ~1.7MB SnakeYAML transitive cost. Marked optional in
+            v1.6.7 (F4), mirroring the existing `poi-ooxml` pattern.
+            Apps that load YAML configs must add this dependency to
+            their own classpath; without it `ConfigLoader` throws
+            `NoClassDefFoundError` when it tries to construct
+            `YAMLFactory`.
+        -->
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-jsonSchema</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>${snakeyaml.version}</version>
+            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/src/main/java/com/demcha/compose/ConfigLoader.java
+++ b/src/main/java/com/demcha/compose/ConfigLoader.java
@@ -21,9 +21,21 @@ public final class ConfigLoader {
     }
 
     /**
-     * Load YAML from classpath resource into the given class.
+     * Load YAML or JSON from a classpath resource into the given class.
      * Supports running from IDE and from a fat JAR.
-     * Optionally resolves ${ENV} or ${ENV:default} placeholders from environment variables.
+     * Optionally resolves {@code ${ENV}} or {@code ${ENV:default}} placeholders
+     * from environment variables.
+     *
+     * <p><strong>Optional dependency:</strong> the YAML path requires
+     * {@code com.fasterxml.jackson.dataformat:jackson-dataformat-yaml} on
+     * the classpath. GraphCompose declares it as an optional Maven
+     * dependency since {@code v1.6.7}; applications that load YAML
+     * configs through this helper must add the artifact to their own
+     * build. JSON configs work without it.
+     *
+     * @throws java.lang.NoClassDefFoundError if {@code fileName} ends with
+     *         {@code .yaml} / {@code .yml} and
+     *         {@code jackson-dataformat-yaml} is not on the classpath.
      */
     public static <T> T loadConfigWithEnv(String fileName, Class<T> clazz, boolean resolveEnv) {
         log.info("Initializing variables from '{}'", fileName);


### PR DESCRIPTION
## Summary

Continues the **v1.6.7 dependency-cleanup cycle**. Implements track
**F4** from the readiness taskboard using the
[F1 audit](docs/private/dependency-analyze-2026-05-31.md) as input.

### What changed

- **`jackson-dataformat-yaml` → `<optional>true</optional>`.** Its
  only consumer is `ConfigLoader.loadConfigWithEnv(...)` on the
  YAML code path. Library consumers that load JSON configs (or
  skip `ConfigLoader` altogether) no longer pay the ~1.7 MB
  SnakeYAML transitive cost. Mirrors the existing `poi-ooxml`
  optional-pattern.
- **Removed `jackson-module-jsonSchema`** — no reachable code path
  references it.
- **Removed the explicit `snakeyaml` dependency** + the
  `snakeyaml.version` property. SnakeYAML now resolves
  transitively (also optional) through `jackson-dataformat-yaml`
  at the version the Jackson BOM picks (2.5), keeping it
  version-aligned with the rest of the Jackson stack.
- **`ConfigLoader` Javadoc** now states the YAML path requires
  `jackson-dataformat-yaml` on the classpath and throws
  `NoClassDefFoundError` when the optional dep is absent.

### Consumer impact

Callers that loaded YAML configs through `ConfigLoader`, or that
relied on `jackson-module-jsonSchema` / `snakeyaml` flowing
transitively through GraphCompose, must declare those dependencies
explicitly.

## Test plan

- [x] `./mvnw test -pl .` — **1031 tests, 0 failures, 0 errors**
- [x] `./mvnw dependency:tree -pl .` —
      `jackson-dataformat-yaml:2.21.3:compile (optional)` and
      `snakeyaml:2.5:compile (optional)` present; no
      `jackson-module-jsonSchema` in tree.
- [x] `./mvnw verify -pl . -P japicmp` — semver OK vs v1.6.6.