### PR TITLE
test(shapes): isolate the ShapeContainer outline-fill render surface

### DIFF
--- a/src/test/java/com/demcha/compose/document/architecture/ShapeOutlineRenderCoverageTest.java
+++ b/src/test/java/com/demcha/compose/document/architecture/ShapeOutlineRenderCoverageTest.java
@@ -22,13 +22,19 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Exhaustiveness guard: every {@link ShapeOutline} permit must render through
- * <em>both</em> outline-consuming surfaces — the shape-container clip path and
- * the inline-shape run — without throwing. Each surface dispatches on the
- * outline kind with an {@code instanceof} chain that ends in an
- * {@code IllegalStateException}; this test reflects over
- * {@code getPermittedSubclasses()} so the next permit added to the sealed type
- * cannot silently miss a render branch (the lesson from the
+ * <em>all three</em> outline-consuming surfaces — the shape-container outline
+ * fill/stroke, the shape-container clip path, and the inline-shape run —
+ * without throwing. Each surface dispatches on the outline kind with an
+ * {@code instanceof} chain that ends in an {@code IllegalStateException}; this
+ * test reflects over {@code getPermittedSubclasses()} so the next permit added
+ * to the sealed type cannot silently miss a render branch (the lesson from the
  * {@code ShapeOutline.Path} clipper, where the inline-shape switch was missed).
+ *
+ * <p>The fill surface is isolated with {@link ClipPolicy#OVERFLOW_VISIBLE}: the
+ * clip test exercises {@code ShapeContainerDefinition}'s fill-geometry chain
+ * transitively (the outline fragment is emitted whether or not the container
+ * clips), but a dedicated fill-only case keeps that branch covered if the clip
+ * surface ever changes.</p>
  */
 class ShapeOutlineRenderCoverageTest {
 
@@ -51,8 +57,33 @@ class ShapeOutlineRenderCoverageTest {
         Set<Class<?>> permits = Set.of(ShapeOutline.class.getPermittedSubclasses());
         Set<Class<?>> covered = REPRESENTATIVES.keySet();
         // If this fails, a new ShapeOutline permit was added — give it a
-        // representative here AND a render branch in BOTH surfaces below.
+        // representative here AND a render branch in all three surfaces below.
         assertThat(covered).containsExactlyInAnyOrderElementsOf(permits);
+    }
+
+    @Test
+    void everyOutlineFillsAContainerWithoutThrowing() throws Exception {
+        // The container's own outline fill/stroke geometry is built by
+        // ShapeContainerDefinition's instanceof chain. OVERFLOW_VISIBLE emits
+        // that fill but no clip, isolating the surface from the clip path.
+        for (ShapeOutline outline : REPRESENTATIVES.values()) {
+            try (DocumentSession session = GraphCompose.document()
+                    .pageSize(200, 160)
+                    .margin(DocumentInsets.of(16))
+                    .create()) {
+                session.add(new ShapeContainerBuilder()
+                        .name("Fill" + outline.getClass().getSimpleName())
+                        .outline(outline)
+                        .clipPolicy(ClipPolicy.OVERFLOW_VISIBLE)
+                        .fillColor(DocumentColor.rgb(20, 80, 95))
+                        .center(spacer())
+                        .build());
+                byte[] pdf = session.toPdfBytes();
+                assertThat(new String(pdf, 0, 5, StandardCharsets.US_ASCII))
+                        .as("fill render of " + outline.getClass().getSimpleName())
+                        .isEqualTo("%PDF-");
+            }
+        }
     }
 
     @Test


### PR DESCRIPTION
## Why

`ShapeOutlineRenderCoverageTest` is the exhaustiveness guard that stops a new
`ShapeOutline` permit from silently missing a render branch. It covered two of
the three outline-consuming surfaces — the shape-container clip path and the
inline-shape run — but not the container's own outline fill/stroke geometry as
a standalone case. That geometry, built by `ShapeContainerDefinition`'s
`instanceof` chain (ending in `IllegalStateException`), was only covered
transitively: the clip test emits the outline fragment whether or not the
container clips, so a missing fill branch would fail it — but the coverage was
implicit and would vanish if the clip surface ever changed.

## What changed

Added `everyOutlineFillsAContainerWithoutThrowing`, which renders each permit
as a container with `ClipPolicy.OVERFLOW_VISIBLE` (fill emitted, no clip),
isolating the fill surface. Updated the class Javadoc to name all three
surfaces and the `everyPermittedOutlineHasARepresentative` hint accordingly.
Test-only; no production change.

## Verification

- `./mvnw test -pl .` → BUILD SUCCESS, 1385 tests, 0 failures.
- Mutation-checked: disabling the `ShapeOutline.Path` branch in
  `ShapeContainerDefinition` turns the new fill case AND the clip case red while
  the inline case (a different render handler) stays green — confirming the new
  test independently drives the fill chain.

Lane: canonical (`document.architecture` guard). No public API change.