### PR TITLE
docs: adopt the Why→What→Verification PR template and flag v1.8.0 in develop

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,25 +1,43 @@
-## Summary
+<!--
+Title (the field above) follows Conventional Commits:  type(scope): concrete effect
+  type:  feat | fix | refactor | chore | docs | test
+  scope: api | engine | layout | style | pdf | docx | svg | charts | text | examples | recipes
+  e.g.   fix(api): reject non-finite chart values   ·   feat(charts): native vector chart subsystem
 
-<!-- 1–3 sentences: what changed and why. Reference any related issue. -->
+Write the body in three beats — Why → What → Verification. Prefer descriptive headings when a
+section has a sharper one (e.g. "What moved", "Before → after", "Binary compatibility").
+Delete any heading you have nothing real to put under — never ship an empty placeholder.
+-->
 
-## Type of change
+## Why
 
-- [ ] Bug fix (no public API change)
-- [ ] New feature / public API addition
-- [ ] Documentation only
-- [ ] CI / build / tooling
-- [ ] Refactor (no behavioural change)
+<!-- The problem or motivation: what was broken, missing, or risky, and where it surfaced.
+     Name the root cause. Do NOT restate the title, and do NOT narrate the review/audit that found it. -->
 
-## Checklist
+## What changed
 
-- [ ] **PR targets `develop`** (the integration branch); **not `main`**.
-- [ ] Branch name follows `<type>/<short-description>` (e.g. `feature/canvas-clip`, `fix/table-overflow`, `docs/recipe-themes`); issue-prefixed names like `42/fix/short-description` are also fine.
-- [ ] `./mvnw -B -ntp clean verify` passes locally.
-- [ ] **Java 17 compatible** &mdash; no `List.getFirst()` / `getLast()`, no `Thread.threadId()`, no switch type / deconstruction patterns, no `case null, default ->`. CI matrices Temurin 17 / 21 / 25 and will catch JDK regressions.
-- [ ] **Public API change** (if any): `CHANGELOG.md` entry added under the next `## v<X.Y.Z> — Planned` heading.
-- [ ] **README touched** (if any): `DocumentationCoverageTest.readmeShouldUseCanonicalDslAndAvoidLegacyApis` still passes &mdash; canonical fingerprints (`GraphCompose.document(`, `DocumentSession`, `document.pageFlow(`, `BusinessTheme`) preserved, no legacy tokens (`GraphCompose.pdf(`, `PdfComposer`, `CvTemplateV1`, …).
-- [ ] **Examples touched** (if any): runnable via `./mvnw -f examples/pom.xml exec:java -Dexec.mainClass=…`; if a new example, also added to `GenerateAllExamples` and the gallery row count in `examples/README.md`.
+<!-- Bullets. Name the real class/method. Justify each non-obvious decision inline (the "why behind the how"). -->
+-
 
-## Linked issue
+## Verification
 
-Closes #<issue-number>
+<!-- The proof it works:
+     - command run + result, e.g.  `./mvnw -B -ntp clean verify` → BUILD SUCCESS, <N> tests, 0 failures
+     - the new tests and what each asserts; regenerate renders if the change is visual -->
+
+**Lane:** <!-- canonical | shared-engine | legacy | test --> — <one-line scope note>
+
+Closes #<!-- issue number; delete this line if none -->
+
+---
+
+<details>
+<summary>Pre-merge checklist</summary>
+
+- [ ] Targets **`develop`** (not `main`); branch is `<type>/<short-description>`.
+- [ ] `./mvnw -B -ntp clean verify` passes locally — this is the **Verification** proof above.
+- [ ] **Java 17 compatible** — no `getFirst()`/`getLast()`, `Thread.threadId()`, type/deconstruction `switch`, `case null, default`. (CI runs Temurin 17 / 21 / 25.)
+- [ ] **Public API changed** → `CHANGELOG.md` entry under the next `## v<X.Y.Z> — Planned` heading.
+- [ ] **README / examples touched** → `DocumentationCoverageTest` stays green; a new example is wired into `GenerateAllExamples` + the `examples/README.md` gallery count.
+
+</details>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@
 
 > **Release status** &mdash;
 > 🟢 **Latest stable**: [v1.7.1](https://github.com/DemchaAV/GraphCompose/releases/tag/v1.7.1) (byte-identical layout / render / measurement performance — text wrapping, font embedding, glyph probing, table pagination; the legacy ECS engine is deprecated; zero breaking from v1.7.0)
-> &nbsp;·&nbsp; 🟡 **In develop**: v1.7.2 (next bug-fix / housekeeping cycle)
+
+> &nbsp;·&nbsp; 🟡 **In develop**: v1.8.0 &mdash; codenamed **"illustrative"** (native vector charts + inline sparklines, free-form `ShapeOutline.Path` clip, sharper SVG-reader errors; additive, zero breaking from v1.7)
 > &nbsp;·&nbsp; See [API stability policy](./docs/api-stability.md) for tier definitions.
 
 <p align="center">


### PR DESCRIPTION
## Why

The PR template still used the old Summary / Type-of-change / Checklist form,
and the README release-status line advertised a placeholder "v1.7.2 housekeeping
cycle" in develop — but develop now carries the v1.8.0 "illustrative" work
(native vector charts, inline sparklines, ShapeOutline.Path clip, sharper
SVG-reader errors).

## What changed

- `.github/pull_request_template.md` — rewritten to the house style: Why →
  What changed → Verification (with a **Lane** line) and a collapsible pre-merge
  checklist, dropping the empty-placeholder Summary / Type-of-change form.
- `README.md` — the release-status line now reads "In develop: v1.8.0 —
  illustrative (additive, zero breaking from v1.7)".

## Verification

- `./mvnw test -Dtest=DocumentationCoverageTest -pl .` → BUILD SUCCESS, 5 tests:
  the README canonical-DSL / no-legacy-token guard stays green after the edit.

**Lane:** docs — no code, no public-API change.