### PR TITLE
test(dsl): cover unparseable emoji glyph and linked inline-SVG on a wrapped line

### DIFF
--- a/src/test/java/com/demcha/compose/document/dsl/InlineSvgRenderTest.java
+++ b/src/test/java/com/demcha/compose/document/dsl/InlineSvgRenderTest.java
@@ -342,6 +342,42 @@ class InlineSvgRenderTest {
         }
     }
 
+    @Test
+    void linkedInlineSvgOnAWrappedLineKeepsTheAnnotationSizedToTheIcon() throws Exception {
+        // The single-line linked case is covered above; here the linked icon lands
+        // on a wrapped line, exercising spanLinkRectangle's alignment/height
+        // geometry when the icon's line is not the paragraph's first line.
+        double iconSize = 8.0;
+        byte[] pdf;
+        int lineCount;
+        try (DocumentSession session = GraphCompose.document()
+                .pageSize(168, 200)
+                .margin(14, 14, 14, 14)
+                .create()) {
+            session.dsl()
+                    .pageFlow()
+                    .name("Flow")
+                    .addParagraph(p -> p
+                            .inlineText("This label is intentionally long so the linked icon wraps onto a later line ")
+                            .inlineSvgIcon(crimsonSquare(), iconSize, InlineImageAlignment.CENTER,
+                                    0.0, new DocumentLinkOptions("https://example.com")))
+                    .build();
+            lineCount = paragraphLines(session.layoutGraph()).size();
+            pdf = session.toPdfBytes();
+        }
+
+        assertThat(lineCount).as("the linked icon sits on a wrapped paragraph").isGreaterThanOrEqualTo(2);
+        try (PDDocument document = Loader.loadPDF(pdf)) {
+            PDAnnotationLink link = (PDAnnotationLink) document.getPage(0).getAnnotations().stream()
+                    .filter(PDAnnotationLink.class::isInstance)
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("no link annotation for the wrapped inline SVG"));
+            assertThat((double) link.getRectangle().getHeight())
+                    .as("link rect still hugs the icon, not the line box, on a wrapped line")
+                    .isCloseTo(iconSize, within(0.5));
+        }
+    }
+
     private static List<ParagraphLine> paragraphLines(LayoutGraph graph) {
         return graph.fragments().stream()
                 .map(PlacedFragment::payload)

--- a/src/test/java/com/demcha/compose/document/emoji/EmojiLibraryTest.java
+++ b/src/test/java/com/demcha/compose/document/emoji/EmojiLibraryTest.java
@@ -3,8 +3,12 @@ package com.demcha.compose.document.emoji;
 import com.demcha.compose.document.svg.SvgIcon;
 import org.junit.jupiter.api.Test;
 
+import org.junit.jupiter.api.io.TempDir;
+
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -68,6 +72,26 @@ class EmojiLibraryTest {
             assertThatThrownBy(() -> absent.require(":star:"))
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("graph-compose-emoji");
+        }
+    }
+
+    @Test
+    void indexedGlyphThatCannotBeParsedResolvesEmptyAndRequireExplains(@TempDir Path classpathRoot) throws Exception {
+        // A set whose index points at a glyph the SVG parser rejects (here an svg
+        // with no drawable geometry). find() must stay lenient — empty, so callers
+        // fall back to literal text — and require()'s message must distinguish
+        // "indexed but unrenderable" from "unknown shortcode".
+        Path svgDir = Files.createDirectories(classpathRoot.resolve("emoji/svg"));
+        Files.writeString(classpathRoot.resolve("emoji/emoji-index.properties"), "broken=0bad1\n");
+        Files.writeString(svgDir.resolve("0bad1.svg"), "<svg viewBox='0 0 10 10'/>");
+        try (URLClassLoader loader = new URLClassLoader(new URL[]{classpathRoot.toUri().toURL()}, null)) {
+            EmojiLibrary lib = new EmojiLibrary(loader);
+
+            assertThat(lib.isAvailable()).isTrue();
+            assertThat(lib.find("broken")).isEmpty();
+            assertThatThrownBy(() -> lib.require("broken"))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("could not be rendered");
         }
     }
 }


### PR DESCRIPTION
## Why

Two lenient/edge paths on the inline-SVG + emoji surface had no direct test:

- `EmojiLibrary.find()` returns empty — and `require()` reports "indexed but its
  glyph could not be rendered" — when an *indexed* shortcode's glyph fails to
  parse, but only the unknown-shortcode and absent-set paths were covered.
- The linked inline-SVG annotation geometry (`spanLinkRectangle`) was asserted
  only for a single-line paragraph; the wrapped-line case (icon not on the first
  line) was untested.

## What changed

- `EmojiLibraryTest.indexedGlyphThatCannotBeParsedResolvesEmptyAndRequireExplains`
  — a `URLClassLoader` set whose index points at an unrenderable glyph (an SVG
  with no drawable geometry); asserts `find()` is empty (text fallback) and
  `require()` throws "could not be rendered".
- `InlineSvgRenderTest.linkedInlineSvgOnAWrappedLineKeepsTheAnnotationSizedToTheIcon`
  — a long label forces the linked icon onto a wrapped line (≥2 lines via the
  layout graph); the click annotation's height still equals the icon size,
  proving the rectangle hugs the icon, not the taller line box.

## Verification

`./mvnw test -pl . -Dtest=EmojiLibraryTest,InlineSvgRenderTest` → **BUILD
SUCCESS** (`EmojiLibraryTest` 8, `InlineSvgRenderTest` 10). Test-only change, no
production code touched.

**Lane:** test — coverage for existing inline-SVG / emoji behaviour.

Independent of any open branch.
