### PR TITLE
fix(benchmarks): add jasperreports-pdf for JR7 PDF export (hotfix to main)

### DIFF
--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -101,6 +101,18 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!--
+            JasperReports 7 modularised PDF export out of the core jar into this
+            separate extension. Without it JasperExportManager.exportReportToPdf
+            fails at runtime with "Missing JasperReports PDF Extension
+            (jasperreports-pdf-x.x.x.jar)". Required by
+            ComparativeBenchmark#benchmarkJasper.
+        -->
+        <dependency>
+            <groupId>net.sf.jasperreports</groupId>
+            <artifactId>jasperreports-pdf</artifactId>
+            <version>${jasperreports.version}</version>
+        </dependency>
 
         <!-- Test scope for the two utility @Test classes that ship with the harness. -->
         <dependency>


### PR DESCRIPTION
## Hotfix -> main

Ports the JasperReports 7 PDF-export fix (already on `develop` via #133) to the released `main` line.

`ComparativeBenchmark#benchmarkJasper` calls `JasperExportManager.exportReportToPdf`, which fails at runtime with `Missing JasperReports PDF Extension (jasperreports-pdf-x.x.x.jar)`. JasperReports 7 split PDF export out of the core jar into a separate `jasperreports-pdf` module that was not on the classpath, so `scripts/run-benchmarks.ps1` dies at step `03-comparative` on main too. The current-speed suite is unaffected.

Fix: add `net.sf.jasperreports:jasperreports-pdf` at the same `${jasperreports.version}` (7.0.7). Benchmark-only — does not touch the published `graph-compose` jar.

## Verification

`./mvnw -f benchmarks/pom.xml exec:java -Dexec.mainClass=com.demcha.compose.ComparativeBenchmark` on this branch -> BUILD SUCCESS; JasperReports renders (GraphCompose ~3.9 ms / iText ~2.7 ms / JasperReports ~6.5 ms).
