### PR TITLE
fix(examples): crop the engine banner tight to its content

### DIFF
--- a/examples/src/main/java/com/demcha/examples/flagships/EngineDeckExample.java
+++ b/examples/src/main/java/com/demcha/examples/flagships/EngineDeckExample.java
@@ -141,9 +141,14 @@ public final class EngineDeckExample {
     public static Path generateBanner() throws Exception {
         Path outputFile = ExampleOutputPaths.prepare("flagships", "engine-banner.pdf");
         try (DocumentSession document = GraphCompose.document(outputFile)
-                .pageSize(DocumentPageSize.A4.landscape())
+                // The banner content is a top-anchored stack; the default
+                // A4-landscape page left a thick dead dark border around it.
+                // Crop the page to wrap the content tightly — width fits the
+                // 749pt rules plus a thin frame, height wraps the logo→chips
+                // stack — so the rasterised hero is all signal, no padding.
+                .pageSize(801, 525)
                 .pageBackground(HERO_BG)
-                .margin(16, 16, 16, 16)
+                .margin(8, 8, 8, 8)
                 .create()) {
             document.metadata(DocumentMetadata.builder()
                     .title("GraphCompose v" + VERSION + " — " + CODENAME)
@@ -306,7 +311,7 @@ public final class EngineDeckExample {
     // ─────────────────────────────────────────────────────────────────────────
 
     private static void banner(SectionBuilder s) {
-        s.softPanel(HERO_BG, 12, 30)
+        s.softPanel(HERO_BG, 12, 18)
                 .spacing(16)
                 // Logo + version badge on one line; tagline below.
                 .add(brandLine())


### PR DESCRIPTION
## Why

`EngineDeckExample.generateBanner()` rendered the standalone engine-banner on a full A4-landscape page (842×595) with a 16pt margin and a 30pt panel pad. The banner content is a top-anchored stack, so it sat inside a thick dead dark border with extra slack below the capability chips — the rasterised hero wasted space and read small.

## What changed

- Page sized to the content: `801×525` (was `DocumentPageSize.A4.landscape()`).
- Margin `16 → 8`, banner panel pad `30 → 18`.
- Net frame ~26pt uniform instead of ~46pt; the width hugs the 749pt rules, the height wraps the logo→chips stack.

Only `generateBanner()` and the banner panel are touched — the four-page deck (`generate()`, snapshot-locked by `EngineDeckLayoutSnapshotTest`) is unchanged.

## Verification

- Rendered the banner via PDFBox at 2×: **one page**, `801×525`, nothing clipped or paginated (512pt paginated — 525 is the safe single-page minimum).
- `./mvnw -f examples/pom.xml compile` → exit 0.

Committed previews are untouched — the release `cut` re-renders the banner card, keeping it consistent.