### PR TITLE
perf(engine): reuse immutable sub-list views when slicing paginated tables (F10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,16 @@ Open cycle — bug-fix / housekeeping. Entries land here as they merge.
   the existing auto-size integration and snapshot tests). No public API or behaviour
   change.
 
+- **Table pagination stops re-copying the tail on every page split.** A table that
+  spans many pages is split page-by-page, and each split re-sliced the shrinking
+  tail by `List.copyOf`-ing its row and row-height lists — even though the source
+  layout already holds those lists immutably, so the copy made continuation
+  O(rows × pages). The body-only slice now reuses the immutable sub-list views
+  directly. **Output is byte-identical** — same rows in the same order (all table
+  layout, pagination, and visual-regression tests pass unchanged); a deterministic
+  allocation probe on a 2,500-row / 68-page table shows warm compile allocation
+  drop 11,155 KB → 9,851 KB (−11.7%). No public API or behaviour change.
+
 ### Deprecations
 
 - **`Font.adjustFontSizeToFit(...)` is deprecated.** The engine-internal

--- a/src/main/java/com/demcha/compose/document/layout/TableLayoutSupport.java
+++ b/src/main/java/com/demcha/compose/document/layout/TableLayoutSupport.java
@@ -377,8 +377,17 @@ final class TableLayoutSupport {
             combinedSource.addAll(bodySource);
             fragmentSourceRows = combinedSource;
         } else {
-            rows = List.copyOf(bodyRows);
-            rowHeights = List.copyOf(bodyHeights);
+            // bodyRows / bodyHeights are sub-list views of the source layout's
+            // rows() / rowHeights(), which resolveTableLayout already built with
+            // List.copyOf — so the views are unmodifiable as-is. Re-copying them
+            // here allocated O(slice) per split, and because a table's tail is
+            // re-sliced on every continuation page that made pagination
+            // O(rows x pages). Reuse the views directly: the result is
+            // byte-identical, and the fragment layout is transient — emit reads
+            // individual rows into fragments, so nothing long-lived retains the
+            // view beyond what the copy would have retained anyway.
+            rows = bodyRows;
+            rowHeights = bodyHeights;
             fragmentSourceRows = bodySource;
         }
         double totalHeight = rowHeights.stream().mapToDouble(Double::doubleValue).sum();

--- a/src/test/java/com/demcha/compose/document/api/TableSlicePaginationTest.java
+++ b/src/test/java/com/demcha/compose/document/api/TableSlicePaginationTest.java
@@ -1,0 +1,54 @@
+package com.demcha.compose.document.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.layout.LayoutGraph;
+import com.demcha.compose.document.layout.PlacedFragment;
+import com.demcha.compose.document.layout.payloads.TableRowFragmentPayload;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Guards the table-pagination slice invariant behind Finding 10. When a table
+ * spans many pages the engine re-slices the shrinking tail page-by-page — a
+ * sub-list of a sub-list of … the resolved layout. The body-only slice reuses
+ * those immutable sub-list views instead of re-copying them, so this test pins
+ * the contract that survives the optimization: every body row still lands on
+ * exactly one page, in order, no matter how many times the tail is re-sliced.
+ */
+class TableSlicePaginationTest {
+
+    @Test
+    void tableSpanningManyPagesPlacesEveryRowOnExactlyOnePage() {
+        int rowCount = 120;
+        try (DocumentSession session = GraphCompose.document()
+                .pageSize(DocumentPageSize.A4)
+                .margin(24, 24, 24, 24)
+                .create()) {
+            session.pageFlow(flow -> flow.addTable(table -> {
+                table.autoColumns(3);
+                for (int i = 0; i < rowCount; i++) {
+                    table.row("Row " + i, "Col B " + i, "Col C " + i);
+                }
+            }));
+
+            LayoutGraph graph = session.layoutGraph();
+            assertThat(graph.totalPages())
+                    .as("120 rows at A4 should span several pages")
+                    .isGreaterThanOrEqualTo(3);
+
+            List<PlacedFragment> rowFragments = graph.fragments().stream()
+                    .filter(fragment -> fragment.payload() instanceof TableRowFragmentPayload)
+                    .toList();
+
+            // Exactly one fragment per body row — the chained tail re-slices
+            // neither drop nor duplicate a row.
+            assertThat(rowFragments).hasSize(rowCount);
+
+            // …and the rows are spread across every page, not collapsed onto one.
+            assertThat(rowFragments.stream().map(PlacedFragment::pageIndex).distinct().count())
+                    .isEqualTo(graph.totalPages());
+        }
+    }
+}


### PR DESCRIPTION
## Finding 10 — table pagination stops re-copying the tail on every page split

A multi-page table is split page-by-page (`NodeDefinitionSupport.splitTable` → `TableLayoutSupport.sliceTablePreparedNode`). Each split re-sliced the shrinking **tail** by `List.copyOf`-ing its row and row-height lists — even though `resolveTableLayout` already builds those lists immutably (`List.copyOf`). Because the tail is re-sliced on every continuation page, that copy made pagination **O(rows × pages)**.

The body-only slice now reuses the immutable sub-list views directly (a `subList` of an immutable list is already unmodifiable, and the fragment layout is transient — emit reads individual rows into fragments, so nothing long-lived retains the view). The repeated-header path still concatenates a genuine new list and is unchanged.

### Before/after — deterministic allocation probe (2,500-row / 68-page table)
| | warm compile allocation |
|---|---|
| before (`List.copyOf` slice) | 11,155 KB |
| after (sub-list view) | 9,851 KB |
| **Δ** | **−1,304 KB (−11.7%)** |

AFTER min = max = 9,851 KB — fully deterministic.

### Byte-identity
Same rows, same order — the slice just stops copying. Proven by:
- full `verify` green: 1151 tests, japicmp + architecture guards;
- 75 table/pagination tests incl. visual-regression demo renders;
- new `TableSlicePaginationTest` pins the invariant — a 120-row (≥3 page) table places **every row on exactly one page** across the chained re-slices.

No public API or behaviour change.