### PR TITLE
ci(dependabot): ignore broken jackson-bom 2.22.0 + central-publishing 0.10.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,19 @@ updates:
       maven-minor-patch:
         patterns: ["*"]
         update-types: ["minor", "patch"]
+    ignore:
+      # jackson-bom 2.22.0 ships ahead of its module jars: jackson-core-2.22.0.jar
+      # returns 404 on repo1.maven.org (Sonatype partial-sync window). Block this
+      # exact release so the grouped PR is buildable. Drop this entry once
+      # jackson-bom >= 2.22.1 (or 2.23.0) lands on Central with full module sync.
+      - dependency-name: "com.fasterxml.jackson:jackson-bom"
+        versions: ["2.22.0"]
+      # central-publishing-maven-plugin 0.10.0 is a 3-minor jump (0.7 → 0.10) on
+      # the plugin that publishes Maven Central artefacts (the v1.6.6 release
+      # used 0.7.0). Block this version until the release profile is validated
+      # against 0.10.x in a focused PR; remove this entry once that work lands.
+      - dependency-name: "org.sonatype.central:central-publishing-maven-plugin"
+        versions: ["0.10.0"]
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
## Summary

PR #110 (the grouped maven-minor-patch Dependabot PR) is being blocked
by two specific upstream issues. Adding explicit `ignore` entries so
Dependabot drops them from the next grouped run while still picking up
future versions when they ship.

### Why each version is ignored

1. **`jackson-bom 2.22.0`** — the BOM is on Maven Central but its module
   jars aren't. `jackson-core-2.22.0.jar` returns **HTTP 404** at
   `repo1.maven.org` (Sonatype partial-sync window — BOM rolled ahead
   of its modules). Every grouped PR that picks 2.22.0 fails CI at
   dependency resolution. Will drop this entry once 2.22.1 / 2.23.0
   lands with full module sync.
2. **`central-publishing-maven-plugin 0.10.0`** — three-minor jump
   (0.7 → 0.10) on the plugin that pushes our Maven Central releases;
   v1.6.6 cut used 0.7.0. Want to validate the release profile against
   0.10.x in a focused PR with a real Sonatype staging run, not let it
   ride along in a group bump.

### After merge

1. Close PR #110 (the broken grouped one).
2. Trigger a fresh Dependabot run (next Monday cycle, or `@dependabot
   recreate` on the closed PR) so the same group rebuilds with these
   two skipped. The other 9 bumps — especially `logback-classic 1.5.34`
   which fixes [CVE-2026-9828](https://www.cve.org/cverecord?id=CVE-2026-9828)
   (deserialization whitelist bypass) — get a clean PR to merge.

## Test plan

- [x] `dependabot.yml` validates against the [config schema](https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore)
      (`dependency-name` is `groupId:artifactId`, `versions: ["..."]`
      pins a specific release).
- [ ] After merge: close #110, request `@dependabot recreate`, confirm
      the rebuilt PR drops jackson-bom 2.22.0 + central-publishing 0.10.0
      while keeping the other 9 bumps.