### PR TITLE
docs(release): prep v1.6.8 — feature summary + migration table (PR-1.6.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,61 @@ follow semantic versioning; release dates are ISO 8601.
 
 ## v1.6.8 — Planned
 
-**CV v2 migration completion + senior-review polish.** Scope being
-assembled — entries are filled in as work lands on `develop`. The
-headline addition is parser-level support for inline markdown links
-(`[label](url)`) so CV/cover-letter authors can render project /
-education entry titles as hyperlinks without changing the existing
-`CvRow` data shape; the rest is small build and code-hygiene
-follow-ups carried over from the v1.6.7 senior review (see
-[ROADMAP.md](ROADMAP.md) and the private taskboard). No breaking
-changes are planned.
+**CV v2 migration completion + design-token expansion.** v1.6.8
+finishes the CV v2 migration with hyperlink-aware project / entry
+titles: a row authored as `"[GraphCompose](https://github.com/x/y)
+(Java, PDFBox)"` now renders the title as a clickable link in the
+final PDF, with the technology stack remaining a plain
+` (Java, PDFBox)` tail. The mechanism is a small extension to
+the inline-Markdown parser used by every CV / cover-letter body
+row — the `[label](url)` syntax produces a `RichText.link(...)`
+run; bare brackets stay literal; everything else (`**bold**`,
+`*italic*`, `_italic_`) keeps working as before. The release also
+ships four contemporary `BusinessTheme` factory presets
+(`nordic()`, `editorial()`, `cinematic()`, `monochrome()`)
+alongside the classic / modern / executive trio, expanding the
+built-in design-token range to seven presets. Senior-review
+follow-ups from v1.6.7 round out the release: the two registry
+mutation entry points on `DocumentSession` are now fully
+interchangeable (both refuse to mutate a closed session and both
+invalidate the layout cache), `target-branch: develop` is pinned
+in Dependabot config so future bumps land on the integration
+branch, and `logback-classic` rolls forward to 1.5.34 which
+fixes [CVE-2026-9828](https://www.cve.org/cverecord?id=CVE-2026-9828)
+(deserialisation whitelist bypass).
+
+**Zero breaking public API changes.** The `japicmp` gate against
+the v1.6.7 baseline reports `semver PATCH, compatible bug fix`
+across every PR in the cycle. New `BusinessTheme` factories are
+pure additions; `MarkdownInline.append` and `plainText` extend
+their behaviour without changing their signatures; `ProjectLabel.
+parse` keeps its two-field record shape (the `title()` field now
+preserves Markdown rather than returning a pre-flattened
+projection, but the type contract is unchanged and the visible
+text projection is one call away via `MarkdownInline.plainText(
+title)`). 1058 tests pass at the release-prep tip.
+
+**Migration from v1.6.7.** No code changes required for typical
+usage. If you build a custom renderer on top of
+`ProjectLabel.parse`:
+
+- Old `title()` was already the visible plain text (emphasis +
+  link syntax stripped). New `title()` preserves the original
+  inline-Markdown. Wrap with `MarkdownInline.plainText(...)` to
+  recover the old behaviour, or route through
+  `MarkdownInline.append(rich, title, style)` to get
+  emphasis / link rendering for free (the same path
+  `ProjectRenderer` now uses).
+- `MarkdownInline.append` consumers automatically pick up link
+  rendering for `[label](url)` syntax. If any CV / cover-letter
+  fixture in your codebase contained a literal `[...](...) `
+  string that previously rendered as text, it will now render
+  as a hyperlink. Escape with HTML entities or restructure the
+  string if you need to keep it literal.
+
+The next release is **v1.7.0** — the additive canonical-DSL
+feature minor (LineBuilder.dashed, inline shapes, TimelineBuilder,
+dx shortcuts, recipes docs). See [ROADMAP.md](ROADMAP.md).
 
 ### Fixes
 


### PR DESCRIPTION
## Summary

Final pre-cut PR for the **v1.6.8 cycle**. Replaces the placeholder
"Scope being assembled" intro on the `v1.6.8 — Planned` CHANGELOG
entry with a three-paragraph release summary (what shipped /
zero-breaking status / migration), mirroring the structure of
[#114](https://github.com/DemchaAV/GraphCompose/pull/114) (v1.6.7
release-prep) and [#100](https://github.com/DemchaAV/GraphCompose/pull/100)
(v1.6.6 release-prep).

### What this PR adds to CHANGELOG

- **Three-paragraph prose summary** for v1.6.8 — Planned: the
  headline (CV v2 hyperlink-aware project titles + 4 contemporary
  `BusinessTheme` presets + senior-review polish), `japicmp`
  verdict (`semver PATCH` across every PR in the cycle), and a
  migration table.
- **Migration callout** for the one semantic shift surfaced by
  the senior review during the M3 wiring: `ProjectLabel.parse`
  no longer strips inline Markdown from `title()`. Callers that
  need the legacy plain-text projection can wrap with
  `MarkdownInline.plainText(title)`, or route through the
  `MarkdownInline.append` path that `ProjectRenderer` itself
  now uses to get emphasis / link rendering "for free".

### What this PR does NOT touch

- **README release-status block + install snippets.** Already in
  the right shape from the post-1.6.7 commit (`9e47443f`):
  latest stable v1.6.7 / in develop v1.6.8 / planned v1.7.0.
  The `1.6.7` &rarr; `1.6.8` version flip in install snippets is
  the job of `scripts/cut-release.ps1` at cut time.
- **pom.xml versions.** Same — bumped atomically by
  `cut-release.ps1` against the aggregator.

### What's in v1.6.8 (PR list since the v1.6.7 cut)

| PR | Track | Skoпe |
|---|---|---|
| [#116](https://github.com/DemchaAV/GraphCompose/pull/116) | N2-prep | Testing-quickstart doc |
| [#117](https://github.com/DemchaAV/GraphCompose/pull/117) | J1+sync | Dependabot target-branch fix + deps sync (logback 1.5.34 CVE) |
| [#118](https://github.com/DemchaAV/GraphCompose/pull/118) | Themes | 4 contemporary BusinessTheme presets |
| [#119](https://github.com/DemchaAV/GraphCompose/pull/119) | M1 | MarkdownInline `[label](url)` parser |
| [#120](https://github.com/DemchaAV/GraphCompose/pull/120) | M3 | ProjectRenderer + ProjectLabel hyperlink wiring |
| [#121](https://github.com/DemchaAV/GraphCompose/pull/121) | J2+J3+J4 | Senior-review polish bundle |

### After this PR merges

The v1.6.8 cut runs through the `graphcompose-release-engineer`
skill:

1. `scripts/cut-release.ps1 -Version 1.6.8` — atomic version bump
   across all four poms, flips JitPack snippet to v1.6.8, dates
   the CHANGELOG, runs verify, tags `v1.6.8`, pushes.
2. `release.yml` creates the GitHub Release from the tag.
3. `publish.yml` re-runs verify at the tagged commit and uploads
   to Maven Central (Central secrets are wired from v1.6.6 cut).
4. javadoc.io auto-mirrors within minutes.
5. Post-release commit on develop: flip japicmp baseline
   `v1.6.7 → v1.6.8`, add `v1.6.9 / v1.7.0 — Planned` stub.

## Test plan

- [x] `./mvnw test -pl . -Dtest=VersionConsistencyGuardTest,DocumentationCoverageTest,DocumentationExamplesTest`
      — **22 tests, 0 failures**.
- [x] Full `./mvnw verify -P japicmp` was green at `31cacc70`
      (the J-bundle merge that closed the feature scope). This
      PR touches only `CHANGELOG.md` prose, so no source/binary
      surface change.