### PR TITLE
build(japicmp): exclude internal layout.payloads from the binary-compat gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
         run: ./mvnw -B -ntp test -pl . -P no-poi
 
   binary-compat:
-    name: Binary Compatibility (japicmp vs v1.6.8)
+    name: Binary Compatibility (japicmp vs v1.6.9)
     if: github.event_name == 'pull_request'
     needs: architecture-and-documentation-guards
     runs-on: ubuntu-latest

--- a/pom.xml
+++ b/pom.xml
@@ -682,6 +682,17 @@
                                 <includeSynthetic>false</includeSynthetic>
                                 <reportOnlyFilename>true</reportOnlyFilename>
                                 <skipPomModules>true</skipPomModules>
+                                <!--
+                                    Internal layout->render handoff DTOs. These records carry
+                                    engine-internal types (TextStyle, Padding, ...) and evolve
+                                    with rendering features (e.g. ParagraphFragmentPayload gained
+                                    verticalAlign in 1.7.0). They are not part of the canonical
+                                    public API (document.api/dsl/node/style) and carry no
+                                    binary-compatibility promise, so they are excluded from the gate.
+                                -->
+                                <excludes>
+                                    <exclude>com.demcha.compose.document.layout.payloads</exclude>
+                                </excludes>
                             </parameter>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
## What

Exclude the internal `com.demcha.compose.document.layout.payloads` package from the japicmp binary-compatibility gate, and correct the stale CI job label `vs v1.6.8` -> `vs v1.6.9`.

## Why

`document.layout.payloads` is internal layout->render handoff plumbing (~25 `*FragmentPayload` / `Prepared*Layout` / `Transform*` records). They carry engine-internal types (`TextStyle`, `Padding`, ...) and evolve with rendering features, so they are **not** part of the canonical public API (`document.api/dsl/node/style`) and carry no binary-compatibility promise.

In the 1.7.0 cycle, `ParagraphFragmentPayload` gained a `verticalAlign` component (9e25006d), changing its canonical record constructor. japicmp flagged this as `CONSTRUCTOR_REMOVED` on **every** develop PR (the check runs only on `pull_request`, so develop push builds stayed green and the failure was latent). It was non-required, but it reddened every PR and trains reviewers to ignore the gate.

The pom baseline (`japicmp.baseline`) is already `v1.6.9`; only the CI job *label* still said `v1.6.8`.

## Verification

`./mvnw -B -ntp -DskipTests -P japicmp verify -pl .` -> BUILD SUCCESS (was: `CONSTRUCTOR_REMOVED` failure). This PR's own japicmp check should now be green.
