### PR TITLE
docs(release): prep v1.6.7 — transitive cleanup summary + migration table (PR-1.6.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,49 @@ follow semantic versioning; release dates are ISO 8601.
 
 ## v1.6.7 — Planned
 
-**Dependency cleanup cycle.** Scope being assembled — entries are
-filled in as work lands on `develop`. No breaking changes are
-planned; the next minor with new canonical DSL primitives is
-**v1.7.0** (see [ROADMAP.md](ROADMAP.md)).
+**Transitive dependency cleanup.** v1.6.7 narrows the runtime
+classpath GraphCompose imposes on consumers. The Kotlin standard
+library is gone (the codebase is Java-first; no production
+`.kt` sources exist), the `flexmark-all` aggregator is replaced
+with the three modules `MarkDownParser` actually references,
+`jackson-dataformat-yaml` is marked `<optional>true</optional>`
+(mirroring the existing `poi-ooxml` pattern — only consumers that
+load YAML configs through `ConfigLoader` need to pull it in),
+`jackson-module-jsonSchema` and the explicit `snakeyaml`
+declaration are dropped as unused, and `jcl-over-slf4j` is added
+explicitly so PDFBox's `commons-logging` call sites keep routing
+through SLF4J after the flexmark narrowing (the bridge was
+previously provided transitively via `flexmark-all`). The cycle
+also fixes a latent layout-cache staleness bug on
+`DocumentSession.registry().register(...)` (Track I3): the
+registry returned by `registry()` is now a session-owned wrapper
+that invalidates the layout cache on every mutation, matching the
+semantics of `DocumentSession.registerNodeDefinition(...)`.
+
+**Zero breaking public API changes.** The `japicmp` gate against
+the v1.6.6 baseline reports `semver PATCH, compatible bug fix` —
+the one surface delta is `NodeRegistry` becoming non-`final` so
+`DocumentSession` can install the auto-invalidating subclass
+described above. All existing call sites compile and run
+unchanged. The transitive cleanup is a runtime-classpath change,
+not a compile-surface change.
+
+**Migration from v1.6.6.** Consumers that relied on dependencies
+flowing transitively through GraphCompose must now declare them
+explicitly:
+
+| If you transitively depended on… | Add to your build |
+|---|---|
+| Kotlin stdlib via GraphCompose | `org.jetbrains.kotlin:kotlin-stdlib-jdk8` |
+| Flexmark extensions (tables, footnotes, gfm-strikethrough, …) | the relevant `com.vladsch.flexmark:flexmark-ext-*` modules |
+| YAML config loading through `ConfigLoader` | `com.fasterxml.jackson.dataformat:jackson-dataformat-yaml` |
+| `jackson-module-jsonSchema` | `com.fasterxml.jackson.module:jackson-module-jsonSchema` |
+| The `commons-logging` API beyond SLF4J routing | declare `commons-logging:commons-logging` explicitly (GraphCompose intentionally excludes it from PDFBox and bridges via `jcl-over-slf4j`) |
+
+No code changes are required for typical usage — pure-PDF
+consumers and JSON-only `ConfigLoader` callers carry on as before.
+The next minor with new canonical DSL primitives is **v1.7.0**
+(see [ROADMAP.md](ROADMAP.md)).
 
 ### Build
 


### PR DESCRIPTION
## Summary

Final pre-cut PR for the **v1.6.7 dependency-cleanup release**.
Replaces the placeholder "Scope being assembled" intro on the
`v1.6.7 — Planned` CHANGELOG entry with the actual release
summary, mirroring the structure used for v1.6.6 release-prep
([#100](https://github.com/DemchaAV/GraphCompose/pull/100)).

### What this PR adds to CHANGELOG

- **Three-paragraph prose summary** at the top of v1.6.7 — Planned:
  what shipped (transitive cleanup details), zero-breaking status
  (japicmp verdict: `semver PATCH, compatible bug fix`), and
  migration framing.
- **Migration table** listing every dependency consumers must now
  declare explicitly if they previously got it transitively
  through GraphCompose: `kotlin-stdlib-jdk8`, the relevant
  `flexmark-ext-*` modules, `jackson-dataformat-yaml` (for YAML
  configs via `ConfigLoader`), `jackson-module-jsonSchema`, and —
  rarely — `commons-logging` (we exclude it from PDFBox and bridge
  via `jcl-over-slf4j`; only callers who want the
  `commons-logging` API outside SLF4J routing need an explicit
  declaration).

### What this PR does NOT touch

- **README release-status block + install snippets.** Already in
  the right shape from the post-1.6.6 commit (`6eb46941`): latest
  stable v1.6.6 / in develop v1.6.7 / planned v1.7.0. The
  `1.6.6` → `1.6.7` version flip in the install snippets is the
  job of `scripts/cut-release.ps1` at cut time, not this PR.
- **pom.xml versions.** Same reason — bumped atomically by
  `cut-release.ps1` against the aggregator.

### After this PR merges

The v1.6.7 cut runs through the `graphcompose-release-engineer`
skill:

1. `scripts/cut-release.ps1 -Version 1.6.7` — atomic version bump
   across all four poms via the aggregator, flips JitPack snippet
   to v1.6.7, dates the CHANGELOG, runs `verify`, tags `v1.6.7`,
   pushes.
2. `release.yml` creates the GitHub Release from the tag.
3. `publish.yml` re-runs `verify` at the tagged commit and uploads
   to Maven Central (assuming the four Central secrets the v1.6.6
   cut wired up are still present).
4. javadoc.io auto-mirrors within minutes.
5. Post-release commit on develop: flip japicmp baseline
   `v1.6.6 → v1.6.7`, add `v1.6.8 / v1.7.0 — Planned` stub.

## Test plan

- [x] `./mvnw test -pl . -Dtest=VersionConsistencyGuardTest,DocumentationCoverageTest,DocumentationExamplesTest`
      — **22 tests, 0 failures**.
- [x] Full `./mvnw verify -P japicmp` was green at `b4720c63`
      (the I3 merge that closed the engineering scope). This PR
      touches only `CHANGELOG.md` prose, so no source/binary
      surface change.