### PR TITLE
perf(measurement): line-metrics cache stop-add instead of clear-on-overflow (F13 cache)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,15 @@ Open cycle — bug-fix / housekeeping. Entries land here as they merge.
   large table this removes the dominant per-cell layout allocation. No public API
   or behaviour change.
 
+- **Process-wide line-metrics cache stops inserting instead of flushing when full.**
+  The static line-metrics cache `clear()`-ed every entry once it passed 50,000
+  distinct styles — a full flush whose non-atomic check-then-clear is a
+  thundering-herd recompute under concurrent rendering. It now stops inserting at
+  the cap and keeps the existing entries (distinct styles are few in real use, so
+  this is only a pathological-explosion guard; it runs on a cache miss, never on
+  the per-measurement path). **Measured line metrics are unchanged.** No public API
+  or behaviour change.
+
 ### Tests / tooling
 
 - **Benchmark regression gate and measurement probe (benchmarks module, not part

--- a/src/main/java/com/demcha/compose/engine/measurement/FontLibraryTextMeasurementSystem.java
+++ b/src/main/java/com/demcha/compose/engine/measurement/FontLibraryTextMeasurementSystem.java
@@ -100,10 +100,16 @@ public final class FontLibraryTextMeasurementSystem implements TextMeasurementSy
     }
 
     private static void cacheGlobalLineMetrics(GlobalPdfStyleKey key, LineMetrics metrics) {
-        if (GLOBAL_PDF_LINE_METRICS_CACHE.size() > GLOBAL_LINE_METRICS_CACHE_LIMIT) {
-            GLOBAL_PDF_LINE_METRICS_CACHE.clear();
+        // Safety cap on the process-wide line-metrics cache. Distinct styles are
+        // few in real use (a handful of font/size/decoration combos); this only
+        // guards a pathological style explosion. Stop inserting once full instead
+        // of clear()-ing: the old full flush wiped every hot entry under
+        // concurrent rendering (a thundering-herd recompute), so keeping the
+        // existing entries is strictly better. This runs on a cache miss only,
+        // never on the per-measurement get() path.
+        if (GLOBAL_PDF_LINE_METRICS_CACHE.size() < GLOBAL_LINE_METRICS_CACHE_LIMIT) {
+            GLOBAL_PDF_LINE_METRICS_CACHE.putIfAbsent(key, metrics);
         }
-        GLOBAL_PDF_LINE_METRICS_CACHE.putIfAbsent(key, metrics);
     }
 
     @Override


### PR DESCRIPTION
The process-wide line-metrics cache `clear()`-ed every entry once it passed 50,000 distinct styles — a non-atomic check-then-clear that is a thundering-herd recompute under concurrent rendering. It now stops inserting at the cap and keeps the existing entries.

- Runs only on a line-metrics cache **miss** (insert), never on the per-measurement `get()` path — so **no hot-path cost**.
- **Measured line metrics are unchanged** (byte-identical) — covered by the snapshot / visual suite.
- Distinct styles are few in real use (a handful of font/size/decoration combos), so this only guards a pathological style explosion (>50k distinct styles).

Scoped to `FontLibraryTextMeasurementSystem`; no public API or behaviour change.

## Dropped F9 (width-cache LRU)

The original PR also turned the per-style width cache into an access-order `LinkedHashMap` LRU. That was dropped after review: access-order reorders the structure on **every `get()`** — a per-hit cost on the measurement hot path — to fix a case that only triggers at >10k distinct strings per style (rare after the F1 wrapping fix). The cost lands on the common case for an edge-case benefit, so the original clear-on-overflow stays.

## Verification

- `./mvnw verify -pl .` — BUILD SUCCESS, 1151 tests, 0 failures (checkstyle + SpotBugs + javadoc); snapshot/visual unchanged (values identical).
