### PR TITLE
ci(javadoc): validate public testing.* helpers under strict doclint (Track N N5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,13 @@ Housekeeping cycle plus the public pixel-level visual-regression API (Track N).
   baseline layout, and cross-platform tolerance calibration.
 - README "Which API should I use?" gains a pixel-level visual-regression row.
 
+### Build
+
+- CI Javadoc validation (`maven-javadoc-plugin`, `doclint=all`) now covers the
+  public `com.demcha.compose.testing.*` helpers (`testing.layout` + `testing.visual`)
+  in addition to the canonical `document` API, so Javadoc regressions on the
+  testing surface fail fast in CI. No artifact or behaviour change.
+
 ## v1.6.8 — 2026-06-01
 
 **CV v2 migration completion + design-token expansion.** v1.6.8

--- a/pom.xml
+++ b/pom.xml
@@ -434,7 +434,7 @@
                 </executions>
             </plugin>
 
-            <!-- Canonical API Javadoc validation -->
+            <!-- Public API Javadoc validation: canonical document API + public testing-support helpers (testing.layout / testing.visual) -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -444,7 +444,7 @@
                     <failOnError>true</failOnError>
                     <show>public</show>
                     <quiet>true</quiet>
-                    <subpackages>com.demcha.compose.document</subpackages>
+                    <subpackages>com.demcha.compose.document:com.demcha.compose.testing</subpackages>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
## Track N / N5 — strict doclint for public testing helpers (cycle 1.6.9)

Small build-lane follow-up to #126 / #127. The CI Javadoc validation (`maven-javadoc-plugin`, `doclint=all`, `failOnError=true`) only covered `com.demcha.compose.document`. This widens it to also include `com.demcha.compose.testing`, so the public testing-support helpers — `testing.layout.*` (semantic snapshots) and `testing.visual.*` (pixel regression, new in #126) — get the same strict-doclint gate.

### Why
The release-profile javadoc jar is lenient (`doclint=none`, `failOnError=false`) and already ships these packages, so a Javadoc mistake in `testing.*` would slip through unnoticed. This closes that gap for the public testing surface.

### Verification
- `./mvnw javadoc:javadoc -pl .` → **BUILD SUCCESS**; `testing.layout` + `testing.visual` now generate apidocs and are **doclint-clean** (no warnings on them).
- The ~100 pre-existing `document.*` template doclint warnings (e.g. `CvTheme` missing `@return`) are unchanged — they predate this PR, remain warnings (not errors), so the build stays green. Out of scope here; candidate for a separate template-Javadoc cleanup.

No artifact or runtime behaviour change.