### PR TITLE
docs(changelog): note MONOTONE showcase and no-overshoot test under v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -373,6 +373,11 @@ Entries land here as they merge.
   through Graphics2D into an embedded PNG; it now uses `ChartSpec.bar()` with a
   `ChartStyle` palette override (navy/gold) and an explicit 0–100 axis —
   ~90 lines of hand-drawn AWT geometry replaced by a declarative spec.
+- **Chart showcase contrasts SMOOTH vs MONOTONE.** `ChartShowcaseExample`
+  gains a paired before/after on a volatile series — the pretty Catmull-Rom
+  curve overshooting its peaks next to the monotone curve that stays within
+  the data range — and the committed `assets/readme/chart-showcase.png` hero
+  preview now shows that comparison.
 
 ### Internal
 
@@ -470,6 +475,10 @@ Entries land here as they merge.
   smooth/area line keeps its marker and label, long category labels stay
   slot-sized, tight-width legends keep every entry, all-negative `NiceScale`
   ranges.
+- Monotone interpolation pinned in `ChartLayoutResolverTest`: the `MONOTONE`
+  curve's bounding box stays within the `LINEAR` data range (ground truth)
+  while `SMOOTH` overshoots it, plus a one-native-Bézier-run assertion and a
+  `charts/line_monotone` layout snapshot.
 
 ## v1.7.1 — 2026-06-09
 


### PR DESCRIPTION
## Why

The MONOTONE line-interpolation feature (PR #206) is merged into `develop`, but the v1.8.0 `### Documentation` and `### Tests` subsections didn't yet record its dev-facing example and its coverage. This closes that gap.

## What changed

- `### Documentation` — note the `ChartShowcaseExample` SMOOTH-vs-MONOTONE comparison cards and the refreshed `assets/readme/chart-showcase.png` hero preview.
- `### Tests` — note the no-overshoot assertion (`MONOTONE` curve stays within the `LINEAR` data range while `SMOOTH` overshoots), the native-Bézier-run assertion, and the `charts/line_monotone` layout snapshot.

CHANGELOG-only; no code change. The feature entry itself already landed under `### Public API` with PR #206.

## Verification

Docs-only — uses canonical API tokens (`ChartShowcaseExample`, `LineInterpolation` modes, `ChartLayoutResolverTest`); no legacy tokens, so `CanonicalSurfaceGuardTest` stays green.