### PR TITLE
ci(dependabot): pin target-branch develop + sync deps from main #115

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,12 @@ updates:
       - "/"
       - "/examples"
       - "/benchmarks"
+    # Send Maven update PRs to the integration branch, not the
+    # default branch. Releases are cut from `develop` then merged
+    # to `main`; targeting `main` (the default) made every Dependabot
+    # PR land alongside the latest release and force-diverge from
+    # ongoing dev work — fixed in v1.6.8 after the #111 / #115 episodes.
+    target-branch: develop
     schedule:
       interval: weekly
       day: monday
@@ -37,6 +43,9 @@ updates:
 
   - package-ecosystem: github-actions
     directory: "/"
+    # Same reasoning as the maven block above — workflow updates
+    # ride the integration branch.
+    target-branch: develop
     schedule:
       interval: weekly
       day: monday

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,31 @@ follow-ups carried over from the v1.6.7 senior review (see
 [ROADMAP.md](ROADMAP.md) and the private taskboard). No breaking
 changes are planned.
 
+### Build
+
+- Bumped `jackson-bom` 2.21.3 &rarr; 2.21.4 (broken 2.22.0 skipped via
+  the `.github/dependabot.yml` ignore entry added in v1.6.7),
+  `logback-classic` 1.5.32 &rarr; 1.5.34 (fixes
+  [CVE-2026-9828](https://www.cve.org/cverecord?id=CVE-2026-9828) —
+  deserialization whitelist bypass in `HardenedModelInputStream`),
+  `central-publishing-maven-plugin` 0.7.0 &rarr; 0.9.0 (0.10.0
+  blocked by the existing ignore entry; revisit after a focused
+  release-profile evaluation), `japicmp-maven-plugin` 0.23.1 &rarr;
+  0.26.1, and a handful of `maven-*-plugin` minor/patch bumps
+  (clean / site / resources / enforcer 3.5.0 &rarr; 3.6.3 / surefire
+  3.5.5 &rarr; 3.5.6 / source 3.3.1 &rarr; 3.4.0 / gpg 3.2.7 &rarr;
+  3.2.8) ([#115](https://github.com/DemchaAV/GraphCompose/pull/115),
+  cherry-picked from `main` to align `develop`).
+
+### CI
+
+- `.github/dependabot.yml` now pins both ecosystems
+  (`maven`, `github-actions`) to `target-branch: develop` so future
+  grouped PRs land on the integration branch instead of `main`.
+  Closes the divergence root cause behind the v1.6.7-era #111 /
+  #115 episodes where every Dependabot PR force-split history
+  between branches and required a cherry-pick to align.
+
 ### Documentation
 
 - New quickstart guide

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -26,7 +26,7 @@
 
         <junit.bom.version>6.1.0</junit.bom.version>
         <assertj.version>3.27.7</assertj.version>
-        <logback.version>1.5.32</logback.version>
+        <logback.version>1.5.34</logback.version>
 
         <openhtmltopdf.version>1.0.10</openhtmltopdf.version>
         <itextpdf.version>5.5.13.3</itextpdf.version>
@@ -129,7 +129,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.5</version>
+                <version>3.5.6</version>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <graphcompose.version>${project.version}</graphcompose.version>
-        <logback.version>1.5.32</logback.version>
+        <logback.version>1.5.34</logback.version>
         <maven.compiler.release>17</maven.compiler.release>
 
         <junit.bom.version>6.1.0</junit.bom.version>
@@ -79,7 +79,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.5</version>
+                <version>3.5.6</version>
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,8 @@
 
         <!-- Runtime / library dependencies -->
         <flexmark.version>0.64.8</flexmark.version>
-        <jackson.bom.version>2.21.3</jackson.bom.version>
-        <logback.version>1.5.32</logback.version>
+        <jackson.bom.version>2.21.4</jackson.bom.version>
+        <logback.version>1.5.34</logback.version>
         <lombok.version>1.18.46</lombok.version>
         <pdfbox.version>3.0.7</pdfbox.version>
         <poi.version>5.5.1</poi.version>
@@ -63,20 +63,20 @@
         <byteBuddy.version>1.18.8</byteBuddy.version>
 
         <!-- Build plugins -->
-        <central.publishing.plugin.version>0.7.0</central.publishing.plugin.version>
+        <central.publishing.plugin.version>0.9.0</central.publishing.plugin.version>
         <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
-        <maven.enforcer.plugin.version>3.5.0</maven.enforcer.plugin.version>
-        <maven.gpg.plugin.version>3.2.7</maven.gpg.plugin.version>
+        <maven.enforcer.plugin.version>3.6.3</maven.enforcer.plugin.version>
+        <maven.gpg.plugin.version>3.2.8</maven.gpg.plugin.version>
         <maven.javadoc.plugin.version>3.12.0</maven.javadoc.plugin.version>
-        <maven.source.plugin.version>3.3.1</maven.source.plugin.version>
-        <maven.surefire.plugin.version>3.5.5</maven.surefire.plugin.version>
+        <maven.source.plugin.version>3.4.0</maven.source.plugin.version>
+        <maven.surefire.plugin.version>3.5.6</maven.surefire.plugin.version>
 
         <!-- Minimum toolchain (enforced by maven-enforcer-plugin) -->
         <enforcer.requireMavenVersion>3.8.0</enforcer.requireMavenVersion>
         <enforcer.requireJavaVersion>17</enforcer.requireJavaVersion>
 
         <!-- Binary compatibility baseline (japicmp profile) -->
-        <japicmp.version>0.23.1</japicmp.version>
+        <japicmp.version>0.26.1</japicmp.version>
         <japicmp.baseline>v1.6.7</japicmp.baseline>
 
         <!--
@@ -313,7 +313,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>3.4.0</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -323,12 +323,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.21.0</version>
+                    <version>3.22.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.3.1</version>
+                    <version>3.5.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary

Closes the **divergence root cause** that bit us twice on the
v1.6.7 cycle (#111 jasperreports, #115 maven-minor-patch group).

### The pattern

Dependabot reads the repo's **default branch** (`main`) and opens
grouped update PRs there. Our release cadence is:

1. Develop work on `develop`
2. Cut release, tag from `develop`
3. Merge `develop` &rarr; `main`

So whenever Dependabot's weekly cycle fires while a release is in
flight, the grouped PR lands on `main` instead of `develop`. By
the next release-prep, `develop` is missing those bumps and needs
a manual cherry-pick to stay aligned.

The episode was painful enough during v1.6.7 (twice) that I dropped
the structural fix into a focused PR rather than carrying it forward
as a perpetual cherry-pick chore.

### Changes

**Commit 1** (cherry-pick of `6668c89e` from main):
- `jackson-bom` 2.21.3 &rarr; 2.21.4
- `logback-classic` 1.5.32 &rarr; 1.5.34 (fixes
  [CVE-2026-9828](https://www.cve.org/cverecord?id=CVE-2026-9828) —
  `HardenedModelInputStream` deserialization whitelist bypass)
- `central-publishing-maven-plugin` 0.7.0 &rarr; 0.9.0 (we blocked
  0.10.0; 0.9.0 is a 2-minor jump and acceptable)
- `japicmp-maven-plugin` 0.23.1 &rarr; 0.26.1
- `maven-enforcer-plugin` 3.5.0 &rarr; 3.6.3
- Plus maven-clean / site / resources / surefire / source / gpg
  minor & patch bumps

Conflict resolution: the cherry-pick'd `japicmp.baseline` flipped
back from `v1.6.7` to `v1.6.6` (because the bump was made on main
before the v1.6.7 cut); kept develop's `v1.6.7` baseline and took
main's plugin-version bump.

**Commit 2** (this PR's own change):
- `.github/dependabot.yml` — `target-branch: develop` added to
  both `maven` and `github-actions` ecosystem blocks. Documented
  inline with the reasoning.

### Test plan

- [x] `./mvnw test -pl .` — **1032 tests, 0 failures**
- [x] `./mvnw verify -P japicmp -pl .` — japicmp 0.26.1 plugin on
      the v1.6.7 baseline; expected `semver PATCH` (no public-API
      surface delta in this PR).
- [ ] After merge: confirm next Dependabot weekly cycle on Monday
      lands its PR on `develop`, not `main`.