### PR TITLE
build(release): central-publishing-maven-plugin 0.9.0 -> 0.10.0 + unblock Dependabot (Track N L2)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,12 +34,6 @@ updates:
       # jackson-bom >= 2.22.1 (or 2.23.0) lands on Central with full module sync.
       - dependency-name: "com.fasterxml.jackson:jackson-bom"
         versions: ["2.22.0"]
-      # central-publishing-maven-plugin 0.10.0 is a 3-minor jump (0.7 → 0.10) on
-      # the plugin that publishes Maven Central artefacts (the v1.6.6 release
-      # used 0.7.0). Block this version until the release profile is validated
-      # against 0.10.x in a focused PR; remove this entry once that work lands.
-      - dependency-name: "org.sonatype.central:central-publishing-maven-plugin"
-        versions: ["0.10.0"]
 
   - package-ecosystem: github-actions
     directory: "/"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ Housekeeping cycle plus the public pixel-level visual-regression API (Track N).
   public `com.demcha.compose.testing.*` helpers (`testing.layout` + `testing.visual`)
   in addition to the canonical `document` API, so Javadoc regressions on the
   testing surface fail fast in CI. No artifact or behaviour change.
+- Bumped `central-publishing-maven-plugin` 0.9.0 → 0.10.0 (the Maven Central
+  publishing plugin) and removed the Dependabot block on 0.10.0; the
+  release-profile build is verified locally and the Central upload is exercised
+  at the next publish.
 
 ## v1.6.8 — 2026-06-01
 

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <byteBuddy.version>1.18.9</byteBuddy.version>
 
         <!-- Build plugins -->
-        <central.publishing.plugin.version>0.9.0</central.publishing.plugin.version>
+        <central.publishing.plugin.version>0.10.0</central.publishing.plugin.version>
         <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
         <maven.enforcer.plugin.version>3.6.3</maven.enforcer.plugin.version>
         <maven.gpg.plugin.version>3.2.8</maven.gpg.plugin.version>


### PR DESCRIPTION
## Track N / L2 — central-publishing-maven-plugin 0.9.0 → 0.10.0 (cycle 1.6.9)

The Dependabot ignore on `central-publishing-maven-plugin 0.10.0` was added in 1.6.8 to defer the bump until it could be validated against the release profile. Since then the pom moved to `0.9.0`, so this is a **1-minor bump (0.9 → 0.10)**, not the "3-minor jump (0.7 → 0.10)" the old ignore comment described — and `0.9.0` already shipped the 1.6.7 and 1.6.8 Maven Central releases.

### What changed
- `central.publishing.plugin.version` 0.9.0 → 0.10.0 (`pom.xml`)
- removed the now-obsolete Dependabot ignore for 0.10.0 + its stale comment (`.github/dependabot.yml`)
- CHANGELOG `### Build` note

### Verification
- `./mvnw -P release package -DskipTests -Dgpg.skip=true -pl .` → **BUILD SUCCESS**; plugin `0.10.0` resolves from Central and the main / sources / javadoc jars build with `<extensions>true</extensions>` loaded.
- ⚠️ The actual Sonatype **staging upload** is only exercised by the publish workflow on a tag (`publish.yml`) — it is validated at the **next cut**. If 0.10.0 misbehaves at publish time it is a follow-up patch (publishing-plumbing only; no artifact / runtime change).

No artifact or runtime behaviour change.