### PR TITLE
refactor(templates): extract the theme layer to templates.core (CvTheme → BrandTheme)

### DIFF
--- a/examples/src/main/java/com/demcha/examples/flagships/EngineShowcase.java
+++ b/examples/src/main/java/com/demcha/examples/flagships/EngineShowcase.java
@@ -174,7 +174,7 @@ public final class EngineShowcase {
                                     "Identical input, identical PDF — byte-comparable. Layout snapshots, JMH-benchmarked hot paths."))
                             .addSection("CapTheme", section -> capabilityColumn(section,
                                     "CINEMATIC THEMING",
-                                    "BusinessTheme · CvTheme palettes, component-level tokens, v2 layered preset architecture.")))
+                                    "BusinessTheme · BrandTheme palettes, component-level tokens, v2 layered preset architecture.")))
 
                     // ── Footer brand stripe ───────────────────────
                     .addShape(s -> s.size(516, 0.6).fillColor(RULE)

--- a/examples/src/main/java/com/demcha/examples/templates/cv/v2/CvBoxedV2Example.java
+++ b/examples/src/main/java/com/demcha/examples/templates/cv/v2/CvBoxedV2Example.java
@@ -14,7 +14,7 @@ import java.nio.file.Path;
 /**
  * Renders the v2 Boxed Sections CV preset against the structured
  * {@code CvDocument} sample data using the default
- * {@code CvTheme.boxedClassic()} theme.
+ * {@code BrandTheme.boxedClassic()} theme.
  *
  * <p>Output:
  * {@code examples/target/generated-pdfs/templates/cv/cv-boxed-sections-v2.pdf}.</p>

--- a/src/main/java/com/demcha/compose/GraphCompose.java
+++ b/src/main/java/com/demcha/compose/GraphCompose.java
@@ -123,7 +123,7 @@ public final class GraphCompose {
      * Returns the logical font families bundled with GraphCompose out of the box.
      *
      * <p>The returned names are the identifiers used by {@code DocumentTextStyle},
-     * {@code CvTheme}, and the font library. They describe what can be referenced
+     * {@code BrandTheme}, and the font library. They describe what can be referenced
      * immediately without registering custom font families.</p>
      */
     public static List<FontName> availableFonts() {

--- a/src/main/java/com/demcha/compose/document/templates/core/theme/BrandTheme.java
+++ b/src/main/java/com/demcha/compose/document/templates/core/theme/BrandTheme.java
@@ -1,4 +1,4 @@
-package com.demcha.compose.document.templates.cv.v2.theme;
+package com.demcha.compose.document.templates.core.theme;
 
 import com.demcha.compose.document.style.DocumentColor;
 import com.demcha.compose.document.style.DocumentTextDecoration;
@@ -16,7 +16,7 @@ import java.util.Objects;
  * RGB tuples, font names, or magic numbers.</p>
  *
  * <p>To define a new visual flavour: add a static factory here
- * returning a fresh {@code CvTheme} with custom sub-records. The
+ * returning a fresh {@code BrandTheme} with custom sub-records. The
  * existing preset code keeps working — only the theme handed to
  * {@code BoxedSections.create(theme)} changes.</p>
  *
@@ -25,15 +25,15 @@ import java.util.Objects;
  * @param spacing    paddings / margins / weights
  * @param decoration glyph / separator tokens
  */
-public record CvTheme(CvPalette palette,
-                      CvTypography typography,
-                      CvSpacing spacing,
-                      CvDecoration decoration) {
+public record BrandTheme(Palette palette,
+                      Typography typography,
+                      Spacing spacing,
+                      Decoration decoration) {
 
     /**
      * Validates that no sub-record is null.
      */
-    public CvTheme {
+    public BrandTheme {
         Objects.requireNonNull(palette, "palette");
         Objects.requireNonNull(typography, "typography");
         Objects.requireNonNull(spacing, "spacing");
@@ -42,21 +42,21 @@ public record CvTheme(CvPalette palette,
 
     /**
      * Backward-compatible 3-arg constructor that fills the
-     * {@link CvDecoration} slot with {@link CvDecoration#classic()}.
+     * {@link Decoration} slot with {@link Decoration#classic()}.
      * Retained so callers built before the decoration token landed
      * keep compiling and behaving identically.
      *
      * @param palette    colour tokens
      * @param typography font + size scale
      * @param spacing    paddings / margins / weights
-     * @deprecated since the introduction of {@link CvDecoration} —
+     * @deprecated since the introduction of {@link Decoration} —
      * pass an explicit decoration so callers can choose
      * a different bullet glyph or contact separator
      * without forking the renderer.
      */
     @Deprecated
-    public CvTheme(CvPalette palette, CvTypography typography, CvSpacing spacing) {
-        this(palette, typography, spacing, CvDecoration.classic());
+    public BrandTheme(Palette palette, Typography typography, Spacing spacing) {
+        this(palette, typography, spacing, Decoration.classic());
     }
 
     // -- canonical factories ---------------------------------------------
@@ -67,14 +67,14 @@ public record CvTheme(CvPalette palette,
      * separators. Visual signature of the original
      * {@code cv-boxed-sections.pdf} reference output.
      *
-     * @return a {@code CvTheme} for the "Boxed Sections" classic look
+     * @return a {@code BrandTheme} for the "Boxed Sections" classic look
      */
-    public static CvTheme boxedClassic() {
-        return new CvTheme(
-                CvPalette.classic(),
-                CvTypography.classic(),
-                CvSpacing.classic(),
-                CvDecoration.classic());
+    public static BrandTheme boxedClassic() {
+        return new BrandTheme(
+                Palette.classic(),
+                Typography.classic(),
+                Spacing.classic(),
+                Decoration.classic());
     }
 
     /**
@@ -85,17 +85,17 @@ public record CvTheme(CvPalette palette,
      * shared with any other v2 preset today.
      *
      * <p>When (or if) a second preset wants the same accent palette,
-     * extract those colours into a new field on {@link CvPalette} and
+     * extract those colours into a new field on {@link Palette} and
      * point both presets at it.</p>
      *
-     * @return a {@code CvTheme} for the "Modern Professional" look
+     * @return a {@code BrandTheme} for the "Modern Professional" look
      */
-    public static CvTheme modernProfessional() {
-        return new CvTheme(
-                CvPalette.classic(),
-                CvTypography.modernProfessional(),
-                CvSpacing.modernProfessional(),
-                CvDecoration.classic());
+    public static BrandTheme modernProfessional() {
+        return new BrandTheme(
+                Palette.classic(),
+                Typography.modernProfessional(),
+                Spacing.modernProfessional(),
+                Decoration.classic());
     }
 
     /**
@@ -105,14 +105,14 @@ public record CvTheme(CvPalette palette,
      * each module. Pipe contact separator matches the classic
      * decoration.
      *
-     * @return a {@code CvTheme} for the "Centered Headline" look
+     * @return a {@code BrandTheme} for the "Centered Headline" look
      */
-    public static CvTheme centeredHeadline() {
-        return new CvTheme(
-                CvPalette.centeredHeadline(),
-                CvTypography.centeredHeadline(),
-                CvSpacing.centeredHeadline(),
-                CvDecoration.classic());
+    public static BrandTheme centeredHeadline() {
+        return new BrandTheme(
+                Palette.centeredHeadline(),
+                Typography.centeredHeadline(),
+                Spacing.centeredHeadline(),
+                Decoration.classic());
     }
 
     /**
@@ -120,14 +120,14 @@ public record CvTheme(CvPalette palette,
      * tan rules, cream profile band, and the roomy pipe separator
      * from the classic decoration.
      *
-     * @return a {@code CvTheme} for the "Classic Serif" look
+     * @return a {@code BrandTheme} for the "Classic Serif" look
      */
-    public static CvTheme classicSerif() {
-        return new CvTheme(
-                CvPalette.classicSerif(),
-                CvTypography.classicSerif(),
-                CvSpacing.classicSerif(),
-                CvDecoration.classic());
+    public static BrandTheme classicSerif() {
+        return new BrandTheme(
+                Palette.classicSerif(),
+                Typography.classicSerif(),
+                Spacing.classicSerif(),
+                Decoration.classic());
     }
 
     /**
@@ -135,14 +135,14 @@ public record CvTheme(CvPalette palette,
      * deep blue-green ink, pale teal profile band/rules, and compact
      * two-column spacing.
      *
-     * @return a {@code CvTheme} for the "Nordic Clean" look
+     * @return a {@code BrandTheme} for the "Nordic Clean" look
      */
-    public static CvTheme nordicClean() {
-        return new CvTheme(
-                CvPalette.nordicClean(),
-                CvTypography.nordicClean(),
-                CvSpacing.nordicClean(),
-                CvDecoration.classic());
+    public static BrandTheme nordicClean() {
+        return new BrandTheme(
+                Palette.nordicClean(),
+                Typography.nordicClean(),
+                Spacing.nordicClean(),
+                Decoration.classic());
     }
 
     /**
@@ -150,14 +150,14 @@ public record CvTheme(CvPalette palette,
      * Mono labels, teal accents, pale left rail, and compact card
      * spacing.
      *
-     * @return a {@code CvTheme} for the "Compact Mono" look
+     * @return a {@code BrandTheme} for the "Compact Mono" look
      */
-    public static CvTheme compactMono() {
-        return new CvTheme(
-                CvPalette.compactMono(),
-                CvTypography.compactMono(),
-                CvSpacing.compactMono(),
-                CvDecoration.compactMono());
+    public static BrandTheme compactMono() {
+        return new BrandTheme(
+                Palette.compactMono(),
+                Typography.compactMono(),
+                Spacing.compactMono(),
+                Decoration.compactMono());
     }
 
     /**
@@ -165,14 +165,14 @@ public record CvTheme(CvPalette palette,
      * compact spacing, blue full-width section banners, and tighter
      * pipe separators.
      *
-     * @return a {@code CvTheme} for the "Blue Banner" look
+     * @return a {@code BrandTheme} for the "Blue Banner" look
      */
-    public static CvTheme blueBanner() {
-        return new CvTheme(
-                CvPalette.blueBanner(),
-                CvTypography.blueBanner(),
-                CvSpacing.blueBanner(),
-                CvDecoration.blueBanner());
+    public static BrandTheme blueBanner() {
+        return new BrandTheme(
+                Palette.blueBanner(),
+                Typography.blueBanner(),
+                Spacing.blueBanner(),
+                Decoration.blueBanner());
     }
 
     /**
@@ -180,14 +180,14 @@ public record CvTheme(CvPalette palette,
      * section rules, centred editorial header, and dense body
      * spacing.
      *
-     * @return a {@code CvTheme} for the "Editorial Blue" look
+     * @return a {@code BrandTheme} for the "Editorial Blue" look
      */
-    public static CvTheme editorialBlue() {
-        return new CvTheme(
-                CvPalette.editorialBlue(),
-                CvTypography.editorialBlue(),
-                CvSpacing.editorialBlue(),
-                CvDecoration.classic());
+    public static BrandTheme editorialBlue() {
+        return new BrandTheme(
+                Palette.editorialBlue(),
+                Typography.editorialBlue(),
+                Spacing.editorialBlue(),
+                Decoration.classic());
     }
 
     /**
@@ -200,14 +200,14 @@ public record CvTheme(CvPalette palette,
      * timeline. Visual signature ported from the v1
      * {@code SidebarPortraitCvTemplateComposer}.
      *
-     * @return a {@code CvTheme} for the "Sidebar Portrait" look
+     * @return a {@code BrandTheme} for the "Sidebar Portrait" look
      */
-    public static CvTheme sidebarPortrait() {
-        return new CvTheme(
-                CvPalette.sidebarPortrait(),
-                CvTypography.sidebarPortrait(),
-                CvSpacing.sidebarPortrait(),
-                CvDecoration.classic());
+    public static BrandTheme sidebarPortrait() {
+        return new BrandTheme(
+                Palette.sidebarPortrait(),
+                Typography.sidebarPortrait(),
+                Spacing.sidebarPortrait(),
+                Decoration.classic());
     }
 
     /**
@@ -219,14 +219,14 @@ public record CvTheme(CvPalette palette,
      * signature ported from the v1
      * {@code MonogramSidebarCvTemplateComposer}.
      *
-     * @return a {@code CvTheme} for the "Monogram Sidebar" look
+     * @return a {@code BrandTheme} for the "Monogram Sidebar" look
      */
-    public static CvTheme monogramSidebar() {
-        return new CvTheme(
-                CvPalette.monogramSidebar(),
-                CvTypography.monogramSidebar(),
-                CvSpacing.monogramSidebar(),
-                CvDecoration.classic());
+    public static BrandTheme monogramSidebar() {
+        return new BrandTheme(
+                Palette.monogramSidebar(),
+                Typography.monogramSidebar(),
+                Spacing.monogramSidebar(),
+                Decoration.classic());
     }
 
     /**
@@ -237,14 +237,14 @@ public record CvTheme(CvPalette palette,
      * Visual signature ported from the v1
      * {@code TechLeadCvTemplateComposer}.
      *
-     * @return a {@code CvTheme} for the "Engineering Resume" look
+     * @return a {@code BrandTheme} for the "Engineering Resume" look
      */
-    public static CvTheme engineeringResume() {
-        return new CvTheme(
-                CvPalette.engineeringResume(),
-                CvTypography.engineeringResume(),
-                CvSpacing.engineeringResume(),
-                CvDecoration.classic());
+    public static BrandTheme engineeringResume() {
+        return new BrandTheme(
+                Palette.engineeringResume(),
+                Typography.engineeringResume(),
+                Spacing.engineeringResume(),
+                Decoration.classic());
     }
 
     /**
@@ -255,14 +255,14 @@ public record CvTheme(CvPalette palette,
      * Visual signature ported from the v1
      * {@code TimelineMinimalCvTemplateComposer}.
      *
-     * @return a {@code CvTheme} for the "Timeline Minimal" look
+     * @return a {@code BrandTheme} for the "Timeline Minimal" look
      */
-    public static CvTheme timelineMinimal() {
-        return new CvTheme(
-                CvPalette.timelineMinimal(),
-                CvTypography.timelineMinimal(),
-                CvSpacing.timelineMinimal(),
-                CvDecoration.classic());
+    public static BrandTheme timelineMinimal() {
+        return new BrandTheme(
+                Palette.timelineMinimal(),
+                Typography.timelineMinimal(),
+                Spacing.timelineMinimal(),
+                Decoration.classic());
     }
 
     /**
@@ -272,14 +272,14 @@ public record CvTheme(CvPalette palette,
      * strip beneath each title. Visual signature ported from the v1
      * {@code PanelCvTemplateComposer} (ProductLeader tokens).
      *
-     * @return a {@code CvTheme} for the "Panel" look
+     * @return a {@code BrandTheme} for the "Panel" look
      */
-    public static CvTheme panel() {
-        return new CvTheme(
-                CvPalette.panel(),
-                CvTypography.panel(),
-                CvSpacing.panel(),
-                CvDecoration.classic());
+    public static BrandTheme panel() {
+        return new BrandTheme(
+                Palette.panel(),
+                Typography.panel(),
+                Spacing.panel(),
+                Decoration.classic());
     }
 
     /**
@@ -289,14 +289,14 @@ public record CvTheme(CvPalette palette,
      * Visual signature ported from the legacy
      * {@code ExecutiveSlateCvTemplate}.
      *
-     * @return a {@code CvTheme} for the "Executive" look
+     * @return a {@code BrandTheme} for the "Executive" look
      */
-    public static CvTheme executive() {
-        return new CvTheme(
-                CvPalette.executive(),
-                CvTypography.executive(),
-                CvSpacing.executive(),
-                CvDecoration.classic());
+    public static BrandTheme executive() {
+        return new BrandTheme(
+                Palette.executive(),
+                Typography.executive(),
+                Spacing.executive(),
+                Decoration.classic());
     }
 
     /**
@@ -309,14 +309,14 @@ public record CvTheme(CvPalette palette,
      * awards, references). Paired 1:1 with the Mint Editorial cover
      * letter, which reuses this exact theme.
      *
-     * @return a {@code CvTheme} for the "Mint Editorial" look
+     * @return a {@code BrandTheme} for the "Mint Editorial" look
      */
-    public static CvTheme mintEditorial() {
-        return new CvTheme(
-                CvPalette.mintEditorial(),
-                CvTypography.mintEditorial(),
-                CvSpacing.mintEditorial(),
-                CvDecoration.classic());
+    public static BrandTheme mintEditorial() {
+        return new BrandTheme(
+                Palette.mintEditorial(),
+                Typography.mintEditorial(),
+                Spacing.mintEditorial(),
+                Decoration.classic());
     }
     // -- pre-built text-style helpers ------------------------------------
     // Renderers ask the theme for an already-composed DocumentTextStyle

--- a/src/main/java/com/demcha/compose/document/templates/core/theme/Decoration.java
+++ b/src/main/java/com/demcha/compose/document/templates/core/theme/Decoration.java
@@ -1,9 +1,9 @@
-package com.demcha.compose.document.templates.cv.v2.theme;
+package com.demcha.compose.document.templates.core.theme;
 
 import java.util.Objects;
 
 /**
- * Glyph / separator tokens for a {@link CvTheme} — the small "what
+ * Glyph / separator tokens for a {@link BrandTheme} — the small "what
  * character renders here" decisions that vary per visual flavour but
  * never depend on the layout or the data.
  *
@@ -11,7 +11,7 @@ import java.util.Objects;
  * to {@code ▶}", "I want to use {@code  · } as the contact-line
  * separator instead of pipes", or "I want stacked-body lines to align
  * with a 3-space indent instead of 2". None of these need a custom
- * renderer — pass a different {@code CvDecoration} into your theme.</p>
+ * renderer — pass a different {@code Decoration} into your theme.</p>
  *
  * <p>Decorations live in the {@code theme} layer because they are
  * cosmetic. They are <strong>not</strong> renderer constants:
@@ -30,14 +30,14 @@ import java.util.Objects;
  *                         address / links on the contact row
  *                         (e.g. {@code "   |   "}, {@code "  ·  "})
  */
-public record CvDecoration(String bulletGlyph,
+public record Decoration(String bulletGlyph,
                            String stackedIndent,
                            String contactSeparator) {
 
     /**
      * Validates that no token is null.
      */
-    public CvDecoration {
+    public Decoration {
         Objects.requireNonNull(bulletGlyph, "bulletGlyph");
         Objects.requireNonNull(stackedIndent, "stackedIndent");
         Objects.requireNonNull(contactSeparator, "contactSeparator");
@@ -45,22 +45,22 @@ public record CvDecoration(String bulletGlyph,
 
     /**
      * The classic decoration: round bullet, two-space stacked indent,
-     * pipe contact separator. Used by {@link CvTheme#boxedClassic()}.
+     * pipe contact separator. Used by {@link BrandTheme#boxedClassic()}.
      *
-     * @return a {@code CvDecoration} for the classic look
+     * @return a {@code Decoration} for the classic look
      */
-    public static CvDecoration classic() {
-        return new CvDecoration("• ", "  ", "   |   ");
+    public static Decoration classic() {
+        return new Decoration("• ", "  ", "   |   ");
     }
 
     /**
      * Blue Banner keeps classic bullets but uses the tighter contact
      * separator spacing from the legacy preset.
      *
-     * @return a {@code CvDecoration} for the Blue Banner look
+     * @return a {@code Decoration} for the Blue Banner look
      */
-    public static CvDecoration blueBanner() {
-        return new CvDecoration("• ", "  ", "  |  ");
+    public static Decoration blueBanner() {
+        return new Decoration("• ", "  ", "  |  ");
     }
 
     /**
@@ -68,9 +68,9 @@ public record CvDecoration(String bulletGlyph,
      * command-bar header. Row bullets keep the classic glyph for
      * callers that reuse shared row renderers with this theme.
      *
-     * @return a {@code CvDecoration} for the Compact Mono look
+     * @return a {@code Decoration} for the Compact Mono look
      */
-    public static CvDecoration compactMono() {
-        return new CvDecoration("• ", "  ", "  /  ");
+    public static Decoration compactMono() {
+        return new Decoration("• ", "  ", "  /  ");
     }
 }

--- a/src/main/java/com/demcha/compose/document/templates/core/theme/Palette.java
+++ b/src/main/java/com/demcha/compose/document/templates/core/theme/Palette.java
@@ -1,11 +1,11 @@
-package com.demcha.compose.document.templates.cv.v2.theme;
+package com.demcha.compose.document.templates.core.theme;
 
 import com.demcha.compose.document.style.DocumentColor;
 
 import java.util.Objects;
 
 /**
- * Colour tokens for a {@link CvTheme}.
+ * Colour tokens for a {@link BrandTheme}.
  *
  * @param ink      primary text colour — headlines, body, entry titles
  * @param muted    secondary text colour — italic subtitles (employer,
@@ -18,7 +18,7 @@ import java.util.Objects;
  *                 {@link DocumentColor#WHITE} for palettes that do not
  *                 need a custom main-area fill.
  */
-public record CvPalette(DocumentColor ink,
+public record Palette(DocumentColor ink,
                         DocumentColor muted,
                         DocumentColor rule,
                         DocumentColor banner,
@@ -27,7 +27,7 @@ public record CvPalette(DocumentColor ink,
     /**
      * Validates that no colour token is null.
      */
-    public CvPalette {
+    public Palette {
         Objects.requireNonNull(ink, "ink");
         Objects.requireNonNull(muted, "muted");
         Objects.requireNonNull(rule, "rule");
@@ -48,7 +48,7 @@ public record CvPalette(DocumentColor ink,
      * @param rule   thin horizontal rules + the contact-line pipe glyph
      * @param banner pale fill behind section title banners
      */
-    public CvPalette(DocumentColor ink,
+    public Palette(DocumentColor ink,
                      DocumentColor muted,
                      DocumentColor rule,
                      DocumentColor banner) {
@@ -59,10 +59,10 @@ public record CvPalette(DocumentColor ink,
      * The classic dark-grey / pale-grey palette used by the original
      * Boxed Sections preset.
      *
-     * @return a {@code CvPalette} for the classic flavour
+     * @return a {@code Palette} for the classic flavour
      */
-    public static CvPalette classic() {
-        return new CvPalette(
+    public static Palette classic() {
+        return new Palette(
                 DocumentColor.rgb(34, 34, 34),
                 DocumentColor.rgb(120, 120, 120),
                 DocumentColor.rgb(170, 170, 170),
@@ -81,10 +81,10 @@ public record CvPalette(DocumentColor ink,
      * style without leaving an obvious gap if a future preset reuses
      * this palette with a banner-style section header.</p>
      *
-     * @return a {@code CvPalette} for the Centered Headline flavour
+     * @return a {@code Palette} for the Centered Headline flavour
      */
-    public static CvPalette centeredHeadline() {
-        return new CvPalette(
+    public static Palette centeredHeadline() {
+        return new Palette(
                 DocumentColor.rgb(54, 54, 54),     // ink (#363636)
                 DocumentColor.rgb(105, 105, 105),  // muted / soft (#696969)
                 DocumentColor.rgb(188, 188, 188),  // rule (#BCBCBC)
@@ -97,10 +97,10 @@ public record CvPalette(DocumentColor ink,
      * its profile band; the bronze accent is preset-local because no
      * other preset shares that fifth colour token today.
      *
-     * @return a {@code CvPalette} for the Classic Serif flavour
+     * @return a {@code Palette} for the Classic Serif flavour
      */
-    public static CvPalette classicSerif() {
-        return new CvPalette(
+    public static Palette classicSerif() {
+        return new Palette(
                 DocumentColor.rgb(45, 43, 40),
                 DocumentColor.rgb(105, 101, 94),
                 DocumentColor.rgb(187, 177, 160),
@@ -113,10 +113,10 @@ public record CvPalette(DocumentColor ink,
      * stronger teal accent and rail fill are preset-local fifth/sixth
      * colours because no other preset shares those tokens yet.
      *
-     * @return a {@code CvPalette} for the Nordic Clean flavour
+     * @return a {@code Palette} for the Nordic Clean flavour
      */
-    public static CvPalette nordicClean() {
-        return new CvPalette(
+    public static Palette nordicClean() {
+        return new Palette(
                 DocumentColor.rgb(18, 39, 52),
                 DocumentColor.rgb(82, 104, 116),
                 DocumentColor.rgb(188, 219, 222),
@@ -128,10 +128,10 @@ public record CvPalette(DocumentColor ink,
      * quiet card rules, and the pale rail fill used by the compact
      * left column.
      *
-     * @return a {@code CvPalette} for the Compact Mono flavour
+     * @return a {@code Palette} for the Compact Mono flavour
      */
-    public static CvPalette compactMono() {
-        return new CvPalette(
+    public static Palette compactMono() {
+        return new Palette(
                 DocumentColor.rgb(28, 34, 42),
                 DocumentColor.rgb(102, 117, 132),
                 DocumentColor.rgb(188, 204, 215),
@@ -142,10 +142,10 @@ public record CvPalette(DocumentColor ink,
      * Blue Banner palette: compact dark ink, blue section fills, and
      * darker blue separator rules.
      *
-     * @return a {@code CvPalette} for the Blue Banner flavour
+     * @return a {@code Palette} for the Blue Banner flavour
      */
-    public static CvPalette blueBanner() {
-        return new CvPalette(
+    public static Palette blueBanner() {
+        return new Palette(
                 DocumentColor.rgb(20, 25, 35),
                 DocumentColor.rgb(85, 85, 85),
                 DocumentColor.rgb(58, 82, 118),
@@ -157,10 +157,10 @@ public record CvPalette(DocumentColor ink,
      * subtitles, vivid blue rules, and a neutral border token reused
      * by compact skill grids.
      *
-     * @return a {@code CvPalette} for the Editorial Blue flavour
+     * @return a {@code Palette} for the Editorial Blue flavour
      */
-    public static CvPalette editorialBlue() {
-        return new CvPalette(
+    public static Palette editorialBlue() {
+        return new Palette(
                 DocumentColor.rgb(60, 72, 106),
                 DocumentColor.rgb(150, 158, 178),
                 DocumentColor.rgb(86, 136, 255),
@@ -176,10 +176,10 @@ public record CvPalette(DocumentColor ink,
      * the same {@code ink}/{@code muted} pair because the preset uses
      * a restrained grey palette throughout.
      *
-     * @return a {@code CvPalette} for the Sidebar Portrait flavour
+     * @return a {@code Palette} for the Sidebar Portrait flavour
      */
-    public static CvPalette sidebarPortrait() {
-        return new CvPalette(
+    public static Palette sidebarPortrait() {
+        return new Palette(
                 DocumentColor.rgb(34, 34, 34),     // ink — V1 INK
                 DocumentColor.rgb(85, 85, 85),     // muted — V1 SOFT
                 DocumentColor.rgb(178, 178, 178),  // rule — V1 RULE
@@ -194,10 +194,10 @@ public record CvPalette(DocumentColor ink,
      * and muted-gold accent stay preset-local because no other v2
      * preset shares them today.
      *
-     * @return a {@code CvPalette} for the Monogram Sidebar flavour
+     * @return a {@code Palette} for the Monogram Sidebar flavour
      */
-    public static CvPalette monogramSidebar() {
-        return new CvPalette(
+    public static Palette monogramSidebar() {
+        return new Palette(
                 DocumentColor.rgb(37, 45, 58),     // ink — V1 INK
                 DocumentColor.rgb(112, 119, 125),  // muted — V1 SOFT
                 DocumentColor.rgb(138, 146, 148),  // rule — V1 SIDEBAR_RULE
@@ -213,10 +213,10 @@ public record CvPalette(DocumentColor ink,
      * cyan-green contact link colour stay preset-local as they are the
      * fifth+ tokens — no other v2 preset shares them today.
      *
-     * @return a {@code CvPalette} for the Engineering Resume flavour
+     * @return a {@code Palette} for the Engineering Resume flavour
      */
-    public static CvPalette engineeringResume() {
-        return new CvPalette(
+    public static Palette engineeringResume() {
+        return new Palette(
                 DocumentColor.rgb(32, 42, 55),     // ink — V1 INK body slate
                 DocumentColor.rgb(91, 105, 119),   // muted — V1 MUTED subtitles
                 DocumentColor.rgb(190, 212, 204),  // rule — V1 RULE pale teal-green
@@ -230,10 +230,10 @@ public record CvPalette(DocumentColor ink,
      * timeline axis and module underlines, and the dot token reused
      * for the three circles of the central timeline axis.
      *
-     * @return a {@code CvPalette} for the Timeline Minimal flavour
+     * @return a {@code Palette} for the Timeline Minimal flavour
      */
-    public static CvPalette timelineMinimal() {
-        return new CvPalette(
+    public static Palette timelineMinimal() {
+        return new Palette(
                 DocumentColor.rgb(74, 74, 74),     // ink — V1 INK
                 DocumentColor.rgb(122, 122, 122),  // muted — V1 SOFT
                 DocumentColor.rgb(195, 195, 195),  // rule — V1 RULE
@@ -249,10 +249,10 @@ public record CvPalette(DocumentColor ink,
      * panel fill are preset-local because they are the fifth/sixth/
      * seventh tokens — other v2 presets do not share them today.
      *
-     * @return a {@code CvPalette} for the Panel flavour
+     * @return a {@code Palette} for the Panel flavour
      */
-    public static CvPalette panel() {
-        return new CvPalette(
+    public static Palette panel() {
+        return new Palette(
                 DocumentColor.rgb(54, 68, 84),     // ink — V1 BODY_TEXT/HEADER_META slate
                 DocumentColor.rgb(105, 117, 132),  // muted — slightly lighter slate
                 DocumentColor.rgb(179, 214, 211),  // rule — V1 PANEL_STROKE pale teal
@@ -269,10 +269,10 @@ public record CvPalette(DocumentColor ink,
      * preset-local because they are the fifth and sixth tokens —
      * other v2 presets do not share them today.
      *
-     * @return a {@code CvPalette} for the Executive flavour
+     * @return a {@code Palette} for the Executive flavour
      */
-    public static CvPalette executive() {
-        return new CvPalette(
+    public static Palette executive() {
+        return new Palette(
                 DocumentColor.rgb(49, 58, 72),     // ink — V1 BODY slate
                 DocumentColor.rgb(105, 115, 130),  // muted — slightly lighter slate
                 DocumentColor.rgb(193, 201, 211),  // rule — V1 MUTED_RULE
@@ -289,10 +289,10 @@ public record CvPalette(DocumentColor ink,
      * {@code palette.banner()} as the single accent source, so the
      * matched set never forks the colour.
      *
-     * @return a {@code CvPalette} for the Mint Editorial flavour
+     * @return a {@code Palette} for the Mint Editorial flavour
      */
-    public static CvPalette mintEditorial() {
-        return new CvPalette(
+    public static Palette mintEditorial() {
+        return new Palette(
                 DocumentColor.rgb(24, 24, 24),     // ink (black)
                 DocumentColor.rgb(82, 82, 82),     // muted
                 DocumentColor.rgb(70, 70, 70),     // rule (skill-bar track)

--- a/src/main/java/com/demcha/compose/document/templates/core/theme/Spacing.java
+++ b/src/main/java/com/demcha/compose/document/templates/core/theme/Spacing.java
@@ -1,16 +1,16 @@
-package com.demcha.compose.document.templates.cv.v2.theme;
+package com.demcha.compose.document.templates.core.theme;
 
 import com.demcha.compose.document.style.DocumentInsets;
 
 import java.util.Objects;
 
 /**
- * Layout / spacing tokens for a {@link CvTheme}.
+ * Layout / spacing tokens for a {@link BrandTheme}.
  *
  * <p>Every magic numeric literal that used to live inside a renderer
  * (padding, margin, gap, weight, accent width) now lives here, so a
  * "compact" or "spacious" variant of the same visual is a new
- * {@code CvSpacing} record — not a forked renderer.</p>
+ * {@code Spacing} record — not a forked renderer.</p>
  *
  * @param pageFlowSpacing       gap between top-level page-flow rows
  * @param sectionBodySpacing    gap between paragraphs inside a
@@ -40,7 +40,7 @@ import java.util.Objects;
  *                              ends and the next begins. Not applied
  *                              before the first entry in a section.
  */
-public record CvSpacing(
+public record Spacing(
         double pageFlowSpacing,
         double sectionBodySpacing,
         DocumentInsets sectionBodyPadding,
@@ -59,7 +59,7 @@ public record CvSpacing(
     /**
      * Validates that no inset token is null.
      */
-    public CvSpacing {
+    public Spacing {
         Objects.requireNonNull(sectionBodyPadding, "sectionBodyPadding");
         Objects.requireNonNull(headlinePadding, "headlinePadding");
         Objects.requireNonNull(contactPadding, "contactPadding");
@@ -97,7 +97,7 @@ public record CvSpacing(
      * {@link #modernProfessional()}.
      */
     @Deprecated
-    public CvSpacing(double pageFlowSpacing,
+    public Spacing(double pageFlowSpacing,
                      double sectionBodySpacing,
                      DocumentInsets sectionBodyPadding,
                      DocumentInsets headlinePadding,
@@ -120,10 +120,10 @@ public record CvSpacing(
     /**
      * The classic spacing used by the original Boxed Sections preset.
      *
-     * @return a {@code CvSpacing} for the classic preset
+     * @return a {@code Spacing} for the classic preset
      */
-    public static CvSpacing classic() {
-        return new CvSpacing(
+    public static Spacing classic() {
+        return new Spacing(
                 7,                                       // pageFlowSpacing
                 4,                                       // sectionBodySpacing
                 new DocumentInsets(4, 4, 0, 4),          // sectionBodyPadding
@@ -148,10 +148,10 @@ public record CvSpacing(
      * unused (the preset uses {@code flatSpacedCaps} section headers,
      * not banners).
      *
-     * @return a {@code CvSpacing} for the Centered Headline preset
+     * @return a {@code Spacing} for the Centered Headline preset
      */
-    public static CvSpacing centeredHeadline() {
-        return new CvSpacing(
+    public static Spacing centeredHeadline() {
+        return new Spacing(
                 0,                                       // pageFlowSpacing (zero — rules supply visual gaps)
                 1.5,                                     // sectionBodySpacing
                 DocumentInsets.zero(),                   // sectionBodyPadding
@@ -173,10 +173,10 @@ public record CvSpacing(
      * framed profile band, quiet cover skills module, and compact
      * detail modules.
      *
-     * @return a {@code CvSpacing} for the Classic Serif preset
+     * @return a {@code Spacing} for the Classic Serif preset
      */
-    public static CvSpacing classicSerif() {
-        return new CvSpacing(
+    public static Spacing classicSerif() {
+        return new Spacing(
                 8,                                       // pageFlowSpacing
                 4,                                       // sectionBodySpacing
                 DocumentInsets.zero(),                   // sectionBodyPadding
@@ -197,10 +197,10 @@ public record CvSpacing(
      * Spacing for Nordic Clean: compact top header, soft profile band,
      * and a dense two-column body with a tinted sidebar rail.
      *
-     * @return a {@code CvSpacing} for the Nordic Clean preset
+     * @return a {@code Spacing} for the Nordic Clean preset
      */
-    public static CvSpacing nordicClean() {
-        return new CvSpacing(
+    public static Spacing nordicClean() {
+        return new Spacing(
                 7,                                       // pageFlowSpacing
                 3,                                       // sectionBodySpacing
                 DocumentInsets.zero(),                   // sectionBodyPadding
@@ -221,10 +221,10 @@ public record CvSpacing(
      * Spacing for Compact Mono: command-bar header, dense rail
      * modules, and same-width cards in the right column.
      *
-     * @return a {@code CvSpacing} for the Compact Mono preset
+     * @return a {@code Spacing} for the Compact Mono preset
      */
-    public static CvSpacing compactMono() {
-        return new CvSpacing(
+    public static Spacing compactMono() {
+        return new Spacing(
                 9,                                       // pageFlowSpacing
                 3.5,                                     // sectionBodySpacing
                 DocumentInsets.zero(),                   // sectionBodyPadding
@@ -248,10 +248,10 @@ public record CvSpacing(
      * are left non-zero so a future preset that wants to draw an MP
      * banner can read them; the canonical MP preset ignores them.
      *
-     * @return a {@code CvSpacing} for the Modern Professional preset
+     * @return a {@code Spacing} for the Modern Professional preset
      */
-    public static CvSpacing modernProfessional() {
-        return new CvSpacing(
+    public static Spacing modernProfessional() {
+        return new Spacing(
                 4,                                       // pageFlowSpacing
                 3,                                       // sectionBodySpacing
                 new DocumentInsets(2, 0, 0, 12),         // sectionBodyPadding (left=12 → body indents from blue section title)
@@ -272,10 +272,10 @@ public record CvSpacing(
      * Compact spacing for Blue Banner: tight body blocks, full-width
      * title banners, and no extra artificial gap between entries.
      *
-     * @return a {@code CvSpacing} for the Blue Banner preset
+     * @return a {@code Spacing} for the Blue Banner preset
      */
-    public static CvSpacing blueBanner() {
-        return new CvSpacing(
+    public static Spacing blueBanner() {
+        return new Spacing(
                 4,                                       // pageFlowSpacing
                 3,                                       // sectionBodySpacing
                 new DocumentInsets(3, 4, 0, 4),          // sectionBodyPadding
@@ -296,10 +296,10 @@ public record CvSpacing(
      * Compact spacing for Editorial Blue: section headers own their
      * rule/title rhythm, while bodies start close to the lower rule.
      *
-     * @return a {@code CvSpacing} for the Editorial Blue preset
+     * @return a {@code Spacing} for the Editorial Blue preset
      */
-    public static CvSpacing editorialBlue() {
-        return new CvSpacing(
+    public static Spacing editorialBlue() {
+        return new Spacing(
                 0,                                       // pageFlowSpacing
                 2,                                       // sectionBodySpacing
                 new DocumentInsets(8, 0, 0, 0),          // sectionBodyPadding
@@ -323,10 +323,10 @@ public record CvSpacing(
      * the preset draws its chrome inline (portrait photo, hero strip,
      * rules).
      *
-     * @return a {@code CvSpacing} for the Sidebar Portrait preset
+     * @return a {@code Spacing} for the Sidebar Portrait preset
      */
-    public static CvSpacing sidebarPortrait() {
-        return new CvSpacing(
+    public static Spacing sidebarPortrait() {
+        return new Spacing(
                 0,                                       // pageFlowSpacing
                 5,                                       // sectionBodySpacing
                 DocumentInsets.zero(),                   // sectionBodyPadding
@@ -351,10 +351,10 @@ public record CvSpacing(
      * spacing; banner tokens are unused — the preset only draws the
      * monogram badge and sidebar heading rules inline.
      *
-     * @return a {@code CvSpacing} for the Monogram Sidebar preset
+     * @return a {@code Spacing} for the Monogram Sidebar preset
      */
-    public static CvSpacing monogramSidebar() {
-        return new CvSpacing(
+    public static Spacing monogramSidebar() {
+        return new Spacing(
                 0,                                       // pageFlowSpacing
                 5,                                       // sectionBodySpacing
                 DocumentInsets.zero(),                   // sectionBodyPadding
@@ -377,10 +377,10 @@ public record CvSpacing(
      * a 2.5pt accent rule under the header and tight 1pt paragraph
      * top so the dense rail + card content reads as a single page.
      *
-     * @return a {@code CvSpacing} for the Engineering Resume preset
+     * @return a {@code Spacing} for the Engineering Resume preset
      */
-    public static CvSpacing engineeringResume() {
-        return new CvSpacing(
+    public static Spacing engineeringResume() {
+        return new Spacing(
                 8,                                       // pageFlowSpacing
                 4,                                       // sectionBodySpacing
                 DocumentInsets.zero(),                   // sectionBodyPadding
@@ -403,10 +403,10 @@ public record CvSpacing(
      * Body content is text-only (no cards / banners), so banner
      * tokens are unused but kept at neutral defaults.
      *
-     * @return a {@code CvSpacing} for the Timeline Minimal preset
+     * @return a {@code Spacing} for the Timeline Minimal preset
      */
-    public static CvSpacing timelineMinimal() {
-        return new CvSpacing(
+    public static Spacing timelineMinimal() {
+        return new Spacing(
                 12,                                      // pageFlowSpacing (gap between header row + rule + body row)
                 5,                                       // sectionBodySpacing
                 DocumentInsets.zero(),                   // sectionBodyPadding
@@ -429,10 +429,10 @@ public record CvSpacing(
      * so paddings and inter-card gaps are tight by design. Corner
      * radius and accent rule width match the V1 ProductLeader tokens.
      *
-     * @return a {@code CvSpacing} for the Panel preset
+     * @return a {@code Spacing} for the Panel preset
      */
-    public static CvSpacing panel() {
-        return new CvSpacing(
+    public static Spacing panel() {
+        return new Spacing(
                 6,                                       // pageFlowSpacing (tight inter-card gap)
                 3,                                       // sectionBodySpacing (inside a card)
                 DocumentInsets.zero(),                   // sectionBodyPadding (the card supplies its own padding)
@@ -454,10 +454,10 @@ public record CvSpacing(
      * an 8pt page-flow rhythm, compact module bodies, and a 1.1pt
      * full-width rule under the masthead.
      *
-     * @return a {@code CvSpacing} for the Executive preset
+     * @return a {@code Spacing} for the Executive preset
      */
-    public static CvSpacing executive() {
-        return new CvSpacing(
+    public static Spacing executive() {
+        return new Spacing(
                 8,                                       // pageFlowSpacing
                 3,                                       // sectionBodySpacing
                 DocumentInsets.zero(),                   // sectionBodyPadding
@@ -482,10 +482,10 @@ public record CvSpacing(
      * column gap are page-composition concerns owned by the preset, not
      * spacing tokens.
      *
-     * @return a {@code CvSpacing} for the Mint Editorial preset
+     * @return a {@code Spacing} for the Mint Editorial preset
      */
-    public static CvSpacing mintEditorial() {
-        return new CvSpacing(
+    public static Spacing mintEditorial() {
+        return new Spacing(
                 18,                                      // pageFlowSpacing (header / rule / grid rhythm)
                 5,                                       // sectionBodySpacing
                 DocumentInsets.zero(),                   // sectionBodyPadding

--- a/src/main/java/com/demcha/compose/document/templates/core/theme/Typography.java
+++ b/src/main/java/com/demcha/compose/document/templates/core/theme/Typography.java
@@ -1,11 +1,11 @@
-package com.demcha.compose.document.templates.cv.v2.theme;
+package com.demcha.compose.document.templates.core.theme;
 
 import com.demcha.compose.font.FontName;
 
 import java.util.Objects;
 
 /**
- * Font + size scale tokens for a {@link CvTheme}.
+ * Font + size scale tokens for a {@link BrandTheme}.
  *
  * <p>Each field names <strong>what</strong> renders at that size, not
  * an abstract "small / medium / large" — that way the call site
@@ -28,7 +28,7 @@ import java.util.Objects;
  * @param bodyLineSpacing   line-spacing multiplier for body
  *                          paragraphs (typically 1.4)
  */
-public record CvTypography(
+public record Typography(
         FontName headlineFont,
         FontName bodyFont,
         double sizeHeadline,
@@ -43,7 +43,7 @@ public record CvTypography(
     /**
      * Validates that the font tokens are not null.
      */
-    public CvTypography {
+    public Typography {
         Objects.requireNonNull(headlineFont, "headlineFont");
         Objects.requireNonNull(bodyFont, "bodyFont");
     }
@@ -52,10 +52,10 @@ public record CvTypography(
      * The classic PT-Serif scale used by the original Boxed Sections
      * preset.
      *
-     * @return a {@code CvTypography} scale for the classic preset
+     * @return a {@code Typography} scale for the classic preset
      */
-    public static CvTypography classic() {
-        return new CvTypography(
+    public static Typography classic() {
+        return new Typography(
                 FontName.PT_SERIF, FontName.PT_SERIF,
                 21.5,    // headline
                 8.5,     // contact
@@ -71,10 +71,10 @@ public record CvTypography(
      * Helvetica scale for the Modern Professional preset — larger
      * display name, larger section titles, comfortable body size.
      *
-     * @return a {@code CvTypography} scale for the Modern Professional preset
+     * @return a {@code Typography} scale for the Modern Professional preset
      */
-    public static CvTypography modernProfessional() {
-        return new CvTypography(
+    public static Typography modernProfessional() {
+        return new Typography(
                 FontName.HELVETICA_BOLD, FontName.HELVETICA,
                 28.0,    // headline (display name)
                 9.0,     // contact
@@ -97,10 +97,10 @@ public record CvTypography(
      * variant — small bold spaced-caps title in the soft palette
      * tone.</p>
      *
-     * @return a {@code CvTypography} scale for the Centered Headline preset
+     * @return a {@code Typography} scale for the Centered Headline preset
      */
-    public static CvTypography centeredHeadline() {
-        return new CvTypography(
+    public static Typography centeredHeadline() {
+        return new Typography(
                 FontName.POPPINS, FontName.LATO,
                 24.0,    // headline (spaced-caps name)
                 8.3,     // contact
@@ -118,10 +118,10 @@ public record CvTypography(
      * Preset-local body variants still override this when the visual
      * needs a distinct summary size.
      *
-     * @return a {@code CvTypography} scale for the Classic Serif preset
+     * @return a {@code Typography} scale for the Classic Serif preset
      */
-    public static CvTypography classicSerif() {
-        return new CvTypography(
+    public static Typography classicSerif() {
+        return new Typography(
                 FontName.PT_SERIF, FontName.PT_SERIF,
                 27.0,    // headline
                 8.7,     // contact
@@ -138,10 +138,10 @@ public record CvTypography(
      * preset. Compact sizes keep the two-column rail/body layout
      * single-page friendly while preserving the crisp editorial feel.
      *
-     * @return a {@code CvTypography} scale for the Nordic Clean preset
+     * @return a {@code Typography} scale for the Nordic Clean preset
      */
-    public static CvTypography nordicClean() {
-        return new CvTypography(
+    public static Typography nordicClean() {
+        return new Typography(
                 FontName.BARLOW, FontName.LATO,
                 27.0,    // headline
                 7.4,     // contact stack
@@ -158,10 +158,10 @@ public record CvTypography(
      * preset. The section-title slot also uses the mono headline font
      * so tick labels keep the terminal/card visual signature.
      *
-     * @return a {@code CvTypography} scale for the Compact Mono preset
+     * @return a {@code Typography} scale for the Compact Mono preset
      */
-    public static CvTypography compactMono() {
-        return new CvTypography(
+    public static Typography compactMono() {
+        return new Typography(
                 FontName.IBM_PLEX_MONO, FontName.LATO,
                 23.5,    // headline
                 8.3,     // contact
@@ -177,10 +177,10 @@ public record CvTypography(
      * Compact PT-Serif headline + Lato body scale used by the Blue
      * Banner preset.
      *
-     * @return a {@code CvTypography} scale for the Blue Banner preset
+     * @return a {@code Typography} scale for the Blue Banner preset
      */
-    public static CvTypography blueBanner() {
-        return new CvTypography(
+    public static Typography blueBanner() {
+        return new Typography(
                 FontName.PT_SERIF, FontName.LATO,
                 20.0,    // headline
                 7.5,     // contact
@@ -195,10 +195,10 @@ public record CvTypography(
     /**
      * Compact Helvetica scale for the Editorial Blue preset.
      *
-     * @return a {@code CvTypography} scale for the Editorial Blue preset
+     * @return a {@code Typography} scale for the Editorial Blue preset
      */
-    public static CvTypography editorialBlue() {
-        return new CvTypography(
+    public static Typography editorialBlue() {
+        return new Typography(
                 FontName.HELVETICA_BOLD, FontName.HELVETICA,
                 22.0,    // headline
                 9.0,     // contact
@@ -217,10 +217,10 @@ public record CvTypography(
      * The sample data is information-dense, so the body sizes are
      * compact and the line spacing trends to 1.35 for readability.
      *
-     * @return a {@code CvTypography} scale for the Sidebar Portrait preset
+     * @return a {@code Typography} scale for the Sidebar Portrait preset
      */
-    public static CvTypography sidebarPortrait() {
-        return new CvTypography(
+    public static Typography sidebarPortrait() {
+        return new Typography(
                 FontName.CRIMSON_TEXT, FontName.LATO,
                 28.0,    // headline (hero name)
                 8.3,     // contact (sidebar contact stack)
@@ -240,10 +240,10 @@ public record CvTypography(
      * The PT-Serif monogram font is preset-local because no other v2
      * preset uses it for a circle-ring badge.
      *
-     * @return a {@code CvTypography} scale for the Monogram Sidebar preset
+     * @return a {@code Typography} scale for the Monogram Sidebar preset
      */
-    public static CvTypography monogramSidebar() {
-        return new CvTypography(
+    public static Typography monogramSidebar() {
+        return new Typography(
                 FontName.CRIMSON_TEXT, FontName.LATO,
                 30.0,    // headline (spaced-caps name lines)
                 7.4,     // contact (sidebar contact stack)
@@ -261,10 +261,10 @@ public record CvTypography(
      * 7.8pt main section headings, 7.25pt body, and a 1.08 line
      * spacing tuned for dense engineering-resume cards.
      *
-     * @return a {@code CvTypography} scale for the Engineering Resume preset
+     * @return a {@code Typography} scale for the Engineering Resume preset
      */
-    public static CvTypography engineeringResume() {
-        return new CvTypography(
+    public static Typography engineeringResume() {
+        return new Typography(
                 FontName.BARLOW, FontName.LATO,
                 24.5,    // headline (UPPERCASE name in navy header)
                 7.2,     // contact (right-aligned navy header stack)
@@ -283,10 +283,10 @@ public record CvTypography(
      * titles, 7.5-7.9pt body. Compact sizes squeeze the 3-column
      * sidebar / axis / main layout onto one page.
      *
-     * @return a {@code CvTypography} scale for the Timeline Minimal preset
+     * @return a {@code Typography} scale for the Timeline Minimal preset
      */
-    public static CvTypography timelineMinimal() {
-        return new CvTypography(
+    public static Typography timelineMinimal() {
+        return new Typography(
                 FontName.BARLOW_CONDENSED, FontName.LATO,
                 28.0,    // headline (spaced uppercase masthead)
                 7.8,     // contact (right-aligned contact stack)
@@ -305,10 +305,10 @@ public record CvTypography(
      * slot for the teal module headings, and a 9.4pt body with 1.2
      * line spacing tuned for the dense card layout.
      *
-     * @return a {@code CvTypography} scale for the Panel preset
+     * @return a {@code Typography} scale for the Panel preset
      */
-    public static CvTypography panel() {
-        return new CvTypography(
+    public static Typography panel() {
+        return new Typography(
                 FontName.POPPINS, FontName.LATO,
                 22.0,    // headline (centered uppercase name)
                 8.9,     // contact (V1 META_SIZE = body - 0.5)
@@ -327,10 +327,10 @@ public record CvTypography(
      * and a 9.5pt body with 1.25 line-spacing tuned for an executive
      * single-column resume density.
      *
-     * @return a {@code CvTypography} scale for the Executive preset
+     * @return a {@code Typography} scale for the Executive preset
      */
-    public static CvTypography executive() {
-        return new CvTypography(
+    public static Typography executive() {
+        return new Typography(
                 FontName.POPPINS, FontName.LATO,
                 24.0,    // headline (uppercase masthead)
                 9.1,     // contact meta (V1 META_SIZE = body - 0.4)
@@ -348,10 +348,10 @@ public record CvTypography(
      * heading, and compact 7.4-8pt metadata/body tuned for the dense
      * two-column editorial layout.
      *
-     * @return a {@code CvTypography} scale for the Mint Editorial preset
+     * @return a {@code Typography} scale for the Mint Editorial preset
      */
-    public static CvTypography mintEditorial() {
-        return new CvTypography(
+    public static Typography mintEditorial() {
+        return new Typography(
                 FontName.POPPINS, FontName.POPPINS,
                 26.0,    // headline (spaced-caps centered name)
                 7.4,     // contact (icon line text)

--- a/src/main/java/com/demcha/compose/document/templates/core/theme/package-info.java
+++ b/src/main/java/com/demcha/compose/document/templates/core/theme/package-info.java
@@ -3,30 +3,30 @@
  *
  * <p>The <strong>shift-able</strong> layer. Every colour, font, size,
  * padding, corner radius, accent width — everything purely visual —
- * lives in {@link com.demcha.compose.document.templates.cv.v2.theme.CvTheme}
+ * lives in {@link com.demcha.compose.document.templates.core.theme.BrandTheme}
  * and its four sub-records:</p>
  *
  * <ul>
- *   <li>{@link com.demcha.compose.document.templates.cv.v2.theme.CvPalette}
+ *   <li>{@link com.demcha.compose.document.templates.core.theme.Palette}
  *       — colours.</li>
- *   <li>{@link com.demcha.compose.document.templates.cv.v2.theme.CvTypography}
+ *   <li>{@link com.demcha.compose.document.templates.core.theme.Typography}
  *       — fonts, sizes, line spacing.</li>
- *   <li>{@link com.demcha.compose.document.templates.cv.v2.theme.CvSpacing}
+ *   <li>{@link com.demcha.compose.document.templates.core.theme.Spacing}
  *       — paddings, margins, banner radius, accent widths, row
  *       weights.</li>
- *   <li>{@link com.demcha.compose.document.templates.cv.v2.theme.CvDecoration}
+ *   <li>{@link com.demcha.compose.document.templates.core.theme.Decoration}
  *       — bullets, contact separators, and other small glyph
  *       choices.</li>
  * </ul>
  *
- * <p>Renderers in {@code cv/v2/components} accept a {@code CvTheme}
+ * <p>Template renderers and widgets accept a {@code BrandTheme}
  * argument and never read constants directly — so a new visual flavour
- * is just a new {@code CvTheme} factory, no renderer changes
+ * is just a new {@code BrandTheme} factory, no renderer changes
  * required.</p>
  *
  * <p>Why split into sub-records: it lets you mix-and-match — a
- * preset can build {@code new CvTheme(palette, defaultTypography,
+ * preset can build {@code new BrandTheme(palette, defaultTypography,
  * tighterSpacing)} for a compact variant without redeclaring every
  * field.</p>
  */
-package com.demcha.compose.document.templates.cv.v2.theme;
+package com.demcha.compose.document.templates.core.theme;

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/presets/ModernProfessionalLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/presets/ModernProfessionalLetter.java
@@ -36,7 +36,7 @@ public final class ModernProfessionalLetter {
     /** Human-readable display name. */
     public static final String DISPLAY_NAME = "Modern Professional Letter";
 
-    /** V1 {@code CvTheme} primary slate-blue used by the display name. */
+    /** V1 {@code BrandTheme} primary slate-blue used by the display name. */
     private static final DocumentColor NAME_COLOR = DocumentColor.rgb(44, 62, 80);
 
     /** V1 link accent (royal blue) used by the contact link row. */

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/components/LetterBody.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/components/LetterBody.java
@@ -7,7 +7,7 @@ import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.coverletter.v2.data.CoverLetterDocument;
 import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
 import com.demcha.compose.document.templates.cv.v2.components.RichParagraphRenderer;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 
 /**
  * Shared cover-letter body renderer — the letter analog of
@@ -39,7 +39,7 @@ public final class LetterBody {
      *              paired CV preset so the body colour / font / size match
      */
     public static void render(SectionBuilder host, CoverLetterDocument doc,
-                              CvTheme theme) {
+                              BrandTheme theme) {
         render(host, doc, theme, theme.typography().sizeBody());
     }
 
@@ -57,7 +57,7 @@ public final class LetterBody {
      * @param bodySize body text size in points
      */
     public static void render(SectionBuilder host, CoverLetterDocument doc,
-                              CvTheme theme, double bodySize) {
+                              BrandTheme theme, double bodySize) {
         DocumentTextStyle bodyStyle = CvTextStyles.of(
                 theme.typography().bodyFont(),
                 bodySize,

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/BlueBannerLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/BlueBannerLetter.java
@@ -5,7 +5,7 @@ import com.demcha.compose.document.dsl.PageFlowBuilder;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.coverletter.v2.components.LetterBody;
 import com.demcha.compose.document.templates.coverletter.v2.data.CoverLetterDocument;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.ContactLine;
 import com.demcha.compose.document.templates.cv.v2.widgets.Headline;
 
@@ -19,7 +19,7 @@ import java.util.Objects;
  * — a centred PT-Serif spaced-caps name over a compact centred contact
  * row — then a single-column letter body via the shared
  * {@link LetterBody}. Both documents read everything from
- * {@link CvTheme#blueBanner()}.</p>
+ * {@link BrandTheme#blueBanner()}.</p>
  *
  * <p>The CV's signature blue banners decorate <em>section</em> titles,
  * which a letter has none of, so the brand identity here is carried by
@@ -53,7 +53,7 @@ public final class BlueBannerLetter {
      * @return a {@code DocumentTemplate} for the "Blue Banner Letter"
      */
     public static DocumentTemplate<CoverLetterDocument> create() {
-        return create(CvTheme.blueBanner());
+        return create(BrandTheme.blueBanner());
     }
 
     /**
@@ -63,12 +63,12 @@ public final class BlueBannerLetter {
      * @param theme the active theme supplying palette, typography, and spacing
      * @return a {@code DocumentTemplate} for the "Blue Banner Letter"
      */
-    public static DocumentTemplate<CoverLetterDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CoverLetterDocument> create(BrandTheme theme) {
         Objects.requireNonNull(theme, "theme");
         return new Template(theme);
     }
 
-    private record Template(CvTheme theme) implements DocumentTemplate<CoverLetterDocument> {
+    private record Template(BrandTheme theme) implements DocumentTemplate<CoverLetterDocument> {
 
         @Override
             public String id() {

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/BoxedSectionsLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/BoxedSectionsLetter.java
@@ -5,7 +5,7 @@ import com.demcha.compose.document.dsl.PageFlowBuilder;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.coverletter.v2.components.LetterBody;
 import com.demcha.compose.document.templates.coverletter.v2.data.CoverLetterDocument;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.ContactLine;
 import com.demcha.compose.document.templates.cv.v2.widgets.Headline;
 
@@ -19,7 +19,7 @@ import java.util.Objects;
  * — a centred letter-spaced PT-Serif name with a thin rule beneath it,
  * then a centred pipe-separated contact line with its own rule beneath
  * — then a single-column letter body via the shared {@link LetterBody}.
- * Both documents read everything from {@link CvTheme#boxedClassic()}.</p>
+ * Both documents read everything from {@link BrandTheme#boxedClassic()}.</p>
  *
  * <p>The header is composed entirely from shared widgets
  * ({@link Headline#spacedCentered} + {@link ContactLine#centered}) at
@@ -52,7 +52,7 @@ public final class BoxedSectionsLetter {
      * @return a {@code DocumentTemplate} for the "Boxed Sections Letter"
      */
     public static DocumentTemplate<CoverLetterDocument> create() {
-        return create(CvTheme.boxedClassic());
+        return create(BrandTheme.boxedClassic());
     }
 
     /**
@@ -62,12 +62,12 @@ public final class BoxedSectionsLetter {
      * @param theme the active theme supplying palette, typography, and spacing
      * @return a {@code DocumentTemplate} for the "Boxed Sections Letter"
      */
-    public static DocumentTemplate<CoverLetterDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CoverLetterDocument> create(BrandTheme theme) {
         Objects.requireNonNull(theme, "theme");
         return new Template(theme);
     }
 
-    private record Template(CvTheme theme) implements DocumentTemplate<CoverLetterDocument> {
+    private record Template(BrandTheme theme) implements DocumentTemplate<CoverLetterDocument> {
 
         @Override
             public String id() {

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/CenteredHeadlineLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/CenteredHeadlineLetter.java
@@ -11,7 +11,7 @@ import com.demcha.compose.document.templates.coverletter.v2.components.LetterBod
 import com.demcha.compose.document.templates.coverletter.v2.data.CoverLetterDocument;
 import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.ContactLine;
 import com.demcha.compose.document.templates.cv.v2.widgets.Headline;
 import com.demcha.compose.document.templates.cv.v2.widgets.Subheadline;
@@ -27,7 +27,7 @@ import java.util.Objects;
  * subheadline, and a centred contact line framed by thin full-width
  * rules — then a single-column letter body via the shared
  * {@link LetterBody}. Both documents read everything from
- * {@link CvTheme#centeredHeadline()}.</p>
+ * {@link BrandTheme#centeredHeadline()}.</p>
  *
  * <p>The subheadline uses the real {@link CvIdentity#jobTitle()} (the
  * CV preset still shows a hard-coded placeholder pending its own
@@ -62,7 +62,7 @@ public final class CenteredHeadlineLetter {
      * @return a {@code DocumentTemplate} for the "Centered Headline Letter"
      */
     public static DocumentTemplate<CoverLetterDocument> create() {
-        return create(CvTheme.centeredHeadline());
+        return create(BrandTheme.centeredHeadline());
     }
 
     /**
@@ -72,12 +72,12 @@ public final class CenteredHeadlineLetter {
      * @param theme the active theme supplying palette, typography, and spacing
      * @return a {@code DocumentTemplate} for the "Centered Headline Letter"
      */
-    public static DocumentTemplate<CoverLetterDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CoverLetterDocument> create(BrandTheme theme) {
         Objects.requireNonNull(theme, "theme");
         return new Template(theme);
     }
 
-    private record Template(CvTheme theme) implements DocumentTemplate<CoverLetterDocument> {
+    private record Template(BrandTheme theme) implements DocumentTemplate<CoverLetterDocument> {
 
         @Override
             public String id() {

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/ClassicSerifLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/ClassicSerifLetter.java
@@ -11,7 +11,7 @@ import com.demcha.compose.document.templates.coverletter.v2.components.LetterBod
 import com.demcha.compose.document.templates.coverletter.v2.data.CoverLetterDocument;
 import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.ContactLine;
 import com.demcha.compose.document.templates.cv.v2.widgets.Headline;
 
@@ -26,7 +26,7 @@ import java.util.Objects;
  * centred contact line with tan-accent underlined links — then a
  * single-column letter body via the shared {@link LetterBody}. Both
  * documents read their palette / typography from
- * {@link CvTheme#classicSerif()}.</p>
+ * {@link BrandTheme#classicSerif()}.</p>
  *
  * <p>The header mirrors the CV's preset-local header DSL (spaced name +
  * rule line + centred contact). The bronze {@code ACCENT} is mirrored
@@ -64,7 +64,7 @@ public final class ClassicSerifLetter {
      * @return a {@code DocumentTemplate} for the "Classic Serif Letter"
      */
     public static DocumentTemplate<CoverLetterDocument> create() {
-        return create(CvTheme.classicSerif());
+        return create(BrandTheme.classicSerif());
     }
 
     /**
@@ -74,12 +74,12 @@ public final class ClassicSerifLetter {
      * @param theme the active theme supplying palette, typography, and spacing
      * @return a {@code DocumentTemplate} for the "Classic Serif Letter"
      */
-    public static DocumentTemplate<CoverLetterDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CoverLetterDocument> create(BrandTheme theme) {
         Objects.requireNonNull(theme, "theme");
         return new Template(theme);
     }
 
-    private record Template(CvTheme theme) implements DocumentTemplate<CoverLetterDocument> {
+    private record Template(BrandTheme theme) implements DocumentTemplate<CoverLetterDocument> {
 
         @Override
             public String id() {

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/CompactMonoLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/CompactMonoLetter.java
@@ -11,7 +11,7 @@ import com.demcha.compose.document.templates.coverletter.v2.components.LetterBod
 import com.demcha.compose.document.templates.coverletter.v2.data.CoverLetterDocument;
 import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.ContactLine;
 import com.demcha.compose.document.templates.cv.v2.widgets.Headline;
 
@@ -27,7 +27,7 @@ import java.util.Objects;
  * {@link com.demcha.compose.document.templates.cv.v2.presets.CompactMono}.
  * Below it, a single-column letter body via the shared
  * {@link LetterBody}. Body palette / typography come from
- * {@link CvTheme#compactMono()}.</p>
+ * {@link BrandTheme#compactMono()}.</p>
  *
  * <p>The four command-bar colours are mirrored from the CV, where they
  * are preset-local. A near-invisible width rule (band-coloured, 0.1pt)
@@ -80,7 +80,7 @@ public final class CompactMonoLetter {
      * @return a {@code DocumentTemplate} for the "Compact Mono Letter"
      */
     public static DocumentTemplate<CoverLetterDocument> create() {
-        return create(CvTheme.compactMono());
+        return create(BrandTheme.compactMono());
     }
 
     /**
@@ -90,12 +90,12 @@ public final class CompactMonoLetter {
      * @param theme the active theme supplying palette, typography, and spacing
      * @return a {@code DocumentTemplate} for the "Compact Mono Letter"
      */
-    public static DocumentTemplate<CoverLetterDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CoverLetterDocument> create(BrandTheme theme) {
         Objects.requireNonNull(theme, "theme");
         return new Template(theme);
     }
 
-    private record Template(CvTheme theme) implements DocumentTemplate<CoverLetterDocument> {
+    private record Template(BrandTheme theme) implements DocumentTemplate<CoverLetterDocument> {
 
         @Override
             public String id() {

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/EditorialBlueLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/EditorialBlueLetter.java
@@ -10,7 +10,7 @@ import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.coverletter.v2.components.LetterBody;
 import com.demcha.compose.document.templates.coverletter.v2.data.CoverLetterDocument;
 import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.Masthead;
 import com.demcha.compose.font.FontName;
 
@@ -25,7 +25,7 @@ import java.util.Objects;
  * contact metadata, and blue underlined profile links, via the shared
  * {@link Masthead#centered} widget — then a single-column letter body
  * via the shared {@link LetterBody}. Both documents read their palette /
- * typography from {@link CvTheme#editorialBlue()}.</p>
+ * typography from {@link BrandTheme#editorialBlue()}.</p>
  *
  * <p>Only the navy {@code NAME_COLOR} is mirrored from the CV (its
  * preset-local token); everything else flows through {@code Masthead}
@@ -62,7 +62,7 @@ public final class EditorialBlueLetter {
      * @return a {@code DocumentTemplate} for the "Editorial Blue Letter"
      */
     public static DocumentTemplate<CoverLetterDocument> create() {
-        return create(CvTheme.editorialBlue());
+        return create(BrandTheme.editorialBlue());
     }
 
     /**
@@ -72,12 +72,12 @@ public final class EditorialBlueLetter {
      * @param theme the active theme supplying palette, typography, and spacing
      * @return a {@code DocumentTemplate} for the "Editorial Blue Letter"
      */
-    public static DocumentTemplate<CoverLetterDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CoverLetterDocument> create(BrandTheme theme) {
         Objects.requireNonNull(theme, "theme");
         return new Template(theme);
     }
 
-    private record Template(CvTheme theme) implements DocumentTemplate<CoverLetterDocument> {
+    private record Template(BrandTheme theme) implements DocumentTemplate<CoverLetterDocument> {
 
         @Override
             public String id() {

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/EngineeringResumeLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/EngineeringResumeLetter.java
@@ -13,7 +13,7 @@ import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
 import com.demcha.compose.document.templates.cv.v2.components.MarkdownInline;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
 import com.demcha.compose.document.templates.cv.v2.data.CvLink;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,7 +31,7 @@ import java.util.Objects;
  * {@link com.demcha.compose.document.templates.cv.v2.presets.EngineeringResume}.
  * Below the band, a single-column letter body via the shared
  * {@link LetterBody}. Body palette / typography come from
- * {@link CvTheme#engineeringResume()}.</p>
+ * {@link BrandTheme#engineeringResume()}.</p>
  *
  * <p>The five navy-header colours are mirrored from the CV, where they
  * are preset-local (the theme only covers body ink / muted / rule /
@@ -88,7 +88,7 @@ public final class EngineeringResumeLetter {
      * @return a {@code DocumentTemplate} for the "Engineering Resume Letter"
      */
     public static DocumentTemplate<CoverLetterDocument> create() {
-        return create(CvTheme.engineeringResume());
+        return create(BrandTheme.engineeringResume());
     }
 
     /**
@@ -98,12 +98,12 @@ public final class EngineeringResumeLetter {
      * @param theme the active theme supplying palette, typography, and spacing
      * @return a {@code DocumentTemplate} for the "Engineering Resume Letter"
      */
-    public static DocumentTemplate<CoverLetterDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CoverLetterDocument> create(BrandTheme theme) {
         Objects.requireNonNull(theme, "theme");
         return new Template(theme);
     }
 
-    private record Template(CvTheme theme) implements DocumentTemplate<CoverLetterDocument> {
+    private record Template(BrandTheme theme) implements DocumentTemplate<CoverLetterDocument> {
 
         @Override
             public String id() {

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/ExecutiveLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/ExecutiveLetter.java
@@ -16,7 +16,7 @@ import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
 import com.demcha.compose.document.templates.cv.v2.components.TextOrnaments;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
 import com.demcha.compose.document.templates.cv.v2.data.CvLink;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.Headline;
 import com.demcha.compose.font.FontName;
 
@@ -31,7 +31,7 @@ import java.util.Objects;
  * bronze-underlined link row, and a thin full-width muted rule — then a
  * single-column letter body (greeting, paragraphs, closing) via the
  * shared {@link LetterBody}. Both documents read all colour, font, and
- * spacing from {@link CvTheme#executive()}, so a writer's CV and cover
+ * spacing from {@link BrandTheme#executive()}, so a writer's CV and cover
  * letter ship as one matched set.</p>
  *
  * <p>The masthead block is preset-local inline DSL mirroring the CV's,
@@ -84,7 +84,7 @@ public final class ExecutiveLetter {
      * @return a {@code DocumentTemplate} for the "Executive Letter"
      */
     public static DocumentTemplate<CoverLetterDocument> create() {
-        return create(CvTheme.executive());
+        return create(BrandTheme.executive());
     }
 
     /**
@@ -94,12 +94,12 @@ public final class ExecutiveLetter {
      * @param theme the active theme supplying palette, typography, and spacing
      * @return a {@code DocumentTemplate} for the "Executive Letter"
      */
-    public static DocumentTemplate<CoverLetterDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CoverLetterDocument> create(BrandTheme theme) {
         Objects.requireNonNull(theme, "theme");
         return new Template(theme);
     }
 
-    private record Template(CvTheme theme) implements DocumentTemplate<CoverLetterDocument> {
+    private record Template(BrandTheme theme) implements DocumentTemplate<CoverLetterDocument> {
 
         @Override
             public String id() {

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/MintEditorialLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/MintEditorialLetter.java
@@ -15,7 +15,7 @@ import com.demcha.compose.document.templates.coverletter.v2.data.CoverLetterDocu
 import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
 import com.demcha.compose.document.templates.cv.v2.components.TextOrnaments;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.Headline;
 import com.demcha.compose.document.templates.cv.v2.widgets.Subheadline;
 
@@ -28,7 +28,7 @@ import java.util.Objects;
  * Poppins name, a centred soft-mint accent tagline, and a full-width 6pt
  * mint accent rule — then a single-column letter body via the shared
  * {@link LetterBody}. Palette / typography / spacing come from the
- * <strong>same</strong> {@link CvTheme#mintEditorial()} the CV uses, and the
+ * <strong>same</strong> {@link BrandTheme#mintEditorial()} the CV uses, and the
  * mint accent is read from {@code theme.palette().banner()} exactly as in the
  * CV, so the CV and the letter read as one matched set. The CV's two-column
  * sidebar grids are a CV-body concern and are intentionally not part of the
@@ -90,7 +90,7 @@ public final class MintEditorialLetter {
      * @return a {@code DocumentTemplate} for the "Mint Editorial Letter"
      */
     public static DocumentTemplate<CoverLetterDocument> create() {
-        return create(CvTheme.mintEditorial(), Options.defaults());
+        return create(BrandTheme.mintEditorial(), Options.defaults());
     }
 
     /**
@@ -100,7 +100,7 @@ public final class MintEditorialLetter {
      * @param theme the active theme supplying palette, typography, and spacing
      * @return a {@code DocumentTemplate} for the "Mint Editorial Letter"
      */
-    public static DocumentTemplate<CoverLetterDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CoverLetterDocument> create(BrandTheme theme) {
         return create(theme, Options.defaults());
     }
 
@@ -111,7 +111,7 @@ public final class MintEditorialLetter {
      * @return a {@code DocumentTemplate} for the "Mint Editorial Letter"
      */
     public static DocumentTemplate<CoverLetterDocument> create(Options options) {
-        return create(CvTheme.mintEditorial(), options);
+        return create(BrandTheme.mintEditorial(), options);
     }
 
     /**
@@ -123,7 +123,7 @@ public final class MintEditorialLetter {
      * @param options masthead colour knobs (accent, rule, name, header band)
      * @return a {@code DocumentTemplate} for the "Mint Editorial Letter"
      */
-    public static DocumentTemplate<CoverLetterDocument> create(CvTheme theme,
+    public static DocumentTemplate<CoverLetterDocument> create(BrandTheme theme,
                                                                Options options) {
         Objects.requireNonNull(theme, "theme");
         Objects.requireNonNull(options, "options");
@@ -237,13 +237,13 @@ public final class MintEditorialLetter {
 
     private static final class Template implements DocumentTemplate<CoverLetterDocument> {
 
-        private final CvTheme theme;
+        private final BrandTheme theme;
         private final DocumentColor accent;
         private final DocumentColor ruleColor;
         private final DocumentColor nameColor;
         private final DocumentColor headerBandColor;
 
-        Template(CvTheme theme, Options options) {
+        Template(BrandTheme theme, Options options) {
             this.theme = theme;
             // Same accent source + Options defaults as the paired CV preset.
             this.accent = options.accentColor() != null

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/ModernProfessionalLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/ModernProfessionalLetter.java
@@ -9,7 +9,7 @@ import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.coverletter.v2.components.LetterBody;
 import com.demcha.compose.document.templates.coverletter.v2.data.CoverLetterDocument;
 import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.ContactLine;
 import com.demcha.compose.document.templates.cv.v2.widgets.Headline;
 import com.demcha.compose.font.FontName;
@@ -25,7 +25,7 @@ import java.util.Objects;
  * right-aligned contact stack with royal-blue underlined links and a
  * bottom accent rule — then a single-column letter body via the shared
  * {@link LetterBody}. Both documents read their scale and palette from
- * {@link CvTheme#modernProfessional()}.</p>
+ * {@link BrandTheme#modernProfessional()}.</p>
  *
  * <p>Unlike Executive, the header is composed almost entirely from
  * shared widgets ({@link Headline#rightAligned} +
@@ -70,7 +70,7 @@ public final class ModernProfessionalLetter {
      * @return a {@code DocumentTemplate} for the "Modern Professional Letter"
      */
     public static DocumentTemplate<CoverLetterDocument> create() {
-        return create(CvTheme.modernProfessional());
+        return create(BrandTheme.modernProfessional());
     }
 
     /**
@@ -80,12 +80,12 @@ public final class ModernProfessionalLetter {
      * @param theme the active theme supplying palette, typography, and spacing
      * @return a {@code DocumentTemplate} for the "Modern Professional Letter"
      */
-    public static DocumentTemplate<CoverLetterDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CoverLetterDocument> create(BrandTheme theme) {
         Objects.requireNonNull(theme, "theme");
         return new Template(theme);
     }
 
-    private record Template(CvTheme theme) implements DocumentTemplate<CoverLetterDocument> {
+    private record Template(BrandTheme theme) implements DocumentTemplate<CoverLetterDocument> {
 
         @Override
             public String id() {

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/MonogramSidebarLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/MonogramSidebarLetter.java
@@ -14,7 +14,7 @@ import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
 import com.demcha.compose.document.templates.cv.v2.components.TextOrnaments;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
 import com.demcha.compose.document.templates.cv.v2.data.CvName;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.ContactLine;
 import com.demcha.compose.font.FontName;
 
@@ -34,7 +34,7 @@ import java.util.Objects;
  * icon contact stack are sidebar-only and are dropped for the
  * single-column letter; the badge + name treatment is what makes the two
  * read as a set. Palette / typography come from
- * {@link CvTheme#monogramSidebar()}.</p>
+ * {@link BrandTheme#monogramSidebar()}.</p>
  *
  * <p>The gold accent, dark monogram ring, and the PT-Serif monogram font
  * are mirrored from the CV, where they are preset-local.</p>
@@ -92,7 +92,7 @@ public final class MonogramSidebarLetter {
      * @return a {@code DocumentTemplate} for the "Monogram Sidebar Letter"
      */
     public static DocumentTemplate<CoverLetterDocument> create() {
-        return create(CvTheme.monogramSidebar());
+        return create(BrandTheme.monogramSidebar());
     }
 
     /**
@@ -102,12 +102,12 @@ public final class MonogramSidebarLetter {
      * @param theme the active theme supplying palette, typography, and spacing
      * @return a {@code DocumentTemplate} for the "Monogram Sidebar Letter"
      */
-    public static DocumentTemplate<CoverLetterDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CoverLetterDocument> create(BrandTheme theme) {
         Objects.requireNonNull(theme, "theme");
         return new Template(theme);
     }
 
-    private record Template(CvTheme theme) implements DocumentTemplate<CoverLetterDocument> {
+    private record Template(BrandTheme theme) implements DocumentTemplate<CoverLetterDocument> {
 
         @Override
             public String id() {

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/NordicCleanLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/NordicCleanLetter.java
@@ -12,7 +12,7 @@ import com.demcha.compose.document.templates.coverletter.v2.data.CoverLetterDocu
 import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
 import com.demcha.compose.document.templates.cv.v2.components.MarkdownInline;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.ContactLine;
 import com.demcha.compose.document.templates.cv.v2.widgets.Headline;
 
@@ -29,7 +29,7 @@ import java.util.Objects;
  * {@link com.demcha.compose.document.templates.cv.v2.presets.NordicClean}.
  * Below it, a single-column letter body via the shared
  * {@link LetterBody}. Body palette / typography come from
- * {@link CvTheme#nordicClean()}; the CV's tinted profile band is a
+ * {@link BrandTheme#nordicClean()}; the CV's tinted profile band is a
  * CV-body element and is intentionally not part of the letter.</p>
  *
  * <p>The teal {@code ACCENT} is mirrored from the CV's default accent
@@ -66,7 +66,7 @@ public final class NordicCleanLetter {
      * @return a {@code DocumentTemplate} for the "Nordic Clean Letter"
      */
     public static DocumentTemplate<CoverLetterDocument> create() {
-        return create(CvTheme.nordicClean());
+        return create(BrandTheme.nordicClean());
     }
 
     /**
@@ -76,12 +76,12 @@ public final class NordicCleanLetter {
      * @param theme the active theme supplying palette, typography, and spacing
      * @return a {@code DocumentTemplate} for the "Nordic Clean Letter"
      */
-    public static DocumentTemplate<CoverLetterDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CoverLetterDocument> create(BrandTheme theme) {
         Objects.requireNonNull(theme, "theme");
         return new Template(theme);
     }
 
-    private record Template(CvTheme theme) implements DocumentTemplate<CoverLetterDocument> {
+    private record Template(BrandTheme theme) implements DocumentTemplate<CoverLetterDocument> {
 
         @Override
             public String id() {

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/PanelLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/PanelLetter.java
@@ -13,7 +13,7 @@ import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
 import com.demcha.compose.document.templates.cv.v2.components.TextOrnaments;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
 import com.demcha.compose.document.templates.cv.v2.data.CvLink;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.widgets.CardWidget;
 import com.demcha.compose.font.FontName;
 
@@ -30,7 +30,7 @@ import java.util.Objects;
  * {@link com.demcha.compose.document.templates.cv.v2.presets.Panel}.
  * Below it, a single-column letter body via the shared
  * {@link LetterBody}. Card shell + body palette come from
- * {@link CvTheme#panel()}.</p>
+ * {@link BrandTheme#panel()}.</p>
  *
  * <p>The two masthead colours (deep-navy header text, teal accent) are
  * mirrored from the CV, where they are preset-local. The header card is
@@ -79,7 +79,7 @@ public final class PanelLetter {
      * @return a {@code DocumentTemplate} for the "Panel Letter"
      */
     public static DocumentTemplate<CoverLetterDocument> create() {
-        return create(CvTheme.panel());
+        return create(BrandTheme.panel());
     }
 
     /**
@@ -89,12 +89,12 @@ public final class PanelLetter {
      * @param theme the active theme supplying palette, typography, and spacing
      * @return a {@code DocumentTemplate} for the "Panel Letter"
      */
-    public static DocumentTemplate<CoverLetterDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CoverLetterDocument> create(BrandTheme theme) {
         Objects.requireNonNull(theme, "theme");
         return new Template(theme);
     }
 
-    private record Template(CvTheme theme) implements DocumentTemplate<CoverLetterDocument> {
+    private record Template(BrandTheme theme) implements DocumentTemplate<CoverLetterDocument> {
 
         @Override
             public String id() {

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/SidebarPortraitLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/SidebarPortraitLetter.java
@@ -12,7 +12,7 @@ import com.demcha.compose.document.templates.coverletter.v2.data.CoverLetterDocu
 import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
 import com.demcha.compose.document.templates.cv.v2.components.TextOrnaments;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.ContactLine;
 
 import java.util.Objects;
@@ -29,7 +29,7 @@ import java.util.Objects;
  * circular portrait, icon contact stack, and pale sidebar column (painted
  * via {@code pageBackgrounds}) are sidebar-only and are intentionally
  * dropped for the single-column letter. Palette / typography come from
- * {@link CvTheme#sidebarPortrait()}.</p>
+ * {@link BrandTheme#sidebarPortrait()}.</p>
  */
 public final class SidebarPortraitLetter {
 
@@ -57,7 +57,7 @@ public final class SidebarPortraitLetter {
      * @return a {@code DocumentTemplate} for the "Sidebar Portrait Letter"
      */
     public static DocumentTemplate<CoverLetterDocument> create() {
-        return create(CvTheme.sidebarPortrait());
+        return create(BrandTheme.sidebarPortrait());
     }
 
     /**
@@ -67,12 +67,12 @@ public final class SidebarPortraitLetter {
      * @param theme the active theme supplying palette, typography, and spacing
      * @return a {@code DocumentTemplate} for the "Sidebar Portrait Letter"
      */
-    public static DocumentTemplate<CoverLetterDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CoverLetterDocument> create(BrandTheme theme) {
         Objects.requireNonNull(theme, "theme");
         return new Template(theme);
     }
 
-    private record Template(CvTheme theme) implements DocumentTemplate<CoverLetterDocument> {
+    private record Template(BrandTheme theme) implements DocumentTemplate<CoverLetterDocument> {
 
         @Override
             public String id() {

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/TimelineMinimalLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/TimelineMinimalLetter.java
@@ -18,7 +18,7 @@ import com.demcha.compose.document.templates.cv.v2.components.SectionLookup;
 import com.demcha.compose.document.templates.cv.v2.components.TextOrnaments;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
 import com.demcha.compose.document.templates.cv.v2.data.CvLink;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.SvgGlyph;
 
 import java.util.*;
@@ -33,7 +33,7 @@ import java.util.*;
  * header as
  * {@link com.demcha.compose.document.templates.cv.v2.presets.TimelineMinimal}.
  * Below it, a single-column letter body via the shared {@link LetterBody}.
- * Palette / typography come from {@link CvTheme#timelineMinimal()}; the
+ * Palette / typography come from {@link BrandTheme#timelineMinimal()}; the
  * CV's three-column timeline axis is a body element and is not part of
  * the letter.</p>
  *
@@ -80,7 +80,7 @@ public final class TimelineMinimalLetter {
      * @return a {@code DocumentTemplate} for the "Timeline Minimal Letter"
      */
     public static DocumentTemplate<CoverLetterDocument> create() {
-        return create(CvTheme.timelineMinimal());
+        return create(BrandTheme.timelineMinimal());
     }
 
     /**
@@ -90,12 +90,12 @@ public final class TimelineMinimalLetter {
      * @param theme the active theme supplying palette, typography, and spacing
      * @return a {@code DocumentTemplate} for the "Timeline Minimal Letter"
      */
-    public static DocumentTemplate<CoverLetterDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CoverLetterDocument> create(BrandTheme theme) {
         Objects.requireNonNull(theme, "theme");
         return new Template(theme);
     }
 
-    private record Template(CvTheme theme) implements DocumentTemplate<CoverLetterDocument> {
+    private record Template(BrandTheme theme) implements DocumentTemplate<CoverLetterDocument> {
 
         @Override
             public String id() {

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/package-info.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/package-info.java
@@ -2,7 +2,7 @@
  * Templates v2 cover-letter presets — one per paired CV preset.
  *
  * <p>Each preset is a thin orchestrator that reads colour, font, and
- * spacing from its paired {@code CvTheme.<brand>()} (the single source
+ * spacing from its paired {@code BrandTheme.<brand>()} (the single source
  * of truth shared with the CV), renders the same masthead treatment as
  * the CV, and delegates the letter body to the shared
  * {@code coverletter.v2.components.LetterBody}. The result is a CV and a

--- a/src/main/java/com/demcha/compose/document/templates/cv/presets/ModernProfessional.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/presets/ModernProfessional.java
@@ -57,10 +57,10 @@ public final class ModernProfessional {
      */
     public static final double RECOMMENDED_MARGIN = 18.0;
 
-    /** V1 {@code CvTheme} primary slate-blue used by the display name. */
+    /** V1 {@code BrandTheme} primary slate-blue used by the display name. */
     private static final DocumentColor V1_NAME_COLOR = DocumentColor.rgb(44, 62, 80);
 
-    /** V1 {@code CvTheme} secondary bright-blue used by section headings. */
+    /** V1 {@code BrandTheme} secondary bright-blue used by section headings. */
     private static final DocumentColor V1_SECTION_COLOR = DocumentColor.rgb(41, 128, 185);
 
     /** V1 link accent (royal blue) used by the contact link row. */

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/BannerRenderer.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/BannerRenderer.java
@@ -1,7 +1,7 @@
 package com.demcha.compose.document.templates.cv.v2.components;
 
 import com.demcha.compose.document.dsl.SectionBuilder;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.SectionHeader;
 
 /**
@@ -26,7 +26,7 @@ public final class BannerRenderer {
      * @deprecated delegates to {@link SectionHeader#banner}.
      */
     @Deprecated
-    public static void render(SectionBuilder section, String title, CvTheme theme) {
+    public static void render(SectionBuilder section, String title, BrandTheme theme) {
         SectionHeader.banner(section, title, theme);
     }
 }

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/ContactRenderer.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/ContactRenderer.java
@@ -2,7 +2,7 @@ package com.demcha.compose.document.templates.cv.v2.components;
 
 import com.demcha.compose.document.dsl.SectionBuilder;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.ContactLine;
 
 /**
@@ -26,7 +26,7 @@ public final class ContactRenderer {
      * @deprecated delegates to {@link ContactLine#centered}.
      */
     @Deprecated
-    public static void render(SectionBuilder section, CvIdentity identity, CvTheme theme) {
+    public static void render(SectionBuilder section, CvIdentity identity, BrandTheme theme) {
         ContactLine.centered(section, identity, theme);
     }
 }

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/EntryRenderer.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/EntryRenderer.java
@@ -5,7 +5,7 @@ import com.demcha.compose.document.node.TextAlign;
 import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.cv.v2.data.CvEntry;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 
 /**
  * Renders one {@link CvEntry} as the canonical four-zone timeline
@@ -37,7 +37,7 @@ public final class EntryRenderer {
      * @param entry   the entry supplying title, date, subtitle, and body
      * @param theme   the active theme supplying palette, typography, and spacing
      */
-    public static void render(SectionBuilder section, CvEntry entry, CvTheme theme) {
+    public static void render(SectionBuilder section, CvEntry entry, BrandTheme theme) {
         DocumentTextStyle titleStyle = theme.entryTitleStyle();
         DocumentTextStyle dateStyle = theme.entryDateStyle();
         DocumentTextStyle subtitleStyle = theme.entrySubtitleStyle();

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/HeadlineRenderer.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/HeadlineRenderer.java
@@ -2,7 +2,7 @@ package com.demcha.compose.document.templates.cv.v2.components;
 
 import com.demcha.compose.document.dsl.SectionBuilder;
 import com.demcha.compose.document.templates.cv.v2.data.CvName;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.Headline;
 
 /**
@@ -26,7 +26,7 @@ public final class HeadlineRenderer {
      * @deprecated delegates to {@link Headline#spacedCentered}.
      */
     @Deprecated
-    public static void render(SectionBuilder section, CvName name, CvTheme theme) {
+    public static void render(SectionBuilder section, CvName name, BrandTheme theme) {
         Headline.spacedCentered(section, name, theme);
     }
 }

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/ParagraphPrimitive.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/ParagraphPrimitive.java
@@ -5,7 +5,7 @@ import com.demcha.compose.document.node.TextAlign;
 import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.style.DocumentTextIndent;
 import com.demcha.compose.document.style.DocumentTextStyle;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 
 /**
  * Internal primitive that owns the shared
@@ -35,7 +35,7 @@ final class ParagraphPrimitive {
      * lines, and plain rows.
      */
     static void writeBody(SectionBuilder host, String text,
-                          DocumentTextStyle style, CvTheme theme) {
+                          DocumentTextStyle style, BrandTheme theme) {
         write(host, text, style,
                 DocumentInsets.top((float) theme.spacing().paragraphMarginTop()),
                 theme.typography().bodyLineSpacing(),
@@ -53,7 +53,7 @@ final class ParagraphPrimitive {
                               DocumentTextStyle style,
                               String bulletGlyph,
                               DocumentInsets margin,
-                              CvTheme theme) {
+                              BrandTheme theme) {
         write(host, text, style,
                 margin,
                 theme.typography().bodyLineSpacing(),

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/ParagraphRenderer.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/ParagraphRenderer.java
@@ -1,7 +1,7 @@
 package com.demcha.compose.document.templates.cv.v2.components;
 
 import com.demcha.compose.document.dsl.SectionBuilder;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 
 /**
  * Draws one prose paragraph (markdown-aware) in body style. Used by
@@ -24,7 +24,7 @@ public final class ParagraphRenderer {
      * @param text    paragraph text; blank inputs are silently skipped
      * @param theme   active theme
      */
-    public static void render(SectionBuilder section, String text, CvTheme theme) {
+    public static void render(SectionBuilder section, String text, BrandTheme theme) {
         if (text == null || text.isBlank()) {
             return;
         }

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/RowRenderer.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/RowRenderer.java
@@ -5,7 +5,7 @@ import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.cv.v2.data.CvRow;
 import com.demcha.compose.document.templates.cv.v2.data.RowStyle;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 
 /**
  * Unified renderer for a {@link CvRow} under any {@link RowStyle}.
@@ -32,7 +32,7 @@ public final class RowRenderer {
      *                bullet glyph, and stacked indent
      */
     public static void render(SectionBuilder section, CvRow row,
-                              RowStyle style, CvTheme theme) {
+                              RowStyle style, BrandTheme theme) {
         switch (style) {
             case PLAIN -> inline(section, row, null, theme);
             case BULLETED -> inline(section, row, theme.decoration().bulletGlyph(), theme);
@@ -47,7 +47,7 @@ public final class RowRenderer {
      * @param bulletGlyph bullet glyph to attach, or null for plain
      */
     private static void inline(SectionBuilder section, CvRow row,
-                               String bulletGlyph, CvTheme theme) {
+                               String bulletGlyph, BrandTheme theme) {
         DocumentTextStyle base = theme.bodyStyle();
         String source = labelColonValue(row);
         DocumentInsets margin = DocumentInsets.top(
@@ -66,7 +66,7 @@ public final class RowRenderer {
      * paragraphs draw through {@link ParagraphPrimitive#writeBulleted}
      * so only the bullet glyph / margin differs.
      */
-    private static void stacked(SectionBuilder section, CvRow row, CvTheme theme) {
+    private static void stacked(SectionBuilder section, CvRow row, BrandTheme theme) {
         DocumentTextStyle base = theme.bodyStyle();
         DocumentTextStyle nameStyle = theme.bodyBoldStyle();
         DocumentInsets topMargin = DocumentInsets.top(

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/SectionDispatcher.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/SectionDispatcher.java
@@ -2,7 +2,7 @@ package com.demcha.compose.document.templates.cv.v2.components;
 
 import com.demcha.compose.document.dsl.SectionBuilder;
 import com.demcha.compose.document.templates.cv.v2.data.*;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 
 /**
  * Single entry point that renders any {@link CvSection} body into a
@@ -33,7 +33,7 @@ public final class SectionDispatcher {
      * @param theme   the active theme supplying palette, typography, and spacing
      * @throws IllegalStateException if the section subtype is unhandled
      */
-    public static void renderBody(SectionBuilder host, CvSection section, CvTheme theme) {
+    public static void renderBody(SectionBuilder host, CvSection section, BrandTheme theme) {
         host.spacing(theme.spacing().sectionBodySpacing())
                 .padding(theme.spacing().sectionBodyPadding());
 

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/SkillsRenderer.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/SkillsRenderer.java
@@ -5,7 +5,7 @@ import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.cv.v2.data.SkillGroup;
 import com.demcha.compose.document.templates.cv.v2.data.SkillsSection;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 
 /**
  * Default renderer for a grouped {@link SkillsSection}.
@@ -32,7 +32,7 @@ public final class SkillsRenderer {
      */
     public static void render(SectionBuilder section,
                               SkillsSection skills,
-                              CvTheme theme) {
+                              BrandTheme theme) {
         DocumentTextStyle style = theme.bodyStyle();
         DocumentInsets margin = DocumentInsets.top(
                 (float) theme.spacing().paragraphMarginTop());

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/package-info.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/package-info.java
@@ -4,7 +4,7 @@
  * <p>Every class here is a static helper that takes a host
  * {@link com.demcha.compose.document.dsl.SectionBuilder}, a
  * {@code cv/v2/data} record, and a
- * {@link com.demcha.compose.document.templates.cv.v2.theme.CvTheme},
+ * {@link com.demcha.compose.document.templates.core.theme.BrandTheme},
  * and draws the data into the host using the theme's tokens.</p>
  *
  * <p>Components <strong>never</strong>:</p>

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/package-info.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/package-info.java
@@ -46,11 +46,11 @@
  *           ▼                                   ▼
  *   ┌──────────────────────┐         ┌──────────────────────────┐
  *   │  components/         │         │  theme/                  │
- *   │    RowRenderer       │ reads   │    CvPalette  (colours)  │
- *   │    EntryRenderer     │◀────────│    CvTypography (fonts)  │
- *   │    ParagraphRenderer │         │    CvSpacing  (margins)  │
- *   │    SectionDispatcher │         │    CvDecoration (glyphs) │
- *   │    ParagraphPrimitive│         │    CvTheme    (bundle)   │
+ *   │    RowRenderer       │ reads   │    Palette  (colours)  │
+ *   │    EntryRenderer     │◀────────│    Typography (fonts)  │
+ *   │    ParagraphRenderer │         │    Spacing  (margins)  │
+ *   │    SectionDispatcher │         │    Decoration (glyphs) │
+ *   │    ParagraphPrimitive│         │    BrandTheme    (bundle)   │
  *   │    MarkdownInline    │         └──────────────────────────┘
  *   │    TextOrnaments     │
  *   └──────────────────────┘
@@ -91,7 +91,7 @@
  *   <dt><b>{@code components/}</b></dt>
  *   <dd>The reusable drawing primitives. <em>"How is a section
  *       row laid out?"</em> Each renderer takes a host
- *       {@code SectionBuilder}, a data record, and a {@code CvTheme}.
+ *       {@code SectionBuilder}, a data record, and a {@code BrandTheme}.
  *       You rarely write a new one — usually you compose the
  *       existing ones in a new preset.</dd>
  *
@@ -132,14 +132,14 @@
  *
  * <pre>{@code
  * // Take the classic look
- * CvTheme theme = CvTheme.boxedClassic();
+ * BrandTheme theme = BrandTheme.boxedClassic();
  *
  * // ... or customise one piece, keep the rest
- * CvTheme custom = new CvTheme(
- *     CvPalette.classic(),
- *     CvTypography.classic(),
- *     CvSpacing.classic(),
- *     new CvDecoration("▶ ", "  ", "  ·  "));   // ▶ bullets, mid-dot separators
+ * BrandTheme custom = new BrandTheme(
+ *     Palette.classic(),
+ *     Typography.classic(),
+ *     Spacing.classic(),
+ *     new Decoration("▶ ", "  ", "  ·  "));   // ▶ bullets, mid-dot separators
  * }</pre>
  *
  * <h3>Step 3. Hand to a preset</h3>

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/BlueBanner.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/BlueBanner.java
@@ -10,7 +10,7 @@ import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.cv.v2.components.*;
 import com.demcha.compose.document.templates.cv.v2.data.*;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.ContactLine;
 import com.demcha.compose.document.templates.cv.v2.widgets.FlowSectionHeader;
 import com.demcha.compose.document.templates.cv.v2.widgets.Headline;
@@ -75,7 +75,7 @@ public final class BlueBanner {
      * @return ready-to-use template
      */
     public static DocumentTemplate<CvDocument> create() {
-        return create(CvTheme.blueBanner());
+        return create(BrandTheme.blueBanner());
     }
 
     /**
@@ -86,12 +86,12 @@ public final class BlueBanner {
      * @param theme active theme
      * @return ready-to-use template
      */
-    public static DocumentTemplate<CvDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CvDocument> create(BrandTheme theme) {
         Objects.requireNonNull(theme, "theme");
         return new Template(theme);
     }
 
-    private record Template(CvTheme theme) implements DocumentTemplate<CvDocument> {
+    private record Template(BrandTheme theme) implements DocumentTemplate<CvDocument> {
 
         @Override
             public String id() {
@@ -144,7 +144,7 @@ public final class BlueBanner {
 
     private static void renderBody(SectionBuilder host,
                                    CvSection section,
-                                   CvTheme theme) {
+                                   BrandTheme theme) {
         host.spacing(theme.spacing().sectionBodySpacing())
                 .padding(theme.spacing().sectionBodyPadding());
 
@@ -166,7 +166,7 @@ public final class BlueBanner {
 
     private static void renderRows(SectionBuilder host,
                                    RowsSection section,
-                                   CvTheme theme) {
+                                   BrandTheme theme) {
         if (section.style() == RowStyle.BULLETED_STACKED) {
             for (CvRow row : section.rows()) {
                 renderPlainProjectRow(host, row, theme);
@@ -180,7 +180,7 @@ public final class BlueBanner {
 
     private static void renderPlainProjectRow(SectionBuilder host,
                                               CvRow row,
-                                              CvTheme theme) {
+                                              BrandTheme theme) {
         ProjectRenderer.plainInline(host, row, theme.entryTitleStyle(),
                 theme.bodyStyle(), theme.typography().bodyLineSpacing(),
                 DocumentInsets.top((float) theme.spacing().paragraphMarginTop()),
@@ -189,7 +189,7 @@ public final class BlueBanner {
 
     private static void renderEntry(SectionBuilder section,
                                     CvEntry entry,
-                                    CvTheme theme) {
+                                    BrandTheme theme) {
         DocumentTextStyle titleStyle = theme.entryTitleStyle();
         DocumentTextStyle dateStyle = CvTextStyles.of(theme.typography().bodyFont(),
                 theme.typography().sizeEntryDate(),

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/BoxedSections.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/BoxedSections.java
@@ -7,7 +7,7 @@ import com.demcha.compose.document.templates.cv.v2.components.SectionDispatcher;
 import com.demcha.compose.document.templates.cv.v2.data.CvDocument;
 import com.demcha.compose.document.templates.cv.v2.data.CvSection;
 import com.demcha.compose.document.templates.cv.v2.data.Slot;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.ContactLine;
 import com.demcha.compose.document.templates.cv.v2.widgets.Headline;
 import com.demcha.compose.document.templates.cv.v2.widgets.SectionHeader;
@@ -27,9 +27,9 @@ import java.util.Objects;
  * <ol>
  *   <li>Define its identity ({@link #ID}, {@link #DISPLAY_NAME},
  *       {@link #RECOMMENDED_MARGIN}).</li>
- *   <li>Pick a default theme — {@link CvTheme#boxedClassic()} — that
+ *   <li>Pick a default theme — {@link BrandTheme#boxedClassic()} — that
  *       callers can override via the
- *       {@link #create(CvTheme)} overload.</li>
+ *       {@link #create(BrandTheme)} overload.</li>
  *   <li>Walk {@link CvDocument#sections()} top-to-bottom, emitting a
  *       banner + body pair per section. All actual drawing is
  *       delegated to {@code cv/v2/components}.</li>
@@ -66,7 +66,7 @@ public final class BoxedSections {
      * @return ready-to-use template
      */
     public static DocumentTemplate<CvDocument> create() {
-        return create(CvTheme.boxedClassic());
+        return create(BrandTheme.boxedClassic());
     }
 
     /**
@@ -78,12 +78,12 @@ public final class BoxedSections {
      * @return ready-to-use template
      * @throws NullPointerException if {@code theme} is null
      */
-    public static DocumentTemplate<CvDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CvDocument> create(BrandTheme theme) {
         Objects.requireNonNull(theme, "theme");
         return new Template(theme);
     }
 
-    private record Template(CvTheme theme) implements DocumentTemplate<CvDocument> {
+    private record Template(BrandTheme theme) implements DocumentTemplate<CvDocument> {
 
         @Override
             public String id() {

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/CenteredHeadline.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/CenteredHeadline.java
@@ -11,7 +11,7 @@ import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.cv.v2.components.ProjectRenderer;
 import com.demcha.compose.document.templates.cv.v2.components.SectionDispatcher;
 import com.demcha.compose.document.templates.cv.v2.data.*;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.ContactLine;
 import com.demcha.compose.document.templates.cv.v2.widgets.Headline;
 import com.demcha.compose.document.templates.cv.v2.widgets.SectionHeader;
@@ -87,12 +87,12 @@ public final class CenteredHeadline {
 
     /**
      * Builds the preset with the classic Centered Headline theme
-     * ({@link CvTheme#centeredHeadline()}).
+     * ({@link BrandTheme#centeredHeadline()}).
      *
      * @return ready-to-use template
      */
     public static DocumentTemplate<CvDocument> create() {
-        return create(CvTheme.centeredHeadline());
+        return create(BrandTheme.centeredHeadline());
     }
 
     /**
@@ -104,12 +104,12 @@ public final class CenteredHeadline {
      * @param theme active theme
      * @return ready-to-use template
      */
-    public static DocumentTemplate<CvDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CvDocument> create(BrandTheme theme) {
         Objects.requireNonNull(theme, "theme");
         return new Template(theme);
     }
 
-    private record Template(CvTheme theme) implements DocumentTemplate<CvDocument> {
+    private record Template(BrandTheme theme) implements DocumentTemplate<CvDocument> {
 
         @Override
             public String id() {

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/ClassicSerif.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/ClassicSerif.java
@@ -11,7 +11,7 @@ import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.cv.v2.components.*;
 import com.demcha.compose.document.templates.cv.v2.data.*;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.ContactLine;
 import com.demcha.compose.document.templates.cv.v2.widgets.Headline;
 import com.demcha.compose.document.templates.cv.v2.widgets.SectionHeader;
@@ -74,7 +74,7 @@ public final class ClassicSerif {
      * @return ready-to-use template
      */
     public static DocumentTemplate<CvDocument> create() {
-        return create(CvTheme.classicSerif());
+        return create(BrandTheme.classicSerif());
     }
 
     /**
@@ -83,12 +83,12 @@ public final class ClassicSerif {
      * @param theme active theme
      * @return ready-to-use template
      */
-    public static DocumentTemplate<CvDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CvDocument> create(BrandTheme theme) {
         Objects.requireNonNull(theme, "theme");
         return new Template(theme);
     }
 
-    private record Template(CvTheme theme) implements DocumentTemplate<CvDocument> {
+    private record Template(BrandTheme theme) implements DocumentTemplate<CvDocument> {
 
         @Override
             public String id() {

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/CompactMono.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/CompactMono.java
@@ -7,7 +7,7 @@ import com.demcha.compose.document.style.*;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.cv.v2.components.*;
 import com.demcha.compose.document.templates.cv.v2.data.*;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.ContactLine;
 import com.demcha.compose.document.templates.cv.v2.widgets.Headline;
 import com.demcha.compose.document.templates.cv.v2.widgets.SectionHeader;
@@ -87,7 +87,7 @@ public final class CompactMono {
      * @return ready-to-use template
      */
     public static DocumentTemplate<CvDocument> create() {
-        return create(CvTheme.compactMono());
+        return create(BrandTheme.compactMono());
     }
 
     /**
@@ -98,12 +98,12 @@ public final class CompactMono {
      * @param theme active theme
      * @return ready-to-use template
      */
-    public static DocumentTemplate<CvDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CvDocument> create(BrandTheme theme) {
         Objects.requireNonNull(theme, "theme");
         return new Template(theme);
     }
 
-    private record Template(CvTheme theme) implements DocumentTemplate<CvDocument> {
+    private record Template(BrandTheme theme) implements DocumentTemplate<CvDocument> {
 
         @Override
             public String id() {

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/EditorialBlue.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/EditorialBlue.java
@@ -11,7 +11,7 @@ import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.cv.v2.components.*;
 import com.demcha.compose.document.templates.cv.v2.data.*;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.FlowSectionHeader;
 import com.demcha.compose.document.templates.cv.v2.widgets.Masthead;
 import com.demcha.compose.document.templates.widgets.TableWidget;
@@ -70,7 +70,7 @@ public final class EditorialBlue {
      * @return ready-to-use template
      */
     public static DocumentTemplate<CvDocument> create() {
-        return create(CvTheme.editorialBlue());
+        return create(BrandTheme.editorialBlue());
     }
 
     /**
@@ -79,12 +79,12 @@ public final class EditorialBlue {
      * @param theme active theme
      * @return ready-to-use template
      */
-    public static DocumentTemplate<CvDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CvDocument> create(BrandTheme theme) {
         Objects.requireNonNull(theme, "theme");
         return new Template(theme);
     }
 
-    private record Template(CvTheme theme) implements DocumentTemplate<CvDocument> {
+    private record Template(BrandTheme theme) implements DocumentTemplate<CvDocument> {
 
         @Override
             public String id() {

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/EngineeringResume.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/EngineeringResume.java
@@ -12,7 +12,7 @@ import com.demcha.compose.document.templates.cv.v2.components.MarkdownInline;
 import com.demcha.compose.document.templates.cv.v2.components.ProjectLabel;
 import com.demcha.compose.document.templates.cv.v2.components.SectionLookup;
 import com.demcha.compose.document.templates.cv.v2.data.*;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -134,7 +134,7 @@ public final class EngineeringResume {
      * @return ready-to-use template
      */
     public static DocumentTemplate<CvDocument> create() {
-        return create(CvTheme.engineeringResume());
+        return create(BrandTheme.engineeringResume());
     }
 
     /**
@@ -143,12 +143,12 @@ public final class EngineeringResume {
      * @param theme active theme
      * @return ready-to-use template
      */
-    public static DocumentTemplate<CvDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CvDocument> create(BrandTheme theme) {
         Objects.requireNonNull(theme, "theme");
         return new Template(theme);
     }
 
-    private record Template(CvTheme theme) implements DocumentTemplate<CvDocument> {
+    private record Template(BrandTheme theme) implements DocumentTemplate<CvDocument> {
 
         @Override
             public String id() {

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/Executive.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/Executive.java
@@ -13,7 +13,7 @@ import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
 import com.demcha.compose.document.templates.cv.v2.components.SectionDispatcher;
 import com.demcha.compose.document.templates.cv.v2.data.*;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.Headline;
 import com.demcha.compose.document.templates.cv.v2.widgets.SectionHeader;
 import com.demcha.compose.font.FontName;
@@ -80,7 +80,7 @@ public final class Executive {
      * @return ready-to-use template
      */
     public static DocumentTemplate<CvDocument> create() {
-        return create(CvTheme.executive());
+        return create(BrandTheme.executive());
     }
 
     /**
@@ -89,12 +89,12 @@ public final class Executive {
      * @param theme active theme
      * @return ready-to-use template
      */
-    public static DocumentTemplate<CvDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CvDocument> create(BrandTheme theme) {
         Objects.requireNonNull(theme, "theme");
         return new Template(theme);
     }
 
-    private record Template(CvTheme theme) implements DocumentTemplate<CvDocument> {
+    private record Template(BrandTheme theme) implements DocumentTemplate<CvDocument> {
 
         @Override
             public String id() {

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/MinimalUnderlined.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/MinimalUnderlined.java
@@ -7,7 +7,7 @@ import com.demcha.compose.document.templates.cv.v2.components.SectionDispatcher;
 import com.demcha.compose.document.templates.cv.v2.data.CvDocument;
 import com.demcha.compose.document.templates.cv.v2.data.CvSection;
 import com.demcha.compose.document.templates.cv.v2.data.Slot;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.ContactLine;
 import com.demcha.compose.document.templates.cv.v2.widgets.Headline;
 import com.demcha.compose.document.templates.cv.v2.widgets.SectionHeader;
@@ -19,7 +19,7 @@ import java.util.Objects;
  * v2 demonstration preset — Minimal Underlined.
  *
  * <p>Same data model ({@link CvDocument}), same theme tokens
- * ({@link CvTheme}), same body renderers — but the section header
+ * ({@link BrandTheme}), same body renderers — but the section header
  * is drawn as a small left-aligned uppercase title with an
  * underline rule instead of a centred banner panel.</p>
  *
@@ -69,7 +69,7 @@ public final class MinimalUnderlined {
      * @return ready-to-use template
      */
     public static DocumentTemplate<CvDocument> create() {
-        return create(CvTheme.boxedClassic());
+        return create(BrandTheme.boxedClassic());
     }
 
     /**
@@ -78,12 +78,12 @@ public final class MinimalUnderlined {
      * @param theme active theme
      * @return ready-to-use template
      */
-    public static DocumentTemplate<CvDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CvDocument> create(BrandTheme theme) {
         Objects.requireNonNull(theme, "theme");
         return new Template(theme);
     }
 
-    private record Template(CvTheme theme) implements DocumentTemplate<CvDocument> {
+    private record Template(BrandTheme theme) implements DocumentTemplate<CvDocument> {
 
         @Override
             public String id() {

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/MintEditorial.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/MintEditorial.java
@@ -19,7 +19,7 @@ import com.demcha.compose.document.templates.cv.v2.components.MarkdownInline;
 import com.demcha.compose.document.templates.cv.v2.components.SectionLookup;
 import com.demcha.compose.document.templates.cv.v2.components.TextOrnaments;
 import com.demcha.compose.document.templates.cv.v2.data.*;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.Headline;
 import com.demcha.compose.document.templates.cv.v2.widgets.IconTextRow;
 import com.demcha.compose.document.templates.cv.v2.widgets.SkillBar;
@@ -265,7 +265,7 @@ public final class MintEditorial {
      * @return ready-to-use template
      */
     public static DocumentTemplate<CvDocument> create() {
-        return create(CvTheme.mintEditorial(), Options.defaults());
+        return create(BrandTheme.mintEditorial(), Options.defaults());
     }
 
     /**
@@ -276,7 +276,7 @@ public final class MintEditorial {
      * @param theme active theme
      * @return ready-to-use template
      */
-    public static DocumentTemplate<CvDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CvDocument> create(BrandTheme theme) {
         return create(theme, Options.defaults());
     }
 
@@ -288,7 +288,7 @@ public final class MintEditorial {
      * @return ready-to-use template
      */
     public static DocumentTemplate<CvDocument> create(Options options) {
-        return create(CvTheme.mintEditorial(), options);
+        return create(BrandTheme.mintEditorial(), options);
     }
 
     /**
@@ -300,7 +300,7 @@ public final class MintEditorial {
      * @param options masthead colour options
      * @return ready-to-use template
      */
-    public static DocumentTemplate<CvDocument> create(CvTheme theme,
+    public static DocumentTemplate<CvDocument> create(BrandTheme theme,
                                                       Options options) {
         Objects.requireNonNull(theme, "theme");
         Objects.requireNonNull(options, "options");
@@ -417,7 +417,7 @@ public final class MintEditorial {
 
     private static final class Template implements DocumentTemplate<CvDocument> {
 
-        private final CvTheme theme;
+        private final BrandTheme theme;
         /**
          * Accent for the tagline + section headings (defaults to mint).
          */
@@ -435,7 +435,7 @@ public final class MintEditorial {
          */
         private final DocumentColor headerBandColor;
 
-        Template(CvTheme theme, Options options) {
+        Template(BrandTheme theme, Options options) {
             this.theme = theme;
             // Mint carries its accent in the palette banner slot — single
             // source shared with the paired cover letter. Each Options knob

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/ModernProfessional.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/ModernProfessional.java
@@ -10,7 +10,7 @@ import com.demcha.compose.document.templates.cv.v2.components.SectionDispatcher;
 import com.demcha.compose.document.templates.cv.v2.data.CvDocument;
 import com.demcha.compose.document.templates.cv.v2.data.CvSection;
 import com.demcha.compose.document.templates.cv.v2.data.Slot;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.ContactLine;
 import com.demcha.compose.document.templates.cv.v2.widgets.Headline;
 import com.demcha.compose.document.templates.cv.v2.widgets.SectionHeader;
@@ -34,13 +34,13 @@ import java.util.Objects;
  * </ul>
  *
  * <p><strong>Why some colours live inside this preset and not in
- * {@link CvTheme}:</strong> the slate-blue display name and the
+ * {@link BrandTheme}:</strong> the slate-blue display name and the
  * bright-blue accent for section titles are unique to this preset —
  * no other v2 preset shares them today. Putting them in
- * {@link com.demcha.compose.document.templates.cv.v2.theme.CvPalette}
+ * {@link com.demcha.compose.document.templates.core.theme.Palette}
  * would pollute the palette with single-use fields. When (or if) a
  * second preset reaches for the same colours, extract them to
- * {@code CvPalette} and update both presets.</p>
+ * {@code Palette} and update both presets.</p>
  *
  * <p><strong>Architectural lesson learned in Phase 2:</strong>
  * single-column presets that don't fit the boxed-banner visual
@@ -88,12 +88,12 @@ public final class ModernProfessional {
 
     /**
      * Builds the preset with the Modern Professional theme
-     * ({@link CvTheme#modernProfessional()}).
+     * ({@link BrandTheme#modernProfessional()}).
      *
      * @return ready-to-use template
      */
     public static DocumentTemplate<CvDocument> create() {
-        return create(CvTheme.modernProfessional());
+        return create(BrandTheme.modernProfessional());
     }
 
     /**
@@ -104,12 +104,12 @@ public final class ModernProfessional {
      * @param theme active theme
      * @return ready-to-use template
      */
-    public static DocumentTemplate<CvDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CvDocument> create(BrandTheme theme) {
         Objects.requireNonNull(theme, "theme");
         return new Template(theme);
     }
 
-    private record Template(CvTheme theme) implements DocumentTemplate<CvDocument> {
+    private record Template(BrandTheme theme) implements DocumentTemplate<CvDocument> {
 
         @Override
             public String id() {

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/MonogramSidebar.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/MonogramSidebar.java
@@ -11,7 +11,7 @@ import com.demcha.compose.document.style.*;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.cv.v2.components.*;
 import com.demcha.compose.document.templates.cv.v2.data.*;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.SvgGlyph;
 import com.demcha.compose.font.FontName;
 
@@ -132,7 +132,7 @@ public final class MonogramSidebar {
      * @return ready-to-use template
      */
     public static DocumentTemplate<CvDocument> create() {
-        return create(CvTheme.monogramSidebar(), Options.defaults());
+        return create(BrandTheme.monogramSidebar(), Options.defaults());
     }
 
     /**
@@ -142,7 +142,7 @@ public final class MonogramSidebar {
      * @param theme active theme
      * @return ready-to-use template
      */
-    public static DocumentTemplate<CvDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CvDocument> create(BrandTheme theme) {
         return create(theme, Options.defaults());
     }
 
@@ -155,7 +155,7 @@ public final class MonogramSidebar {
      * @param options sidebar colour options
      * @return ready-to-use template
      */
-    public static DocumentTemplate<CvDocument> create(CvTheme theme,
+    public static DocumentTemplate<CvDocument> create(BrandTheme theme,
                                                       Options options) {
         Objects.requireNonNull(theme, "theme");
         Objects.requireNonNull(options, "options");
@@ -272,13 +272,13 @@ public final class MonogramSidebar {
 
     private static final class Template implements DocumentTemplate<CvDocument> {
 
-        private final CvTheme theme;
+        private final BrandTheme theme;
         private final DocumentColor sidebarFill;
         private final DocumentColor mainFill;
         private final DocumentColor accent;
         private final DocumentColor monogramRing;
 
-        Template(CvTheme theme, Options options) {
+        Template(BrandTheme theme, Options options) {
             this.theme = theme;
             this.sidebarFill = options.sidebarFillColor() != null
                     ? options.sidebarFillColor()

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/NordicClean.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/NordicClean.java
@@ -7,7 +7,7 @@ import com.demcha.compose.document.style.*;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.cv.v2.components.*;
 import com.demcha.compose.document.templates.cv.v2.data.*;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.ContactLine;
 import com.demcha.compose.document.templates.cv.v2.widgets.Headline;
 import com.demcha.compose.document.templates.cv.v2.widgets.ProfileBand;
@@ -33,14 +33,14 @@ import java.util.Objects;
  *
  * <h2>Customising the rail and colours</h2>
  *
- * <p>Use {@link #create(CvTheme, Options)} when you want the same
+ * <p>Use {@link #create(BrandTheme, Options)} when you want the same
  * Nordic layout with a different accent colour, rail fill, profile
  * band fill, or rail side. The default {@link #create()} stays
  * byte-for-byte compatible with the shipped teal-left-rail look.</p>
  *
  * <pre>{@code
  * DocumentTemplate<CvDocument> template = NordicClean.create(
- *         CvTheme.nordicClean(),
+ *         BrandTheme.nordicClean(),
  *         NordicClean.Options.builder()
  *                 .railSide(NordicClean.RailSide.RIGHT)
  *                 .accentColor(DocumentColor.rgb(40, 110, 120))
@@ -93,7 +93,7 @@ public final class NordicClean {
      * @return ready-to-use template
      */
     public static DocumentTemplate<CvDocument> create() {
-        return create(CvTheme.nordicClean(), Options.defaults());
+        return create(BrandTheme.nordicClean(), Options.defaults());
     }
 
     /**
@@ -102,7 +102,7 @@ public final class NordicClean {
      * @param theme active theme
      * @return ready-to-use template
      */
-    public static DocumentTemplate<CvDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CvDocument> create(BrandTheme theme) {
         return create(theme, Options.defaults());
     }
 
@@ -114,7 +114,7 @@ public final class NordicClean {
      * @param options Nordic-specific layout and colour options
      * @return ready-to-use template
      */
-    public static DocumentTemplate<CvDocument> create(CvTheme theme,
+    public static DocumentTemplate<CvDocument> create(BrandTheme theme,
                                                       Options options) {
         Objects.requireNonNull(theme, "theme");
         Objects.requireNonNull(options, "options");
@@ -166,7 +166,7 @@ public final class NordicClean {
 
         /**
          * Default Nordic look: left rail, teal accent, pale rail fill,
-         * and profile fill read from {@code CvTheme.nordicClean()}.
+         * and profile fill read from {@code BrandTheme.nordicClean()}.
          *
          * @return the default Nordic options
          */
@@ -183,7 +183,7 @@ public final class NordicClean {
             return new Builder();
         }
 
-        private DocumentColor resolvedProfileFill(CvTheme theme) {
+        private DocumentColor resolvedProfileFill(BrandTheme theme) {
             return profileFillColor == null
                     ? theme.palette().banner()
                     : profileFillColor;
@@ -257,7 +257,7 @@ public final class NordicClean {
         }
     }
 
-    private record Template(CvTheme theme, Options options) implements DocumentTemplate<CvDocument> {
+    private record Template(BrandTheme theme, Options options) implements DocumentTemplate<CvDocument> {
 
         @Override
             public String id() {

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/Panel.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/Panel.java
@@ -9,7 +9,7 @@ import com.demcha.compose.document.style.*;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.cv.v2.components.*;
 import com.demcha.compose.document.templates.cv.v2.data.*;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.widgets.CardWidget;
 import com.demcha.compose.font.FontName;
 
@@ -121,7 +121,7 @@ public final class Panel {
      * @return ready-to-use template
      */
     public static DocumentTemplate<CvDocument> create() {
-        return create(CvTheme.panel());
+        return create(BrandTheme.panel());
     }
 
     /**
@@ -130,12 +130,12 @@ public final class Panel {
      * @param theme active theme
      * @return ready-to-use template
      */
-    public static DocumentTemplate<CvDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CvDocument> create(BrandTheme theme) {
         Objects.requireNonNull(theme, "theme");
         return new Template(theme);
     }
 
-    private record Template(CvTheme theme) implements DocumentTemplate<CvDocument> {
+    private record Template(BrandTheme theme) implements DocumentTemplate<CvDocument> {
 
         @Override
             public String id() {

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/SidebarPortrait.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/SidebarPortrait.java
@@ -17,7 +17,7 @@ import com.demcha.compose.document.templates.cv.v2.components.MarkdownInline;
 import com.demcha.compose.document.templates.cv.v2.components.ProjectLabel;
 import com.demcha.compose.document.templates.cv.v2.components.SectionLookup;
 import com.demcha.compose.document.templates.cv.v2.data.*;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.SvgGlyph;
 
 import java.io.IOException;
@@ -188,7 +188,7 @@ public final class SidebarPortrait {
      * @return ready-to-use template
      */
     public static DocumentTemplate<CvDocument> create() {
-        return create(CvTheme.sidebarPortrait(), Options.defaults());
+        return create(BrandTheme.sidebarPortrait(), Options.defaults());
     }
 
     /**
@@ -198,7 +198,7 @@ public final class SidebarPortrait {
      * @param theme active theme
      * @return ready-to-use template
      */
-    public static DocumentTemplate<CvDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CvDocument> create(BrandTheme theme) {
         return create(theme, Options.defaults());
     }
 
@@ -211,7 +211,7 @@ public final class SidebarPortrait {
      * @param options sidebar colour options
      * @return ready-to-use template
      */
-    public static DocumentTemplate<CvDocument> create(CvTheme theme,
+    public static DocumentTemplate<CvDocument> create(BrandTheme theme,
                                                       Options options) {
         Objects.requireNonNull(theme, "theme");
         Objects.requireNonNull(options, "options");
@@ -310,12 +310,12 @@ public final class SidebarPortrait {
 
     private static final class Template implements DocumentTemplate<CvDocument> {
 
-        private final CvTheme theme;
+        private final BrandTheme theme;
         private final DocumentColor sidebarFill;
         private final DocumentColor mainFill;
         private final DocumentColor accent;
 
-        Template(CvTheme theme, Options options) {
+        Template(BrandTheme theme, Options options) {
             this.theme = theme;
             this.sidebarFill = options.sidebarFillColor() != null
                     ? options.sidebarFillColor()

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/TimelineMinimal.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/TimelineMinimal.java
@@ -16,7 +16,7 @@ import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
 import com.demcha.compose.document.templates.cv.v2.components.MarkdownInline;
 import com.demcha.compose.document.templates.cv.v2.components.SectionLookup;
 import com.demcha.compose.document.templates.cv.v2.data.*;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.SvgGlyph;
 import com.demcha.compose.document.templates.widgets.TimelineAxisWidget;
 
@@ -121,7 +121,7 @@ public final class TimelineMinimal {
      * @return ready-to-use template
      */
     public static DocumentTemplate<CvDocument> create() {
-        return create(CvTheme.timelineMinimal());
+        return create(BrandTheme.timelineMinimal());
     }
 
     /**
@@ -130,12 +130,12 @@ public final class TimelineMinimal {
      * @param theme active theme
      * @return ready-to-use template
      */
-    public static DocumentTemplate<CvDocument> create(CvTheme theme) {
+    public static DocumentTemplate<CvDocument> create(BrandTheme theme) {
         Objects.requireNonNull(theme, "theme");
         return new Template(theme);
     }
 
-    private record Template(CvTheme theme) implements DocumentTemplate<CvDocument> {
+    private record Template(BrandTheme theme) implements DocumentTemplate<CvDocument> {
 
         @Override
             public String id() {

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/package-info.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/package-info.java
@@ -7,7 +7,7 @@
  * <ol>
  *   <li>A {@link com.demcha.compose.document.templates.cv.v2.data.CvDocument}
  *       supplied by the caller (the data).</li>
- *   <li>A {@link com.demcha.compose.document.templates.cv.v2.theme.CvTheme}
+ *   <li>A {@link com.demcha.compose.document.templates.core.theme.BrandTheme}
  *       picked at construction (the cosmetics).</li>
  *   <li>A loop over the document's sections that calls renderers
  *       from {@code cv/v2/components}.</li>

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/widgets/ContactLine.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/widgets/ContactLine.java
@@ -8,7 +8,7 @@ import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.cv.v2.data.CvContact;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
 import com.demcha.compose.document.templates.cv.v2.data.CvLink;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -52,14 +52,14 @@ public final class ContactLine {
      * @param identity the CV identity supplying contact fields and links
      * @param theme    the active theme supplying palette, typography, and spacing
      */
-    public static void centered(SectionBuilder host, CvIdentity identity, CvTheme theme) {
+    public static void centered(SectionBuilder host, CvIdentity identity, BrandTheme theme) {
         render(host, identity, theme, TextAlign.CENTER, Order.PHONE_FIRST);
     }
 
     /**
      * Centred contact row with explicit text-style overrides for
      * non-link text, clickable links, and separators. Same ordering as
-     * {@link #centered(SectionBuilder, CvIdentity, CvTheme)}, but lets
+     * {@link #centered(SectionBuilder, CvIdentity, BrandTheme)}, but lets
      * editorial presets tint / underline the links without forking the
      * contact assembly logic.
      *
@@ -77,7 +77,7 @@ public final class ContactLine {
      *                               {@code theme.contactSeparatorStyle()}
      */
     public static void centered(SectionBuilder host, CvIdentity identity,
-                                CvTheme theme,
+                                BrandTheme theme,
                                 DocumentTextStyle bodyStyleOverride,
                                 DocumentTextStyle linkStyleOverride,
                                 DocumentTextStyle separatorStyleOverride) {
@@ -94,7 +94,7 @@ public final class ContactLine {
      * @param identity the CV identity supplying contact fields and links
      * @param theme    the active theme supplying palette, typography, and spacing
      */
-    public static void rightAligned(SectionBuilder host, CvIdentity identity, CvTheme theme) {
+    public static void rightAligned(SectionBuilder host, CvIdentity identity, BrandTheme theme) {
         render(host, identity, theme, TextAlign.RIGHT, Order.ADDRESS_FIRST);
     }
 
@@ -108,7 +108,7 @@ public final class ContactLine {
      * @param theme    the active theme supplying palette, typography, and spacing
      */
     public static void leftAligned(SectionBuilder host, CvIdentity identity,
-                                   CvTheme theme) {
+                                   BrandTheme theme) {
         render(host, identity, theme, TextAlign.LEFT, Order.ADDRESS_FIRST);
     }
 
@@ -130,7 +130,7 @@ public final class ContactLine {
      *                               {@code theme.contactSeparatorStyle()}
      */
     public static void leftAligned(SectionBuilder host, CvIdentity identity,
-                                   CvTheme theme,
+                                   BrandTheme theme,
                                    DocumentTextStyle bodyStyleOverride,
                                    DocumentTextStyle linkStyleOverride,
                                    DocumentTextStyle separatorStyleOverride) {
@@ -169,7 +169,7 @@ public final class ContactLine {
      *                               {@code theme.contactSeparatorStyle()}
      */
     public static void twoRowRightAligned(SectionBuilder host, CvIdentity identity,
-                                          CvTheme theme,
+                                          BrandTheme theme,
                                           DocumentTextStyle bodyStyleOverride,
                                           DocumentTextStyle linkStyleOverride,
                                           DocumentTextStyle separatorStyleOverride) {
@@ -219,7 +219,7 @@ public final class ContactLine {
      */
     public static void rightAlignedStacked(SectionBuilder host,
                                            CvIdentity identity,
-                                           CvTheme theme) {
+                                           BrandTheme theme) {
         rightAlignedStacked(host, identity, theme, null, null);
     }
 
@@ -237,7 +237,7 @@ public final class ContactLine {
      */
     public static void rightAlignedStacked(SectionBuilder host,
                                            CvIdentity identity,
-                                           CvTheme theme,
+                                           BrandTheme theme,
                                            DocumentTextStyle bodyStyleOverride,
                                            DocumentTextStyle linkStyleOverride) {
         DocumentTextStyle bodyStyle = bodyStyleOverride != null
@@ -274,7 +274,7 @@ public final class ContactLine {
      * @param alignment horizontal text alignment for the row
      * @param order     the field order in the rendered line
      */
-    public static void render(SectionBuilder host, CvIdentity identity, CvTheme theme,
+    public static void render(SectionBuilder host, CvIdentity identity, BrandTheme theme,
                               TextAlign alignment, Order order) {
         List<Part> parts = parts(identity, order);
         DocumentTextStyle textStyle = theme.contactStyle();
@@ -303,7 +303,7 @@ public final class ContactLine {
     }
 
     private static void renderStyled(SectionBuilder host, CvIdentity identity,
-                                     CvTheme theme, TextAlign alignment,
+                                     BrandTheme theme, TextAlign alignment,
                                      Order order,
                                      DocumentTextStyle bodyStyleOverride,
                                      DocumentTextStyle linkStyleOverride,

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/widgets/FlowSectionHeader.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/widgets/FlowSectionHeader.java
@@ -5,7 +5,7 @@ import com.demcha.compose.document.node.TextAlign;
 import com.demcha.compose.document.style.DocumentColor;
 import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.style.DocumentTextStyle;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 
 /**
  * Page-flow section-header widget for presets whose title treatment
@@ -39,7 +39,7 @@ public final class FlowSectionHeader {
                               String name,
                               String title,
                               double ruleWidth,
-                              CvTheme theme,
+                              BrandTheme theme,
                               DocumentTextStyle titleStyle,
                               DocumentInsets topRuleMargin,
                               DocumentInsets bottomRuleMargin) {
@@ -64,7 +64,7 @@ public final class FlowSectionHeader {
                               String name,
                               String title,
                               double ruleWidth,
-                              CvTheme theme,
+                              BrandTheme theme,
                               DocumentTextStyle titleStyle,
                               DocumentColor ruleColor,
                               DocumentInsets topRuleMargin,
@@ -96,7 +96,7 @@ public final class FlowSectionHeader {
                              String name,
                              String title,
                              double ruleWidth,
-                             CvTheme theme,
+                             BrandTheme theme,
                              DocumentTextStyle titleStyle,
                              DocumentInsets topRuleMargin,
                              DocumentInsets titlePadding,
@@ -127,7 +127,7 @@ public final class FlowSectionHeader {
                              String name,
                              String title,
                              double ruleWidth,
-                             CvTheme theme,
+                             BrandTheme theme,
                              DocumentTextStyle titleStyle,
                              DocumentColor ruleColor,
                              DocumentInsets topRuleMargin,
@@ -154,7 +154,7 @@ public final class FlowSectionHeader {
                                 String name,
                                 double width,
                                 DocumentColor color,
-                                CvTheme theme,
+                                BrandTheme theme,
                                 DocumentInsets margin) {
         flow.addLine(line -> line
                 .name(name)

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/widgets/Headline.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/widgets/Headline.java
@@ -6,7 +6,7 @@ import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.cv.v2.components.TextOrnaments;
 import com.demcha.compose.document.templates.cv.v2.data.CvName;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 
 /**
  * Top-of-document headline widget — the subject's name as the page's
@@ -55,7 +55,7 @@ public final class Headline {
      * @param name  name to render
      * @param theme the active theme supplying palette, typography, and spacing
      */
-    public static void spacedCentered(SectionBuilder host, CvName name, CvTheme theme) {
+    public static void spacedCentered(SectionBuilder host, CvName name, BrandTheme theme) {
         render(host, name, theme, TextAlign.CENTER, true);
     }
 
@@ -69,7 +69,7 @@ public final class Headline {
      * @param theme the active theme supplying palette, typography, and spacing
      */
     public static void uppercaseCentered(SectionBuilder host, CvName name,
-                                         CvTheme theme) {
+                                         BrandTheme theme) {
         uppercaseCentered(host, name, theme, null);
     }
 
@@ -84,7 +84,7 @@ public final class Headline {
      *                      back to {@code theme.headlineStyle()}
      */
     public static void uppercaseCentered(SectionBuilder host, CvName name,
-                                         CvTheme theme,
+                                         BrandTheme theme,
                                          DocumentTextStyle styleOverride) {
         renderText(host, name.full().toUpperCase(java.util.Locale.ROOT),
                 theme, TextAlign.CENTER, styleOverride);
@@ -100,7 +100,7 @@ public final class Headline {
      * @param theme the active theme supplying palette, typography, and spacing
      */
     public static void uppercaseLeftAligned(SectionBuilder host, CvName name,
-                                            CvTheme theme) {
+                                            BrandTheme theme) {
         uppercaseLeftAligned(host, name, theme, null);
     }
 
@@ -115,7 +115,7 @@ public final class Headline {
      *                      back to {@code theme.headlineStyle()}
      */
     public static void uppercaseLeftAligned(SectionBuilder host, CvName name,
-                                            CvTheme theme,
+                                            BrandTheme theme,
                                             DocumentTextStyle styleOverride) {
         renderText(host, name.full().toUpperCase(java.util.Locale.ROOT),
                 theme, TextAlign.LEFT, styleOverride);
@@ -123,7 +123,7 @@ public final class Headline {
 
     /**
      * Right-aligned plain headline using the theme's default
-     * {@link CvTheme#headlineStyle() headline style}. Visual
+     * {@link BrandTheme#headlineStyle() headline style}. Visual
      * signature of corporate / modern presets that don't need a
      * custom display colour.
      *
@@ -131,7 +131,7 @@ public final class Headline {
      * @param name  name to render
      * @param theme the active theme supplying palette, typography, and spacing
      */
-    public static void rightAligned(SectionBuilder host, CvName name, CvTheme theme) {
+    public static void rightAligned(SectionBuilder host, CvName name, BrandTheme theme) {
         rightAligned(host, name, theme, null);
     }
 
@@ -147,7 +147,7 @@ public final class Headline {
      * @param styleOverride text style for the headline; pass {@code null}
      *                      to fall back to {@code theme.headlineStyle()}
      */
-    public static void rightAligned(SectionBuilder host, CvName name, CvTheme theme,
+    public static void rightAligned(SectionBuilder host, CvName name, BrandTheme theme,
                                     DocumentTextStyle styleOverride) {
         render(host, name, theme, TextAlign.RIGHT, false, styleOverride);
     }
@@ -155,7 +155,7 @@ public final class Headline {
     /**
      * Lower-level entry. Pick the alignment and whether the name
      * should be transformed to spaced uppercase. Text style comes
-     * from {@link CvTheme#headlineStyle()}; padding from
+     * from {@link BrandTheme#headlineStyle()}; padding from
      * {@code theme.spacing().headlinePadding()}.
      *
      * @param host       host section
@@ -165,14 +165,14 @@ public final class Headline {
      * @param spacedCaps if true, transforms to letter-spaced
      *                   uppercase; if false, renders verbatim
      */
-    public static void render(SectionBuilder host, CvName name, CvTheme theme,
+    public static void render(SectionBuilder host, CvName name, BrandTheme theme,
                               TextAlign alignment, boolean spacedCaps) {
         render(host, name, theme, alignment, spacedCaps, null);
     }
 
     /**
      * Lower-level entry with explicit style override. Same shape as
-     * the 5-arg {@link #render(SectionBuilder, CvName, CvTheme, TextAlign, boolean)}
+     * the 5-arg {@link #render(SectionBuilder, CvName, BrandTheme, TextAlign, boolean)}
      * but lets the caller supply a custom {@link DocumentTextStyle}.
      *
      * @param host          host section
@@ -184,7 +184,7 @@ public final class Headline {
      * @param styleOverride explicit style; pass {@code null} to fall
      *                      back to {@code theme.headlineStyle()}
      */
-    public static void render(SectionBuilder host, CvName name, CvTheme theme,
+    public static void render(SectionBuilder host, CvName name, BrandTheme theme,
                               TextAlign alignment, boolean spacedCaps,
                               DocumentTextStyle styleOverride) {
         DocumentTextStyle style = styleOverride != null
@@ -197,7 +197,7 @@ public final class Headline {
         renderText(host, text, theme, alignment, style);
     }
 
-    private static void renderText(SectionBuilder host, String text, CvTheme theme,
+    private static void renderText(SectionBuilder host, String text, BrandTheme theme,
                                    TextAlign alignment,
                                    DocumentTextStyle styleOverride) {
         DocumentTextStyle style = styleOverride != null

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/widgets/Masthead.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/widgets/Masthead.java
@@ -7,7 +7,7 @@ import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
 import com.demcha.compose.document.templates.cv.v2.data.CvLink;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,11 +29,11 @@ public final class Masthead {
      * @param identity the CV identity supplying name, contact, and links
      * @param theme    the active theme supplying palette, typography, and spacing
      * @param style    styling knobs for the masthead; {@code null} uses
-     *                 {@link Style#defaults(CvTheme)}
+     *                 {@link Style#defaults(BrandTheme)}
      */
     public static void centered(SectionBuilder host,
                                 CvIdentity identity,
-                                CvTheme theme,
+                                BrandTheme theme,
                                 Style style) {
         Style safeStyle = style == null ? Style.defaults(theme) : style;
         DocumentTextStyle nameStyle = safeStyle.nameStyle() == null
@@ -67,7 +67,7 @@ public final class Masthead {
 
     private static void addLinkRow(SectionBuilder host,
                                    CvIdentity identity,
-                                   CvTheme theme,
+                                   BrandTheme theme,
                                    Style style) {
         List<LinkPart> parts = linkParts(identity);
         if (parts.isEmpty()) {
@@ -170,7 +170,7 @@ public final class Masthead {
          * @param theme the active theme supplying the default styles
          * @return a {@code Style} populated from the theme defaults
          */
-        public static Style defaults(CvTheme theme) {
+        public static Style defaults(BrandTheme theme) {
             return builder()
                     .nameStyle(theme.headlineStyle())
                     .titleStyle(theme.bodyStyle())

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/widgets/SectionHeader.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/widgets/SectionHeader.java
@@ -7,7 +7,7 @@ import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.style.DocumentTextDecoration;
 import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.cv.v2.components.TextOrnaments;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 
 import java.util.Locale;
 
@@ -69,7 +69,7 @@ public final class SectionHeader {
      * @param title the section title text
      * @param theme the active theme supplying palette, typography, and spacing
      */
-    public static void banner(SectionBuilder host, String title, CvTheme theme) {
+    public static void banner(SectionBuilder host, String title, BrandTheme theme) {
         host.softPanel(theme.palette().banner(),
                         theme.spacing().bannerCornerRadius(),
                         theme.spacing().bannerInnerPadding())
@@ -92,7 +92,7 @@ public final class SectionHeader {
      * @param title the section title text
      * @param theme the active theme supplying palette, typography, and spacing
      */
-    public static void fullWidthBanner(SectionBuilder host, String title, CvTheme theme) {
+    public static void fullWidthBanner(SectionBuilder host, String title, BrandTheme theme) {
         fullWidthBanner(host, title, theme, null);
     }
 
@@ -104,10 +104,10 @@ public final class SectionHeader {
      * @param theme              the active theme supplying palette, typography, and spacing
      * @param titleStyleOverride text style for the banner label; pass
      *                           {@code null} to use
-     *                           {@link CvTheme#bannerStyle()}
+     *                           {@link BrandTheme#bannerStyle()}
      */
     public static void fullWidthBanner(SectionBuilder host, String title,
-                                       CvTheme theme,
+                                       BrandTheme theme,
                                        DocumentTextStyle titleStyleOverride) {
         DocumentTextStyle titleStyle = titleStyleOverride != null
                 ? titleStyleOverride
@@ -131,7 +131,7 @@ public final class SectionHeader {
      * @param title the section title text
      * @param theme the active theme supplying palette, typography, and spacing
      */
-    public static void underlined(SectionBuilder host, String title, CvTheme theme) {
+    public static void underlined(SectionBuilder host, String title, BrandTheme theme) {
         DocumentTextStyle titleStyle = theme.entryTitleStyle();
         host.accentBottom(theme.palette().rule(),
                         theme.spacing().accentRuleWidth())
@@ -155,7 +155,7 @@ public final class SectionHeader {
      * @param theme the active theme supplying palette, typography, and spacing
      */
     public static void flat(SectionBuilder host, String title,
-                            DocumentColor color, CvTheme theme) {
+                            DocumentColor color, BrandTheme theme) {
         DocumentTextStyle titleStyle = DocumentTextStyle.builder()
                 .fontName(theme.typography().headlineFont())
                 .size(theme.typography().sizeBanner())
@@ -193,7 +193,7 @@ public final class SectionHeader {
      *                   fall back to the theme-derived default
      */
     public static void flatSpacedCaps(SectionBuilder host, String title,
-                                      DocumentColor color, CvTheme theme,
+                                      DocumentColor color, BrandTheme theme,
                                       DocumentTextStyle titleStyle) {
         DocumentTextStyle resolved = titleStyle != null
                 ? titleStyle
@@ -224,7 +224,7 @@ public final class SectionHeader {
      * @param tickWidth width of the short rule above the label
      */
     public static void tickLabel(SectionBuilder host, String title,
-                                 CvTheme theme, DocumentColor color,
+                                 BrandTheme theme, DocumentColor color,
                                  double tickWidth) {
         tickLabel(host, title, theme, color, tickWidth, null);
     }
@@ -244,7 +244,7 @@ public final class SectionHeader {
      *                   font and banner size
      */
     public static void tickLabel(SectionBuilder host, String title,
-                                 CvTheme theme, DocumentColor color,
+                                 BrandTheme theme, DocumentColor color,
                                  double tickWidth,
                                  DocumentTextStyle titleStyle) {
         DocumentTextStyle resolved = titleStyle != null
@@ -282,7 +282,7 @@ public final class SectionHeader {
      * @param ruleWidth  width in points of the rule beneath the label
      */
     public static void upperRule(SectionBuilder host, String title,
-                                 CvTheme theme, DocumentTextStyle titleStyle,
+                                 BrandTheme theme, DocumentTextStyle titleStyle,
                                  DocumentColor ruleColor, double ruleWidth) {
         host.spacing(3)
                 .addParagraph(paragraph -> paragraph
@@ -312,7 +312,7 @@ public final class SectionHeader {
      * @param ruleMargin    outer margin of the rule
      */
     public static void spacedCapsRule(SectionBuilder host, String title,
-                                      CvTheme theme, DocumentTextStyle titleStyle,
+                                      BrandTheme theme, DocumentTextStyle titleStyle,
                                       DocumentColor ruleColor,
                                       double ruleWidth,
                                       double ruleThickness,

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/widgets/SectionModule.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/widgets/SectionModule.java
@@ -3,7 +3,7 @@ package com.demcha.compose.document.templates.cv.v2.widgets;
 import com.demcha.compose.document.dsl.SectionBuilder;
 import com.demcha.compose.document.style.DocumentColor;
 import com.demcha.compose.document.style.DocumentTextStyle;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 
 import java.util.Objects;
 import java.util.function.Consumer;
@@ -34,7 +34,7 @@ public final class SectionModule {
     public static void tick(SectionBuilder parent,
                             String name,
                             String title,
-                            CvTheme theme,
+                            BrandTheme theme,
                             DocumentColor color,
                             double tickWidth,
                             DocumentTextStyle titleStyle,
@@ -59,7 +59,7 @@ public final class SectionModule {
     public static void upperRule(SectionBuilder parent,
                                  String name,
                                  String title,
-                                 CvTheme theme,
+                                 BrandTheme theme,
                                  DocumentTextStyle titleStyle,
                                  DocumentColor ruleColor,
                                  double ruleWidth,

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/widgets/SkillBar.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/widgets/SkillBar.java
@@ -8,7 +8,7 @@ import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
 import com.demcha.compose.document.templates.cv.v2.components.TextOrnaments;
 import com.demcha.compose.document.templates.cv.v2.data.CvSkill;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 
 import java.util.Objects;
 
@@ -103,7 +103,7 @@ public final class SkillBar {
      *                   colour, and the rule colour for the track
      */
     public static void render(SectionBuilder host, CvSkill skill,
-                              double trackWidth, CvTheme theme) {
+                              double trackWidth, BrandTheme theme) {
         Objects.requireNonNull(host, "host");
         Objects.requireNonNull(skill, "skill");
         Objects.requireNonNull(theme, "theme");

--- a/src/main/java/com/demcha/compose/document/templates/themes/Spacing.java
+++ b/src/main/java/com/demcha/compose/document/templates/themes/Spacing.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 /**
  * One source of truth for all template spacing tokens.
  *
- * <p>Replaces the historical {@code CvTheme.spacing}/{@code CvTheme.spacingModuleName}
+ * <p>Replaces the historical {@code BrandTheme.spacing}/{@code BrandTheme.spacingModuleName}
  * fields plus the hard-coded {@code MINIMUM_TOP_LEVEL_MODULE_SPACING}
  * constant scattered throughout the legacy composers. Templates v2 presets
  * read every spacing decision from a {@code Spacing} instance and pass it

--- a/src/main/java/com/demcha/compose/document/templates/themes/Typography.java
+++ b/src/main/java/com/demcha/compose/document/templates/themes/Typography.java
@@ -55,7 +55,7 @@ public record Typography(
 
     /**
      * Returns the default Helvetica-based typography matching the historical
-     * {@code CvTheme.defaultTheme()} sizing.
+     * {@code BrandTheme.defaultTheme()} sizing.
      *
      * @return Helvetica typography preset
      */

--- a/src/test/java/com/demcha/compose/document/templates/core/theme/DecorationTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/core/theme/DecorationTest.java
@@ -1,15 +1,15 @@
-package com.demcha.compose.document.templates.cv.v2.theme;
+package com.demcha.compose.document.templates.core.theme;
 
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-class CvDecorationTest {
+class DecorationTest {
 
     @Test
     void classic_carries_the_canonical_glyphs() {
-        CvDecoration d = CvDecoration.classic();
+        Decoration d = Decoration.classic();
         assertThat(d.bulletGlyph()).isEqualTo("• ");
         assertThat(d.stackedIndent()).isEqualTo("  ");
         assertThat(d.contactSeparator()).isEqualTo("   |   ");
@@ -17,14 +17,14 @@ class CvDecorationTest {
 
     @Test
     void rejects_null_field() {
-        assertThatThrownBy(() -> new CvDecoration(null, "  ", " | "))
+        assertThatThrownBy(() -> new Decoration(null, "  ", " | "))
                 .isInstanceOf(NullPointerException.class)
                 .hasMessageContaining("bulletGlyph");
     }
 
     @Test
     void custom_decoration_is_carried_verbatim() {
-        CvDecoration d = new CvDecoration("▶ ", "   ", "  ·  ");
+        Decoration d = new Decoration("▶ ", "   ", "  ·  ");
         assertThat(d.bulletGlyph()).isEqualTo("▶ ");
         assertThat(d.stackedIndent()).isEqualTo("   ");
         assertThat(d.contactSeparator()).isEqualTo("  ·  ");
@@ -36,27 +36,27 @@ class CvDecorationTest {
         // The pre-decoration call shape must keep working and yield
         // the classic decoration, so older callers keep rendering
         // pixel-identical output.
-        CvTheme theme = new CvTheme(
-                CvPalette.classic(),
-                CvTypography.classic(),
-                CvSpacing.classic());
-        assertThat(theme.decoration()).isEqualTo(CvDecoration.classic());
+        BrandTheme theme = new BrandTheme(
+                Palette.classic(),
+                Typography.classic(),
+                Spacing.classic());
+        assertThat(theme.decoration()).isEqualTo(Decoration.classic());
     }
 
     @Test
     void canonical_four_arg_theme_constructor_carries_custom_decoration() {
-        CvDecoration custom = new CvDecoration("· ", "  ", "  /  ");
-        CvTheme theme = new CvTheme(
-                CvPalette.classic(),
-                CvTypography.classic(),
-                CvSpacing.classic(),
+        Decoration custom = new Decoration("· ", "  ", "  /  ");
+        BrandTheme theme = new BrandTheme(
+                Palette.classic(),
+                Typography.classic(),
+                Spacing.classic(),
                 custom);
         assertThat(theme.decoration()).isSameAs(custom);
     }
 
     @Test
     void boxedClassic_carries_classic_decoration() {
-        assertThat(CvTheme.boxedClassic().decoration())
-                .isEqualTo(CvDecoration.classic());
+        assertThat(BrandTheme.boxedClassic().decoration())
+                .isEqualTo(Decoration.classic());
     }
 }

--- a/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/BlueBannerSmokeTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/BlueBannerSmokeTest.java
@@ -10,7 +10,7 @@ import com.demcha.compose.document.templates.cv.v2.data.EntriesSection;
 import com.demcha.compose.document.templates.cv.v2.data.ParagraphSection;
 import com.demcha.compose.document.templates.cv.v2.data.RowStyle;
 import com.demcha.compose.document.templates.cv.v2.data.RowsSection;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,7 +38,7 @@ class BlueBannerSmokeTest {
     @Test
     void custom_theme_factory_renders() throws Exception {
         DocumentTemplate<CvDocument> template =
-                BlueBanner.create(CvTheme.blueBanner());
+                BlueBanner.create(BrandTheme.blueBanner());
         renderAndAssertNonEmpty(template, fullDocument());
     }
 

--- a/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/BoxedSectionsSmokeTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/BoxedSectionsSmokeTest.java
@@ -12,7 +12,7 @@ import com.demcha.compose.document.templates.cv.v2.data.ParagraphSection;
 import com.demcha.compose.document.templates.cv.v2.data.RowStyle;
 import com.demcha.compose.document.templates.cv.v2.data.RowsSection;
 import com.demcha.compose.document.templates.cv.v2.data.SkillsSection;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -43,7 +43,7 @@ class BoxedSectionsSmokeTest {
     @Test
     void custom_theme_factory_renders() throws Exception {
         DocumentTemplate<CvDocument> template =
-                BoxedSections.create(CvTheme.boxedClassic());
+                BoxedSections.create(BrandTheme.boxedClassic());
         renderAndAssertNonEmpty(template, fullDocument());
     }
 

--- a/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/ClassicSerifSmokeTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/ClassicSerifSmokeTest.java
@@ -11,7 +11,7 @@ import com.demcha.compose.document.templates.cv.v2.data.ParagraphSection;
 import com.demcha.compose.document.templates.cv.v2.data.RowStyle;
 import com.demcha.compose.document.templates.cv.v2.data.RowsSection;
 import com.demcha.compose.document.templates.cv.v2.data.SkillsSection;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,7 +37,7 @@ class ClassicSerifSmokeTest {
 
     @Test
     void custom_theme_factory_renders() throws Exception {
-        renderAndAssertNonEmpty(ClassicSerif.create(CvTheme.classicSerif()),
+        renderAndAssertNonEmpty(ClassicSerif.create(BrandTheme.classicSerif()),
                 fullDocument());
     }
 

--- a/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/CompactMonoSmokeTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/CompactMonoSmokeTest.java
@@ -11,7 +11,7 @@ import com.demcha.compose.document.templates.cv.v2.data.ParagraphSection;
 import com.demcha.compose.document.templates.cv.v2.data.RowStyle;
 import com.demcha.compose.document.templates.cv.v2.data.RowsSection;
 import com.demcha.compose.document.templates.cv.v2.data.SkillsSection;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,7 +36,7 @@ class CompactMonoSmokeTest {
 
     @Test
     void custom_theme_factory_renders() throws Exception {
-        renderAndAssertNonEmpty(CompactMono.create(CvTheme.compactMono()),
+        renderAndAssertNonEmpty(CompactMono.create(BrandTheme.compactMono()),
                 fullDocument());
     }
 

--- a/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/EditorialBlueSmokeTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/EditorialBlueSmokeTest.java
@@ -11,7 +11,7 @@ import com.demcha.compose.document.templates.cv.v2.data.ParagraphSection;
 import com.demcha.compose.document.templates.cv.v2.data.RowStyle;
 import com.demcha.compose.document.templates.cv.v2.data.RowsSection;
 import com.demcha.compose.document.templates.cv.v2.data.SkillsSection;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,7 +36,7 @@ class EditorialBlueSmokeTest {
 
     @Test
     void custom_theme_factory_renders() throws Exception {
-        renderAndAssertNonEmpty(EditorialBlue.create(CvTheme.editorialBlue()),
+        renderAndAssertNonEmpty(EditorialBlue.create(BrandTheme.editorialBlue()),
                 fullDocument());
     }
 

--- a/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/EngineeringResumeSmokeTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/EngineeringResumeSmokeTest.java
@@ -5,8 +5,8 @@ import com.demcha.compose.document.api.DocumentSession;
 import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.cv.v2.data.*;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTypography;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
+import com.demcha.compose.document.templates.core.theme.Typography;
 import com.demcha.compose.font.FontFamilyDefinition;
 import com.demcha.compose.font.FontName;
 import org.apache.pdfbox.Loader;
@@ -55,7 +55,7 @@ class EngineeringResumeSmokeTest {
 
     @Test
     void custom_theme_factory_renders() throws Exception {
-        renderAndAssertNonEmpty(EngineeringResume.create(CvTheme.engineeringResume()),
+        renderAndAssertNonEmpty(EngineeringResume.create(BrandTheme.engineeringResume()),
                 fullDocument());
     }
 
@@ -188,9 +188,9 @@ class EngineeringResumeSmokeTest {
                 .build();
     }
 
-    private static CvTheme multiscriptTheme() {
-        CvTheme base = CvTheme.engineeringResume();
-        CvTypography typography = new CvTypography(
+    private static BrandTheme multiscriptTheme() {
+        BrandTheme base = BrandTheme.engineeringResume();
+        Typography typography = new Typography(
                 MULTISCRIPT_FONT,
                 MULTISCRIPT_FONT,
                 base.typography().sizeHeadline(),
@@ -201,7 +201,7 @@ class EngineeringResumeSmokeTest {
                 base.typography().sizeEntrySubtitle(),
                 base.typography().sizeBody(),
                 base.typography().bodyLineSpacing());
-        return new CvTheme(base.palette(), typography, base.spacing(), base.decoration());
+        return new BrandTheme(base.palette(), typography, base.spacing(), base.decoration());
     }
 
     private static Path resolveMultiscriptFont() {

--- a/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/ExecutiveSmokeTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/ExecutiveSmokeTest.java
@@ -11,7 +11,7 @@ import com.demcha.compose.document.templates.cv.v2.data.ParagraphSection;
 import com.demcha.compose.document.templates.cv.v2.data.RowStyle;
 import com.demcha.compose.document.templates.cv.v2.data.RowsSection;
 import com.demcha.compose.document.templates.cv.v2.data.SkillsSection;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,7 +38,7 @@ class ExecutiveSmokeTest {
 
     @Test
     void custom_theme_factory_renders() throws Exception {
-        renderAndAssertNonEmpty(Executive.create(CvTheme.executive()),
+        renderAndAssertNonEmpty(Executive.create(BrandTheme.executive()),
                 fullDocument());
     }
 

--- a/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/MinimalUnderlinedSmokeTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/MinimalUnderlinedSmokeTest.java
@@ -9,7 +9,7 @@ import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
 import com.demcha.compose.document.templates.cv.v2.data.EntriesSection;
 import com.demcha.compose.document.templates.cv.v2.data.ParagraphSection;
 import com.demcha.compose.document.templates.cv.v2.data.SkillsSection;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,7 +43,7 @@ class MinimalUnderlinedSmokeTest {
     @Test
     void custom_theme_factory_renders() throws Exception {
         DocumentTemplate<CvDocument> template =
-                MinimalUnderlined.create(CvTheme.boxedClassic());
+                MinimalUnderlined.create(BrandTheme.boxedClassic());
         try (DocumentSession session = GraphCompose.document()
                 .pageSize(420, 595)
                 .margin(DocumentInsets.of(24))

--- a/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/MintEditorialSmokeTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/MintEditorialSmokeTest.java
@@ -14,7 +14,7 @@ import com.demcha.compose.document.templates.cv.v2.data.ParagraphSection;
 import com.demcha.compose.document.templates.cv.v2.data.RowStyle;
 import com.demcha.compose.document.templates.cv.v2.data.RowsSection;
 import com.demcha.compose.document.templates.cv.v2.data.SkillsSection;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.style.DocumentColor;
 import org.junit.jupiter.api.Test;
 
@@ -61,7 +61,7 @@ class MintEditorialSmokeTest {
                 .pageSize(DocumentPageSize.A4)
                 .margin(48, 48, 48, 48)
                 .create()) {
-            MintEditorial.create(CvTheme.mintEditorial())
+            MintEditorial.create(BrandTheme.mintEditorial())
                     .compose(session, fullDocument());
             assertThat(session.roots()).isNotEmpty();
         }

--- a/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/ModernProfessionalSmokeTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/ModernProfessionalSmokeTest.java
@@ -9,7 +9,7 @@ import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
 import com.demcha.compose.document.templates.cv.v2.data.EntriesSection;
 import com.demcha.compose.document.templates.cv.v2.data.ParagraphSection;
 import com.demcha.compose.document.templates.cv.v2.data.SkillsSection;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,7 +37,7 @@ class ModernProfessionalSmokeTest {
     @Test
     void custom_theme_factory_renders() throws Exception {
         DocumentTemplate<CvDocument> template =
-                ModernProfessional.create(CvTheme.modernProfessional());
+                ModernProfessional.create(BrandTheme.modernProfessional());
         renderAndAssertNonEmpty(template, fullDocument());
     }
 
@@ -46,7 +46,7 @@ class ModernProfessionalSmokeTest {
         // Preset should not assume any specific theme — handing it the
         // boxedClassic theme must not throw.
         DocumentTemplate<CvDocument> template =
-                ModernProfessional.create(CvTheme.boxedClassic());
+                ModernProfessional.create(BrandTheme.boxedClassic());
         renderAndAssertNonEmpty(template, fullDocument());
     }
 

--- a/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/MonogramSidebarSmokeTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/MonogramSidebarSmokeTest.java
@@ -13,7 +13,7 @@ import com.demcha.compose.document.templates.cv.v2.data.ParagraphSection;
 import com.demcha.compose.document.templates.cv.v2.data.RowStyle;
 import com.demcha.compose.document.templates.cv.v2.data.RowsSection;
 import com.demcha.compose.document.templates.cv.v2.data.SkillsSection;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,7 +39,7 @@ class MonogramSidebarSmokeTest {
 
     @Test
     void custom_theme_factory_renders() throws Exception {
-        renderAndAssertNonEmpty(MonogramSidebar.create(CvTheme.monogramSidebar()),
+        renderAndAssertNonEmpty(MonogramSidebar.create(BrandTheme.monogramSidebar()),
                 fullDocument());
     }
 

--- a/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/NordicCleanSmokeTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/NordicCleanSmokeTest.java
@@ -12,7 +12,7 @@ import com.demcha.compose.document.templates.cv.v2.data.ParagraphSection;
 import com.demcha.compose.document.templates.cv.v2.data.RowStyle;
 import com.demcha.compose.document.templates.cv.v2.data.RowsSection;
 import com.demcha.compose.document.templates.cv.v2.data.SkillsSection;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,7 +38,7 @@ class NordicCleanSmokeTest {
 
     @Test
     void custom_theme_factory_renders() throws Exception {
-        renderAndAssertNonEmpty(NordicClean.create(CvTheme.nordicClean()),
+        renderAndAssertNonEmpty(NordicClean.create(BrandTheme.nordicClean()),
                 fullDocument());
     }
 
@@ -51,7 +51,7 @@ class NordicCleanSmokeTest {
                 .profileFillColor(DocumentColor.rgb(230, 246, 247))
                 .build();
 
-        renderAndAssertNonEmpty(NordicClean.create(CvTheme.nordicClean(),
+        renderAndAssertNonEmpty(NordicClean.create(BrandTheme.nordicClean(),
                 options), fullDocument());
     }
 

--- a/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/PanelSmokeTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/PanelSmokeTest.java
@@ -11,7 +11,7 @@ import com.demcha.compose.document.templates.cv.v2.data.ParagraphSection;
 import com.demcha.compose.document.templates.cv.v2.data.RowStyle;
 import com.demcha.compose.document.templates.cv.v2.data.RowsSection;
 import com.demcha.compose.document.templates.cv.v2.data.SkillsSection;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,7 +41,7 @@ class PanelSmokeTest {
 
     @Test
     void custom_theme_factory_renders() throws Exception {
-        renderAndAssertNonEmpty(Panel.create(CvTheme.panel()), fullDocument());
+        renderAndAssertNonEmpty(Panel.create(BrandTheme.panel()), fullDocument());
     }
 
     private static void renderAndAssertNonEmpty(

--- a/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/SidebarPortraitSmokeTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/SidebarPortraitSmokeTest.java
@@ -11,7 +11,7 @@ import com.demcha.compose.document.templates.cv.v2.data.ParagraphSection;
 import com.demcha.compose.document.templates.cv.v2.data.RowStyle;
 import com.demcha.compose.document.templates.cv.v2.data.RowsSection;
 import com.demcha.compose.document.templates.cv.v2.data.SkillsSection;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,7 +37,7 @@ class SidebarPortraitSmokeTest {
 
     @Test
     void custom_theme_factory_renders() throws Exception {
-        renderAndAssertNonEmpty(SidebarPortrait.create(CvTheme.sidebarPortrait()),
+        renderAndAssertNonEmpty(SidebarPortrait.create(BrandTheme.sidebarPortrait()),
                 fullDocument());
     }
 

--- a/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/TimelineMinimalSmokeTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/v2/presets/TimelineMinimalSmokeTest.java
@@ -11,7 +11,7 @@ import com.demcha.compose.document.templates.cv.v2.data.ParagraphSection;
 import com.demcha.compose.document.templates.cv.v2.data.RowStyle;
 import com.demcha.compose.document.templates.cv.v2.data.RowsSection;
 import com.demcha.compose.document.templates.cv.v2.data.SkillsSection;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,7 +37,7 @@ class TimelineMinimalSmokeTest {
 
     @Test
     void custom_theme_factory_renders() throws Exception {
-        renderAndAssertNonEmpty(TimelineMinimal.create(CvTheme.timelineMinimal()),
+        renderAndAssertNonEmpty(TimelineMinimal.create(BrandTheme.timelineMinimal()),
                 fullDocument());
     }
 

--- a/src/test/java/com/demcha/compose/document/templates/cv/v2/widgets/WidgetSmokeTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/v2/widgets/WidgetSmokeTest.java
@@ -10,7 +10,7 @@ import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
 import com.demcha.compose.document.templates.cv.v2.data.CvName;
 import com.demcha.compose.document.templates.cv.v2.data.CvSkill;
-import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.font.FontName;
 import org.junit.jupiter.api.Test;
 
@@ -27,19 +27,19 @@ class WidgetSmokeTest {
     @Test
     void headline_variants_render_without_throwing() throws Exception {
         renderWithSection(section -> {
-            Headline.spacedCentered(section, name(), CvTheme.boxedClassic());
+            Headline.spacedCentered(section, name(), BrandTheme.boxedClassic());
         });
         renderWithSection(section -> {
-            Headline.uppercaseCentered(section, name(), CvTheme.editorialBlue());
+            Headline.uppercaseCentered(section, name(), BrandTheme.editorialBlue());
         });
         renderWithSection(section -> {
-            Headline.uppercaseLeftAligned(section, name(), CvTheme.nordicClean());
+            Headline.uppercaseLeftAligned(section, name(), BrandTheme.nordicClean());
         });
         renderWithSection(section -> {
-            Headline.rightAligned(section, name(), CvTheme.boxedClassic());
+            Headline.rightAligned(section, name(), BrandTheme.boxedClassic());
         });
         renderWithSection(section -> {
-            Headline.render(section, name(), CvTheme.boxedClassic(),
+            Headline.render(section, name(), BrandTheme.boxedClassic(),
                     TextAlign.LEFT, false);
         });
     }
@@ -47,32 +47,32 @@ class WidgetSmokeTest {
     @Test
     void contactLine_variants_render_without_throwing() throws Exception {
         renderWithSection(section -> {
-            ContactLine.centered(section, identity(), CvTheme.boxedClassic());
+            ContactLine.centered(section, identity(), BrandTheme.boxedClassic());
         });
         renderWithSection(section -> {
-            ContactLine.centered(section, identity(), CvTheme.boxedClassic(),
+            ContactLine.centered(section, identity(), BrandTheme.boxedClassic(),
                     null, underlinedLinkStyle(), null);
         });
         renderWithSection(section -> {
-            ContactLine.rightAligned(section, identity(), CvTheme.boxedClassic());
+            ContactLine.rightAligned(section, identity(), BrandTheme.boxedClassic());
         });
         renderWithSection(section -> {
-            ContactLine.leftAligned(section, identity(), CvTheme.compactMono(),
+            ContactLine.leftAligned(section, identity(), BrandTheme.compactMono(),
                     null, underlinedLinkStyle(), null);
         });
         renderWithSection(section -> {
             ContactLine.rightAlignedStacked(section, identity(),
-                    CvTheme.nordicClean(), null, underlinedLinkStyle());
+                    BrandTheme.nordicClean(), null, underlinedLinkStyle());
         });
         renderWithSection(section -> {
-            ContactLine.render(section, identity(), CvTheme.boxedClassic(),
+            ContactLine.render(section, identity(), BrandTheme.boxedClassic(),
                     TextAlign.LEFT, ContactLine.Order.PHONE_FIRST);
         });
     }
 
     @Test
     void subheadline_variants_render_without_throwing() throws Exception {
-        CvTheme theme = CvTheme.centeredHeadline();
+        BrandTheme theme = BrandTheme.centeredHeadline();
         renderWithSection(section ->
                 Subheadline.centeredSpacedCaps(section, "Professional Title",
                         theme.bodyStyle()));
@@ -80,7 +80,7 @@ class WidgetSmokeTest {
 
     @Test
     void skillBar_renders_with_and_without_level() throws Exception {
-        CvTheme theme = CvTheme.mintEditorial();
+        BrandTheme theme = BrandTheme.mintEditorial();
         // Levelled skill → label + proficiency bar.
         renderWithSection(section ->
                 SkillBar.render(section, CvSkill.of("Java 21", 0.9), 120, theme));
@@ -91,7 +91,7 @@ class WidgetSmokeTest {
 
     @Test
     void iconTextRow_renders_with_and_without_link() throws Exception {
-        CvTheme theme = CvTheme.mintEditorial();
+        BrandTheme theme = BrandTheme.mintEditorial();
         SvgGlyph icon = SvgGlyph.fromResource("/templates/cv/mint-editorial/icons/phone.svg");
         DocumentColor iconColor = DocumentColor.rgb(47, 122, 106);
         // Linked row (whole row clickable) and plain row.
@@ -106,12 +106,12 @@ class WidgetSmokeTest {
 
     @Test
     void sectionHeader_variants_render_without_throwing() throws Exception {
-        CvTheme theme = CvTheme.boxedClassic();
+        BrandTheme theme = BrandTheme.boxedClassic();
         renderWithSection(section ->
                 SectionHeader.banner(section, "Professional Summary", theme));
         renderWithSection(section ->
                 SectionHeader.fullWidthBanner(section, "Professional Summary",
-                        CvTheme.blueBanner()));
+                        BrandTheme.blueBanner()));
         renderWithSection(section ->
                 SectionHeader.underlined(section, "Skills", theme));
         renderWithSection(section ->
@@ -122,11 +122,11 @@ class WidgetSmokeTest {
                         theme.palette().muted(), theme, null));
         renderWithSection(section ->
                 SectionHeader.tickLabel(section, "Projects",
-                        CvTheme.compactMono(),
+                        BrandTheme.compactMono(),
                         DocumentColor.rgb(0, 126, 151), 22));
         renderWithSection(section ->
                 SectionHeader.upperRule(section, "Skills",
-                        CvTheme.nordicClean(), bodyStyle(),
+                        BrandTheme.nordicClean(), bodyStyle(),
                         DocumentColor.rgb(28, 128, 135), 64));
         renderWithSection(section ->
                 SectionHeader.spacedCapsRule(section, "Experience", theme,
@@ -136,19 +136,19 @@ class WidgetSmokeTest {
 
     @Test
     void flowSectionHeader_variants_render_without_throwing() throws Exception {
-        CvTheme theme = CvTheme.blueBanner();
+        BrandTheme theme = BrandTheme.blueBanner();
         renderWithFlow(flow -> FlowSectionHeader.banner(flow, "FlowBanner",
                 "Experience", 240, theme, bodyStyle(),
                 DocumentInsets.top(2), DocumentInsets.bottom(2)));
         renderWithFlow(flow -> FlowSectionHeader.label(flow, "FlowLabel",
-                "PROJECTS", 240, CvTheme.editorialBlue(), bodyStyle(),
+                "PROJECTS", 240, BrandTheme.editorialBlue(), bodyStyle(),
                 DocumentInsets.top(2), DocumentInsets.of(2),
                 DocumentInsets.zero(), true));
     }
 
     @Test
     void moduleAndBand_widgets_render_without_throwing() throws Exception {
-        CvTheme theme = CvTheme.nordicClean();
+        BrandTheme theme = BrandTheme.nordicClean();
         renderWithSection(section -> ProfileBand.render(section, "Profile",
                 "**Markdown** body", ProfileBand.Style.builder()
                         .titleStyle(bodyStyle())
@@ -156,7 +156,7 @@ class WidgetSmokeTest {
                         .accentLeft(DocumentColor.rgb(28, 128, 135), 2)
                         .build()));
         renderWithSection(section -> SectionModule.tick(section, "Tick",
-                "Skills", CvTheme.compactMono(),
+                "Skills", BrandTheme.compactMono(),
                 DocumentColor.rgb(0, 126, 151), 24, bodyStyle(),
                 body -> body.addParagraph(p -> p.text("Java").textStyle(bodyStyle()))));
         renderWithSection(section -> SectionModule.upperRule(section, "Rule",
@@ -168,7 +168,7 @@ class WidgetSmokeTest {
 
     @Test
     void masthead_renders_without_throwing() throws Exception {
-        CvTheme theme = CvTheme.editorialBlue();
+        BrandTheme theme = BrandTheme.editorialBlue();
         renderWithSection(section -> Masthead.centered(section, identity(),
                 theme, Masthead.Style.builder()
                         .nameStyle(bodyStyle())
@@ -182,7 +182,7 @@ class WidgetSmokeTest {
 
     @Test
     void widgets_work_against_modernProfessional_theme() throws Exception {
-        CvTheme theme = CvTheme.modernProfessional();
+        BrandTheme theme = BrandTheme.modernProfessional();
         renderWithSection(section -> Headline.rightAligned(section, name(), theme));
         renderWithSection(section -> ContactLine.rightAligned(section, identity(), theme));
         renderWithSection(section -> SectionHeader.flat(section, "Summary",


### PR DESCRIPTION
## Why

The shared theme layer (palette / typography / spacing / decoration) lives inside
`cv.v2`, and `coverletter.v2` reaches into it — so CV is the de-facto owner of tokens
that are not CV-specific. To let invoice, proposal, and any future family build on the
same theme without depending on `cv`, the theme records move to a family-neutral
`templates.core`. Renaming public records is a binary break, so this lands on the 2.0
line.

## What changed

- Moved `cv.v2.theme.{CvTheme, CvPalette, CvTypography, CvSpacing, CvDecoration}` →
  `templates.core.theme.{BrandTheme, Palette, Typography, Spacing, Decoration}`.
- Repointed every caller across `cv.v2`, `coverletter.v2`, examples and tests (82 files).
- Moved the theme test mirror to `core.theme.DecorationTest`.
- Pure rename / move — no behavioural change.

**Lane:** templates (canonical). **Target:** `2.0-dev`.

**Deferred to the Stage-1 docs refresh:** markdown docs that still name `CvTheme`
(api-stability §4, package-map, `cv/v2/AUTHORS.md`, ADR-0015, recipes) are updated in a
follow-up doc pass — kept out of this diff so the rename stays reviewable. Import order
in repointed files is not re-sorted (no import-order gate; avoids noise here).

## Verification

- `./mvnw test -pl .` → `Tests run: 1607, Failures: 0, Errors: 0`. All snapshot and
  visual-parity tests pass with **zero snapshot updates** → render is byte-identical.
- `./mvnw -P japicmp verify -pl .` → BUILD SUCCESS; javadoc gate clean. japicmp runs
  report-only on the 2.0 line and its report documents the intended break
  (`core.theme.*` added; CV preset / `LetterBody` signatures change `CvTheme`→`BrandTheme`).
- `examples` test-compile + `GenerateAllExamples` → every example PDF regenerates.
