### PR TITLE
docs(recipes): nine pages complete the cookbook coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,13 @@ Entries land here as they merge.
 
 ### Documentation
 
+- **Recipe coverage is complete.** Nine new cookbook pages close every gap the
+  recipe index tracked: rich text, lists, timelines, barcodes, images,
+  PDF chrome (metadata / watermark / running header-footer / protection /
+  links / bookmarks), translucency, semantic DOCX export, and layout-snapshot
+  regression testing. Every snippet is verified against the current API;
+  the folder index (`docs/recipes/README.md`) no longer carries a
+  "not yet covered" list.
 - **`BusinessReportExample` chart is now a native vector chart.** The flagship
   report's five-quarter Revenue/Profit block previously rasterised a bar chart
   through Graphics2D into an embedded PNG; it now uses `ChartSpec.bar()` with a

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -19,6 +19,15 @@ authoring API; public application code should not import
 | [Layered page design](recipes/layered-page-design.md) | Choosing between page backgrounds, rows, layer stacks, and canvases |
 | [Absolute placement](recipes/absolute-placement.md) | `addCanvas` + `position(x, y)` for pixel-precise certificates and badges |
 | [Tables](recipes/tables.md) | Row span, zebra rows, totals row, repeated header on page break |
+| [Rich text](recipes/rich-text.md) | `RichText` mixed-style runs, inline links/images/shapes, checkboxes |
+| [Lists](recipes/lists.md) | `addList`, marker customisation, nested lists with per-depth markers |
+| [Timelines](recipes/timelines.md) | `addTimeline`: markers on a connector rail, geometry and text-style controls |
+| [Barcodes](recipes/barcodes.md) | QR / Code 128 / EAN / UPC and friends, tinting, quiet zone |
+| [Images](recipes/images.md) | Sources, sizing precedence, fit modes, images in rows and cards |
+| [PDF chrome](recipes/pdf-chrome.md) | Metadata, watermarks, running header/footer placeholders, protection, links, bookmarks |
+| [Translucency](recipes/translucency.md) | `DocumentColor.rgba` / `withOpacity`, alpha coverage, layered tints |
+| [DOCX export](recipes/docx-export.md) | Semantic export, node mapping, fallbacks and skipped kinds |
+| [Snapshot testing](recipes/snapshot-testing.md) | Layout-snapshot regression testing in consumer projects |
 | [Streaming and output](recipes/streaming.md) | `buildPdf` / `writePdf` / `toPdfBytes`, DOCX export, layout snapshots, header / footer chrome, guide lines |
 | [Extending GraphCompose](recipes/extending.md) | New semantic node, fluent setter, render backend, snapshot-based regression tests |
 

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -8,6 +8,9 @@ API, with copy-pasteable snippets verified against the current release.
 | Recipe | Covers |
 |---|---|
 | [charts.md](charts.md) | Native vector bar / line / area / pie-donut charts: data–spec–style layers, axis & grid toggles, point markers, value-label halos, legend placement, translucent area fills |
+| [rich-text.md](rich-text.md) | `RichText` mixed-style runs in one paragraph: bold/accent/styled segments, inline links, inline images, inline shapes and checkboxes |
+| [lists.md](lists.md) | `addList`: quick bulleted lists, marker customisation, nested lists with per-depth markers, spacing and styled items |
+| [timelines.md](timelines.md) | `addTimeline`: markers (dot / circle / numbered / square) on a connector rail, geometry and text-style controls, pagination opt-ins |
 | [keep-together.md](keep-together.md) | `keepTogether()` / `keepEntriesTogether()` — blocks that relocate whole instead of orphaning a heading at a page break |
 | [shapes.md](shapes.md) | Filled cards, dividers, accent bars, lines, spacers, ellipses, images |
 | [shape-as-container.md](shape-as-container.md) | Circles/ellipses/rounded cards holding clipped children, `ClipPolicy` |
@@ -17,21 +20,14 @@ API, with copy-pasteable snippets verified against the current release.
 | [transforms.md](transforms.md) | Rotation, scaling, skewing |
 | [tables.md](tables.md) | Tabular layouts: columns, headers, zebra rows, composed cells |
 | [themes.md](themes.md) | `BusinessTheme` presets and custom palettes |
+| [barcodes.md](barcodes.md) | QR / Code 128 / Code 39 / EAN / UPC / PDF417 / DataMatrix, tinting, quiet zone, card centring |
+| [images.md](images.md) | Sources (bytes/path), sizing precedence, STRETCH/CONTAIN/COVER fit modes, images in rows and cards |
+| [pdf-chrome.md](pdf-chrome.md) | Metadata, watermarks, running header/footer with `{page}/{pages}/{date}`, protection, links and outline bookmarks |
+| [translucency.md](translucency.md) | `DocumentColor.rgba` / `withOpacity`: which primitives honour alpha, byte-identity for opaque colours, layered tints |
+| [docx-export.md](docx-export.md) | Semantic DOCX export: 1:1 node mapping, chart/shape-container fallbacks, skipped kinds |
+| [snapshot-testing.md](snapshot-testing.md) | Layout-snapshot regression testing in consumer projects, baseline update flow |
 | [streaming.md](streaming.md) | Streaming PDFs to HTTP responses |
 | [extending.md](extending.md) | Extension patterns: custom nodes via the `NodeDefinition` SPI |
 
-## Not yet covered (planned)
-
-Functionality that ships in the library but does not have a dedicated recipe
-yet — until then, the runnable [examples](../../examples/README.md) are the
-reference for these:
-
-- Rich text and inline runs (mixed styles, inline images/shapes, checkboxes)
-- Lists and nested lists
-- Timelines (`addTimeline`, markers, connector rail)
-- Barcodes and QR codes
-- Images: sources, sizing, fit modes
-- Links, bookmarks, and PDF chrome (metadata, watermark, header/footer, protection)
-- Translucent colours (`DocumentColor.rgba` / `withOpacity`) beyond their chart usage
-- Semantic DOCX export and its fallbacks
-- Layout-snapshot regression testing in consumer projects
+Every shipped feature now has a recipe; the runnable
+[examples](../../examples/README.md) remain the end-to-end references.

--- a/docs/recipes/barcodes.md
+++ b/docs/recipes/barcodes.md
@@ -1,0 +1,126 @@
+# Barcodes and QR codes
+
+A barcode is a first-class canonical node: `addBarcode` lives on
+`AbstractFlowBuilder`, so codes drop into `pageFlow`, `module`, and
+`section` containers — and combine with rows, cards, layer stacks, and
+tables — like any other block. The builder is `BarcodeBuilder`; the
+result is a `BarcodeNode` carrying `DocumentBarcodeOptions`.
+
+## Quick start: a QR code
+
+```java
+document.pageFlow()
+        .addBarcode(barcode -> barcode
+                .name("RepoQr")
+                .qrCode()
+                .data("https://github.com/DemchaAV/GraphCompose")
+                .size(150, 150))
+        .build();
+```
+
+`data(...)` sets the encoded content; `size(width, height)` (or the
+separate `width(...)` / `height(...)` setters) fixes the drawn box in
+points.
+
+## Symbologies
+
+Five formats have fluent shortcuts — each is a single call:
+
+```java
+barcode.qrCode();      // QR code (2D)
+barcode.code128();     // Code 128 — invoice numbers, logistics ids
+barcode.code39();      // Code 39 — alphanumeric asset tags
+barcode.ean13();       // EAN-13 — 13-digit retail
+barcode.ean8();        // EAN-8 — 8-digit compact retail
+```
+
+The full `DocumentBarcodeType` enum also covers `UPC_A`, `PDF_417`,
+and `DATA_MATRIX` — select those through the generic setter:
+
+```java
+import com.demcha.compose.document.node.DocumentBarcodeType;
+
+barcode.type(DocumentBarcodeType.DATA_MATRIX)
+        .data("LOT-2026-04-001");
+```
+
+## Brand tinting and quiet zone
+
+Foreground and background take any `DocumentColor`, so a QR code can
+match the document palette instead of shipping in black-on-white.
+`quietZone(n)` adds the symbology's blank margin, measured in barcode
+modules:
+
+```java
+import com.demcha.compose.document.style.DocumentColor;
+
+section.addBarcode(barcode -> barcode
+        .qrCode()
+        .data("https://demcha.io/graphcompose")
+        .foreground(DocumentColor.rgb(20, 80, 95))      // brand teal
+        .background(DocumentColor.rgb(232, 244, 245))   // soft tint
+        .quietZone(2)
+        .size(150, 150));
+```
+
+Keep the foreground much darker than the background — scanners need
+the contrast.
+
+## Clickable codes
+
+A barcode accepts the same link and bookmark metadata as paragraphs
+and images, so the printed QR can double as a clickable area in the
+PDF viewer:
+
+```java
+import com.demcha.compose.document.node.DocumentLinkOptions;
+
+barcode.qrCode()
+        .data("https://github.com/DemchaAV/GraphCompose")
+        .link(new DocumentLinkOptions("https://github.com/DemchaAV/GraphCompose"))
+        .size(150, 150);
+```
+
+## Centring a barcode in a card
+
+Barcodes have fixed sizes, so inside a card they sit at the leading
+edge by default. Wrap the built node in a shape container sized to the
+card's content width with `CENTER` alignment — `OVERFLOW_VISIBLE`
+skips clipping (see the
+[shape-as-container recipe](shape-as-container.md)):
+
+```java
+import com.demcha.compose.document.dsl.BarcodeBuilder;
+import com.demcha.compose.document.node.BarcodeNode;
+import com.demcha.compose.document.style.ClipPolicy;
+
+BarcodeNode code = new BarcodeBuilder()
+        .ean13()
+        .data("5901234123457")
+        .size(190, 90)
+        .build();
+
+section
+        .softPanel(DocumentColor.WHITE, 8, 14)
+        .addContainer(card -> card
+                .name("Ean13_Center")
+                .rectangle(228, code.height())   // card content width
+                .clipPolicy(ClipPolicy.OVERFLOW_VISIBLE)
+                .center(code));
+```
+
+The container's rectangle spans the available slot; the barcode lands
+at the visual midline regardless of its natural aspect ratio.
+
+## See also
+
+- [Shape-as-container](shape-as-container.md) — the centring pattern
+  above, plus clipped circles and rounded cards.
+- [PDF chrome](pdf-chrome.md) — links and bookmarks on any node,
+  including barcodes.
+
+Runnable showcase:
+[`BarcodeShowcaseExample`](../../examples/src/main/java/com/demcha/examples/features/barcodes/BarcodeShowcaseExample.java)
+([rendered PDF](../../assets/readme/examples/barcode-showcase.pdf)) —
+all five fluent symbologies plus a brand-tinted QR, each centred in a
+two-column card grid.

--- a/docs/recipes/docx-export.md
+++ b/docs/recipes/docx-export.md
@@ -1,0 +1,79 @@
+# DOCX export: the semantic backend
+
+PDF is GraphCompose's fixed-layout output — every fragment lands at exact
+coordinates. DOCX is different on purpose: it is a **semantic export** that
+walks the document graph and writes editable Word content, skipping the
+layout pass entirely (no per-page pagination, no PDF chrome). Use it when
+the recipient needs to *edit* the document; use PDF when pixels must match.
+
+## Exporting a session
+
+```java
+import com.demcha.compose.document.backend.semantic.DocxSemanticBackend;
+
+try (DocumentSession document = GraphCompose.document()
+        .pageSize(595, 842)
+        .margin(DocumentInsets.of(36))
+        .create()) {
+    document.pageFlow().name("Flow")
+            .addParagraph(p -> p.text("Hello Word"))
+            .addTable(t -> t
+                    .columns(DocumentTableColumn.auto(), DocumentTableColumn.auto())
+                    .row("R1C1", "R1C2"))
+            .build();
+
+    byte[] docx = document.export(new DocxSemanticBackend());
+    // or write straight to disk:
+    document.export(new DocxSemanticBackend(), Path.of("out/report.docx"));
+}
+```
+
+`export(backend)` returns the DOCX bytes and also writes the session's
+default output file when one was given to `GraphCompose.document(path)`;
+the two-argument overload targets an explicit path.
+
+**Dependency note:** the backend requires `org.apache.poi:poi-ooxml` on
+the classpath. GraphCompose declares it **optional** in its POM, so
+consumers who export DOCX must add it explicitly — consumers who only
+render PDF carry no POI footprint.
+
+## What maps 1:1
+
+| Document node | DOCX output |
+|---|---|
+| Paragraphs | Word paragraphs with alignment, font, size, colour, bold/italic/underline; inline runs preserved |
+| Tables | Word tables, one cell per cell |
+| Images | Embedded pictures at the node's declared size |
+| Rows | A one-row table, so editors keep the side-by-side layout (cell content limited to atomic children) |
+| Sections / containers | Children written in order |
+| Spacers | Empty paragraphs carrying the vertical gap as spacing-after |
+| Page breaks | Explicit Word page breaks |
+
+Page geometry (size and margins) and session metadata (title, author,
+subject, keywords) carry into the Word document as well.
+
+## What falls back
+
+- **Charts → data table.** The semantic export has no layout pass, so a
+  chart's compiled vector geometry does not exist here. Its *semantic*
+  content is its data, so the backend writes a categories-by-series table
+  (values formatted with the chart's own axis format) and logs **one
+  capability warning per export**. See [charts.md](charts.md).
+- **Shape containers → inline layers.** DOCX has no portable equivalent
+  of a graphics-state path clip, so the container's layers are written
+  inline, in source order, without the outline frame and without clipping
+  — again with one warning per export.
+
+## What is skipped
+
+Lines, ellipses, standalone shapes, and barcodes are **silently skipped**
+— they are pure fixed-layout geometry with no semantic equivalent.
+Headers/footers, watermarks, and protection options are also ignored by
+the current exporter.
+
+The rule of thumb: if the document leans on geometry — shapes, layered
+designs, precise placement — export PDF for the reader and DOCX only as
+an editable companion.
+
+Round-trip coverage (paragraphs, tables, metadata, chart fallback) lives in
+[`DocxSemanticBackendTest`](../../src/test/java/com/demcha/compose/document/backend/semantic/DocxSemanticBackendTest.java).

--- a/docs/recipes/images.md
+++ b/docs/recipes/images.md
@@ -1,0 +1,126 @@
+# Images: sources, sizing, and fit modes
+
+Images go through `addImage` on `AbstractFlowBuilder` (so they work in
+`pageFlow`, `module`, `section`, and row cells) and through
+`ImageBuilder` when you build the node yourself. The source descriptor
+is `DocumentImageData` — a small value type that keeps authoring code
+independent from the image cache and the PDF backend.
+
+## Sources: path or bytes
+
+```java
+import com.demcha.compose.document.image.DocumentImageData;
+
+import java.nio.file.Path;
+
+image.source(Path.of("assets/logo.png"));          // filesystem Path
+image.source("assets/logo.png");                   // path string
+image.source(readBytesFromAnywhere());             // in-memory byte[]
+image.source(DocumentImageData.fromPath(path));    // explicit descriptor
+```
+
+`fromPath` normalizes to an absolute path so adapters resolve it
+deterministically; `fromBytes` defensively copies. There is no URL
+source — download the bytes yourself and pass them through
+`source(byte[])`.
+
+## Sizing: explicit, scaled, or natural
+
+Dimension resolution follows a strict precedence:
+
+1. `size(w, h)` — exact box; `fitMode` decides how the image fills it.
+2. `width(w)` *or* `height(h)` alone — the other side comes from the
+   image's intrinsic aspect ratio.
+3. `scale(s)` — natural pixel size multiplied uniformly (only applies
+   when width and height are both omitted).
+4. Nothing — the image draws at its natural pixel size in points.
+
+In every case the result is clamped to the available content width,
+preserving aspect ratio, so an oversized photo never overflows its
+column.
+
+```java
+page.addImage(image -> image.source(logo).size(96, 48))   // exact box
+    .addImage(image -> image.source(logo).width(120))     // height from ratio
+    .addImage(image -> image.source(photo).scale(0.5));   // half natural size
+```
+
+## Fit modes
+
+`DocumentImageFitMode` controls drawing inside an explicit box:
+`STRETCH` (default) fills it exactly, `CONTAIN` letterboxes the whole
+image inside, `COVER` fills and crops the overflow.
+`fitToBounds(w, h)` is the common shortcut — it sets the box *and*
+switches to `CONTAIN`:
+
+```java
+import com.demcha.compose.document.image.DocumentImageFitMode;
+
+page.addImage(image -> image
+                .name("Logo")
+                .source(Path.of("assets/logo.png"))
+                .fitToBounds(96, 48))                      // CONTAIN
+    .addImage(image -> image
+                .name("Avatar")
+                .source(Path.of("assets/avatar.png"))
+                .size(48, 48)
+                .fitMode(DocumentImageFitMode.COVER));     // fill + crop
+```
+
+## Images inside rows and cards
+
+An image is an ordinary block node, so the classic "photo card" is a
+filled section in a weighted row:
+
+```java
+import com.demcha.compose.document.style.DocumentColor;
+import com.demcha.compose.document.style.DocumentStroke;
+
+page.addRow("Gallery", row -> row
+        .spacing(14)
+        .weights(1, 1)
+        .addSection("PhotoCard", card -> card
+                .fillColor(DocumentColor.rgb(230, 235, 255))
+                .stroke(DocumentStroke.of(DocumentColor.rgb(180, 193, 226), 0.7))
+                .cornerRadius(7)
+                .addImage(image -> image
+                        .source(photoFile)
+                        .fitToBounds(250, 134)
+                        .fitMode(DocumentImageFitMode.COVER)))
+        .addSection("Caption", caption -> caption
+                .addParagraph(p -> p.text("Riverside site, week 14."))));
+```
+
+## Inline images in paragraphs
+
+For an icon or logo flowing *with* text, use
+`ParagraphBuilder.inlineImage(data, width, height)` — the run is
+measured on the same baseline as the surrounding text and defaults to
+`InlineImageAlignment.CENTER`; overloads add explicit alignment, a
+baseline offset, and link metadata:
+
+```java
+section.addParagraph(p -> p
+        .inlineText("Built with ")
+        .inlineImage(DocumentImageData.fromPath("assets/logo.png"), 12, 12)
+        .inlineText(" GraphCompose."));
+```
+
+## Links and bookmarks
+
+`ImageBuilder.link(DocumentLinkOptions)` makes the whole image a
+clickable area; `bookmark(DocumentBookmarkOptions)` adds it to the PDF
+outline. Both are covered end-to-end in the
+[PDF chrome recipe](pdf-chrome.md).
+
+## See also
+
+- [Shapes](shapes.md) — `addImage` alongside the other visual
+  primitives, plus the CONTAIN vs COVER comparison.
+- [Shape-as-container](shape-as-container.md) — clip an image to a
+  circle or rounded card.
+
+Runnable usage in a real document:
+[`CinematicProposalFileExample`](../../examples/src/main/java/com/demcha/examples/templates/proposal/CinematicProposalFileExample.java)
+([rendered PDF](../../assets/readme/examples/project-proposal-cinematic.pdf))
+— a `COVER`-fitted photo inside a rounded, stroked card.

--- a/docs/recipes/lists.md
+++ b/docs/recipes/lists.md
@@ -1,0 +1,116 @@
+# Lists: bullets, markers, and nesting
+
+`addList` builds a semantic list node — items plus a marker policy —
+instead of hand-rolling indented paragraphs. It lives on every flow
+container (`pageFlow`, `module`, `section`), with a varargs shortcut for
+the common case and a full `ListBuilder` lambda for everything else.
+
+## Quick lists
+
+```java
+section.addList("Crisp vector output", "Deterministic layout", "Snapshot tests");
+```
+
+`addList(String...)` and `addList(List<String>)` render bulleted items
+with the default `•` marker. Leading raw markers in the input
+(`"- item"`, `"• item"`) are stripped by default so data from mixed
+sources normalises cleanly; switch that off with
+`normalizeMarkers(false)` when the prefix is intentional.
+
+## Configured lists
+
+```java
+import com.demcha.compose.document.style.DocumentTextStyle;
+import com.demcha.compose.font.FontName;
+
+section.addList(list -> list
+        .name("Highlights")
+        .textStyle(DocumentTextStyle.builder()
+                .fontName(FontName.HELVETICA)
+                .size(10.5)
+                .build())
+        .itemSpacing(3)          // gap between items, in points
+        .lineSpacing(1.5)        // gap between wrapped lines of one item
+        .items("First highlight", "Second highlight", "Third highlight"));
+```
+
+`align(TextAlign...)`, `padding(...)`, and `margin(...)` round out the
+block-level controls — the same `DocumentInsets` conventions as every
+other builder.
+
+## Markers
+
+```java
+import com.demcha.compose.document.node.ListMarker;
+
+section.addList(list -> list.dash().items("Dash-marked item"));
+section.addList(list -> list.noMarker().items("Markerless row"));
+section.addList(list -> list.marker(">").items("Custom prefix"));
+section.addList(list -> list
+        .marker(ListMarker.custom("✓"))   // explicit ListMarker value
+        .items("Tick-marked item"));
+```
+
+`bullet()`, `dash()`, and `noMarker()` are shortcuts over
+`marker(ListMarker)`. A custom marker can be any string; a trailing
+space is added automatically. For markerless lists,
+`continuationIndent("  ")` sets the prefix used only on wrapped
+continuation lines, keeping hanging indents readable.
+
+## Nested lists
+
+`addItem(label, body)` opens a child scope: every `addItem` inside the
+callback adds a child of that item, recursively. Unset depths fall back
+to a built-in marker cascade (`•` → `◦` → `▪` → `·`), and
+`markerFor(depth, marker)` overrides the marker for one depth:
+
+```java
+import com.demcha.compose.document.node.ListMarker;
+
+section.addList(list -> list
+        .name("Roadmap")
+        .markerFor(1, ListMarker.dash())
+        .markerFor(2, ListMarker.custom("*"))
+        .addItem("Engineering", eng -> eng
+                .addItem("Document engine", engine -> engine
+                        .addItem("Nested lists")
+                        .addItem("Composed table cells"))
+                .addItem("Backend SPI", spi -> spi
+                        .addItem("DOCX semantic backend")))
+        .addItem("Documentation", docs -> docs
+                .addItem("Migration guide")
+                .addItem("Published ADRs")));
+```
+
+Precedence per depth: an explicit per-item marker wins over
+`markerFor(depth, ...)`, which wins over the cascade. Mixing flat
+`addItem(String)` and nested `addItem(label, body)` on the same builder
+is supported — flat items become depth-0 leaves and source order is
+preserved.
+
+## Styled items inside cards
+
+A list is an ordinary block node, so it composes with the usual section
+chrome — soft panels, accents, spacing:
+
+```java
+import com.demcha.compose.document.style.DocumentColor;
+import com.demcha.compose.document.style.DocumentInsets;
+
+section.addSection("Checklist", card -> card
+        .fillColor(DocumentColor.rgb(248, 244, 234))
+        .cornerRadius(8)
+        .padding(DocumentInsets.of(10))
+        .addList(list -> list
+                .marker("✓")
+                .itemSpacing(2)
+                .items("Tests green", "Docs updated", "Changelog entry")));
+```
+
+For bullets that are *drawn shapes* rather than text glyphs (diamonds,
+stars, rating dots), use inline shape runs instead — see the
+[rich-text recipe](rich-text.md).
+
+Runnable showcase:
+[NestedListExample](../../examples/src/main/java/com/demcha/examples/features/lists/NestedListExample.java)
+(depth cascade, per-depth overrides, mixed flat/nested authoring).

--- a/docs/recipes/pdf-chrome.md
+++ b/docs/recipes/pdf-chrome.md
@@ -1,0 +1,154 @@
+# PDF chrome: metadata, watermarks, headers/footers, protection
+
+Everything *around* the body content — document properties, page-wide
+watermarks, running headers and footers, encryption, clickable links,
+and the outline panel — is configured through backend-neutral value
+types in `com.demcha.compose.document.output` and applied with
+`DocumentSession` mutators: `metadata`, `watermark`, `header`,
+`footer`, `protect`. Backends that cannot honour a surface ignore it
+(DOCX honours metadata, skips watermark/header/footer/bookmarks).
+
+## Document metadata
+
+```java
+import com.demcha.compose.document.output.DocumentMetadata;
+
+document.metadata(DocumentMetadata.builder()
+        .title("Q2 business report")
+        .author("Jordan Rivera")
+        .subject("Quarterly performance summary")
+        .keywords("graphcompose, report, q2")
+        .creator("GraphCompose Examples")   // defaults to "GraphCompose"
+        .producer("GraphCompose")
+        .build());
+```
+
+The values land in the PDF information dictionary — visible under
+*Document Properties* in any viewer.
+
+## Watermark
+
+A watermark paints on every page, text- or image-based:
+
+```java
+import com.demcha.compose.document.output.DocumentWatermark;
+import com.demcha.compose.document.output.DocumentWatermarkLayer;
+import com.demcha.compose.document.output.DocumentWatermarkPosition;
+
+document.watermark(DocumentWatermark.builder()
+        .text("DRAFT")
+        .fontSize(96f)
+        .rotation(45f)
+        .color(DocumentColor.rgb(196, 153, 76))
+        .opacity(0.12f)
+        .layer(DocumentWatermarkLayer.BEHIND_CONTENT)   // or ABOVE_CONTENT
+        .position(DocumentWatermarkPosition.CENTER)
+        .build());
+```
+
+- **Layer** — `BEHIND_CONTENT` sits under the body; `ABOVE_CONTENT`
+  paints on top of it.
+- **Position** — `CENTER`, the four corners (`TOP_LEFT` …
+  `BOTTOM_RIGHT`), or `TILE` for a repeated pattern across the page.
+- **Image mode** — set `imagePath(...)` or `imageBytes(...)` instead
+  of `text(...)` to stamp a logo.
+
+## Running header and footer
+
+Header and footer share the `DocumentHeaderFooter` type, targeted by
+`zone`. Each zone has independent left / center / right text slots,
+and the text supports the placeholder tokens `{page}`, `{pages}`, and
+`{date}`:
+
+```java
+import com.demcha.compose.document.output.DocumentHeaderFooter;
+import com.demcha.compose.document.output.DocumentHeaderFooterZone;
+
+document.header(DocumentHeaderFooter.builder()
+        .zone(DocumentHeaderFooterZone.HEADER)
+        .leftText("GraphCompose · Chrome showcase")
+        .rightText("{date}")
+        .fontSize(9f)
+        .textColor(DocumentColor.rgb(112, 116, 128))
+        .showSeparator(true)                 // rule between chrome and body
+        .separatorColor(DocumentColor.rgb(224, 224, 224))
+        .separatorThickness(0.5f)
+        .build());
+
+document.footer(DocumentHeaderFooter.builder()
+        .zone(DocumentHeaderFooterZone.FOOTER)
+        .centerText("Page {page} of {pages}")
+        .fontSize(9f)
+        .showSeparator(true)
+        .build());
+```
+
+The flagship `BusinessReportExample` uses exactly this footer in a
+real document — `"Confidential and proprietary"` on the left,
+`"Page {page} of {pages}"` on the right, with a 0.5pt separator rule.
+
+## Protection (passwords and permissions)
+
+```java
+import com.demcha.compose.document.output.DocumentProtection;
+
+document.protect(DocumentProtection.builder()
+        .userPassword("preview")        // required to open
+        .ownerPassword("change-me")     // required to change permissions
+        .canPrint(true)
+        .canCopyContent(false)
+        .canModify(false)
+        .canFillForms(true)
+        .keyLength(128)
+        .build());
+```
+
+Further toggles: `canExtractForAccessibility`, `canAssemble`,
+`canPrintHighQuality`. The PDF backend maps these to PDFBox
+encryption settings.
+
+## Clickable links
+
+`DocumentLinkOptions` is a one-field record holding a validated
+absolute URI. Three levels of granularity:
+
+```java
+import com.demcha.compose.document.node.DocumentLinkOptions;
+
+// 1. Whole paragraph as a link — the addLink shortcut:
+section.addLink("Project repository", "https://github.com/DemchaAV/GraphCompose");
+
+// 2. A link run inside a longer paragraph:
+section.addParagraph(p -> p
+        .inlineText("Full details in the ")
+        .inlineLink("online docs", new DocumentLinkOptions("https://demcha.io/graphcompose"))
+        .inlineText("."));
+
+// 3. Node-level: images and barcodes take .link(...) on their builders.
+```
+
+## Outline bookmarks
+
+`ParagraphBuilder.bookmark(...)` materialises a PDF outline entry —
+the navigable side panel in most viewers. `DocumentBookmarkOptions`
+takes a title and a nesting level (`0` is a root entry; the one-arg
+constructor defaults to root):
+
+```java
+import com.demcha.compose.document.node.DocumentBookmarkOptions;
+
+section.addParagraph(p -> p
+        .text("1. Executive summary")
+        .bookmark(new DocumentBookmarkOptions("Executive summary", 0)))
+       .addParagraph(p -> p
+        .text("1.1 Highlights")
+        .bookmark(new DocumentBookmarkOptions("Highlights", 1)));
+```
+
+Image and barcode builders accept the same `bookmark(...)` metadata.
+
+Runnable showcase:
+[`PdfChromeExample`](../../examples/src/main/java/com/demcha/examples/features/chrome/PdfChromeExample.java)
+([rendered PDF](../../assets/readme/examples/pdf-chrome.pdf)) —
+metadata, a diagonal DRAFT watermark, bordered header/footer with
+page tokens, and a three-level outline, all in one A4 page.

--- a/docs/recipes/rich-text.md
+++ b/docs/recipes/rich-text.md
@@ -1,0 +1,155 @@
+# Rich text: mixed styles in one paragraph
+
+`RichText` is the fluent builder for paragraphs that need more than one
+styled segment — label/value pairs, accented status keywords, inline
+links, even small geometric shapes drawn on the text baseline. Each
+chained call appends one inline run; the runs wrap together as a single
+paragraph. Author it through `addRich` on any flow container
+(`pageFlow`, `module`, `section`).
+
+## Mixed styles in one paragraph
+
+```java
+import com.demcha.compose.document.style.DocumentColor;
+
+section.addRich(rich -> rich
+        .plain("Status: ")
+        .bold("Pending")
+        .plain(" — last review on ")
+        .accent("Mar 14", DocumentColor.rgb(40, 90, 180))
+        .plain(", supersedes ")
+        .strikethrough("Mar 02"));
+```
+
+The full set of decorated runs: `plain`, `bold`, `italic`, `boldItalic`,
+`underline`, `strikethrough`, `color(text, color)`, `size(text, points)`,
+and `accent(text, color)` — bold-and-coloured in one call, the typical
+pattern for status keywords ("Paid", "Overdue"). For anything beyond
+those, `style(text, DocumentTextStyle)` takes a fully explicit style:
+
+```java
+import com.demcha.compose.document.style.DocumentTextStyle;
+import com.demcha.compose.font.FontName;
+
+section.addRich(rich -> rich
+        .plain("Code: ")
+        .style("RT-2026-04", DocumentTextStyle.builder()
+                .fontName(FontName.COURIER_BOLD)
+                .size(10)
+                .build()));
+```
+
+## Reusable fragments
+
+`RichText.text(...)` starts a standalone builder; `append(other)` splices
+its runs into another paragraph, so recurring fragments (a badge, a
+branded product name) live in one place:
+
+```java
+import com.demcha.compose.document.dsl.RichText;
+
+RichText badge = RichText.text("GraphCompose ").bold("v1.8");
+
+section.addRich(rich -> rich
+        .plain("Built with ")
+        .append(badge)
+        .plain(" — see the changelog."));
+```
+
+`addRich(RichText)` also accepts a pre-built instance directly.
+
+## Inline links
+
+```java
+section.addRich(rich -> rich
+        .plain("Read the ")
+        .link("authoring cheatsheet", "https://example.com/cheatsheet")
+        .plain(" before writing a template."));
+
+// Shortcut when the whole paragraph is one link sentence:
+section.addLink("Open the project page", "https://example.com");
+```
+
+`link(text, uri)` renders with default link styling and a clickable
+annotation on supporting backends; `with(text, style, linkOptions)`
+combines an explicit style with link metadata. On `ParagraphBuilder`,
+`inlineLink(text, options)` is the equivalent low-level call.
+
+## Inline images
+
+```java
+import com.demcha.compose.document.image.DocumentImageData;
+import com.demcha.compose.document.node.InlineImageAlignment;
+
+section.addRich(rich -> rich
+        .plain("Powered by ")
+        .image(DocumentImageData.fromPath("assets/logo.png"), 24, 12,
+                InlineImageAlignment.CENTER)
+        .plain(" since 2024."));
+```
+
+The image flows with the text and wraps like a word. Alignment is
+relative to the surrounding line (`CENTER` by default); the full
+overload adds a `baselineOffset` and `DocumentLinkOptions` for a
+clickable inline image.
+
+## Inline shapes and checkboxes
+
+Geometric figures drawn from geometry — not font glyphs — so they render
+identically regardless of font coverage. Rating dots, directional
+arrows, breadcrumb chevrons, and todo checkboxes are the headline uses:
+
+```java
+import com.demcha.compose.document.style.DocumentStroke;
+import com.demcha.compose.document.style.ShapeOutline;
+
+section.addRich(rich -> rich
+        .plain("Java ")
+        .dot(5, brand).dot(5, brand).dot(5, brand)
+        .dot(5, null, DocumentStroke.of(brand, 0.6))   // outlined = empty slot
+        .plain("    Draft ")
+        .arrow(8, ShapeOutline.Direction.RIGHT, accent)
+        .plain(" Review ")
+        .chevron(6, ShapeOutline.Direction.RIGHT, muted)
+        .plain(" Done ")
+        .diamond(7, accent).star(8, accent));
+
+section.addRich(rich -> rich
+        .checkbox(10, true, green)
+        .plain("  Checked todo marker"));
+section.addRich(rich -> rich
+        .checkbox(10, false, muted)
+        .plain("  Unchecked todo marker"));
+```
+
+Beyond the named shortcuts (`dot`, `ellipse`, `diamond`, `triangle`,
+`star`, `arrow`, `chevron`), `shape(ShapeOutline, fill)` accepts any
+`ShapeOutline` — e.g. `ShapeOutline.checkmark(8, 8)` or
+`ShapeOutline.regularPolygon(8, 8, 6)` for a hexagon. The checkbox has
+"pick your tick" overloads: pass a `ShapeOutline.CheckmarkStyle`, or any
+sized `ShapeOutline` as the checked-state mark. Arrows likewise take a
+`ShapeOutline.ArrowStyle` to swap the design.
+
+## Paragraph-level controls
+
+`addRich` is a shorthand for `addParagraph(p -> p.rich(...))`. Drop down
+to the paragraph builder when the rich content needs alignment, line
+spacing, or margins:
+
+```java
+import com.demcha.compose.document.node.TextAlign;
+
+section.addParagraph(p -> p
+        .rich(rich -> rich
+                .plain("Centred line with an ")
+                .accent("accented", brand)
+                .plain(" keyword."))
+        .align(TextAlign.CENTER)
+        .lineSpacing(2));
+```
+
+Runnable showcases:
+[RichTextShowcaseExample](../../examples/src/main/java/com/demcha/examples/features/text/RichTextShowcaseExample.java)
+(every fluent run) and
+[InlineShapesExample](../../examples/src/main/java/com/demcha/examples/features/text/InlineShapesExample.java)
+(shapes, checkboxes, and design variants).

--- a/docs/recipes/snapshot-testing.md
+++ b/docs/recipes/snapshot-testing.md
@@ -1,0 +1,94 @@
+# Layout snapshot testing: catch re-flows before they ship
+
+GraphCompose's layout engine is deterministic: the same document produces
+the same resolved geometry, every run, on every machine. That makes layout
+itself testable — `DocumentSession.layoutSnapshot()` captures the page
+count, canvas, and the depth-first list of every node's resolved bounds
+and metadata as stable JSON, deliberately leaving out renderer-specific
+bytes (font embedding, PDFBox object IDs, timestamps). When a change
+re-flows something it shouldn't have, the JSON diff shows it instantly —
+no PDF diffing, no golden images.
+
+## A snapshot test in three lines
+
+```java
+import com.demcha.compose.testing.layout.LayoutSnapshotAssertions;
+
+@Test
+void invoiceLayoutIsStable() throws Exception {
+    try (DocumentSession document = GraphCompose.document()
+            .pageSize(DocumentPageSize.A4)
+            .margin(DocumentInsets.of(28))
+            .create()) {
+        new InvoiceTemplateV2(theme).compose(document, sampleInvoice());
+
+        LayoutSnapshotAssertions.assertMatches(document, "templates/invoice/invoice_baseline");
+    }
+}
+```
+
+The slash-delimited key is a logical path: this example compares against
+`src/test/resources/layout-snapshots/templates/invoice/invoice_baseline.json`.
+`LayoutSnapshotAssertions` ships in the main GraphCompose artifact, so
+consumer projects can use it without any extra test dependency.
+
+## First run and updates
+
+On the **first run** the baseline does not exist: the assertion fails,
+writes the actual snapshot, and tells you how to accept it. Accepting —
+and updating after any *deliberate* layout change — is one flag:
+
+```
+./mvnw test -Dtest=YourSnapshotTest -Dgraphcompose.updateSnapshots=true
+```
+
+This overwrites the committed baseline with the current layout. Review
+the JSON diff before committing: that diff *is* the layout change.
+
+## On mismatch
+
+A failed comparison writes the offending snapshot to
+`target/visual-tests/layout-snapshots/<path>.actual.json` and the
+assertion message names both files:
+
+```
+Layout snapshot mismatch for invoice_baseline.
+Expected: src/test/resources/layout-snapshots/templates/invoice/invoice_baseline.json
+Actual:   target/visual-tests/layout-snapshots/templates/invoice/invoice_baseline.actual.json
+Re-run with -Dgraphcompose.updateSnapshots=true to update the baseline.
+```
+
+Diff the two to see exactly which node moved, grew, or paginated
+differently. A passing run cleans up any stale `.actual.json`.
+
+## Using it in consumer projects
+
+This is not just an internal tool — if you build templates *on*
+GraphCompose, snapshot tests are the cheapest regression net for them:
+compose the template with fixed sample data, assert the snapshot, and a
+GraphCompose upgrade (or your own refactor) that shifts the layout fails
+loudly instead of silently re-flowing a customer document.
+
+Baselines default to `src/test/resources/layout-snapshots`; overloads
+take explicit roots when your project keeps them elsewhere:
+
+```java
+LayoutSnapshotAssertions.assertMatches(document,
+        Path.of("src", "test", "resources", "my-baselines"),
+        Path.of("target", "snapshot-failures"),
+        "quotes/quote_standard");
+```
+
+For non-JUnit flows, the underlying pieces are public too:
+`document.layoutSnapshot()` returns the snapshot and
+`LayoutSnapshotJson.toJson(snapshot)` serialises it, so you can wire the
+same check into any harness.
+
+Pair the snapshot with a rendered PDF from the same session
+(`document.toPdfBytes()`) when you want human-reviewable output next to
+the machine check.
+
+Runnable walkthrough of the full workflow:
+[`LayoutSnapshotRegressionExample`](../../examples/src/main/java/com/demcha/examples/features/snapshots/LayoutSnapshotRegressionExample.java).
+A real in-tree test using the production pattern:
+[`ShapeContainerLayoutSnapshotTest`](../../src/test/java/com/demcha/compose/document/dsl/ShapeContainerLayoutSnapshotTest.java).

--- a/docs/recipes/timelines.md
+++ b/docs/recipes/timelines.md
@@ -1,0 +1,124 @@
+# Timelines: markers on a connector rail
+
+`addTimeline` builds a vertical timeline: a sequence of entries, each a
+`TimelineMarker` sitting in a continuous connector rail, paired with its
+content (title, meta, body). Pairing the marker with its entry — instead
+of hand-placing a bullet plus a left margin per row — is the semantic
+win. The rail auto-stretches to each entry's height, so it spans
+variable-length content and reads as one continuous line.
+
+## A basic timeline
+
+```java
+import com.demcha.compose.document.dsl.TimelineMarker;
+import com.demcha.compose.document.style.DocumentColor;
+
+DocumentColor accent = DocumentColor.rgb(40, 90, 120);
+
+section.addTimeline(timeline -> timeline
+        .entry(TimelineMarker.dot(8, accent), e -> e
+                .title("Senior Engineer")
+                .meta("2021 - present")
+                .body("Led the rendering pipeline rewrite and mentored three engineers."))
+        .entry(TimelineMarker.dot(8, accent), e -> e
+                .title("Engineer")
+                .meta("2019 - 2021")
+                .body("Shipped the layout engine and the table system.")));
+```
+
+Each entry slot is optional — a marker with only a title, or only a
+body, renders fine. `e.add(content -> ...)` appends arbitrary extra
+blocks below the body (chips, nested rows, lists), configured against
+the entry's content section.
+
+## Marker kinds
+
+```java
+import com.demcha.compose.document.style.DocumentStroke;
+
+TimelineMarker.dot(8, accent);                          // solid filled dot
+TimelineMarker.circle(10, null,                         // outlined ring
+        DocumentStroke.of(accent, 1.2));
+TimelineMarker.numbered(3, 16, accent,                  // numbered disc
+        DocumentColor.WHITE);
+TimelineMarker.square(8, accent);                       // filled square
+```
+
+`circle(size, fill, stroke)` takes an optional fill and/or outline —
+pass a fill for a two-tone disc, or only a stroke for an empty ring.
+`numbered(n, size, fill, textColor)` centres the step number in the
+disc; the label scales with the disc size. A marker carries its own size
+into the rail column, so mixed marker sizes in one timeline lay out
+correctly.
+
+## Rail and geometry
+
+```java
+section.addTimeline(timeline -> timeline
+        .connector(DocumentColor.rgb(150, 158, 172), 1.5) // rail colour + width
+        .gutter(8)              // rail → marker/content gap
+        .markerGap(8)           // marker → title gap
+        .markerColumnWeight(0.12) // widen for large numbered discs
+        .spacing(14)            // vertical gap between entries
+        .entry(TimelineMarker.dot(8, accent), e -> e.title("Kick-off")));
+```
+
+The rail is a left accent border on each entry that spans the entry
+spacing too, so the line never breaks between entries. Increase
+`markerColumnWeight` (relative to a content weight of 1.0) when large
+numbered discs crowd a narrow timeline.
+
+## Text styles
+
+Timeline-wide defaults and per-entry overrides:
+
+```java
+import com.demcha.compose.document.style.DocumentTextStyle;
+import com.demcha.compose.font.FontName;
+
+section.addTimeline(timeline -> timeline
+        .titleStyle(DocumentTextStyle.builder()
+                .fontName(FontName.HELVETICA_BOLD)
+                .size(11)
+                .build())
+        .metaStyle(DocumentTextStyle.builder()
+                .fontName(FontName.HELVETICA)
+                .size(8.5)
+                .build())
+        .entry(TimelineMarker.dot(8, accent), e -> e
+                .title("Launch", DocumentTextStyle.builder()  // per-entry override
+                        .fontName(FontName.HELVETICA_BOLD)
+                        .size(13)
+                        .build())
+                .meta("June 2026")
+                .body("General availability.")));
+```
+
+`titleStyle` / `metaStyle` / `bodyStyle` on the timeline set the
+defaults for every entry; the two-argument `title(text, style)`,
+`meta(text, style)`, and `body(text, style)` (or the matching
+`*Style(...)` setters on the entry) override one entry.
+
+## Pagination
+
+A timeline paginates between entries by default, and a tall entry splits
+within itself — the rail continues across the page break. Two opt-in
+controls tighten that (both `@since 1.8.0`):
+
+```java
+section.addTimeline(timeline -> timeline
+        .keepTogether()          // relocate the whole timeline to a fresh page
+        .keepEntriesTogether()   // never split one entry across pages
+        .entry(TimelineMarker.dot(8, accent), e -> e.title("Atomic entry")));
+```
+
+`keepTogether()` moves the whole timeline to the next page when it does
+not fit in the remaining space but would fit on a fresh page — timelines
+taller than a page still flow. `keepEntriesTogether()` keeps each entry
+whole while still allowing breaks between entries. Same semantics as
+the section-level controls in the
+[keep-together recipe](keep-together.md).
+
+Runnable demo:
+[TimelineDemoTest](../../src/test/java/com/demcha/testing/visual/TimelineDemoTest.java)
+renders a marker/rail sheet to `target/visual-tests/timeline/timeline.pdf`.

--- a/docs/recipes/translucency.md
+++ b/docs/recipes/translucency.md
@@ -1,0 +1,90 @@
+# Translucency: alpha colours in PDF output
+
+`DocumentColor` carries an optional alpha channel. The PDF backend renders
+it as a **graphics-state alpha constant** — genuine translucency where the
+content behind shows through, not a pre-mixed tint against an assumed
+background. That matters on tinted pages and layered designs, where a
+pre-mixed colour would only look right on white.
+
+## Creating translucent colours
+
+```java
+import com.demcha.compose.document.style.DocumentColor;
+
+DocumentColor glass  = DocumentColor.rgba(255, 255, 255, 178);  // alpha 0–255
+DocumentColor tint   = DocumentColor.rgb(20, 80, 95).withOpacity(0.35);
+```
+
+`rgba(r, g, b, a)` takes an explicit alpha byte (0 = transparent, 255 =
+opaque); `withOpacity(0.0–1.0)` derives a translucent copy of any existing
+colour — handy for turning one brand colour into a family of tints.
+Opacities outside `[0, 1]` are rejected at construction.
+
+## What honours alpha (and what does not)
+
+In the PDF backend, alpha applies to **shape fills and strokes**:
+
+- rectangles, panels (`softPanel(...)`), and chart bars
+- ellipses, including chart point markers
+- polygons (pie/donut slices, line-chart area fills)
+- inline shapes
+- chart value-label halo chips
+
+**Text and lines render fully opaque** regardless of alpha, and the
+semantic DOCX export ignores the alpha channel entirely. If a translucent
+colour reaches one of those, you get the opaque colour — never an error.
+
+## Opaque colours stay byte-identical
+
+The alpha machinery only engages for translucent colours: a fully opaque
+fill or stroke emits **no extended graphics state at all**, so documents
+that never use alpha produce byte-identical PDFs before and after this
+feature. Each translucent fill is also scoped to its own fragment — the
+alpha never leaks into content drawn afterwards.
+
+## Recipe: a translucent panel over a page background
+
+A frosted-glass card that lets the page tint shimmer through
+(see [page-backgrounds.md](page-backgrounds.md) for the background API):
+
+```java
+document.pageBackground(DocumentColor.rgb(28, 42, 56));     // deep navy page
+
+document.pageFlow()
+        .addSection("GlassCard", section -> section
+                .softPanel(DocumentColor.rgba(255, 255, 255, 200), 8, 16)
+                .addParagraph(p -> p.text("Readable on navy, without going solid white.")))
+        .build();
+```
+
+## Recipe: chart value-label halos on tinted cards
+
+Line-chart value labels draw behind a halo chip that is themed white. On a
+tinted card a solid white chip looks like a sticker — a translucent halo
+blends into the card instead (full chart API in [charts.md](charts.md)):
+
+```java
+section.chart(lineSpec, ChartStyle.builder()
+        .valueLabelHalo(DocumentPaint.solid(DocumentColor.rgba(255, 255, 255, 190)))
+        .build());
+```
+
+The same idea drives `area(true)` line charts: area fills use genuine
+graphics-state alpha (`ChartStyle.areaOpacity`, default 0.35), so
+overlapping series stay legible.
+
+## Recipe: layered tints from one brand colour
+
+Because the alpha mixes with whatever is behind it at render time, one
+base colour plus `withOpacity` gives consistent tint steps on any surface:
+
+```java
+DocumentColor brand = DocumentColor.rgb(20, 80, 95);
+
+section.addShape(120, 24, brand.withOpacity(0.15));   // faint band
+section.addShape(120, 24, brand.withOpacity(0.45));   // mid band
+section.addShape(120, 24, brand);                     // full strength
+```
+
+Verified end-to-end (including the opaque byte-identity guarantee) by
+[`PdfShapeAlphaTest`](../../src/test/java/com/demcha/compose/document/backend/fixed/pdf/PdfShapeAlphaTest.java).


### PR DESCRIPTION
## Summary

Closes every gap tracked in the recipe index's *Not yet covered* list — nine new cookbook pages under `docs/recipes/`:

| Page | Covers |
|---|---|
| rich-text.md | `RichText` mixed-style runs, inline links/images/shapes, checkboxes |
| lists.md | `addList`, marker customisation, nested per-depth markers |
| timelines.md | marker kinds, connector-rail geometry, pagination opt-ins |
| barcodes.md | all symbologies, tinting, quiet zone, card centring |
| images.md | sources, sizing precedence, fit modes |
| pdf-chrome.md | metadata, watermarks, running header/footer placeholders, protection, links, bookmarks |
| translucency.md | `rgba`/`withOpacity`, alpha coverage, byte-identity note |
| docx-export.md | semantic node mapping, chart/shape-container fallbacks, skipped kinds |
| snapshot-testing.md | consumer-project layout-regression flow, baseline updates |

Every snippet was verified against current sources rather than written from memory (e.g. `fromUrl` does not exist and is not claimed; UPC-A/PDF417/DataMatrix are shown via the enum because no fluent shortcuts exist; the watermark layer enum is `BEHIND_CONTENT`/`ABOVE_CONTENT`). Features without a runnable example link the relevant test instead. Both indexes updated; the folder README drops its *not yet covered* list.

## Testing

Full canonical suite green (1181 tests) — the markdown guards validate link resolution and canonical-surface tokens across all new pages.