### PR TITLE
docs(contributing): document the emoji module release path

### DIFF
--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -132,6 +132,32 @@ is a convenience aggregate `io.github.demchaav:graph-compose-bundle` (under
   benchmarks) need `graph-compose-fonts` in the local repo — their CI jobs run
   `./mvnw -f fonts/pom.xml install` before building.
 
+### 2.E The emoji artifact (since v1.9.0)
+
+The colour-emoji glyphs ship as a **separate, independently-versioned**
+artifact, `io.github.demchaav:graph-compose-emoji` (under `emoji/`), mirroring
+the fonts arrangement above — with one difference: the **bundle does NOT
+include emoji** (it stays opt-in), so a fonts-style consumer re-pin is not
+needed.
+
+- **NOT bumped by the engine release.** It carries its own version line
+  (started at `1.0.0`) and is bumped **only when the glyph set or shortcode
+  index changes**. `cut-release.ps1` does not touch `emoji/pom.xml`, and the
+  version guard does not require it to equal the engine version.
+- **Cutting an emoji release** (only when the set changes): bump
+  `emoji/pom.xml` `<version>`, push an `emoji-vX.Y.Z` tag. That tag triggers
+  [`publish-emoji.yml`](../../.github/workflows/publish-emoji.yml), which deploys
+  only `graph-compose-emoji` to Central. The engine has no dependency on the
+  emoji artifact (its tests read the glyphs from the sibling module's source via
+  `<testResources>`), so nothing else needs re-pinning.
+- **Regenerating the set.** `emoji/tools/build-emoji-set.py` rebuilds
+  `emoji/svg/` + `emoji-index.properties` from fresh Noto Emoji + gemoji sources,
+  copying **only** the glyphs a shortcode resolves (see
+  [`emoji/NOTICE.md`](../../emoji/NOTICE.md)). Bump the version when the
+  regenerated set changes, then cut an `emoji-v*` release.
+- **First publish:** `emoji/pom.xml` is already `1.0.0`; tag `emoji-v1.0.0` (on a
+  commit that includes `publish-emoji.yml`) to ship it.
+
 ---
 
 ## 2.C One-time Maven Central setup (maintainer)


### PR DESCRIPTION
## Why

The release runbook (`docs/contributing/release-process.md`) documents the
independently-versioned `graph-compose-fonts` artifact (§2.D) but predates the
`graph-compose-emoji` module, so the emoji publish path was undocumented.

## What changed

- Add §2.E "The emoji artifact" mirroring the fonts section: `graph-compose-emoji`
  versions independently (bump `emoji/pom.xml`, push an `emoji-v*` tag →
  [`publish-emoji.yml`](.github/workflows/publish-emoji.yml)), is **not** bumped
  by the engine release, is **not** in the bundle (so no consumer re-pin, unlike
  fonts), and is regenerated via `build-emoji-set.py`. Notes the first publish is
  `emoji-v1.0.0`.

## Verification

`./mvnw test -pl . -Dtest=CanonicalSurfaceGuardTest,DocumentationCoverageTest,PackageMapGuardTest,VersionConsistencyGuardTest`
→ **BUILD SUCCESS** (21 tests) — markdown links resolve, no legacy API tokens
leak into the doc. Documentation only.

**Lane:** docs (contributing) — release runbook, no code change.

Independent of any open branch.
