### PR TITLE
chore(bench): cross-platform A/B benchmark tooling, refreshed baseline, dev docs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Shell scripts must keep LF endings so they run on Linux/macOS regardless of
+# the contributor's core.autocrlf setting (a CRLF shebang breaks on Unix).
+*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,8 @@
 # Shell scripts must keep LF endings so they run on Linux/macOS regardless of
 # the contributor's core.autocrlf setting (a CRLF shebang breaks on Unix).
 *.sh text eol=lf
+
+# Maven wrapper: the POSIX `mvnw` must stay LF to execute on Linux/macOS/WSL
+# (a CRLF shebang is unrunnable there); the Windows `mvnw.cmd` batch stays CRLF.
+mvnw text eol=lf
+mvnw.cmd text eol=crlf

--- a/.github/workflows/ab-bench-smoke.yml
+++ b/.github/workflows/ab-bench-smoke.yml
@@ -1,0 +1,46 @@
+name: A/B bench smoke (Linux)
+
+# Proves the cross-platform A/B harness scripts/ab-bench.sh actually RUNS
+# end-to-end on Linux: the re-exec survives the in-script branch switches, the
+# unix mvnw builds each side, and the median/diff is produced. This is a SMOKE
+# test of the script orchestration, NOT a perf gate — the numbers it prints are
+# informational (CI noise). Narrowly triggered (only when the script or this
+# workflow changes, or on demand) so it never burdens unrelated PRs. The coarse
+# perf smoke + weekly benchmark diff live in ci.yml; strict JMH in benchmarks-jmh.yml.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'scripts/ab-bench.sh'
+      - '.github/workflows/ab-bench-smoke.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  ab-bench-smoke:
+    name: ab-bench.sh smoke (main vs develop)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      JAVA_TOOL_OPTIONS: -Djava.awt.headless=true
+
+    steps:
+      - name: Check out repository (full history for the A/B branch switches)
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Temurin JDK 17
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Make main + develop available as local branches
+        run: git fetch --no-tags origin main:main develop:develop
+
+      - name: A/B smoke (single run; asserts the script runs on Linux, exit 0)
+        run: bash scripts/ab-bench.sh -a main -b develop -r 1 --cooldown 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ When writing new code, avoid Java 21+ APIs and language constructs that don't ex
 - The blocking validation gate for repository work is `./mvnw -B -ntp clean verify`.
 - Run the guard-focused suite with `./mvnw -B -ntp "-Dtest=EnginePdfBoundaryTest,CanonicalTemplateComposerPdfBoundaryTest,PdfRenderInterfaceGuardTest,PdfRenderingSystemECSDispatchTest,DocumentationCoverageTest,DocumentationExamplesTest,CanonicalSurfaceGuardTest" test`.
 - Run a focused documentation sanity check with `./mvnw -B -ntp "-Dtest=DocumentationExamplesTest" test`.
-- Run the local benchmark wrapper with `powershell -ExecutionPolicy Bypass -File .\scripts\run-benchmarks.ps1` when you change performance-sensitive code or benchmark tooling.
+- Run the local benchmark wrapper when you change performance-sensitive code or benchmark tooling: `powershell -ExecutionPolicy Bypass -File .\scripts\run-benchmarks.ps1` (Windows). To compare two branches fairly, use `scripts/ab-bench.ps1` (Windows) or the cross-platform `scripts/ab-bench.sh` (Linux/macOS/Git Bash). See [docs/operations/benchmarks.md](./docs/operations/benchmarks.md).
 
 ## How to propose changes
 
@@ -110,7 +110,7 @@ See [docs/contributing/release-process.md](./docs/contributing/release-process.m
 - `aggregator/pom.xml`
   Maven reactor (aggregator POM); release tooling propagates the version bump across all modules through it in one pass
 - `baselines/`
-  Committed performance-benchmark baseline summaries (`BASELINE_SUMMARY.md`, `COMPARISON.md`) — the reference numbers benchmark runs compare against
+  Committed performance-benchmark baselines: `current-speed-full.json` is the median reference the `11-verdict-current-speed` gate judges runs against; `BASELINE_SUMMARY.md` / `COMPARISON.md` are historical pre-optimization snapshots
 
 ## Recommended workflow
 

--- a/baselines/current-speed-full.json
+++ b/baselines/current-speed-full.json
@@ -1,5 +1,5 @@
 {
-  "timestamp" : "2026-06-08 12:07:23",
+  "timestamp" : "2026-06-09 17:19:39",
   "profile" : "full",
   "warmupIterations" : 12,
   "measurementIterations" : 40,
@@ -8,81 +8,91 @@
   "latency" : [ {
     "scenario" : "cv-template",
     "description" : "Compose-first CV template",
-    "avgMillis" : 4.28,
-    "p50Millis" : 3.93,
-    "p95Millis" : 5.83,
-    "maxMillis" : 7.15,
-    "docsPerSecond" : 233.52,
-    "avgKilobytes" : 2.29,
-    "peakHeapMb" : 33.08
+    "avgMillis" : 2.45,
+    "p50Millis" : 2.24,
+    "p95Millis" : 3.53,
+    "maxMillis" : 4.27,
+    "docsPerSecond" : 408.15,
+    "avgKilobytes" : 2.22,
+    "peakHeapMb" : 20.0
   }, {
     "scenario" : "engine-simple",
     "description" : "One-page engine composition",
-    "avgMillis" : 3.17,
-    "p50Millis" : 2.96,
-    "p95Millis" : 5.01,
-    "maxMillis" : 5.9,
-    "docsPerSecond" : 315.87,
+    "avgMillis" : 2.0,
+    "p50Millis" : 1.8,
+    "p95Millis" : 2.88,
+    "maxMillis" : 3.97,
+    "docsPerSecond" : 498.91,
     "avgKilobytes" : 1.08,
-    "peakHeapMb" : 12.0
+    "peakHeapMb" : 8.0
   }, {
     "scenario" : "feature-rich",
     "description" : "QR, barcode, watermark, header/footer, page break",
-    "avgMillis" : 45.37,
-    "p50Millis" : 37.09,
-    "p95Millis" : 60.65,
-    "maxMillis" : 69.62,
-    "docsPerSecond" : 22.04,
-    "avgKilobytes" : 6.37,
-    "peakHeapMb" : 86.14
+    "avgMillis" : 31.99,
+    "p50Millis" : 31.32,
+    "p95Millis" : 36.35,
+    "maxMillis" : 40.65,
+    "docsPerSecond" : 31.26,
+    "avgKilobytes" : 6.33,
+    "peakHeapMb" : 58.89
   }, {
     "scenario" : "invoice-template",
     "description" : "Compose-first invoice template",
-    "avgMillis" : 19.42,
-    "p50Millis" : 18.75,
-    "p95Millis" : 27.88,
-    "maxMillis" : 34.26,
-    "docsPerSecond" : 51.5,
+    "avgMillis" : 13.12,
+    "p50Millis" : 12.88,
+    "p95Millis" : 17.01,
+    "maxMillis" : 19.6,
+    "docsPerSecond" : 76.22,
     "avgKilobytes" : 9.72,
-    "peakHeapMb" : 85.09
+    "peakHeapMb" : 45.11
+  }, {
+    "scenario" : "long-token",
+    "description" : "Long unbreakable tokens (URLs/IDs) forcing character-level wrap",
+    "avgMillis" : 3.38,
+    "p50Millis" : 3.15,
+    "p95Millis" : 4.72,
+    "maxMillis" : 5.51,
+    "docsPerSecond" : 295.43,
+    "avgKilobytes" : 3.97,
+    "peakHeapMb" : 52.0
   }, {
     "scenario" : "proposal-template",
     "description" : "Long multi-page proposal template",
-    "avgMillis" : 14.41,
-    "p50Millis" : 13.71,
-    "p95Millis" : 19.18,
-    "maxMillis" : 19.93,
-    "docsPerSecond" : 69.38,
-    "avgKilobytes" : 7.72,
-    "peakHeapMb" : 97.52
+    "avgMillis" : 9.63,
+    "p50Millis" : 9.24,
+    "p95Millis" : 12.44,
+    "maxMillis" : 13.24,
+    "docsPerSecond" : 103.84,
+    "avgKilobytes" : 7.68,
+    "peakHeapMb" : 51.99
   } ],
   "throughput" : [ {
     "scenario" : "invoice-template",
     "threads" : 1,
     "totalDocs" : 12,
-    "docsPerSecond" : 81.22,
-    "avgMillisPerDoc" : 12.31
+    "docsPerSecond" : 121.21,
+    "avgMillisPerDoc" : 8.25
   }, {
     "scenario" : "invoice-template",
     "threads" : 2,
     "totalDocs" : 24,
-    "docsPerSecond" : 158.68,
-    "avgMillisPerDoc" : 6.3
+    "docsPerSecond" : 223.67,
+    "avgMillisPerDoc" : 4.47
   }, {
     "scenario" : "invoice-template",
     "threads" : 4,
     "totalDocs" : 48,
-    "docsPerSecond" : 265.11,
-    "avgMillisPerDoc" : 3.77
+    "docsPerSecond" : 335.65,
+    "avgMillisPerDoc" : 2.98
   }, {
     "scenario" : "invoice-template",
     "threads" : 8,
     "totalDocs" : 96,
-    "docsPerSecond" : 356.61,
-    "avgMillisPerDoc" : 2.8
+    "docsPerSecond" : 414.73,
+    "avgMillisPerDoc" : 2.41
   } ],
-  "totalBytes" : 2905520,
+  "totalBytes" : 3062560,
   "aggregation" : "median",
-  "sourceCount" : 7,
-  "sourceRuns" : [ "C:\\Users\\Demch\\OneDrive\\Java\\GraphCompose\\target\\benchmarks\\current-speed\\run-20260608-120624.json", "C:\\Users\\Demch\\OneDrive\\Java\\GraphCompose\\target\\benchmarks\\current-speed\\run-20260608-120635.json", "C:\\Users\\Demch\\OneDrive\\Java\\GraphCompose\\target\\benchmarks\\current-speed\\run-20260608-120645.json", "C:\\Users\\Demch\\OneDrive\\Java\\GraphCompose\\target\\benchmarks\\current-speed\\run-20260608-120655.json", "C:\\Users\\Demch\\OneDrive\\Java\\GraphCompose\\target\\benchmarks\\current-speed\\run-20260608-120704.json", "C:\\Users\\Demch\\OneDrive\\Java\\GraphCompose\\target\\benchmarks\\current-speed\\run-20260608-120713.json", "C:\\Users\\Demch\\OneDrive\\Java\\GraphCompose\\target\\benchmarks\\current-speed\\run-20260608-120722.json" ]
+  "sourceCount" : 5,
+  "sourceRuns" : [ "C:\\Dev\\Java\\GraphCompose\\target\\benchmarks\\current-speed\\run-20260609-171909.json", "C:\\Dev\\Java\\GraphCompose\\target\\benchmarks\\current-speed\\run-20260609-171916.json", "C:\\Dev\\Java\\GraphCompose\\target\\benchmarks\\current-speed\\run-20260609-171924.json", "C:\\Dev\\Java\\GraphCompose\\target\\benchmarks\\current-speed\\run-20260609-171931.json", "C:\\Dev\\Java\\GraphCompose\\target\\benchmarks\\current-speed\\run-20260609-171938.json" ]
 }

--- a/docs/operations/benchmarks.md
+++ b/docs/operations/benchmarks.md
@@ -246,11 +246,12 @@ cp -f target/benchmarks/aggregates/current-speed/full/latest.json baselines/curr
 ```
 
 The baseline is machine-class-specific; the JSON records provenance
-(`timestamp`, `profile`, `sourceRuns`). Validate the refresh by running the
-verdict tool against an independent run on that branch — it should score
-NEUTRAL and exit `0`:
+(`timestamp`, `profile`, `sourceRuns`). Validate the refresh against a *fresh*
+run — not one of the five that built the median — on that branch; it should
+score NEUTRAL and exit `0`:
 
 ```bash
+java -Dgraphcompose.benchmark.profile=full -cp "$cp" com.demcha.compose.CurrentSpeedBenchmark
 java -cp "$cp" com.demcha.compose.BenchmarkVerdictTool baselines/current-speed-full.json target/benchmarks/current-speed/latest.json
 ```
 

--- a/docs/operations/benchmarks.md
+++ b/docs/operations/benchmarks.md
@@ -53,6 +53,10 @@ The script prints numbered sections so you can map console output to the pipelin
    Diffs the newest compatible current-speed reports.
 10. `10-diff-comparative`
    Diffs the two newest comparative reports.
+11. `11-verdict-current-speed`
+   Judges the newest current-speed median against the committed baseline
+   (`baselines/current-speed-full.json`). Hard gate on average latency; peak
+   heap is advisory. See [Refreshing the committed baseline](#refreshing-the-committed-baseline-perf-gate).
 
 Each step writes a dedicated log file under `target/benchmark-runs/<timestamp>/logs/`, and the wrapper mirrors that log back to the console after the step finishes.
 
@@ -170,6 +174,84 @@ powershell -ExecutionPolicy Bypass -File .\scripts\run-benchmarks.ps1 -SkipDiff
 
 ```powershell
 powershell -ExecutionPolicy Bypass -File .\scripts\run-benchmarks.ps1 -OpenResults
+```
+
+## A/B comparison between two branches
+
+The wrappers above benchmark whatever is currently checked out. To answer "is
+branch B faster or slower than branch A?" fairly on a noisy laptop, use the
+dedicated A/B scripts. They **interleave** the two branches (A,B,A,B,…) so
+thermal drift averages out, **repeat** each branch and compare **medians**, and
+**cool down** between runs. Each branch is rebuilt (`install -pl .`) before its
+runs so the benchmark measures that branch's engine, and untracked benchmark
+probes are moved aside around the branch switch so they cannot break the other
+branch's compile.
+
+- **Windows (PowerShell)** — `scripts/ab-bench.ps1`, full suite (latency,
+  throughput, scalability, stress, comparative):
+
+  ```powershell
+  ./scripts/ab-bench.ps1 -BranchA main -BranchB develop -Repeat 3
+  ./scripts/ab-bench.ps1 -BranchA develop -BranchB feature/x -Repeat 5
+  ```
+
+- **Linux / macOS / Windows Git Bash** — `scripts/ab-bench.sh`, `current-speed`
+  suite (per-scenario latency + parallel throughput, the primary engine-speed
+  signal):
+
+  ```bash
+  ./scripts/ab-bench.sh -a main -b develop -r 3
+  ./scripts/ab-bench.sh --branch-a develop --branch-b feature/x --repeat 5 --cooldown 45
+  ./scripts/ab-bench.sh -a main -b origin/anothertree -r 3   # remote-only ref (detached)
+  ```
+
+Both accept any pair of checkout-able refs (local branches or `origin/<name>`).
+Deltas are reported as **B relative to A** (negative latency % and positive
+docs-per-sec % mean B is faster). The working tree must have no uncommitted
+**tracked** changes — the scripts switch branches. Output lands under
+`target/ab-compare/` and `target/benchmarks/diffs/`. Treat sub-~5-10% deltas on
+a laptop as inconclusive; close other JVMs/IDEs and stay on AC power for the
+cleanest numbers.
+
+## Refreshing the committed baseline (perf gate)
+
+`baselines/current-speed-full.json` is a committed median `current-speed` report
+that `11-verdict-current-speed` judges new runs against (hard gate: average
+latency ±10%; peak heap is advisory, GC-timing noisy). Refresh it **only** for an
+intended, verified improvement so the gate ratchets down — never to turn a red
+gate green. Capture a median of **≥5** runs on the branch that defines the new
+reference, with the IDE closed:
+
+**Windows (PowerShell):**
+
+```powershell
+.\mvnw.cmd -B -ntp -f benchmarks\pom.xml test-compile dependency:build-classpath -DincludeScope=test -Dmdep.outputFile=target/benchmark.classpath
+$cp = 'benchmarks\target\test-classes;benchmarks\target\classes;' + (Get-Content benchmarks\target\benchmark.classpath -Raw).Trim()
+1..5 | ForEach-Object { & java "-Dgraphcompose.benchmark.profile=full" -cp "$cp" com.demcha.compose.CurrentSpeedBenchmark }
+$runs = Get-ChildItem target\benchmarks\current-speed\run-*.json | Sort-Object Name | Select-Object -Last 5 | ForEach-Object { $_.FullName }
+& java -cp "$cp" com.demcha.compose.BenchmarkMedianTool current-speed @runs
+Copy-Item target\benchmarks\aggregates\current-speed\full\latest.json baselines\current-speed-full.json -Force
+```
+
+**Linux / macOS / Git Bash:**
+
+```bash
+./mvnw -B -ntp -f benchmarks/pom.xml test-compile dependency:build-classpath -DincludeScope=test -Dmdep.outputFile=target/benchmark.classpath
+sep=':'; case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) sep=';';; esac
+cp="benchmarks/target/test-classes${sep}benchmarks/target/classes${sep}$(cat benchmarks/target/benchmark.classpath)"
+for i in 1 2 3 4 5; do java -Dgraphcompose.benchmark.profile=full -cp "$cp" com.demcha.compose.CurrentSpeedBenchmark; done
+runs=$(ls -t target/benchmarks/current-speed/run-*.json | head -5)
+java -cp "$cp" com.demcha.compose.BenchmarkMedianTool current-speed $runs
+cp -f target/benchmarks/aggregates/current-speed/full/latest.json baselines/current-speed-full.json
+```
+
+The baseline is machine-class-specific; the JSON records provenance
+(`timestamp`, `profile`, `sourceRuns`). Validate the refresh by running the
+verdict tool against an independent run on that branch — it should score
+NEUTRAL and exit `0`:
+
+```bash
+java -cp "$cp" com.demcha.compose.BenchmarkVerdictTool baselines/current-speed-full.json target/benchmarks/current-speed/latest.json
 ```
 
 ## Artifact layout

--- a/docs/operations/benchmarks.md
+++ b/docs/operations/benchmarks.md
@@ -176,6 +176,36 @@ powershell -ExecutionPolicy Bypass -File .\scripts\run-benchmarks.ps1 -SkipDiff
 powershell -ExecutionPolicy Bypass -File .\scripts\run-benchmarks.ps1 -OpenResults
 ```
 
+## Measuring the impact of an engine change
+
+Changing the engine (layout, pagination, render ordering, PDF session, text
+measurement, fonts) and want to see how it moves performance? Pick the view that
+fits, cheapest first:
+
+- **"Did I regress?" — gate against the committed baseline.** Run a median and
+  let the `11-verdict-current-speed` step score each scenario IMPROVED /
+  NEUTRAL / REGRESSED against `baselines/current-speed-full.json` (hard gate:
+  average latency ±10%, non-zero exit on a regression):
+
+  ```powershell
+  powershell -ExecutionPolicy Bypass -File .\scripts\run-benchmarks.ps1 -CurrentSpeedProfile full -Repeat 5
+  ```
+
+- **"What exactly moved?" — A/B your branch against its base (any OS).** Commit
+  your change, then compare it to `develop` with the A/B scripts (see
+  [A/B comparison between two branches](#ab-comparison-between-two-branches)).
+  Both sides are rebuilt and benchmarked, with a per-scenario delta:
+
+  ```bash
+  ./scripts/ab-bench.sh -a develop -b my/engine-change -r 5
+  ```
+
+If a change is *meant* to improve performance and the gate confirms it, refresh
+the baseline so the gate ratchets down — see
+[Refreshing the committed baseline](#refreshing-the-committed-baseline-perf-gate).
+Treat sub-~5-10% laptop deltas as inconclusive, and re-run on the final checkout
+before citing a number.
+
 ## A/B comparison between two branches
 
 The wrappers above benchmark whatever is currently checked out. To answer "is

--- a/scripts/ab-bench.ps1
+++ b/scripts/ab-bench.ps1
@@ -28,6 +28,15 @@ only scenarios present on BOTH branches are compared.
 .EXAMPLE
   # Close your IDE, plug in AC power, then:
   ./scripts/ab-bench.ps1 -Repeat 3
+
+.NOTES
+  No "re-exec from a temp copy" guard is needed here, unlike the bash twin
+  scripts/ab-bench.sh. PowerShell parses the whole script into memory before
+  executing, so when the in-script 'git checkout <other-branch>' removes this
+  file (it is absent on a branch that predates the script) the running script
+  is unaffected. The bash twin streams from its file descriptor and must
+  re-exec out of the work tree to survive the same checkout. Verified on
+  Windows: a committed-script main<->develop run completes and recovers cleanly.
 #>
 param(
     [ValidateRange(1, 10)] [int]$Repeat = 3,

--- a/scripts/ab-bench.ps1
+++ b/scripts/ab-bench.ps1
@@ -1,0 +1,271 @@
+[CmdletBinding()]
+<#
+.SYNOPSIS
+Trustworthy A/B benchmark comparison between two branches (default main vs develop).
+
+.DESCRIPTION
+Wraps scripts/run-benchmarks.ps1 to produce a *fair* engine-speed comparison that
+controls the confounds that wreck single back-to-back runs on a laptop:
+
+  * INTERLEAVES the two branches (A,B,A,B,...) instead of all-A-then-all-B, so
+    CPU thermal drift on a mobile chip (e.g. i7-9750H) averages out between them.
+  * Repeats each branch N times and compares MEDIANS, not one noisy run.
+  * Inserts a cooldown between runs to let the laptop shed heat.
+  * Pre-flight warns about the two biggest noise sources: running on battery and
+    other JVMs/IDE competing for cores.
+  * Temporarily moves the untracked benchmark probes aside (they reference
+    develop-only CountingTextMeasurementSystem and break the bench compile on main),
+    then restores them.
+
+It then parses every run's JSON + logs and prints a single MAIN-vs-DEVELOP table
+(latency per scenario, parallel throughput, scalability, comparative, core/full-cv,
+stress) with median values and % delta, and writes a CSV.
+
+Calls run-benchmarks.ps1 with NO parameters for maximum compatibility (the older
+copy on main lacks the newer flags). Each branch runs its own committed harness;
+only scenarios present on BOTH branches are compared.
+
+.EXAMPLE
+  # Close your IDE, plug in AC power, then:
+  ./scripts/ab-bench.ps1 -Repeat 3
+#>
+param(
+    [ValidateRange(1, 10)] [int]$Repeat = 3,
+    [int]$CooldownSec = 45,
+    [string]$BranchA = "main",
+    [string]$BranchB = "develop",
+    [switch]$KeepProbes,        # don't move/restore the untracked probes (manage them yourself)
+    [switch]$SkipPreflight,     # skip the battery/IDE warnings + confirm
+    [double]$NoisePct = 3.0     # |delta| below this is reported as ~ (within noise)
+)
+
+$ErrorActionPreference = "Stop"
+if (Get-Variable -Name PSNativeCommandUseErrorActionPreference -ErrorAction SilentlyContinue) {
+    $PSNativeCommandUseErrorActionPreference = $false   # we check $LASTEXITCODE ourselves
+}
+
+$repoRoot   = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$runner     = Join-Path $repoRoot "scripts\run-benchmarks.ps1"
+$probeStash = Join-Path (Split-Path $repoRoot -Parent) "_probe-stash"
+$csDir      = Join-Path $repoRoot "target\benchmarks\current-speed"
+$cmpDir     = Join-Path $repoRoot "target\benchmarks\comparative"
+$runsDir    = Join-Path $repoRoot "target\benchmark-runs"
+$outDir     = Join-Path $repoRoot "target\ab-compare"
+New-Item -ItemType Directory -Force -Path $outDir | Out-Null
+
+function Fail($msg) { Write-Host "ERROR: $msg" -ForegroundColor Red; exit 1 }
+function Section($t) { Write-Host ""; Write-Host ("=" * 78) -ForegroundColor DarkGray; Write-Host $t -ForegroundColor Cyan; Write-Host ("=" * 78) -ForegroundColor DarkGray }
+
+function Get-Median([double[]]$v) {
+    if (-not $v -or $v.Count -eq 0) { return $null }
+    $s = $v | Sort-Object
+    $n = $s.Count
+    if ($n % 2 -eq 1) { return [double]$s[($n - 1) / 2] }
+    return ([double]$s[$n / 2 - 1] + [double]$s[$n / 2]) / 2.0
+}
+
+# Native git wrappers. git writes informational text to STDERR ("Switched to branch ...");
+# under $ErrorActionPreference='Stop' a 2>&1 merge turns that into a TERMINATING error.
+# So run git with ErrorActionPreference=Continue, discard stderr, and check $LASTEXITCODE.
+function GitTry { param([Parameter(ValueFromRemainingArguments)]$a)
+    $old = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
+    try { & git @a 2>$null | Out-Null } finally { $ErrorActionPreference = $old }
+    return $LASTEXITCODE }
+function GitOut { param([Parameter(ValueFromRemainingArguments)]$a)
+    $old = $ErrorActionPreference; $ErrorActionPreference = 'Continue'
+    try { $o = & git @a 2>$null } finally { $ErrorActionPreference = $old }
+    return $o }
+function Get-Git() { $b = GitOut rev-parse --abbrev-ref HEAD; if (-not $b) { Fail "not a git repo" }; return (($b | Select-Object -First 1)).ToString().Trim() }
+function Checkout($b) { if ((GitTry checkout $b) -ne 0) { Fail "git checkout $b failed" } }
+
+# ---- parsers (return hashtable metricKey -> value) ---------------------------
+function Parse-CurrentSpeed($jsonPath) {
+    $o = @{}
+    $j = Get-Content $jsonPath -Raw | ConvertFrom-Json
+    foreach ($l in $j.latency) {
+        $o["latency | $($l.scenario) | avg ms"]   = [double]$l.avgMillis
+        $o["latency | $($l.scenario) | p95 ms"]   = [double]$l.p95Millis
+        $o["latency | $($l.scenario) | docs/s"]   = [double]$l.docsPerSecond
+        $o["latency | $($l.scenario) | heap MB"]  = [double]$l.peakHeapMb
+    }
+    foreach ($t in $j.throughput) {
+        $o["throughput | $($t.scenario) | $($t.threads)t docs/s"] = [double]$t.docsPerSecond
+    }
+    return $o
+}
+function Parse-Comparative($jsonPath) {
+    $o = @{}
+    $j = Get-Content $jsonPath -Raw | ConvertFrom-Json
+    foreach ($lib in $j.libraries) { $o["comparative | $($lib.library) | avg ms"] = [double]$lib.avgTimeMs }
+    return $o
+}
+function Parse-Logs($logsDir) {
+    $o = @{}
+    $scal = Join-Path $logsDir "06-scalability.log"
+    if (Test-Path $scal) {
+        foreach ($line in (Get-Content $scal)) {
+            if ($line -match '^\s*(\d+)\s*\|\s*\d+\s*\|\s*([\d.]+)\s*$') {
+                $o["scalability | $($matches[1])t | docs/s"] = [double]$matches[2]
+            }
+        }
+    }
+    foreach ($pair in @(@("04-core-engine.log", "core-engine"), @("05-full-cv.log", "full-cv"))) {
+        $p = Join-Path $logsDir $pair[0]
+        if (Test-Path $p) {
+            $txt = Get-Content $p -Raw
+            if ($txt -match 'Median[^\r\n]*?:\s*([\d.]+)\s*ms') { $o["$($pair[1]) | median ms"] = [double]$matches[1] }
+        }
+    }
+    $stress = Join-Path $logsDir "07-stress.log"
+    if (Test-Path $stress) {
+        $txt = Get-Content $stress -Raw
+        if ($txt -match 'Time:\s*(\d+)\s*ms') { $o["stress | total ms"] = [double]$matches[1] }
+    }
+    return $o
+}
+function Newest-Since($dir, $pattern, [datetime]$since) {
+    if (-not (Test-Path $dir)) { return $null }
+    Get-ChildItem -Path $dir -Filter $pattern -ErrorAction SilentlyContinue |
+        Where-Object { $_.LastWriteTime -gt $since } |
+        Sort-Object LastWriteTime -Descending | Select-Object -First 1
+}
+function Newest-LogsDirSince([datetime]$since) {
+    if (-not (Test-Path $runsDir)) { return $null }
+    $d = Get-ChildItem -Path $runsDir -Directory -ErrorAction SilentlyContinue |
+        Where-Object { $_.LastWriteTime -gt $since } |
+        Sort-Object LastWriteTime -Descending | Select-Object -First 1
+    if ($d) { return (Join-Path $d.FullName "logs") }
+    return $null
+}
+
+# ---- pre-flight --------------------------------------------------------------
+if (-not (Test-Path $runner)) { Fail "run-benchmarks.ps1 not found at $runner" }
+$dirty = GitOut status --porcelain --untracked-files=no
+if ($dirty) { Fail ("working tree has uncommitted TRACKED changes; commit/stash them before A/B (branch switching would carry them).`n" + ($dirty -join "`n")) }
+
+if (-not $SkipPreflight) {
+    $warn = @()
+    $bat = Get-CimInstance Win32_Battery -ErrorAction SilentlyContinue
+    if ($bat -and $bat.BatteryStatus -eq 1) { $warn += "On BATTERY power - CPU will throttle. Plug in AC + set High-performance power plan." }
+    $jvm = Get-Process -Name java, javaw, idea64, idea, studio64 -ErrorAction SilentlyContinue
+    if ($jvm) { $warn += "Other JVM/IDE processes running ($([string]::Join(', ', ($jvm | Select-Object -Expand ProcessName -Unique)))) - they steal cores. Close your IDE." }
+    if ($warn.Count -gt 0) {
+        Write-Host ""
+        foreach ($w in $warn) { Write-Host "  ⚠  $w" -ForegroundColor Yellow }
+        $ans = Read-Host "Continue anyway? (y/N)"
+        if ($ans -notmatch '^(y|yes)$') { Write-Host "Aborted."; exit 0 }
+    }
+}
+
+# ---- run ---------------------------------------------------------------------
+$startBranch = Get-Git
+Write-Host "A/B: $BranchA vs $BranchB | repeats=$Repeat | cooldown=${CooldownSec}s | start branch=$startBranch" -ForegroundColor Green
+
+# Move ALL untracked .java under benchmarks/ aside: they may reference branch-only symbols
+# (e.g. develop-only CountingTextMeasurementSystem) and break the bench compile on the other
+# branch. Committed benchmarks don't depend on them. Detected via git so new probes are handled.
+$moved = New-Object System.Collections.Generic.List[object]
+if (-not $KeepProbes) {
+    New-Item -ItemType Directory -Force -Path $probeStash | Out-Null
+    $untracked = (GitOut status --porcelain --untracked-files=all -- benchmarks) |
+        Where-Object { $_ -match '^\?\?\s' -and $_ -match '\.java\s*$' } |
+        ForEach-Object { (($_ -replace '^\s*\?\?\s+', '').Trim() -replace '/', '\') }
+    $i = 0
+    foreach ($rel in $untracked) {
+        $full = Join-Path $repoRoot $rel
+        if (Test-Path $full) {
+            $stashed = Join-Path $probeStash ("{0:000}_{1}" -f $i, (Split-Path $rel -Leaf))
+            Move-Item -Force $full $stashed
+            $moved.Add([pscustomobject]@{ Rel = $rel; Stashed = $stashed }); $i++
+        }
+    }
+    if ($moved.Count) { Write-Host "Moved $($moved.Count) untracked benchmark .java aside -> $probeStash" -ForegroundColor DarkGray }
+}
+
+$samples = New-Object System.Collections.Generic.List[object]   # {Branch, Map}
+try {
+    foreach ($rep in 1..$Repeat) {
+        foreach ($br in @($BranchA, $BranchB)) {
+            Section "repeat $rep/$Repeat | branch $br"
+            Checkout $br
+            $t0 = Get-Date
+            $ok = $true
+            try { & $runner } catch { $ok = $false; Write-Host "  run-benchmarks.ps1 failed on $br : $($_.Exception.Message)" -ForegroundColor Red }
+            if ($ok) {
+                $map = @{}
+                $csJson  = Newest-Since $csDir  "run-*.json" $t0
+                $cmpJson = Newest-Since $cmpDir "run-*.json" $t0
+                $logsDir = Newest-LogsDirSince $t0
+                if ($csJson)  { (Parse-CurrentSpeed $csJson.FullName).GetEnumerator()  | ForEach-Object { $map[$_.Key] = $_.Value } }
+                if ($cmpJson) { (Parse-Comparative $cmpJson.FullName).GetEnumerator()  | ForEach-Object { $map[$_.Key] = $_.Value } }
+                if ($logsDir) { (Parse-Logs $logsDir).GetEnumerator()                  | ForEach-Object { $map[$_.Key] = $_.Value } }
+                if ($map.Count -gt 0) { $samples.Add([pscustomobject]@{ Branch = $br; Map = $map }) }
+                else { Write-Host "  WARN: no fresh outputs parsed for $br (run may have failed early)" -ForegroundColor Yellow }
+            }
+            if (-not ($rep -eq $Repeat -and $br -eq $BranchB)) {
+                Write-Host "  cooldown ${CooldownSec}s..." -ForegroundColor DarkGray
+                Start-Sleep -Seconds $CooldownSec
+            }
+        }
+    }
+}
+finally {
+    # restore probes FIRST (filesystem; they're untracked so they survive the checkout),
+    # so a checkout hiccup can never strand them in the stash.
+    if (-not $KeepProbes -and $moved.Count) {
+        foreach ($m in $moved) {
+            if (Test-Path $m.Stashed) {
+                $dest = Join-Path $repoRoot $m.Rel
+                New-Item -ItemType Directory -Force -Path (Split-Path $dest -Parent) | Out-Null
+                Move-Item -Force $m.Stashed $dest
+            }
+        }
+        Write-Host "Restored $($moved.Count) probe(s) to working tree" -ForegroundColor DarkGray
+    }
+    Checkout $startBranch
+    Write-Host "Back on branch $startBranch" -ForegroundColor DarkGray
+}
+
+# ---- aggregate ---------------------------------------------------------------
+$byBranch = @{ $BranchA = @{}; $BranchB = @{} }
+foreach ($s in $samples) {
+    foreach ($k in $s.Map.Keys) {
+        if (-not $byBranch[$s.Branch].ContainsKey($k)) { $byBranch[$s.Branch][$k] = New-Object System.Collections.Generic.List[double] }
+        $byBranch[$s.Branch][$k].Add([double]$s.Map[$k])
+    }
+}
+$nA = ($samples | Where-Object Branch -eq $BranchA).Count
+$nB = ($samples | Where-Object Branch -eq $BranchB).Count
+if ($nA -eq 0 -or $nB -eq 0) { Fail "no parsed runs for one branch (A=$nA B=$nB). Check target\benchmark-runs logs." }
+
+$allKeys = ($byBranch[$BranchA].Keys + $byBranch[$BranchB].Keys) | Sort-Object -Unique
+$rows = foreach ($k in $allKeys) {
+    if (-not ($byBranch[$BranchA].ContainsKey($k) -and $byBranch[$BranchB].ContainsKey($k))) { continue }  # common-only
+    $a = Get-Median $byBranch[$BranchA][$k].ToArray()
+    $b = Get-Median $byBranch[$BranchB][$k].ToArray()
+    $delta = if ($a -ne 0) { ($b - $a) / $a * 100.0 } else { 0 }
+    $higherBetter = ($k -match 'docs/s')
+    $better = if ([math]::Abs($delta) -lt $NoisePct) { "~" }
+              elseif (($higherBetter -and $delta -gt 0) -or (-not $higherBetter -and $delta -lt 0)) { $BranchB }
+              else { $BranchA }
+    [pscustomobject]([ordered]@{
+        Metric    = $k
+        $BranchA  = [math]::Round($a, 2)
+        $BranchB  = [math]::Round($b, 2)
+        "delta_%" = [math]::Round($delta, 1)
+        Better    = $better
+    })
+}
+
+Section "MEDIAN COMPARISON  ($BranchA n=$nA  vs  $BranchB n=$nB)   [lower=better, except docs/s]"
+$rows | Format-Table -AutoSize
+
+$csv = Join-Path $outDir ("ab-" + (Get-Date -Format "yyyyMMdd-HHmmss") + ".csv")
+$rows | Export-Csv -NoTypeInformation -Encoding UTF8 $csv
+Write-Host ""
+Write-Host "CSV: $csv"
+$improved = ($rows | Where-Object Better -eq $BranchB).Count
+$regressed = ($rows | Where-Object Better -eq $BranchA).Count
+$neutral = ($rows | Where-Object Better -eq "~").Count
+Write-Host ("Summary: {0} metrics  ->  {1} better on {2},  {3} better on {4},  {5} within +/-{6}% (noise)" -f $rows.Count, $improved, $BranchB, $regressed, $BranchA, $neutral, $NoisePct) -ForegroundColor Green
+Write-Host "Note: laptop (i7-9750H) results are still noisy; treat <~5-10% deltas as inconclusive." -ForegroundColor DarkGray

--- a/scripts/ab-bench.sh
+++ b/scripts/ab-bench.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+#
+# A/B engine-speed comparison between two branches — cross-platform (Linux, macOS,
+# Windows Git Bash). Companion to scripts/ab-bench.ps1 (Windows/PowerShell).
+#
+# It interleaves the two branches (A,B,A,B,...) so laptop thermal drift averages
+# out, repeats each branch N times, aggregates each branch's runs to a MEDIAN with
+# the cross-platform Java tool, then diffs the two medians. The heavy lifting
+# (median, diff, parsing) is done by the already-cross-platform benchmark tools
+# (BenchmarkMedianTool, BenchmarkDiffTool) so this script stays thin and portable.
+#
+# Scope: the current-speed suite — per-scenario latency (avg/p95/docs-per-sec/heap)
+# plus parallel throughput. That is the primary "did branch B get faster or slower
+# than branch A" signal. The PowerShell ab-bench.ps1 additionally reports
+# scalability / stress / comparative on Windows.
+#
+# Both branches must (a) be checkout-able refs and (b) carry the benchmark tooling
+# (any recent main/develop does). The working tree must have no uncommitted TRACKED
+# changes (branch switching would carry them).
+#
+# Usage:
+#   ./scripts/ab-bench.sh                                   # main vs develop, 3 repeats
+#   ./scripts/ab-bench.sh -a main -b develop -r 3
+#   ./scripts/ab-bench.sh --branch-a develop --branch-b feature/x --repeat 5 --cooldown 45
+#   ./scripts/ab-bench.sh -a main -b origin/anothertree -r 3   # remote-only ref (detached)
+#
+# Options:
+#   -a, --branch-a REF     baseline branch (default: main)
+#   -b, --branch-b REF     candidate branch (default: develop); deltas are B relative to A
+#   -r, --repeat N         runs per branch, median compared (default: 3; >=2 recommended)
+#   -c, --cooldown SEC     pause between runs to shed heat (default: 45)
+#   -p, --profile NAME     current-speed profile: full | smoke (default: full)
+#       --keep-probes      do not move/restore untracked benchmark .java probes
+#   -h, --help             show this help
+
+set -euo pipefail
+
+BRANCH_A=main
+BRANCH_B=develop
+REPEAT=3
+COOLDOWN=45
+PROFILE=full
+KEEP_PROBES=0
+
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -a|--branch-a) BRANCH_A="$2"; shift 2 ;;
+    -b|--branch-b) BRANCH_B="$2"; shift 2 ;;
+    -r|--repeat)   REPEAT="$2";   shift 2 ;;
+    -c|--cooldown) COOLDOWN="$2"; shift 2 ;;
+    -p|--profile)  PROFILE="$2";  shift 2 ;;
+    --keep-probes) KEEP_PROBES=1; shift ;;
+    -h|--help)     sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) die "unknown option: $1 (use --help)" ;;
+  esac
+done
+
+case "$REPEAT" in ''|*[!0-9]*) die "--repeat must be a positive integer" ;; esac
+[ "$REPEAT" -ge 1 ] || die "--repeat must be >= 1"
+
+# Repo root (this script lives in <root>/scripts).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Classpath separator: ';' on Windows shells (Git Bash / MSYS / Cygwin), ':' elsewhere.
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*) SEP=';' ;;
+  *) SEP=':' ;;
+esac
+
+MVNW="./mvnw"
+[ -x "$MVNW" ] || die "unix maven wrapper not found/executable at $MVNW"
+command -v java >/dev/null 2>&1 || die "java not on PATH"
+command -v git  >/dev/null 2>&1 || die "git not on PATH"
+
+CS_DIR="$REPO_ROOT/target/benchmarks/current-speed"
+OUT_DIR="$REPO_ROOT/target/ab-compare"
+mkdir -p "$OUT_DIR"
+
+# Preflight: no uncommitted TRACKED changes (branch switching would carry them).
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+  git status --porcelain --untracked-files=no >&2
+  die "working tree has uncommitted TRACKED changes; commit/stash them before A/B."
+fi
+
+START_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+printf 'A/B: %s vs %s | repeats=%s | cooldown=%ss | profile=%s | start=%s\n' \
+  "$BRANCH_A" "$BRANCH_B" "$REPEAT" "$COOLDOWN" "$PROFILE" "$START_BRANCH"
+
+# Move untracked benchmark .java aside: probes may reference branch-only symbols and
+# break the bench compile on the other branch. Detected via git so new probes are handled.
+STASH_DIR="$(mktemp -d 2>/dev/null || echo "${TMPDIR:-/tmp}/ab-bench.$$")"
+mkdir -p "$STASH_DIR"
+MOVED=()   # entries: "relpath|stashedpath"
+if [ "$KEEP_PROBES" -eq 0 ]; then
+  while IFS= read -r rel; do
+    [ -z "$rel" ] && continue
+    [ -f "$rel" ] || continue
+    stashed="$STASH_DIR/$(printf '%s' "$rel" | tr '/\\' '__')"
+    mv -f "$rel" "$stashed"
+    MOVED+=("$rel|$stashed")
+  done < <(git status --porcelain --untracked-files=all -- benchmarks \
+             | sed -n 's/^?? //p' | grep '\.java$' || true)
+  [ "${#MOVED[@]}" -gt 0 ] && printf 'Moved %s untracked benchmark .java aside -> %s\n' "${#MOVED[@]}" "$STASH_DIR"
+fi
+
+restore() {
+  # Restore probes FIRST (they are untracked, so they survive a checkout) so a
+  # checkout hiccup can never strand them, then return to the start branch.
+  if [ "$KEEP_PROBES" -eq 0 ] && [ "${#MOVED[@]}" -gt 0 ]; then
+    for m in "${MOVED[@]}"; do
+      rel="${m%%|*}"; src="${m##*|}"
+      if [ -f "$src" ]; then
+        mkdir -p "$(dirname "$rel")"
+        mv -f "$src" "$rel"
+      fi
+    done
+    printf 'Restored %s probe(s) to working tree\n' "${#MOVED[@]}"
+  fi
+  rmdir "$STASH_DIR" 2>/dev/null || true
+  git checkout -q "$START_BRANCH" 2>/dev/null || true
+  printf 'Back on branch %s\n' "$START_BRANCH"
+}
+trap restore EXIT
+
+CP=""
+build_engine_and_classpath() {
+  # Install the engine for the current branch so the benchmark runs against IT,
+  # then (re)build the benchmark classpath.
+  "$MVNW" -B -ntp -DskipTests install -pl . >/dev/null
+  "$MVNW" -B -ntp -f benchmarks/pom.xml test-compile dependency:build-classpath \
+          -DincludeScope=test -Dmdep.outputFile=target/benchmark.classpath >/dev/null
+  CP="benchmarks/target/test-classes${SEP}benchmarks/target/classes${SEP}$(cat benchmarks/target/benchmark.classpath)"
+}
+
+run_current_speed() {
+  java "-Dgraphcompose.benchmark.profile=$PROFILE" -cp "$CP" com.demcha.compose.CurrentSpeedBenchmark >/dev/null
+  # Newest run-*.json without `ls | head` (which SIGPIPEs ls under `set -o pipefail`).
+  local newest="" f
+  for f in "$CS_DIR"/run-*.json; do
+    [ -f "$f" ] || continue
+    if [ -z "$newest" ] || [ "$f" -nt "$newest" ]; then newest="$f"; fi
+  done
+  printf '%s\n' "$newest"
+}
+
+A_RUNS=()
+B_RUNS=()
+rep=1
+while [ "$rep" -le "$REPEAT" ]; do
+  for br in "$BRANCH_A" "$BRANCH_B"; do
+    printf '\n=== repeat %s/%s | branch %s ===\n' "$rep" "$REPEAT" "$br"
+    git checkout -q "$br" || die "git checkout $br failed"
+    build_engine_and_classpath
+    produced="$(run_current_speed)"
+    [ -n "$produced" ] || die "no current-speed run produced on $br"
+    if [ "$br" = "$BRANCH_A" ]; then A_RUNS+=("$produced"); else B_RUNS+=("$produced"); fi
+    printf '  -> %s\n' "$(basename "$produced")"
+    # Cooldown unless this was the very last run.
+    if ! { [ "$rep" -eq "$REPEAT" ] && [ "$br" = "$BRANCH_B" ]; }; then
+      printf '  cooldown %ss...\n' "$COOLDOWN"
+      sleep "$COOLDOWN"
+    fi
+  done
+  rep=$((rep + 1))
+done
+
+# We are currently on BRANCH_B with its CP set; its compiled benchmark tooling
+# (Median/Diff) plus the JSON run files (under target/, untouched by checkout) are
+# all we need — no extra install.
+resolve_median() {
+  # args: out_label run1 [run2 ...]; echoes the median JSON path (or the single run).
+  local label="$1"; shift
+  if [ "$#" -lt 2 ]; then printf '%s\n' "$1"; return; fi
+  local log raw
+  log="$(java -cp "$CP" com.demcha.compose.BenchmarkMedianTool current-speed "$@")" \
+    || die "median aggregation failed for branch $label"
+  printf '%s\n' "$log" >&2
+  raw="$(printf '%s\n' "$log" | sed -n 's/.*Saved JSON [a-z]* report to //p' | tr -d '\r')"
+  [ -n "$raw" ] || die "could not locate median JSON for branch $label"
+  cp -f "$raw" "$OUT_DIR/median-$label.json"
+  printf '%s\n' "$OUT_DIR/median-$label.json"
+}
+
+printf '\n=== aggregating medians ===\n'
+MED_A="$(resolve_median A "${A_RUNS[@]}")"
+sleep 1   # avoid second-resolution filename collision in the aggregates dir
+MED_B="$(resolve_median B "${B_RUNS[@]}")"
+
+printf '\n'
+printf '==============================================================================\n'
+printf 'DIFF  (%s n=%s  ->  %s n=%s)   [deltas are %s relative to %s; lower=better, docs/s higher=better]\n' \
+  "$BRANCH_A" "${#A_RUNS[@]}" "$BRANCH_B" "${#B_RUNS[@]}" "$BRANCH_B" "$BRANCH_A"
+printf '==============================================================================\n'
+java -cp "$CP" com.demcha.compose.BenchmarkDiffTool "$MED_A" "$MED_B"
+
+printf '\nbaseline (%s) median: %s\ncandidate (%s) median: %s\n' "$BRANCH_A" "$MED_A" "$BRANCH_B" "$MED_B"
+if [ "$REPEAT" -lt 2 ]; then
+  printf 'NOTE: --repeat 1 compares single runs (noisy). Use --repeat >=3 for a real decision.\n'
+fi
+printf 'NOTE: laptop results are noisy; treat <~5-10%% deltas as inconclusive.\n'

--- a/scripts/ab-bench.sh
+++ b/scripts/ab-bench.sh
@@ -35,6 +35,22 @@
 
 set -euo pipefail
 
+# Re-exec from a copy outside the work tree. This script switches branches with
+# `git checkout`, and checking out a branch that does not contain this file would
+# otherwise unlink the very file being executed (Windows locks it; WSL/DrvFs and
+# native git unlink it). Running from a temp copy on a filesystem the checkout
+# never touches makes the run immune. REPO_ROOT is resolved here, while the cwd is
+# still inside the repo, and passed through.
+if [ "${AB_BENCH_REEXEC:-}" != 1 ]; then
+  _ab_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+  [ -n "$_ab_root" ] || _ab_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+  _ab_self="$(mktemp 2>/dev/null || mktemp -t ab-bench 2>/dev/null || echo "${TMPDIR:-/tmp}/ab-bench.reexec.$$")"
+  cat "${BASH_SOURCE[0]}" > "$_ab_self"
+  AB_BENCH_REEXEC=1 AB_BENCH_REPO_ROOT="$_ab_root" AB_BENCH_SELF="$_ab_self" exec bash "$_ab_self" "$@"
+fi
+# Remove the temp copy on exit even if we bail before the main restore() trap.
+trap 'rm -f "${AB_BENCH_SELF:-}" 2>/dev/null || true' EXIT
+
 BRANCH_A=main
 BRANCH_B=develop
 REPEAT=3
@@ -60,9 +76,8 @@ done
 case "$REPEAT" in ''|*[!0-9]*) die "--repeat must be a positive integer" ;; esac
 [ "$REPEAT" -ge 1 ] || die "--repeat must be >= 1"
 
-# Repo root (this script lives in <root>/scripts).
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# Repo root (resolved before re-exec and passed via env; fall back to git/source).
+REPO_ROOT="${AB_BENCH_REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || (cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd))}"
 cd "$REPO_ROOT"
 
 # Classpath separator: ';' on Windows shells (Git Bash / MSYS / Cygwin), ':' elsewhere.
@@ -126,6 +141,7 @@ restore() {
   fi
   rmdir "$STASH_DIR" 2>/dev/null || true
   git checkout -q "$START_BRANCH" 2>/dev/null || true
+  rm -f "${AB_BENCH_SELF:-}" 2>/dev/null || true
   printf 'Back on branch %s\n' "$START_BRANCH"
 }
 trap restore EXIT

--- a/scripts/ab-bench.sh
+++ b/scripts/ab-bench.sh
@@ -86,13 +86,17 @@ if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
   die "working tree has uncommitted TRACKED changes; commit/stash them before A/B."
 fi
 
-START_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+# Symbolic branch name, or the commit SHA when started from a detached HEAD,
+# so the EXIT trap returns exactly where we began.
+START_BRANCH="$(git symbolic-ref -q --short HEAD || git rev-parse HEAD)"
 printf 'A/B: %s vs %s | repeats=%s | cooldown=%ss | profile=%s | start=%s\n' \
   "$BRANCH_A" "$BRANCH_B" "$REPEAT" "$COOLDOWN" "$PROFILE" "$START_BRANCH"
 
 # Move untracked benchmark .java aside: probes may reference branch-only symbols and
 # break the bench compile on the other branch. Detected via git so new probes are handled.
-STASH_DIR="$(mktemp -d 2>/dev/null || echo "${TMPDIR:-/tmp}/ab-bench.$$")"
+# Portable temp dir: GNU `mktemp -d` works bare; BSD/macOS needs a template (-t).
+STASH_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t ab-bench 2>/dev/null || true)"
+[ -n "$STASH_DIR" ] || STASH_DIR="${TMPDIR:-/tmp}/ab-bench.$$"
 mkdir -p "$STASH_DIR"
 MOVED=()   # entries: "relpath|stashedpath"
 if [ "$KEEP_PROBES" -eq 0 ]; then
@@ -187,7 +191,7 @@ resolve_median() {
 
 printf '\n=== aggregating medians ===\n'
 MED_A="$(resolve_median A "${A_RUNS[@]}")"
-sleep 1   # avoid second-resolution filename collision in the aggregates dir
+sleep 1   # cosmetic; median-A is already copied to OUT_DIR above (the real guard)
 MED_B="$(resolve_median B "${B_RUNS[@]}")"
 
 printf '\n'


### PR DESCRIPTION
## What
Cross-platform A/B benchmark tooling, a refreshed perf-gate baseline, and developer-facing docs. No production engine code changes.

- **`scripts/ab-bench.sh`** (new) — portable (Linux / macOS / Windows Git Bash) A/B engine-speed comparison between two branches; the bash twin of `ab-bench.ps1`. Interleaves branches with cooldowns, compares medians, rebuilds each branch's engine, and delegates median + diff to the existing cross-platform `BenchmarkMedianTool` / `BenchmarkDiffTool`. Re-execs from a temp copy so a `git checkout` of a branch that lacks the script can't delete the running file. Covers the `current-speed` suite (per-scenario latency + parallel throughput).
- **`scripts/ab-bench.ps1`** (new) — Windows/PowerShell A/B (full suite: latency, throughput, scalability, stress, comparative).
- **`baselines/current-speed-full.json`** — refreshed to a 5-run `develop` median captured under `C:\Dev`. The prior baseline was a 7-run median taken in the slower OneDrive working copy before the F1–F4 perf work, so it overstated the verdict delta and predated the `long-token` scenario.
- **`.gitattributes`** (new) — pin `*.sh` and `mvnw` to LF (a CRLF shebang is unrunnable on Linux/macOS/WSL); `mvnw.cmd` stays CRLF.
- **`docs/operations/benchmarks.md`** — A/B comparison, baseline-refresh procedure, the `11-verdict-current-speed` gate step, and a "Measuring the impact of an engine change" signpost for engine contributors.
- **`CONTRIBUTING.md`** — benchmark guidance now points at the cross-platform scripts + `benchmarks.md`.

## Why
Benchmark orchestration was Windows/PowerShell-only. This gives Linux/macOS contributors the same A/B capability and documents how an engine change's perf impact is measured (verdict gate vs the committed baseline; A/B vs `develop`).

## Validation
- `ab-bench.sh` — end-to-end on real Linux (WSL, native clone): the re-exec survived `git checkout` of both `main` and `develop`, the unix `mvnw` built each branch, and the per-scenario diff was produced.
- `ab-bench.ps1` — end-to-end on Windows (committed): no self-deletion issue (PowerShell parses the script into memory), clean recovery to the start branch.
- `develop` measured faster than `main` across the board on both platforms (consistent with prior A/B runs).
