### PR TITLE
test(benchmarks): cover the CurrentSpeedBenchmark performance gate

### DIFF
--- a/benchmarks/src/main/java/com/demcha/compose/CurrentSpeedBenchmark.java
+++ b/benchmarks/src/main/java/com/demcha/compose/CurrentSpeedBenchmark.java
@@ -461,7 +461,12 @@ public final class CurrentSpeedBenchmark {
                 parseThreadCounts(System.getProperty("graphcompose.benchmark.threads", defaultThreadCounts)));
     }
 
-    private PerformanceGateResult evaluatePerformanceGate(BenchmarkProfile profile, List<LatencyRow> latencyRows) {
+    // Package-private and static (uses no instance state) so
+    // CurrentSpeedBenchmarkPerfGateTest can drive it with synthetic LatencyRow
+    // values instead of real, non-deterministic measurements. LatencyRow,
+    // PerformanceGateResult and BenchmarkProfile are package-private for the
+    // same reason.
+    static PerformanceGateResult evaluatePerformanceGate(BenchmarkProfile profile, List<LatencyRow> latencyRows) {
         if (profile != BenchmarkProfile.SMOKE) {
             return new PerformanceGateResult(true, "Performance gate skipped for profile " + profile.id());
         }
@@ -721,7 +726,7 @@ public final class CurrentSpeedBenchmark {
                                     long totalBytes) {
     }
 
-    private record LatencyRow(String scenario,
+    record LatencyRow(String scenario,
                               String description,
                               double avgMillis,
                               double p50Millis,
@@ -762,10 +767,10 @@ public final class CurrentSpeedBenchmark {
     private record SmokeThreshold(double maxAvgMillis, double maxPeakHeapMb) {
     }
 
-    private record PerformanceGateResult(boolean passed, String message) {
+    record PerformanceGateResult(boolean passed, String message) {
     }
 
-    private enum BenchmarkProfile {
+    enum BenchmarkProfile {
         FULL("full", true, Map.of()),
         SMOKE("smoke", false, Map.of(
                 // Thresholds calibrated against the post-warmup smoke profile

--- a/benchmarks/src/test/java/com/demcha/compose/CurrentSpeedBenchmarkPerfGateTest.java
+++ b/benchmarks/src/test/java/com/demcha/compose/CurrentSpeedBenchmarkPerfGateTest.java
@@ -1,0 +1,137 @@
+package com.demcha.compose;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link CurrentSpeedBenchmark#evaluatePerformanceGate} — the
+ * absolute smoke-profile performance gate that actually fails a benchmark run.
+ *
+ * <p>The gate is driven with synthetic {@code LatencyRow} values so the
+ * pass/fail decision is deterministic and independent of real measurement
+ * (which varies by machine and would make these tests flaky). engine-simple
+ * smoke thresholds are avg {@code 8.0} ms / peak heap {@code 96.0} MB.</p>
+ */
+class CurrentSpeedBenchmarkPerfGateTest {
+
+    private static final String ENGINE_SIMPLE = "engine-simple";
+    private static final String GATE_AVG =
+            "graphcompose.benchmark.gate." + ENGINE_SIMPLE + ".maxAvgMillis";
+    private static final String GATE_HEAP =
+            "graphcompose.benchmark.gate." + ENGINE_SIMPLE + ".maxPeakHeapMb";
+
+    @AfterEach
+    void clearGateOverrides() {
+        System.clearProperty(GATE_AVG);
+        System.clearProperty(GATE_HEAP);
+    }
+
+    @Test
+    void passesWhenEveryScenarioIsWithinSmokeThresholds() {
+        CurrentSpeedBenchmark.PerformanceGateResult result =
+                CurrentSpeedBenchmark.evaluatePerformanceGate(
+                        CurrentSpeedBenchmark.BenchmarkProfile.SMOKE,
+                        List.of(latency(ENGINE_SIMPLE, 1.0, 24.0)));
+
+        assertThat(result.passed()).isTrue();
+        assertThat(result.message()).contains("passed");
+    }
+
+    @Test
+    void failsWhenAverageLatencyExceedsThreshold() {
+        CurrentSpeedBenchmark.PerformanceGateResult result =
+                CurrentSpeedBenchmark.evaluatePerformanceGate(
+                        CurrentSpeedBenchmark.BenchmarkProfile.SMOKE,
+                        List.of(latency(ENGINE_SIMPLE, 50.0, 24.0))); // 50 > 8
+
+        assertThat(result.passed()).isFalse();
+        assertThat(result.message()).contains(ENGINE_SIMPLE + " avg");
+    }
+
+    @Test
+    void failsWhenPeakHeapExceedsThreshold() {
+        CurrentSpeedBenchmark.PerformanceGateResult result =
+                CurrentSpeedBenchmark.evaluatePerformanceGate(
+                        CurrentSpeedBenchmark.BenchmarkProfile.SMOKE,
+                        List.of(latency(ENGINE_SIMPLE, 1.0, 999.0))); // 999 > 96
+
+        assertThat(result.passed()).isFalse();
+        assertThat(result.message()).contains("peak heap");
+    }
+
+    @Test
+    void reportsEveryFailingScenarioWhenMultipleBreach() {
+        CurrentSpeedBenchmark.PerformanceGateResult result =
+                CurrentSpeedBenchmark.evaluatePerformanceGate(
+                        CurrentSpeedBenchmark.BenchmarkProfile.SMOKE,
+                        List.of(
+                                latency(ENGINE_SIMPLE, 50.0, 24.0),      // avg breach
+                                latency("cv-template", 1.0, 24.0),       // ok (avg 25 / heap 192)
+                                latency("invoice-template", 1.0, 999.0)));// heap breach (heap 384)
+
+        assertThat(result.passed()).isFalse();
+        assertThat(result.message())
+                .contains(ENGINE_SIMPLE + " avg")
+                .contains("invoice-template peak heap")
+                .doesNotContain("cv-template");
+    }
+
+    @Test
+    void skipsGateForNonSmokeProfiles() {
+        CurrentSpeedBenchmark.PerformanceGateResult result =
+                CurrentSpeedBenchmark.evaluatePerformanceGate(
+                        CurrentSpeedBenchmark.BenchmarkProfile.FULL,
+                        List.of(latency(ENGINE_SIMPLE, 9999.0, 9999.0)));
+
+        assertThat(result.passed()).isTrue();
+        assertThat(result.message()).contains("skipped");
+    }
+
+    @Test
+    void ignoresScenariosWithoutAConfiguredThreshold() {
+        CurrentSpeedBenchmark.PerformanceGateResult result =
+                CurrentSpeedBenchmark.evaluatePerformanceGate(
+                        CurrentSpeedBenchmark.BenchmarkProfile.SMOKE,
+                        List.of(latency("scenario-without-threshold", 9999.0, 9999.0)));
+
+        assertThat(result.passed()).isTrue();
+        assertThat(result.message()).contains("passed");
+    }
+
+    @Test
+    void honorsSystemPropertyThresholdOverride() {
+        // Tighten engine-simple to 2.0 ms: a 5.0 ms row passes the default
+        // 8.0 ms threshold but must fail under the override.
+        System.setProperty(GATE_AVG, "2.0");
+
+        CurrentSpeedBenchmark.PerformanceGateResult result =
+                CurrentSpeedBenchmark.evaluatePerformanceGate(
+                        CurrentSpeedBenchmark.BenchmarkProfile.SMOKE,
+                        List.of(latency(ENGINE_SIMPLE, 5.0, 24.0)));
+
+        assertThat(result.passed()).isFalse();
+        assertThat(result.message()).contains(ENGINE_SIMPLE + " avg");
+    }
+
+    /**
+     * Builds a latency row where only {@code scenario}, {@code avgMillis} and
+     * {@code peakHeapMb} matter to the gate; the rest are filler.
+     */
+    private static CurrentSpeedBenchmark.LatencyRow latency(String scenario, double avgMillis, double peakHeapMb) {
+        return new CurrentSpeedBenchmark.LatencyRow(
+                scenario,
+                "test row",
+                avgMillis, // avgMillis
+                0.0,       // p50Millis
+                0.0,       // p95Millis
+                0.0,       // maxMillis
+                0.0,       // docsPerSecond
+                0.0,       // avgKilobytes
+                peakHeapMb // peakHeapMb
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds the missing test for `CurrentSpeedBenchmark#evaluatePerformanceGate` — the **only** benchmark check that actually fails a run. It enforces the smoke-profile absolute thresholds (avg latency + peak heap per scenario); previously it had zero coverage.

## What's covered

`CurrentSpeedBenchmarkPerfGateTest` drives the gate with synthetic `LatencyRow` values, so the verdict is deterministic and machine-independent (the gate is **not** run against real measurements, which would be flaky):

- passes when every scenario is within thresholds
- fails on average-latency breach (message names the scenario)
- fails on peak-heap breach
- aggregates failures across multiple scenarios (and leaves passing ones out)
- skips the gate for non-smoke profiles
- ignores scenarios that have no configured threshold
- honors the per-scenario `graphcompose.benchmark.gate.<scenario>.maxAvgMillis` override

## Production change

Minimal test seam only — no behaviour change:

- `evaluatePerformanceGate` -> `static` package-private (it uses no instance state)
- `LatencyRow`, `PerformanceGateResult`, `BenchmarkProfile` -> package-private

so the same-package test can build inputs and read the verdict (same pattern as the existing `BenchmarkDiffTool.ResolvedRunPair` seam).

## Verification

`./mvnw -f benchmarks/pom.xml test` -> **11/11 green** (7 new perf-gate + 2 selection + 2 median); the new class runs in ~30 ms.

## Note

Independent of #133 (different file: `CurrentSpeedBenchmark` vs `BenchmarkDiffTool`); both target `develop` and do not overlap.
