### PR TITLE
feat(testing): promote visual-regression harness to public API (Track N N1, @since 1.6.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,18 @@ follow semantic versioning; release dates are ISO 8601.
 
 ## v1.6.9 — Planned
 
-Next bug-fix / housekeeping cycle. Track open in `docs/private/` taskboard.
+Housekeeping cycle plus the public pixel-level visual-regression API (Track N).
+
+### Public API
+
+- **Promoted the pixel-level visual-regression harness to public API.**
+  `com.demcha.compose.testing.visual.PdfVisualRegression` and
+  `com.demcha.compose.testing.visual.ImageDiff` (`@since 1.6.9`) move from the
+  test source set into `src/main/java`, alongside the existing
+  `com.demcha.compose.testing.layout.*` semantic snapshot helpers. Library
+  consumers can now run the same render-PDF → diff-PNG baseline gate against
+  their own presets and templates instead of copying the harness. Behaviour is
+  unchanged; the PDF→image step is inlined on PDFBox's `PDFRenderer`.
 
 ## v1.6.8 — 2026-06-01
 

--- a/docs/operations/test-your-document.md
+++ b/docs/operations/test-your-document.md
@@ -221,17 +221,15 @@ shipped CV / cover-letter preset and for the engine showcase tests
 (see `CvV2VisualParityTest`, `CoverLetterV2VisualParityTest`,
 `TableRowSpanDemoTest` and friends).
 
-The harness behind those tests
-(`com.demcha.testing.visual.PdfVisualRegression` +
-`ImageDiff`) is currently **test-only** inside the GraphCompose
-build. Promoting it to a public `com.demcha.compose.testing.visual.*`
-API so library consumers can adopt the same pixel-level gate against
-their own presets is queued as **v1.6.8 / v1.7.0 Track N** — see the
-release-readiness taskboard. Until that ships, the recommended
-public path is layout snapshot above; for pixel-level work, copy
-the pattern from `PdfVisualRegression` (it builds on the public
-`com.demcha.compose.devtool.PdfRenderBridge` for PDF page → image
-conversion).
+The harness behind those tests is the public
+`com.demcha.compose.testing.visual.PdfVisualRegression` +
+`ImageDiff` API (`@since 1.6.9`), a sibling to the
+`com.demcha.compose.testing.layout.*` snapshot helpers — library
+consumers can adopt the same pixel-level gate against their own
+presets. Start from `PdfVisualRegression.standard()`, point
+`baselineRoot(...)` at your own baseline directory, and call
+`assertMatchesBaseline(name, pdfBytes)`; run with
+`-Dgraphcompose.visual.approve=true` to (re)bless baselines.
 
 ---
 
@@ -241,7 +239,7 @@ conversion).
 |---|---|
 | The document compiles + renders at all | smoke (just call `buildPdf()` in a test) |
 | The semantic graph and resolved coordinates are stable across engine refactors | **layout snapshot** |
-| The PDF visually looks identical, fonts/colours and all | pixel-level visual (Track N) |
+| The PDF visually looks identical, fonts/colours and all | **pixel-level visual** (`PdfVisualRegression`) |
 | A specific layout math rule holds | a focused unit test |
 
 The advice scales: a flagship template or a preset you publish to

--- a/src/main/java/com/demcha/compose/testing/visual/ImageDiff.java
+++ b/src/main/java/com/demcha/compose/testing/visual/ImageDiff.java
@@ -1,4 +1,4 @@
-package com.demcha.testing.visual;
+package com.demcha.compose.testing.visual;
 
 import java.awt.Color;
 import java.awt.image.BufferedImage;
@@ -21,6 +21,7 @@ import java.util.Objects;
  * can write the diff to disk for inspection.</p>
  *
  * @author Artem Demchyshyn
+ * @since 1.6.9
  */
 public final class ImageDiff {
 
@@ -105,6 +106,7 @@ public final class ImageDiff {
      * @param maxChannelDelta largest single-channel delta observed
      * @param summary human-readable summary line for failure messages
      * @param diffImage optional visualisation; {@code null} when sizes differed
+     * @since 1.6.9
      */
     public record Result(
             boolean differs,

--- a/src/main/java/com/demcha/compose/testing/visual/PdfVisualRegression.java
+++ b/src/main/java/com/demcha/compose/testing/visual/PdfVisualRegression.java
@@ -1,8 +1,9 @@
-package com.demcha.testing.visual;
+package com.demcha.compose.testing.visual;
 
-import com.demcha.compose.devtool.PdfRenderBridge;
 import org.apache.pdfbox.Loader;
 import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.rendering.ImageType;
+import org.apache.pdfbox.rendering.PDFRenderer;
 
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
@@ -14,13 +15,19 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * Test harness for "render PDF → diff PNG" visual regression checks.
+ * Pixel-level visual-regression harness: renders a PDF and diffs each page
+ * against a stored PNG baseline. Public companion to the semantic
+ * {@code com.demcha.compose.testing.layout} snapshot layer — reach for this
+ * when byte-for-byte pixel fidelity matters, and for the snapshot layer when
+ * structural geometry is enough.
  *
- * <p>Each baseline lives at {@code src/test/resources/visual-baselines/&lt;name&gt;-page-N.png}.
- * In the default mode the harness renders the supplied PDF, converts each page
- * to a {@link BufferedImage} via {@link PdfRenderBridge}, and compares against
- * the baseline using {@link ImageDiff}. A failing comparison writes the actual
- * render and the diff image next to the baseline for inspection.</p>
+ * <p>The default baseline directory is {@code src/test/resources/visual-baselines}
+ * (override with {@link #baselineRoot(Path)}); each page is stored as
+ * {@code &lt;name&gt;-page-N.png}. In the default mode the harness renders the
+ * supplied PDF, converts each page to a {@link BufferedImage} with PDFBox's
+ * {@link PDFRenderer}, and compares against the baseline using {@link ImageDiff}.
+ * A failing comparison writes the actual render and the diff image next to the
+ * baseline for inspection.</p>
  *
  * <p>To re-bless baselines, run the test with the system property
  * {@code -Dgraphcompose.visual.approve=true} (or environment variable
@@ -29,6 +36,7 @@ import java.util.Objects;
  * assertion.</p>
  *
  * @author Artem Demchyshyn
+ * @since 1.6.9
  */
 public final class PdfVisualRegression {
 
@@ -94,8 +102,12 @@ public final class PdfVisualRegression {
      *
      * @param perPixelTolerance tolerance per channel
      * @return updated harness
+     * @throws IllegalArgumentException if {@code perPixelTolerance} is outside {@code 0..255}
      */
     public PdfVisualRegression perPixelTolerance(int perPixelTolerance) {
+        if (perPixelTolerance < 0 || perPixelTolerance > 255) {
+            throw new IllegalArgumentException("perPixelTolerance must be 0..255, got " + perPixelTolerance);
+        }
         return new PdfVisualRegression(baselineRoot, renderScale, perPixelTolerance, mismatchedPixelBudget);
     }
 
@@ -176,9 +188,10 @@ public final class PdfVisualRegression {
     public List<BufferedImage> renderPages(byte[] pdfBytes) throws IOException {
         Objects.requireNonNull(pdfBytes, "pdfBytes");
         try (PDDocument document = Loader.loadPDF(pdfBytes)) {
+            PDFRenderer renderer = new PDFRenderer(document);
             List<BufferedImage> pages = new ArrayList<>(document.getNumberOfPages());
             for (int i = 0; i < document.getNumberOfPages(); i++) {
-                pages.add(PdfRenderBridge.renderToImage(document, i, renderScale));
+                pages.add(renderer.renderImage(i, renderScale, ImageType.RGB));
             }
             return pages;
         }

--- a/src/main/java/com/demcha/compose/testing/visual/package-info.java
+++ b/src/main/java/com/demcha/compose/testing/visual/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * Public test helpers for pixel-level visual regression of rendered PDFs.
+ *
+ * <p>Ownership: Owned by the testing support surface and intended for consumer regression tests.</p>
+ * <p>Extension rules: Extend with diff and render-harness utilities only; runtime engine code must not depend on this package.</p>
+ *
+ * @since 1.6.9
+ */
+package com.demcha.compose.testing.visual;

--- a/src/test/java/com/demcha/compose/document/templates/coverletter/presets/PresetVisualParityTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/coverletter/presets/PresetVisualParityTest.java
@@ -7,7 +7,7 @@ import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.coverletter.spec.CoverLetterHeader;
 import com.demcha.compose.document.templates.coverletter.spec.CoverLetterSpec;
 import com.demcha.compose.document.theme.BusinessTheme;
-import com.demcha.testing.visual.PdfVisualRegression;
+import com.demcha.compose.testing.visual.PdfVisualRegression;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/src/test/java/com/demcha/compose/document/templates/coverletter/v2/presets/CoverLetterV2VisualParityTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/coverletter/v2/presets/CoverLetterV2VisualParityTest.java
@@ -6,7 +6,7 @@ import com.demcha.compose.document.api.DocumentSession;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.coverletter.v2.data.CoverLetterDocument;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
-import com.demcha.testing.visual.PdfVisualRegression;
+import com.demcha.compose.testing.visual.PdfVisualRegression;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/src/test/java/com/demcha/compose/document/templates/cv/presets/PresetVisualParityTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/presets/PresetVisualParityTest.java
@@ -13,7 +13,7 @@ import com.demcha.compose.document.templates.cv.spec.CvHeader;
 import com.demcha.compose.document.templates.cv.spec.CvModule;
 import com.demcha.compose.document.templates.cv.spec.CvSpec;
 import com.demcha.compose.document.theme.BusinessTheme;
-import com.demcha.testing.visual.PdfVisualRegression;
+import com.demcha.compose.testing.visual.PdfVisualRegression;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/CvV2VisualParityTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/CvV2VisualParityTest.java
@@ -12,7 +12,7 @@ import com.demcha.compose.document.templates.cv.v2.data.ParagraphSection;
 import com.demcha.compose.document.templates.cv.v2.data.RowStyle;
 import com.demcha.compose.document.templates.cv.v2.data.RowsSection;
 import com.demcha.compose.document.templates.cv.v2.data.SkillsSection;
-import com.demcha.testing.visual.PdfVisualRegression;
+import com.demcha.compose.testing.visual.PdfVisualRegression;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/src/test/java/com/demcha/testing/visual/PdfVisualRegressionTest.java
+++ b/src/test/java/com/demcha/testing/visual/PdfVisualRegressionTest.java
@@ -3,6 +3,8 @@ package com.demcha.testing.visual;
 import com.demcha.compose.GraphCompose;
 import com.demcha.compose.document.api.DocumentSession;
 import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.testing.visual.ImageDiff;
+import com.demcha.compose.testing.visual.PdfVisualRegression;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -69,6 +71,16 @@ class PdfVisualRegressionTest {
         assertThat(diff.mismatchedPixelCount()).isEqualTo(Long.MAX_VALUE);
         assertThat(diff.maxChannelDelta()).isEqualTo(255);
         assertThat(diff.diffImage()).isNull();
+    }
+
+    @Test
+    void perPixelToleranceOutsideChannelRangeIsRejected() {
+        assertThatThrownBy(() -> PdfVisualRegression.standard().perPixelTolerance(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("perPixelTolerance");
+        assertThatThrownBy(() -> PdfVisualRegression.standard().perPixelTolerance(256))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("perPixelTolerance");
     }
 
     @Test

--- a/src/test/java/com/demcha/testing/visual/ShapeContainerVisualRegressionTest.java
+++ b/src/test/java/com/demcha/testing/visual/ShapeContainerVisualRegressionTest.java
@@ -13,6 +13,7 @@ import com.demcha.compose.document.style.DocumentStroke;
 import com.demcha.compose.document.style.DocumentTextDecoration;
 import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.font.FontName;
+import com.demcha.compose.testing.visual.PdfVisualRegression;
 import org.junit.jupiter.api.Test;
 
 class ShapeContainerVisualRegressionTest {

--- a/src/test/java/com/demcha/testing/visual/TableRowSpanDemoTest.java
+++ b/src/test/java/com/demcha/testing/visual/TableRowSpanDemoTest.java
@@ -14,6 +14,7 @@ import com.demcha.compose.document.table.DocumentTableCell;
 import com.demcha.compose.document.table.DocumentTableColumn;
 import com.demcha.compose.document.table.DocumentTableStyle;
 import com.demcha.compose.engine.components.content.table.TableResolvedCell;
+import com.demcha.compose.testing.visual.PdfVisualRegression;
 import com.demcha.testing.VisualTestOutputs;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
## Track N / N1 — public pixel-level visual-regression API (cycle 1.6.9)

Promotes the pixel-level visual-regression harness from the test source set to a public API under `com.demcha.compose.testing.visual`, sibling to the existing public `com.demcha.compose.testing.layout.*` snapshot helpers — so library consumers can run the same render-PDF -> diff-PNG baseline gate against their own presets/templates.

### What changed
- **Promoted** `PdfVisualRegression` + `ImageDiff` + new `package-info` to `src/main/java/...` (`@since 1.6.9`).
- **Inlined** the PDF -> image step on PDFBox's `PDFRenderer`, dropping the test-only `PdfRenderBridge` dependency from the public surface (`PdfRenderBridge` stays in test for `GraphComposeDevTool`).
- **Eager `0..255` guard** on `perPixelTolerance(int)` for fail-fast symmetry with `renderScale`/`mismatchedPixelBudget`, plus a negative test (from senior review).
- **Rewired** 7 in-repo callers to the new package.
- **Docs/CHANGELOG**: corrected the now-public framing in `docs/operations/test-your-document.md`; added a `### Public API` entry under `## v1.6.9 — Planned`.

### Verification
- Full suite **1059/1059 green** (incl. 4 visual-parity tests + `PublicApiSinceTagCoverage` / `PublicApiNoEngineLeak` guards).
- **Behavior-preserving**: pixel baselines unchanged (single `PDFRenderer` per document = PDFBox-recommended usage, identical output).
- `javadoc:javadoc` green; release-profile javadoc jar includes the new package (consistent with `testing.layout`).

### Follow-ups (PR-2 in cycle 1.6.9)
- N2 `docs/operations/visual-regression-testing.md`
- N3 README "What can I do with this?" row
- N4 `PublicVisualApiDogfoodTest` (consumer-package dogfood)
- (optional) widen CI javadoc-validation `<subpackages>` to include `com.demcha.compose.testing`