### PR TITLE
fix(docx): list marker spacing + audit-driven edge-case coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,14 @@ Entries land here as they merge.
   text-metrics fake; `ChartLayoutSnapshotTest` layout snapshots + a
   fragment-lowering assertion; `SectionKeepTogetherTest` covers section,
   module, and timeline relocation plus the unchanged default.
+- Audit-driven edge-case coverage. DOCX semantic export: nested lists indent
+  two spaces per depth, per-depth custom markers survive, lists inside
+  sections export, empty lists are a no-op. Pagination: a keep-together
+  section taller than a full page still flows instead of relocating. Charts:
+  negative bar values extend the axis below zero and measure from the nice
+  floor, stacked bars skip non-positive segments, a one-point smooth/area
+  line keeps its marker and label, long category labels stay slot-sized,
+  tight-width legends keep every entry, all-negative `NiceScale` ranges.
 
 ## v1.7.1 — 2026-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,11 @@ Entries land here as they merge.
   style, with nested items indented per depth and keeping their own markers.
   (Found by the recipe fact-check: the docx-export recipe's "what is skipped"
   list could not honestly be written without it.)
+- **DOCX list items no longer double-space after the marker.** The new list
+  branch concatenated `ListMarker.value()` — which already carries its
+  trailing space — with another literal space, so every exported item read
+  `"•  text"`, and markerless lists gained a stray leading space. The export
+  now uses `ListMarker.prefix()`, matching the fixed-layout text pipeline.
 
 ### Documentation
 

--- a/src/main/java/com/demcha/compose/document/backend/semantic/DocxSemanticBackend.java
+++ b/src/main/java/com/demcha/compose/document/backend/semantic/DocxSemanticBackend.java
@@ -166,7 +166,7 @@ public final class DocxSemanticBackend implements SemanticBackend<byte[]> {
                            com.demcha.compose.document.node.ListNode list) {
         for (String item : list.items()) {
             writeListLine(document, list.textStyle(),
-                    list.marker().value() + " " + item, 0);
+                    list.marker().prefix() + item, 0);
         }
         for (com.demcha.compose.document.node.ListItem item : list.nestedItems()) {
             writeNestedItem(document, list, item, 0);
@@ -177,8 +177,11 @@ public final class DocxSemanticBackend implements SemanticBackend<byte[]> {
                                  com.demcha.compose.document.node.ListNode list,
                                  com.demcha.compose.document.node.ListItem item,
                                  int depth) {
-        String marker = item.marker() != null ? item.marker().value() : list.marker().value();
-        writeListLine(document, list.textStyle(), marker + " " + item.label(), depth);
+        // prefix() carries its own trailing space (and is empty for
+        // markerless lists), matching the fixed-layout text pipeline.
+        com.demcha.compose.document.node.ListMarker marker =
+                item.marker() != null ? item.marker() : list.marker();
+        writeListLine(document, list.textStyle(), marker.prefix() + item.label(), depth);
         for (com.demcha.compose.document.node.ListItem child : item.children()) {
             writeNestedItem(document, list, child, depth + 1);
         }

--- a/src/test/java/com/demcha/compose/document/backend/semantic/DocxSemanticBackendTest.java
+++ b/src/test/java/com/demcha/compose/document/backend/semantic/DocxSemanticBackendTest.java
@@ -4,6 +4,7 @@ import com.demcha.compose.GraphCompose;
 import com.demcha.compose.document.api.DocumentSession;
 import com.demcha.compose.document.dsl.ParagraphBuilder;
 import com.demcha.compose.document.dsl.ShapeContainerBuilder;
+import com.demcha.compose.document.node.ListMarker;
 import com.demcha.compose.document.node.ParagraphNode;
 import com.demcha.compose.document.output.DocumentMetadata;
 import com.demcha.compose.document.style.DocumentColor;
@@ -86,6 +87,107 @@ class DocxSemanticBackendTest {
                     .map(XWPFParagraph::getText).toList();
             assertThat(texts).anyMatch(t -> t.endsWith("First") && t.length() > "First".length());
             assertThat(texts).anyMatch(t -> t.endsWith("Second"));
+        }
+    }
+
+    @Test
+    void nestedListItemsIndentTwoSpacesPerDepth() throws Exception {
+        byte[] docxBytes;
+        try (DocumentSession session = GraphCompose.document()
+                .pageSize(595, 842)
+                .margin(DocumentInsets.of(36))
+                .create()) {
+            session.dsl().pageFlow().name("Flow")
+                    .addList(list -> list
+                            .name("Outline")
+                            .addItem("Level zero", l1 -> l1
+                                    .addItem("Level one", l2 -> l2
+                                            .addItem("Level two"))))
+                    .build();
+            docxBytes = session.export(new DocxSemanticBackend());
+        }
+
+        try (XWPFDocument document = new XWPFDocument(new ByteArrayInputStream(docxBytes))) {
+            List<String> texts = document.getParagraphs().stream()
+                    .map(XWPFParagraph::getText).toList();
+            // Two spaces of indent per depth; without per-item markers the
+            // semantic export falls back to the list's top-level bullet at
+            // every level (the visual depth cascade is a layout-pass concern).
+            assertThat(texts).contains(
+                    "• Level zero",
+                    "  • Level one",
+                    "    • Level two");
+        }
+    }
+
+    @Test
+    void nestedListItemsKeepTheirCustomMarkers() throws Exception {
+        byte[] docxBytes;
+        try (DocumentSession session = GraphCompose.document()
+                .pageSize(595, 842)
+                .margin(DocumentInsets.of(36))
+                .create()) {
+            session.dsl().pageFlow().name("Flow")
+                    .addList(list -> list
+                            .marker("→")
+                            .markerFor(1, ListMarker.custom("‣"))
+                            .addItem("Root", child -> child.addItem("Child")))
+                    .build();
+            docxBytes = session.export(new DocxSemanticBackend());
+        }
+
+        try (XWPFDocument document = new XWPFDocument(new ByteArrayInputStream(docxBytes))) {
+            List<String> texts = document.getParagraphs().stream()
+                    .map(XWPFParagraph::getText).toList();
+            // The top-level custom marker and the per-depth override both
+            // survive the export.
+            assertThat(texts).contains(
+                    "→ Root",
+                    "  ‣ Child");
+        }
+    }
+
+    @Test
+    void listInsideASectionIsExported() throws Exception {
+        byte[] docxBytes;
+        try (DocumentSession session = GraphCompose.document()
+                .pageSize(595, 842)
+                .margin(DocumentInsets.of(36))
+                .create()) {
+            session.dsl().pageFlow().name("Flow")
+                    .addSection("Wrapper", s -> s.addList("Inside section"))
+                    .build();
+            docxBytes = session.export(new DocxSemanticBackend());
+        }
+
+        try (XWPFDocument document = new XWPFDocument(new ByteArrayInputStream(docxBytes))) {
+            List<String> texts = document.getParagraphs().stream()
+                    .map(XWPFParagraph::getText).toList();
+            // writeNode recurses through section/container wrappers, so the
+            // nested list is not dropped.
+            assertThat(texts).contains("• Inside section");
+        }
+    }
+
+    @Test
+    void emptyListExportsNothingAndDoesNotFail() throws Exception {
+        byte[] docxBytes;
+        try (DocumentSession session = GraphCompose.document()
+                .pageSize(595, 842)
+                .margin(DocumentInsets.of(36))
+                .create()) {
+            session.dsl().pageFlow().name("Flow")
+                    .addParagraph(paragraph -> paragraph.text("Before"))
+                    .addList(list -> list.name("Empty"))
+                    .build();
+            docxBytes = session.export(new DocxSemanticBackend());
+        }
+
+        try (XWPFDocument document = new XWPFDocument(new ByteArrayInputStream(docxBytes))) {
+            List<String> texts = document.getParagraphs().stream()
+                    .map(XWPFParagraph::getText).toList();
+            assertThat(texts).contains("Before");
+            assertThat(texts).noneMatch(t -> t.contains("•"));
         }
     }
 

--- a/src/test/java/com/demcha/compose/document/chart/ChartLayoutResolverTest.java
+++ b/src/test/java/com/demcha/compose/document/chart/ChartLayoutResolverTest.java
@@ -196,6 +196,122 @@ class ChartLayoutResolverTest {
     }
 
     @Test
+    void groupedBarsWithNegativeValuesMeasureFromTheNiceFloor() {
+        ChartData data = ChartData.builder()
+                .categories("A", "B")
+                .series("S", 10.0, -2.0)
+                .build();
+        ChartSpec.Bar bar = ChartSpec.bar().data(data).build();
+
+        List<ChartPrimitive> out = ChartLayoutResolver.resolve(
+                bar, baseStyle(), ChartDefaults.DEFAULT_THEME, 200.0, 100.0, METRICS);
+
+        // Domain [-2, 10] with the zero baseline rounds to the nice range
+        // [-5, 10]: the axis extends below zero and both bars anchor at the
+        // -5 floor, so the negative bar renders as a short positive-height
+        // column reaching its value level (no crash, no inverted geometry).
+        ChartPrimitive positive = byName(out, "bar_c0_s0");
+        ChartPrimitive negative = byName(out, "bar_c1_s0");
+        assertThat(negative.y()).isEqualTo(positive.y());
+        // fractionOf(10) = 1.0 vs fractionOf(-2) = 0.2 over [-5, 10].
+        assertThat(negative.height()).isCloseTo(positive.height() * 0.2, within(1e-9));
+        // The negative bound appears as a tick label.
+        assertThat(out.stream().anyMatch(p -> p.node() instanceof ParagraphNode pn
+                && pn.name().startsWith("tick_") && "-5".equals(pn.text()))).isTrue();
+    }
+
+    @Test
+    void stackedBarsSkipNonPositiveSegments() {
+        ChartData data = ChartData.builder().categories("A")
+                .series("Up", 5.0)
+                .series("Down", -3.0)
+                .series("Zero", 0.0)
+                .build();
+        ChartSpec.Bar bar = ChartSpec.bar().data(data)
+                .grouping(BarGrouping.STACKED).valueLabels(ValueLabelMode.OUTSIDE).build();
+
+        List<ChartPrimitive> out = ChartLayoutResolver.resolve(
+                bar, baseStyle(), ChartDefaults.DEFAULT_THEME, 200.0, 120.0, METRICS);
+
+        // Only the positive segment stacks; negative and zero segments are
+        // skipped and the category total counts the positives alone.
+        assertThat(out.stream().filter(p -> p.node().name().startsWith("bar_c0_")).count())
+                .isEqualTo(1);
+        byName(out, "bar_c0_s0");
+        ParagraphNode total = (ParagraphNode) byName(out, "total_c0").node();
+        assertThat(total.text()).isEqualTo("5");
+    }
+
+    @Test
+    void onePointLineEmitsItsMarkerButNoSegments() {
+        ChartData data = ChartData.builder().categories("A").series("S", 7.0).build();
+        ChartStyle style = baseStyle().mergedUnder(ChartStyle.builder()
+                .pointMarker(PointMarker.circle(5.0))
+                .build());
+        // smooth + area exercise the interpolation and fill paths with a
+        // single sample as well.
+        ChartSpec.Line line = ChartSpec.line().data(data)
+                .smooth(true).area(true)
+                .valueLabels(ValueLabelMode.OUTSIDE).build();
+
+        List<ChartPrimitive> out = ChartLayoutResolver.resolve(
+                line, style, ChartDefaults.DEFAULT_THEME, 200.0, 100.0, METRICS);
+
+        // No connecting stroke exists, but the lone point still gets its
+        // marker and value label.
+        assertThat(out.stream().noneMatch(p -> p.node().name().startsWith("line_s0_seg")))
+                .isTrue();
+        byName(out, "point_s0_c0");
+        ParagraphNode label = (ParagraphNode) byName(out, "value_s0_c0").node();
+        assertThat(label.text()).isEqualTo("7");
+    }
+
+    @Test
+    void veryLongCategoryLabelsKeepTheirSlotWidth() {
+        ChartData data = ChartData.builder()
+                .categories("Short", "An extremely long category label that far exceeds the slot")
+                .series("S", 10.0, 20.0)
+                .build();
+        ChartSpec.Bar bar = ChartSpec.bar().data(data).build();
+
+        List<ChartPrimitive> out = ChartLayoutResolver.resolve(
+                bar, baseStyle(), ChartDefaults.DEFAULT_THEME, 200.0, 100.0, METRICS);
+
+        // Category labels are slot-sized: a long text wraps/centres inside
+        // its category slot instead of widening the geometry.
+        ChartPrimitive shortLabel = byName(out, "cat_0");
+        ChartPrimitive longLabel = byName(out, "cat_1");
+        assertThat(longLabel.width()).isEqualTo(shortLabel.width());
+        assertThat(longLabel.x()).isGreaterThan(shortLabel.x());
+    }
+
+    @Test
+    void bottomLegendInTightWidthStillEmitsEveryEntry() {
+        ChartData data = ChartData.builder().categories("A")
+                .series("First series with a long name", 1.0)
+                .series("Second series with a long name", 2.0)
+                .series("Third series with a long name", 3.0)
+                .series("Fourth series with a long name", 4.0)
+                .series("Fifth series with a long name", 5.0)
+                .build();
+        ChartSpec.Bar bar = ChartSpec.bar().data(data)
+                .legend(LegendPosition.BOTTOM).build();
+
+        // 120pt is far too narrow for five long legend entries: layout must
+        // stay deterministic and keep every entry (overflow, not loss).
+        List<ChartPrimitive> out = ChartLayoutResolver.resolve(
+                bar, baseStyle(), ChartDefaults.DEFAULT_THEME, 120.0, 100.0, METRICS);
+
+        double previousX = Double.NEGATIVE_INFINITY;
+        for (int s = 0; s < 5; s++) {
+            byName(out, "legend_swatch_" + s);
+            ChartPrimitive label = byName(out, "legend_label_" + s);
+            assertThat(label.x()).isGreaterThan(previousX);
+            previousX = label.x();
+        }
+    }
+
+    @Test
     void areaFillsRenderUnderEveryStroke() {
         ChartData data = ChartData.builder().categories("A", "B", "C")
                 .series("S1", 1.0, 3.0, 2.0).series("S2", 2.0, 1.0, 3.0).build();

--- a/src/test/java/com/demcha/compose/document/chart/NiceScaleTest.java
+++ b/src/test/java/com/demcha/compose/document/chart/NiceScaleTest.java
@@ -47,6 +47,16 @@ class NiceScaleTest {
     }
 
     @Test
+    void allNegativeRangeKeepsNegativeBounds() {
+        NiceScale s = NiceScale.compute(-30.0, -5.0, false, 5);
+        assertThat(s.niceMin()).isEqualTo(-30.0);
+        // ceil(-5 / 10) rounds the upper bound up to (negative) zero.
+        assertThat(s.niceMax()).isCloseTo(0.0, within(1e-12));
+        assertThat(s.tickStep()).isEqualTo(10.0);
+        assertThat(s.tickCount()).isEqualTo(4);
+    }
+
+    @Test
     void degenerateFlatRangeStillPlots() {
         NiceScale s = NiceScale.compute(7.0, 7.0, false, 5);
         assertThat(s.niceMax()).isGreaterThan(s.niceMin());

--- a/src/test/java/com/demcha/compose/document/dsl/SectionKeepTogetherTest.java
+++ b/src/test/java/com/demcha/compose/document/dsl/SectionKeepTogetherTest.java
@@ -106,6 +106,37 @@ class SectionKeepTogetherTest {
     }
 
     @Test
+    void keepTogetherSectionTallerThanAPageStillFlows() {
+        try (DocumentSession document = GraphCompose.document()
+                .pageSize(300, 400)
+                .margin(DocumentInsets.of(20))
+                .create()) {
+            document.pageFlow().name("Flow").spacing(12)
+                    .addSection("Filler", s -> s.addShape(260, 250, DocumentColor.rgb(220, 220, 220)))
+                    .addSection("Oversized", s -> {
+                        s.keepTogether().spacing(8);
+                        // 5 × 100pt + spacing ≈ 532pt — taller than the 360pt
+                        // inner page, so relocation cannot help.
+                        for (int i = 0; i < 5; i++) {
+                            s.addShape(260, 100, DocumentColor.rgb(20, 80, 95));
+                        }
+                    })
+                    .build();
+
+            PlacedNode oversized = document.layoutGraph().nodes().stream()
+                    .filter(n -> "Oversized".equals(n.semanticName()))
+                    .findFirst().orElseThrow();
+            // The keep-together request is ignored for a block taller than a
+            // full page: the section starts in the remaining space on page 0
+            // (no pointless relocation) and flows across the boundary.
+            assertThat(oversized.startPage()).isEqualTo(0);
+            assertThat(oversized.endPage()).isGreaterThan(oversized.startPage());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
     void withoutKeepTogetherTheCardStraddlesThePageBoundary() {
         PlacedNode card = cardNode(false);
         // Default behavior: the section flows across the boundary (heading on the


### PR DESCRIPTION
## What

**Fix.** Every list item in the semantic DOCX export rendered with a double space after the marker (`"•  text"`), and markerless lists gained a stray leading space: `ListMarker` normalizes `value()` to carry its own trailing space, and the new list branch from #156 concatenated another literal `" "` on top. The export now uses the documented `ListMarker.prefix()` — exactly what the fixed-layout text pipeline uses (`TextFlowSupport`), so PDF and DOCX agree.

**Coverage.** Closes the verification gaps the June audit flagged:

- DOCX semantic export: nested lists indent two spaces per depth, per-depth custom markers survive, lists inside sections export, empty lists are a no-op (3 of these tests fail without the fix above).
- Pagination: a `keepTogether()` section taller than a full page still flows across the boundary instead of relocating — the `LayoutCompiler` capacity guard was implemented but untested.
- Charts: grouped bars with negative values anchor at the nice floor and label the negative tick; stacked bars skip non-positive segments; a one-point smooth/area line keeps its marker and value label; long category labels stay slot-sized; a bottom legend in tight width keeps every entry; all-negative `NiceScale` ranges keep negative bounds.

## Tests

`./mvnw verify -pl .` — **1220 tests, 0 failures** (+11 new). No snapshot baselines changed.

## Notes

Known follow-up (not in scope): DOCX nested items without explicit markers fall back to the list's top-level marker, while the PDF layout applies the per-depth cascade (• → ◦ → ▪) — fidelity gap documented in the test.