### PR TITLE
chore(imports): drop the java.awt.* / java.util.* co-wildcard in four files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -329,6 +329,13 @@ Entries land here as they merge.
 
 ### Internal
 
+- **Removed the `java.awt.*` / `java.util.*` co-wildcard in four files.**
+  `InvoiceTemplateComposer`, `ProposalTemplateComposer`,
+  `WeeklyScheduleTemplateComposer`, and the engine `PdfRenderingSystemECS`
+  imported both wildcards, leaving `List` resolvable from either
+  `java.awt.List` or `java.util.List` — sound today only because `java.awt.List`
+  was never referenced. Each used only `java.awt.Color`, so the wildcard is now
+  an explicit `import java.awt.Color;`. No behaviour change.
 - **Sweep follow-up note for future bisectors.** The v1.8.0 import/Javadoc
   sweep (`f04a7dce`, part of #162) also carried mechanical code rewrites in
   roughly 40 files beyond its stated scope: ~30 private preset `Template`

--- a/src/main/java/com/demcha/compose/document/templates/support/business/InvoiceTemplateComposer.java
+++ b/src/main/java/com/demcha/compose/document/templates/support/business/InvoiceTemplateComposer.java
@@ -11,7 +11,7 @@ import com.demcha.compose.engine.components.layout.Anchor;
 import com.demcha.compose.engine.components.style.Margin;
 import com.demcha.compose.engine.components.style.Padding;
 
-import java.awt.*;
+import java.awt.Color;
 import java.util.*;
 import java.util.List;
 

--- a/src/main/java/com/demcha/compose/document/templates/support/business/ProposalTemplateComposer.java
+++ b/src/main/java/com/demcha/compose/document/templates/support/business/ProposalTemplateComposer.java
@@ -11,7 +11,7 @@ import com.demcha.compose.engine.components.layout.Anchor;
 import com.demcha.compose.engine.components.style.Margin;
 import com.demcha.compose.engine.components.style.Padding;
 
-import java.awt.*;
+import java.awt.Color;
 import java.util.*;
 import java.util.List;
 

--- a/src/main/java/com/demcha/compose/document/templates/support/schedule/WeeklyScheduleTemplateComposer.java
+++ b/src/main/java/com/demcha/compose/document/templates/support/schedule/WeeklyScheduleTemplateComposer.java
@@ -14,7 +14,7 @@ import com.demcha.compose.engine.components.layout.Anchor;
 import com.demcha.compose.engine.components.style.Margin;
 import com.demcha.compose.engine.components.style.Padding;
 
-import java.awt.*;
+import java.awt.Color;
 import java.util.*;
 import java.util.List;
 

--- a/src/main/java/com/demcha/compose/engine/render/pdf/ecs/PdfRenderingSystemECS.java
+++ b/src/main/java/com/demcha/compose/engine/render/pdf/ecs/PdfRenderingSystemECS.java
@@ -36,7 +36,7 @@ import org.apache.pdfbox.pdmodel.graphics.state.PDExtendedGraphicsState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.awt.*;
+import java.awt.Color;
 import java.io.IOException;
 import java.util.*;
 import java.util.List;


### PR DESCRIPTION
Four files imported both `java.awt.*` and `java.util.*`, which leaves `List` resolvable from either `java.awt.List` or `java.util.List` — it compiles today only because `java.awt.List` is never referenced, but a future `java.awt` reference would turn it into an ambiguous-import break.

Each file uses only `java.awt.Color` from the awt wildcard (`Stroke` is explicitly imported from `com.demcha.compose.engine.components.content.shape`, and `List` is already explicitly imported as `java.util.List`), so the wildcard becomes an explicit `import java.awt.Color;`:

- `InvoiceTemplateComposer`
- `ProposalTemplateComposer`
- `WeeklyScheduleTemplateComposer`
- `PdfRenderingSystemECS` (engine renderer)

No behaviour change — import-only. Full suite **1378** green. Scoped deliberately to the awt/util ambiguity; the broader `style.*` / `node.*` wildcard convention introduced by the v1.8 sweep is left as-is.

Lane: hygiene (templates + engine imports).