### PR TITLE
fix(svg): drop SVG icon layers with no drawing segment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -228,6 +228,14 @@ Entries land here as they merge.
 
 ### Bug fixes
 
+- **A stray non-drawing element no longer breaks a whole SVG icon.** A
+  visible-painted SVG element that lowers to a moveto-only or moveto+close
+  path — `d="M12 12"`, a zero-length arc, the stray subpaths real exporters
+  emit — drew no ink, yet a lone moveto threw at `SvgIcon#node(...)` (an empty
+  `PathNode`) and a moveto+close rendered blank. `SvgIconReader` now drops a
+  layer with no drawing segment, so one degenerate element no longer fails the
+  icon; an icon of only such elements still fails loudly with "no drawable
+  geometry".
 - **Stacked bars anchor at zero even with an explicit positive axis minimum.**
   A stacked bar chart with `valueAxis().min(positive)` lifted the baseline
   while segment heights stayed measured from zero, so the stack overshot its

--- a/src/main/java/com/demcha/compose/document/svg/SvgIconReader.java
+++ b/src/main/java/com/demcha/compose/document/svg/SvgIconReader.java
@@ -192,6 +192,13 @@ final class SvgIconReader {
             return;
         }
         SvgPath geometry = SvgPath.parseTransformed(d, matrix, box[0], box[1], box[2], box[3]);
+        if (!geometry.hasDrawingSegment()) {
+            // A moveto-only or moveto+close element (e.g. d="M12 12", or a
+            // zero-length arc that lowers to a lone moveto) draws no ink. Drop
+            // it so one degenerate element a real-world exporter emitted does
+            // not fail the whole icon at SvgIcon#node(...).
+            return;
+        }
 
         // Gradients resolve here, where the shape's geometry (the
         // objectBoundingBox reference) and accumulated affine exist. The flat

--- a/src/main/java/com/demcha/compose/document/svg/SvgPath.java
+++ b/src/main/java/com/demcha/compose/document/svg/SvgPath.java
@@ -154,6 +154,25 @@ public final class SvgPath {
         return sourceWidth / sourceHeight;
     }
 
+    /**
+     * Whether this path actually draws ink: it carries at least one
+     * {@code lineTo} / {@code cubicTo} after the leading {@code moveTo}. A
+     * moveto-only path, or a moveto followed only by {@code close} (which a
+     * degenerate SVG element such as {@code d="M12 12"} or a zero-length arc
+     * lowers to), draws nothing.
+     *
+     * @return {@code true} if a drawing segment is present
+     */
+    boolean hasDrawingSegment() {
+        for (DocumentPathSegment segment : segments) {
+            if (segment instanceof DocumentPathSegment.LineTo
+                    || segment instanceof DocumentPathSegment.CubicTo) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     // ------------------------------------------------------------------
     // Normalization (y-flip into the unit box)
     // ------------------------------------------------------------------

--- a/src/test/java/com/demcha/compose/document/svg/SvgIconTest.java
+++ b/src/test/java/com/demcha/compose/document/svg/SvgIconTest.java
@@ -68,6 +68,35 @@ class SvgIconTest {
     }
 
     @Test
+    void degenerateGeometryIsDroppedSoOneStrayElementDoesNotFailTheIcon() {
+        // Real exporters emit stray moveto-only / moveto+close subpaths that
+        // draw nothing. They must not break the whole icon: a lone moveto used
+        // to throw at node() (an empty PathNode), a moveto+close rendered blank.
+        SvgIcon icon = SvgIcon.parse("""
+                <svg viewBox="0 0 10 10">
+                  <path d="M5 5" fill="#000"/>
+                  <path d="M5 5 Z" fill="#000"/>
+                  <path d="M0 0 H10 V10 Z" fill="#f00"/>
+                </svg>
+                """);
+
+        // Only the drawable box survives; both degenerate paths are dropped.
+        assertThat(icon.layers()).hasSize(1);
+        assertThat(icon.node(24)).isNotNull();   // threw before the drop guard
+    }
+
+    @Test
+    void anIconOfOnlyDegenerateGeometryFailsLoudly() {
+        assertThatThrownBy(() -> SvgIcon.parse("""
+                <svg viewBox="0 0 10 10">
+                  <path d="M5 5" fill="#000"/>
+                </svg>
+                """))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("no drawable geometry");
+    }
+
+    @Test
     void basicShapesLowerToPathGeometry() {
         SvgIcon icon = SvgIcon.parse("""
                 <svg viewBox="0 0 20 20">


### PR DESCRIPTION
## Why

A visible-painted SVG element that lowers to a moveto-only or moveto+close path — `d="M12 12"`, a zero-length arc, the stray subpaths real exporters emit — draws no ink, yet on `develop`:
- a **lone moveto** threw at `SvgIcon#node(...)` (it builds an empty `PathNode`), failing the **whole** icon;
- a **moveto+close** rendered a blank layer.

One degenerate element from a messy exporter should not break the rest of the icon.

## What

- `SvgPath` gains a package-private `hasDrawingSegment()` (true when a `LineTo`/`CubicTo` is present).
- `SvgIconReader.emitLayer` drops a layer whose geometry has no drawing segment, so a degenerate element contributes nothing instead of breaking the icon.
- An icon composed **only** of such elements still fails loudly via the existing `layers.isEmpty()` → "no drawable geometry" guard.

## Tests

`SvgIconTest`: a stray moveto-only + moveto+close alongside a real box → only the box survives and `node(...)` builds (it threw before); a degenerate-only icon fails with "no drawable geometry". Full suite **1380** green.

Lane: canonical `document.svg` (@Beta reader robustness).