### PR TITLE
ci(deploy-web): trigger on v* tags, drop the paths filter

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -9,13 +9,20 @@ name: Deploy web showcase to GitHub Pages
 # REQUIRES: repository Settings → Pages → Source = "GitHub Actions"
 # (one-time switch from "Deploy from a branch"). Until that switch is made,
 # this workflow builds the artifact but Pages keeps serving the old source.
+#
+# Triggers: every push to `main` AND every `v*` release tag. The tag trigger
+# is the reliable one for releases — the v1.8.0 release fast-forwarded `main`
+# with 67 changed `web/` files yet the old `paths: web/**` filter silently
+# skipped the deploy, so the live site kept serving the previous release. We
+# dropped the paths filter rather than depend on it: `main` is only pushed at
+# releases / hotfixes, so deploying unconditionally is cheap and correct, and
+# the `v*` tag is a second guaranteed trigger. `concurrency` de-dupes the two
+# triggers a release fires.
 
 on:
   push:
     branches: [main]
-    paths:
-      - "web/**"
-      - ".github/workflows/deploy-web.yml"
+    tags: ["v*"]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Why

The v1.8.0 release fast-forwarded `main` with 67 changed `web/` files, but `deploy-web` never ran — the `push` `paths: web/**` filter silently skipped it, so the live showcase kept serving the v1.7.1 site (stale thumbnails) until a manual `workflow_dispatch`.

## What

- Drop the `paths` filter. `main` is only pushed at releases / hotfixes, so deploying unconditionally is cheap (~30s) and always correct — and it removes the exact thing that swallowed the v1.8.0 deploy.
- Add a `tags: ["v*"]` trigger as a second, guaranteed deploy path for releases. (Combining `tags` with `paths` is unreliable — tag pushes have no clean before/after to path-diff — which is the other reason `paths` had to go.)
- The existing `concurrency: { group: pages, cancel-in-progress: true }` de-dupes the two triggers a release fires (main ff + tag).

## Tests

- YAML validated (parses; `on.push.branches=[main]`, `on.push.tags=[v*]`, single `deploy` job intact).
- No behaviour change to the deploy steps themselves — only the trigger surface.