### PR TITLE
fix(svg): reject malformed 'd' that loops forever after a Z

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,14 @@ Entries land here as they merge.
 
 ### Bug fixes
 
+- **SVG path reader no longer hangs on malformed `d` data.** A `Z`/`z`
+  close command (which consumes no operands) followed by a stray
+  non-command token — e.g. `"M0 0 Z5"` — made the scanner loop forever,
+  appending a close op every pass until the heap was exhausted. A single
+  malformed or hostile path string could therefore DoS the `@Beta`
+  `SvgPath.parse` / `SvgIcon` reader. The scanner now fails fast with the
+  usual position-carrying `IllegalArgumentException` when an iteration
+  consumes neither a command nor an operand.
 - **`BEHIND_CONTENT` watermarks no longer wash out the page.** The PDF
   watermark renderer set its low-opacity graphics state in a *prepended*
   content stream without a save/restore pair; PDFBox's `resetContext` only

--- a/src/main/java/com/demcha/compose/document/svg/SvgPathParser.java
+++ b/src/main/java/com/demcha/compose/document/svg/SvgPathParser.java
@@ -54,6 +54,7 @@ final class SvgPathParser {
                 break;
             }
             char c = d.charAt(pos);
+            int loopStart = pos;
             if (isCommand(c)) {
                 cmd = c;
                 pos++;
@@ -68,6 +69,15 @@ final class SvgPathParser {
                 }
             }
             apply(cmd);
+            if (pos == loopStart) {
+                // No command letter and no operand was consumed this iteration.
+                // This only happens when an operand-less command (Z/z) is
+                // implicitly repeated by a stray non-command token, e.g.
+                // "M0 0 Z5": apply(Z) consumes nothing, so without this guard
+                // the loop would spin forever, appending a close op each pass
+                // until the heap is exhausted. Fail loudly instead of hanging.
+                throw fail("a command letter");
+            }
         }
         return ops;
     }

--- a/src/test/java/com/demcha/compose/document/svg/SvgPathTest.java
+++ b/src/test/java/com/demcha/compose/document/svg/SvgPathTest.java
@@ -5,8 +5,10 @@ import com.demcha.compose.document.style.DocumentPathSegment.Close;
 import com.demcha.compose.document.style.DocumentPathSegment.CubicTo;
 import com.demcha.compose.document.style.DocumentPathSegment.LineTo;
 import com.demcha.compose.document.style.DocumentPathSegment.MoveTo;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
+import java.time.Duration;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -196,5 +198,23 @@ class SvgPathTest {
         assertThatThrownBy(() -> SvgPath.parse("M0 0 L1 1", 0, 0, 0, 10))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("viewBox");
+    }
+
+    @Test
+    void strayTokenAfterCloseIsRejectedAndDoesNotHang() {
+        // Regression: an operand-less Z/z followed by a non-command token used
+        // to spin forever (the close op consumes no characters, so the scanner
+        // never advanced), appending a close op per iteration until OOM. A
+        // single malformed/hostile 'd' string would DoS the @Beta reader.
+        // Each call must fail fast; the assertTimeout pins that it cannot hang.
+        Assertions.assertTimeoutPreemptively(
+                Duration.ofSeconds(2), () -> {
+                    assertThatThrownBy(() -> SvgPath.parse("M0 0 Z5"))
+                            .isInstanceOf(IllegalArgumentException.class)
+                            .hasMessageContaining("position");
+                    assertThatThrownBy(() -> SvgPath.parse("M0 0 z9 9"))
+                            .isInstanceOf(IllegalArgumentException.class)
+                            .hasMessageContaining("position");
+                });
     }
 }


### PR DESCRIPTION
## Why

Senior-review audit of the v1.8 SVG workstream surfaced a confirmed **DoS** in the `@Beta` SVG path reader: a `Z`/`z` close command consumes no operands, so a stray non-command token after it (e.g. `"M0 0 Z5"`) made the scanner re-apply `Z` indefinitely, appending a close op to the ops list on every iteration until the heap was exhausted. Reachable from the public `SvgPath.parse` / `SvgIcon` surface on a single malformed (or hostile) path string.

## What

- `SvgPathParser` main loop gains a **no-progress guard**: if an iteration consumes neither a command letter nor an operand, it fails with the usual position-carrying `IllegalArgumentException` instead of spinning. Generic — covers any operand-less command followed by a stray token, not just `Z`.
- `SvgPathTest.strayTokenAfterCloseIsRejectedAndDoesNotHang` pins it, wrapped in `assertTimeoutPreemptively(2s)` so the hang can never silently return.

## Tests

`./mvnw test -Dtest=SvgPathTest -pl .` → 15/15, BUILD SUCCESS. Valid paths (`"M0 0 Z"`, `"M0 0 Z Z"`, implicit repeats) unaffected.

Lane: canonical / `document.svg` (@Beta). No public-surface change.