### PR TITLE
fix(api): honor negative bottom margin, reject negative page margin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ PDF `GoTo` actions. External links are unchanged.
 
 ### Public API
 
+- **Negative-margin handling** (`@since 1.9.0`). A negative **page** margin
+  (`DocumentSession.margin(...)` or the builder's `margin(...)`) is now rejected
+  with an `IllegalArgumentException` — it would make the content area larger than
+  the sheet, silently overflowing it; use a node's `bleed(...)` to reach the page
+  edge instead. Separately, a negative **node** bottom margin now pulls the
+  following content up — symmetric with a negative top margin, which was already
+  honoured (the vertical flow previously dropped it). Existing documents are
+  unaffected, since neither shape was usable before.
+
 - **`DocumentSession.pageIndex()` + `PageIndex` / `PageReference`** (`@since 1.9.0`).
   Resolves every declared `anchor(...)` to its final page in a single,
   backend-neutral pass over the laid-out document — `pageNumberOf("intro")` for a

--- a/src/main/java/com/demcha/compose/document/api/DocumentSession.java
+++ b/src/main/java/com/demcha/compose/document/api/DocumentSession.java
@@ -100,7 +100,7 @@ public final class DocumentSession implements AutoCloseable {
                            boolean guideLines) {
         this.defaultOutputFile = defaultOutputFile;
         this.pageSize = Objects.requireNonNull(pageSize, "pageSize");
-        this.margin = margin == null ? DocumentInsets.zero() : margin;
+        this.margin = margin == null ? DocumentInsets.zero() : requireNonNegativePageMargin(margin);
         this.canvas = LayoutCanvas.from(pageSize.width(), pageSize.height(), toEngineMargin(this.margin));
         this.markdown = markdown;
         this.debug = DocumentDebugOptions.none().withGuides(guideLines);
@@ -297,14 +297,36 @@ public final class DocumentSession implements AutoCloseable {
      *
      * @param margin new canvas margin, or {@code null} to reset to zero
      * @return this session
-     * @throws IllegalStateException if this session has already been closed
+     * @throws IllegalStateException    if this session has already been closed
+     * @throws IllegalArgumentException if any margin component is negative — a
+     *                                  negative page margin overflows the sheet;
+     *                                  use a node's {@code bleed(...)} instead
      */
     public DocumentSession margin(DocumentInsets margin) {
         ensureOpen();
-        this.margin = margin == null ? DocumentInsets.zero() : margin;
+        this.margin = margin == null ? DocumentInsets.zero() : requireNonNegativePageMargin(margin);
         this.canvas = LayoutCanvas.from(pageSize.width(), pageSize.height(), toEngineMargin(this.margin));
         invalidate();
         return this;
+    }
+
+    /**
+     * Rejects a negative page margin. Unlike a node margin (where a negative
+     * value is a valid overlap / inset trick), a negative page margin makes the
+     * content area larger than the page, so content silently overflows the sheet.
+     * To draw content past the page edge, use a node's {@code bleed(...)} instead.
+     *
+     * @param margin the requested page margin
+     * @return {@code margin} when every component is non-negative
+     * @throws IllegalArgumentException if any component is negative
+     */
+    private static DocumentInsets requireNonNegativePageMargin(DocumentInsets margin) {
+        if (margin.top() < 0 || margin.right() < 0 || margin.bottom() < 0 || margin.left() < 0) {
+            throw new IllegalArgumentException(
+                    "page margin must be non-negative: " + margin
+                    + " — use a node's bleed(...) to extend content past the page edge");
+        }
+        return margin;
     }
 
     /**

--- a/src/main/java/com/demcha/compose/document/layout/LayoutCompiler.java
+++ b/src/main/java/com/demcha/compose/document/layout/LayoutCompiler.java
@@ -390,7 +390,7 @@ public final class LayoutCompiler {
             }
         }
 
-        advanceSpace(padding.bottom() + margin.bottom(), state);
+        closeBottomSpace(padding.bottom() + margin.bottom(), state);
         int endPage = state.pageIndex;
         double endPageBottomY = state.pageTop() - state.usedHeight + margin.bottom();
 
@@ -1525,6 +1525,25 @@ public final class LayoutCompiler {
         }
         state.touchPage();
         state.usedHeight = Math.min(state.canvas.innerHeight(), state.usedHeight + amount);
+    }
+
+    /**
+     * Closes out a composite's bottom edge. A positive bottom inset advances the
+     * flow as usual; a NEGATIVE one (a negative bottom margin) pulls the following
+     * sibling up — symmetric with a negative top margin, which already offsets via
+     * {@code placementTopY}. The plain {@link #advanceSpace} drops a non-positive
+     * amount, so the closing edge needs this dedicated path. The top-of-node
+     * reservation deliberately stays on {@link #advanceSpace} so a negative top
+     * margin keeps its existing flow behaviour; only the closing edge gains the
+     * pull-up. The cursor never drops below the page top.
+     */
+    private void closeBottomSpace(double amount, CompilerState state) {
+        if (amount >= EPS) {
+            advanceSpace(amount, state);
+        } else if (amount <= -EPS) {
+            state.touchPage();
+            state.usedHeight = Math.max(0.0, state.usedHeight + amount);
+        }
     }
 
     private String pathFor(DocumentNode node, String parentPath, int childIndex) {

--- a/src/test/java/com/demcha/compose/document/api/NegativeMarginTest.java
+++ b/src/test/java/com/demcha/compose/document/api/NegativeMarginTest.java
@@ -1,0 +1,72 @@
+package com.demcha.compose.document.api;
+
+import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.layout.PlacedNode;
+import com.demcha.compose.document.style.DocumentInsets;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * A negative <em>page</em> margin is rejected (it would make the content area
+ * larger than the sheet), while a negative <em>node</em> bottom margin now pulls
+ * following content up — symmetric with a negative top margin, which was already
+ * honoured. Previously the vertical flow silently dropped it.
+ */
+class NegativeMarginTest {
+
+    @Test
+    void negativePageMarginIsRejectedViaTheBuilder() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> GraphCompose.document().pageSize(300, 300).margin(-2, 0, 0, 0).create())
+                .withMessageContaining("bleed");
+    }
+
+    @Test
+    void negativePageMarginIsRejectedViaTheSessionSetter() {
+        try (DocumentSession session = GraphCompose.document().pageSize(300, 300).create()) {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> session.margin(new DocumentInsets(0, 0, -5, 0)))
+                    .withMessageContaining("non-negative");
+        }
+    }
+
+    @Test
+    void zeroAndPositivePageMarginAreAccepted() {
+        GraphCompose.document().pageSize(300, 300).margin(0, 0, 0, 0).create().close();
+        GraphCompose.document().pageSize(300, 300).margin(DocumentInsets.of(24)).create().close();
+    }
+
+    @Test
+    void negativeBottomNodeMarginPullsFollowingContentUp() {
+        double baseline = followingNodeY(0);
+        double pulled = followingNodeY(-20);
+
+        // y grows upward, so "pulled up" means a larger y; the shift equals the margin.
+        assertThat(pulled).isGreaterThan(baseline);
+        assertThat(pulled - baseline).isCloseTo(20.0, within(0.5));
+    }
+
+    /** Lays out [filler, section A (bottom margin = m), section B] and returns B's placed y. */
+    private double followingNodeY(double aBottomMargin) {
+        try (DocumentSession session = GraphCompose.document()
+                .pageSize(240, 400)
+                .margin(DocumentInsets.of(20))
+                .create()) {
+            session.pageFlow(page -> {
+                page.addParagraph("filler so the cursor is well below the page top");
+                page.addSection(s -> s.name("A")
+                        .margin(new DocumentInsets(0, 0, aBottomMargin, 0))
+                        .addParagraph("A"));
+                page.addSection(s -> s.name("B").addParagraph("B"));
+            });
+            PlacedNode b = session.layoutGraph().nodes().stream()
+                    .filter(n -> "B".equals(n.semanticName()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("section B not found in layout graph"));
+            return b.placementY();
+        }
+    }
+}


### PR DESCRIPTION
## Why

Two sides of the same gap in how the layout flow treats a negative margin:

- A **negative bottom margin** on a section/container was **silently dropped** — the vertical flow's bottom-edge advance early-returned on any non-positive amount, so the "pull the next block up" you'd expect (and that a negative *top* margin already gives) just didn't happen.
- A **negative page margin** was **silently accepted**, which makes the content area *larger* than the sheet, so content quietly overflowed the trimmed page.

## What changed

- **Engine:** composites now close their bottom edge through a new `closeBottomSpace`. A positive bottom inset advances the flow as before; a negative one pulls the following sibling up — symmetric with a negative top margin, which already offsets via `placementTopY`. The top-of-node reservation, the inter-child spacing, and the row/leaf paths are **untouched** (rows/leaves already fold the bottom inset into their positive content height), so **every existing layout is byte-identical**.
- **Public API:** `DocumentSession.margin(...)` (and the builder's `margin(...)`) now reject a negative page margin with `IllegalArgumentException`, pointing the caller at a node's `bleed(...)` to reach the page edge. **Node** margins still allow negatives — they're a legitimate overlap/inset trick (e.g. a widget pulling up over the band above it).

Lane: shared-engine (`LayoutCompiler`) + canonical (`DocumentSession`). Purely additive at the signature level → japicmp-safe.

## Verification

- `./mvnw test -pl .` — **1530 green, 0 visual baselines changed** (the engine change is byte-identical for all existing content; the EPS boundary was checked to confirm no divergence for non-negative bottom insets).
- `NegativeMarginTest`: negative page margin rejected **via the builder** and **via the session setter**, zero/positive accepted, and a section with a negative bottom margin **shifts the following section up by exactly that margin**.

Behavior note: callers that previously passed a negative *page* margin (and got silent overflow) now get a clear exception — intended, and called out in the CHANGELOG.