### PR TITLE
docs(test): state test invariants directly instead of citing internal plan refs

### DIFF
--- a/src/test/java/com/demcha/compose/document/dsl/InlineHighlightRenderTest.java
+++ b/src/test/java/com/demcha/compose/document/dsl/InlineHighlightRenderTest.java
@@ -133,7 +133,7 @@ class InlineHighlightRenderTest {
 
     @Test
     void multiWordChipStaysOneSpanAndCollapsesNewlines() throws Exception {
-        // PR-1 invariant: a chip is one atomic token — a multi-word chip is a
+        // Invariant: a chip is one atomic token — a multi-word chip is a
         // single span (not split per word), and an embedded newline collapses to
         // a space (unlike a plain text run, which would split into lines).
         List<ParagraphTextSpan> badge = textSpans(p -> p.inlineChip(" On hold ", DocumentColor.rgb(146, 64, 14), FILL));
@@ -151,7 +151,7 @@ class InlineHighlightRenderTest {
 
     @Test
     void overWideAtomicChipRendersWithoutThrowing() throws Exception {
-        // A chip wider than the column is emitted on its own line (PR-1 atomic);
+        // A chip wider than the column is emitted on its own line (atomic);
         // it must still render the text on one page without throwing.
         byte[] pdf;
         try (DocumentSession session = GraphCompose.document().pageSize(90, 140).margin(10, 10, 10, 10).create()) {

--- a/src/test/java/com/demcha/compose/document/templates/coverletter/presets/PresetVisualParityTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/coverletter/presets/PresetVisualParityTest.java
@@ -24,9 +24,9 @@ import java.util.stream.Stream;
  * <p>Each preset renders a fixed canonical {@link CoverLetterSpec} on
  * full A4 with the gallery-standard 48pt margin, the resulting PDF is
  * rasterized via PDFBox, and the per-pixel diff against a checked-in
- * baseline PNG is asserted to stay within the budget specified in
- * {@code docs/private/templates-restructure-plan.md} sec 6.2 (2500
- * mismatched pixels at per-channel tolerance 8). Re-run with
+ * baseline PNG is asserted to stay within the {@code PIXEL_DIFF_BUDGET}
+ * mismatched-pixel budget at {@code PER_PIXEL_TOLERANCE} per-channel
+ * colour tolerance. Re-run with
  * {@code -Dgraphcompose.visual.approve=true} to refresh the baselines
  * after a deliberate visual change.</p>
  *

--- a/src/test/java/com/demcha/compose/document/templates/cv/presets/PresetVisualParityTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/presets/PresetVisualParityTest.java
@@ -29,9 +29,9 @@ import java.util.stream.Stream;
  * <p>Each preset renders a fixed canonical {@link CvSpec} on full A4
  * with the preset's {@code RECOMMENDED_MARGIN}, the resulting PDF is
  * rasterized via PDFBox, and the per-pixel diff against a checked-in
- * baseline PNG is asserted to stay within the budget specified in
- * {@code docs/private/templates-restructure-plan.md} sec 6.2 (2500
- * mismatched pixels at per-channel tolerance 8). Re-run with
+ * baseline PNG is asserted to stay within the {@code PIXEL_DIFF_BUDGET}
+ * mismatched-pixel budget at {@code PER_PIXEL_TOLERANCE} per-channel
+ * colour tolerance. Re-run with
  * {@code -Dgraphcompose.visual.approve=true} to refresh the baselines
  * after a deliberate visual change.</p>
  *

--- a/src/test/java/com/demcha/documentation/VersionConsistencyGuardTest.java
+++ b/src/test/java/com/demcha/documentation/VersionConsistencyGuardTest.java
@@ -75,7 +75,7 @@ class VersionConsistencyGuardTest {
         // the sibling module's source), so the ${graphcompose.fonts.version}
         // property that pins the artifact lives only in the modules that consume
         // it: the aggregator (inherited by examples + benchmarks) and the bundle.
-        // This guards the PR-7.1 drift class: those must always agree, even
+        // This guards the version-literal drift class: those must always agree, even
         // though they differ from the engine version line.
         String aggregator = fontsVersionProperty(PROJECT_ROOT.resolve("aggregator/pom.xml"));
 


### PR DESCRIPTION
## Why

Several merged test files referenced internal planning identifiers and a gitignored planning-doc path in their comments and Javadoc. A public reader of the repo cannot resolve those references, so they read as noise rather than documentation.

## What changed

Reworded the affected comments/Javadoc to describe the invariant or behaviour each test guards, directly:

- **`InlineHighlightRenderTest`** — the chip-is-one-atomic-token invariant, and the over-wide-chip-emitted-on-its-own-line behaviour.
- **`cv` + `coverletter` `PresetVisualParityTest`** — the pixel-diff parity gate now points at its in-source `PIXEL_DIFF_BUDGET` / `PER_PIXEL_TOLERANCE` constants, also dropping a stale figure that contradicted them.
- **`VersionConsistencyGuardTest`** — the version-literal drift class it guards.

`CanonicalSurfaceGuardTest` is intentionally left unchanged — excluding the gitignored planning directory is the behaviour under test there.

No production code, public API, or test behaviour changes; comments/Javadoc only.

## Verification

- `./mvnw test -Dtest=InlineHighlightRenderTest,PresetVisualParityTest,VersionConsistencyGuardTest -pl .` → 49 passed, 0 failures.
- `./mvnw -q compile -pl .` → clean.