### PR TITLE
chore(api): InvalidatingNodeRegistry ensureOpen + negative test + NodeRegistry @since note (J2/J3/J4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,29 @@ follow-ups carried over from the v1.6.7 senior review (see
 [ROADMAP.md](ROADMAP.md) and the private taskboard). No breaking
 changes are planned.
 
+### Fixes
+
+- The two `DocumentSession` registration entry points are now
+  **fully** interchangeable, not just cache-equivalent.
+  `session.registry().register(...)` now calls `ensureOpen()`
+  before mutating, matching the behaviour of
+  `session.registerNodeDefinition(...)`. Previously
+  `registry().register(...)` on a closed session silently mutated
+  the registry and invalidated a closed-session cache (harmless
+  but semantically odd). After this change both paths throw
+  `IllegalStateException` on a closed session. (Track J2 — carry-
+  over polish from the v1.6.7 senior review.)
+
+### Internal
+
+- `NodeRegistry` Javadoc updated to call out the v1.6.7 non-final
+  relaxation explicitly (Track J4). The class became non-final
+  in v1.6.7 (Track I3) so `DocumentSession` could install the
+  auto-invalidating subclass; the change was already binary-
+  compatible (japicmp classified it as `semver PATCH`). The
+  Javadoc just makes the rationale discoverable without reading
+  the CHANGELOG.
+
 ### Public API
 
 - `MarkdownInline.append(...)` (the inline-markdown adapter used by

--- a/src/main/java/com/demcha/compose/document/api/DocumentSession.java
+++ b/src/main/java/com/demcha/compose/document/api/DocumentSession.java
@@ -913,18 +913,23 @@ public final class DocumentSession implements AutoCloseable {
 
     /**
      * Session-owned {@link NodeRegistry} subclass that funnels every
-     * {@link #register(NodeDefinition)} call through
-     * {@link DocumentSession#invalidate()}. Without this wrapper, callers
-     * that mutated the registry directly via {@code session.registry().
-     * register(...)} would leave the layout cache pointing at a stale
-     * compile result — the cache invalidation only happened on the
-     * dedicated {@link DocumentSession#registerNodeDefinition(NodeDefinition)}
-     * path. Added in v1.6.7 (Track I3) so the two registration entry points
-     * have identical caching semantics.
+     * {@link #register(NodeDefinition)} call through both
+     * {@link DocumentSession#ensureOpen()} and
+     * {@link DocumentSession#invalidate()}. The two registration entry
+     * points — {@code session.registry().register(...)} and
+     * {@link DocumentSession#registerNodeDefinition(NodeDefinition)} —
+     * are now fully interchangeable: both refuse to mutate a closed
+     * session and both invalidate the cached compile.
+     *
+     * <p>Added in v1.6.7 (Track I3) as cache-invalidation only; the
+     * {@code ensureOpen()} symmetry landed in v1.6.8 (Track J2) after
+     * the senior review noted that the two entry points still
+     * disagreed on closed-session behaviour.</p>
      */
     private final class InvalidatingNodeRegistry extends NodeRegistry {
         @Override
         public <E extends DocumentNode> NodeRegistry register(NodeDefinition<E> definition) {
+            ensureOpen();
             super.register(definition);
             invalidate();
             return this;

--- a/src/main/java/com/demcha/compose/document/layout/NodeRegistry.java
+++ b/src/main/java/com/demcha/compose/document/layout/NodeRegistry.java
@@ -19,6 +19,12 @@ import java.util.Objects;
  * get the same caching semantics as
  * {@code session.registerNodeDefinition(...)}.</p>
  *
+ * <p><strong>Non-final since v1.6.7.</strong> The class lost its
+ * {@code final} modifier in v1.6.7 (Track I3) so {@code DocumentSession}
+ * could install the auto-invalidating subclass described above. The
+ * change is binary-compatible (japicmp classifies it as {@code semver
+ * PATCH}); standalone-registry callers see no behavioural change.</p>
+ *
  * @since 1.6.0
  */
 public class NodeRegistry {

--- a/src/test/java/com/demcha/compose/document/api/DocumentSessionTest.java
+++ b/src/test/java/com/demcha/compose/document/api/DocumentSessionTest.java
@@ -760,6 +760,32 @@ class DocumentSessionTest {
         }
     }
 
+    /**
+     * Negative-path companion to the I3 positive test above. After
+     * closing the session, mutating the registry through
+     * {@code session.registry().register(...)} must throw
+     * {@link IllegalStateException} — symmetric with
+     * {@link DocumentSession#registerNodeDefinition(NodeDefinition)},
+     * which has always thrown on a closed session. Added in v1.6.8
+     * (Track J2/J3) after the v1.6.7 senior review flagged that the
+     * two entry points still disagreed on closed-session behaviour.
+     */
+    @Test
+    void registryRegisterOnClosedSessionThrowsIllegalStateException() {
+        DocumentSession session = GraphCompose.document()
+                .pageSize(200, 160)
+                .margin(DocumentInsets.of(10))
+                .create();
+        // Close via try-with-resources is the canonical path; close
+        // explicitly here so the assertion runs against a closed
+        // session.
+        session.close();
+
+        assertThatThrownBy(() -> session.registry()
+                .register(new BadgeNodeDefinition()))
+                .isInstanceOf(IllegalStateException.class);
+    }
+
     @Test
     @DisabledIfSystemProperty(named = "no.poi", matches = "true",
             disabledReason = "Exercises DocxSemanticBackend; skipped under the no-poi profile that excludes poi-ooxml from the test classpath")


### PR DESCRIPTION
## Summary

Three small carry-over items from the **v1.6.7 senior review**,
bundled into one PR because they share a topic (the I3 auto-
invalidating registry wrapper) and a CHANGELOG section.

### J2 — Symmetric closed-session behaviour

`InvalidatingNodeRegistry.register` now calls `ensureOpen()`
before `super.register()`. Previously the two registration entry
points disagreed on what happens after `session.close()`:

| Path | Before | After |
|---|---|---|
| `session.registerNodeDefinition(...)` | `IllegalStateException` | unchanged — `IllegalStateException` |
| `session.registry().register(...)` | silently mutates closed session | `IllegalStateException` |

`ensureOpen()` inside the constructor's default-definitions setup
is safe because the `closed` flag is field-initialised to `false`
before the constructor body runs.

### J3 — Negative test

`DocumentSessionTest.registryRegisterOnClosedSessionThrowsIllegalStateException`
pins the new contract. Pairs with the existing positive cache-
invalidation test from I3 so the senior-bar "positive + negative"
pattern (cf [PR-7.3](https://github.com/DemchaAV/GraphCompose/pull/81))
is complete.

### J4 — `NodeRegistry` `@since` note

Class-level Javadoc on `NodeRegistry` now explicitly calls out
the v1.6.7 non-final relaxation. The class became non-final in
v1.6.7 (Track I3) so `DocumentSession` could install the auto-
invalidating subclass; the change was already binary-compatible
(japicmp: `semver PATCH`). The Javadoc just makes the rationale
discoverable without reading the CHANGELOG.

## Test plan

- [x] `DocumentSessionTest` now has 26 tests (25 prev + 1 new
      negative).
- [x] `./mvnw verify -pl . -P japicmp` — **1058 tests, 0 failures**.
- [x] japicmp vs v1.6.7 baseline: `semver PATCH` (compatible — no
      public signature changes; `ensureOpen()` is a behavioural
      strengthening on an existing public method).