### PR TITLE
refactor(templates): extract the text layer to templates.core.text

### DIFF
--- a/src/main/java/com/demcha/compose/document/templates/components/Module.java
+++ b/src/main/java/com/demcha/compose/document/templates/components/Module.java
@@ -1,5 +1,7 @@
 package com.demcha.compose.document.templates.components;
 
+import com.demcha.compose.document.templates.core.text.MarkdownText;
+
 import com.demcha.compose.document.node.*;
 import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.style.DocumentTextStyle;

--- a/src/main/java/com/demcha/compose/document/templates/core/text/MarkdownInline.java
+++ b/src/main/java/com/demcha/compose/document/templates/core/text/MarkdownInline.java
@@ -1,10 +1,9 @@
-package com.demcha.compose.document.templates.cv.v2.components;
+package com.demcha.compose.document.templates.core.text;
 
 import com.demcha.compose.document.dsl.RichText;
 import com.demcha.compose.document.node.InlineRun;
 import com.demcha.compose.document.node.InlineTextRun;
 import com.demcha.compose.document.style.DocumentTextStyle;
-import com.demcha.compose.document.templates.components.MarkdownText;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -15,8 +14,8 @@ import java.util.regex.Pattern;
  * (non-emphasised) segments.
  *
  * <p>Honours {@code **bold**}, {@code *italic*}, {@code _italic_} via
- * the shared {@link MarkdownText} parser. Lives in the components
- * layer because every body / row / entry renderer calls it.</p>
+ * the shared {@link MarkdownText} parser. Part of the neutral core text
+ * layer, shared by every template family's body / row / entry rendering.</p>
  *
  * <p><strong>Inline links (since v1.6.8).</strong> Recognises the
  * standard Markdown {@code [label](url)} syntax and emits a clickable

--- a/src/main/java/com/demcha/compose/document/templates/core/text/MarkdownText.java
+++ b/src/main/java/com/demcha/compose/document/templates/core/text/MarkdownText.java
@@ -1,4 +1,4 @@
-package com.demcha.compose.document.templates.components;
+package com.demcha.compose.document.templates.core.text;
 
 import com.demcha.compose.document.node.InlineRun;
 import com.demcha.compose.document.node.InlineTextRun;

--- a/src/main/java/com/demcha/compose/document/templates/core/text/RichParagraphRenderer.java
+++ b/src/main/java/com/demcha/compose/document/templates/core/text/RichParagraphRenderer.java
@@ -1,4 +1,4 @@
-package com.demcha.compose.document.templates.cv.v2.components;
+package com.demcha.compose.document.templates.core.text;
 
 import com.demcha.compose.document.dsl.SectionBuilder;
 import com.demcha.compose.document.node.TextAlign;
@@ -6,7 +6,7 @@ import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.style.DocumentTextStyle;
 
 /**
- * Reusable rich paragraph primitive for CV presets that need explicit
+ * Reusable rich paragraph primitive for any preset that needs explicit
  * style, line spacing, and margin while still honouring inline markdown.
  */
 public final class RichParagraphRenderer {

--- a/src/main/java/com/demcha/compose/document/templates/core/text/TextOrnaments.java
+++ b/src/main/java/com/demcha/compose/document/templates/core/text/TextOrnaments.java
@@ -1,4 +1,4 @@
-package com.demcha.compose.document.templates.cv.v2.components;
+package com.demcha.compose.document.templates.core.text;
 
 import java.util.Locale;
 

--- a/src/main/java/com/demcha/compose/document/templates/core/text/TextStyles.java
+++ b/src/main/java/com/demcha/compose/document/templates/core/text/TextStyles.java
@@ -1,4 +1,4 @@
-package com.demcha.compose.document.templates.cv.v2.components;
+package com.demcha.compose.document.templates.core.text;
 
 import com.demcha.compose.document.style.DocumentColor;
 import com.demcha.compose.document.style.DocumentTextDecoration;
@@ -8,8 +8,8 @@ import com.demcha.compose.font.FontName;
 /**
  * Small factory for preset-local text styles.
  */
-public final class CvTextStyles {
-    private CvTextStyles() {
+public final class TextStyles {
+    private TextStyles() {
     }
 
     /**

--- a/src/main/java/com/demcha/compose/document/templates/core/text/package-info.java
+++ b/src/main/java/com/demcha/compose/document/templates/core/text/package-info.java
@@ -1,0 +1,23 @@
+/**
+ * <h2>Core — neutral text rendering (text)</h2>
+ *
+ * <p>Family-agnostic text primitives shared by every template family. They turn
+ * text plus a {@link com.demcha.compose.document.style.DocumentTextStyle} (or a
+ * theme-derived style) into DSL nodes, and depend on no document family's data
+ * model — so invoice, proposal, CV, and cover-letter all build on the same text
+ * layer.</p>
+ *
+ * <ul>
+ *   <li>{@link com.demcha.compose.document.templates.core.text.MarkdownText}
+ *       — parse inline {@code **bold**} / {@code *italic*} markdown into inline runs.</li>
+ *   <li>{@link com.demcha.compose.document.templates.core.text.MarkdownInline}
+ *       — append parsed inline markdown into a {@code RichText} run.</li>
+ *   <li>{@link com.demcha.compose.document.templates.core.text.RichParagraphRenderer}
+ *       — render a markdown paragraph into a section.</li>
+ *   <li>{@link com.demcha.compose.document.templates.core.text.TextStyles}
+ *       — {@code DocumentTextStyle} factory helpers.</li>
+ *   <li>{@link com.demcha.compose.document.templates.core.text.TextOrnaments}
+ *       — spaced-caps, pipe-joins, and other small string helpers.</li>
+ * </ul>
+ */
+package com.demcha.compose.document.templates.core.text;

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/builder/CoverLetterBuilder.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/builder/CoverLetterBuilder.java
@@ -9,7 +9,7 @@ import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.components.Header;
-import com.demcha.compose.document.templates.components.MarkdownText;
+import com.demcha.compose.document.templates.core.text.MarkdownText;
 import com.demcha.compose.document.templates.coverletter.layouts.LetterFormat;
 import com.demcha.compose.document.templates.coverletter.spec.CoverLetterHeader;
 import com.demcha.compose.document.templates.coverletter.spec.CoverLetterSpec;

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/components/LetterBody.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/components/LetterBody.java
@@ -5,8 +5,8 @@ import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.style.DocumentTextDecoration;
 import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.coverletter.v2.data.CoverLetterDocument;
-import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
-import com.demcha.compose.document.templates.cv.v2.components.RichParagraphRenderer;
+import com.demcha.compose.document.templates.core.text.TextStyles;
+import com.demcha.compose.document.templates.core.text.RichParagraphRenderer;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
 
 /**
@@ -58,7 +58,7 @@ public final class LetterBody {
      */
     public static void render(SectionBuilder host, CoverLetterDocument doc,
                               BrandTheme theme, double bodySize) {
-        DocumentTextStyle bodyStyle = CvTextStyles.of(
+        DocumentTextStyle bodyStyle = TextStyles.of(
                 theme.typography().bodyFont(),
                 bodySize,
                 DocumentTextDecoration.DEFAULT,
@@ -80,7 +80,7 @@ public final class LetterBody {
         // The signed name sits on the line directly below the sign-off
         // (standard letter convention), so it gets only a small gap.
         double signatureGap = bodySize * 0.4;
-        DocumentTextStyle signatureStyle = CvTextStyles.of(
+        DocumentTextStyle signatureStyle = TextStyles.of(
                 theme.typography().bodyFont(),
                 bodySize,
                 DocumentTextDecoration.ITALIC,

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/CenteredHeadlineLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/CenteredHeadlineLetter.java
@@ -9,7 +9,7 @@ import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.coverletter.v2.components.LetterBody;
 import com.demcha.compose.document.templates.coverletter.v2.data.CoverLetterDocument;
-import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
+import com.demcha.compose.document.templates.core.text.TextStyles;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.ContactLine;
@@ -122,7 +122,7 @@ public final class CenteredHeadlineLetter {
             }
 
             private DocumentTextStyle subheadlineStyle() {
-                return CvTextStyles.of(theme.typography().headlineFont(), 8.6,
+                return TextStyles.of(theme.typography().headlineFont(), 8.6,
                         DocumentTextDecoration.DEFAULT, theme.palette().muted());
             }
 

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/ClassicSerifLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/ClassicSerifLetter.java
@@ -9,7 +9,7 @@ import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.coverletter.v2.components.LetterBody;
 import com.demcha.compose.document.templates.coverletter.v2.data.CoverLetterDocument;
-import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
+import com.demcha.compose.document.templates.core.text.TextStyles;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.ContactLine;
@@ -128,21 +128,21 @@ public final class ClassicSerifLetter {
             }
 
             private DocumentTextStyle contactMetaStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.DEFAULT,
                         theme.palette().muted());
             }
 
             private DocumentTextStyle contactLinkStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.UNDERLINE,
                         ACCENT);
             }
 
             private DocumentTextStyle contactSeparatorStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.DEFAULT,
                         theme.palette().rule());

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/CompactMonoLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/CompactMonoLetter.java
@@ -9,7 +9,7 @@ import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.coverletter.v2.components.LetterBody;
 import com.demcha.compose.document.templates.coverletter.v2.data.CoverLetterDocument;
-import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
+import com.demcha.compose.document.templates.core.text.TextStyles;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.ContactLine;
@@ -150,25 +150,25 @@ public final class CompactMonoLetter {
             }
 
             private DocumentTextStyle headerNameStyle() {
-                return CvTextStyles.of(theme.typography().headlineFont(),
+                return TextStyles.of(theme.typography().headlineFont(),
                         theme.typography().sizeHeadline(),
                         DocumentTextDecoration.BOLD, DocumentColor.WHITE);
             }
 
             private DocumentTextStyle headerMetaStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.DEFAULT, HEADER_SOFT);
             }
 
             private DocumentTextStyle headerLinkStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.UNDERLINE, LINK_CYAN);
             }
 
             private DocumentTextStyle headerSeparatorStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.DEFAULT, SEPARATOR_GRAY);
             }

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/EditorialBlueLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/EditorialBlueLetter.java
@@ -9,7 +9,7 @@ import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.coverletter.v2.components.LetterBody;
 import com.demcha.compose.document.templates.coverletter.v2.data.CoverLetterDocument;
-import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
+import com.demcha.compose.document.templates.core.text.TextStyles;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.Masthead;
 import com.demcha.compose.font.FontName;
@@ -110,13 +110,13 @@ public final class EditorialBlueLetter {
             }
 
             private Masthead.Style mastheadStyle() {
-                DocumentTextStyle nameStyle = CvTextStyles.of(FontName.HELVETICA_BOLD,
+                DocumentTextStyle nameStyle = TextStyles.of(FontName.HELVETICA_BOLD,
                         theme.typography().sizeHeadline(),
                         DocumentTextDecoration.BOLD, NAME_COLOR);
-                DocumentTextStyle titleStyle = CvTextStyles.of(FontName.HELVETICA,
+                DocumentTextStyle titleStyle = TextStyles.of(FontName.HELVETICA,
                         10.0, DocumentTextDecoration.DEFAULT,
                         theme.palette().ink());
-                DocumentTextStyle linkStyle = CvTextStyles.of(FontName.HELVETICA,
+                DocumentTextStyle linkStyle = TextStyles.of(FontName.HELVETICA,
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.UNDERLINE,
                         theme.palette().rule());

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/EngineeringResumeLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/EngineeringResumeLetter.java
@@ -9,8 +9,8 @@ import com.demcha.compose.document.style.*;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.coverletter.v2.components.LetterBody;
 import com.demcha.compose.document.templates.coverletter.v2.data.CoverLetterDocument;
-import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
-import com.demcha.compose.document.templates.cv.v2.components.MarkdownInline;
+import com.demcha.compose.document.templates.core.text.TextStyles;
+import com.demcha.compose.document.templates.core.text.MarkdownInline;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
 import com.demcha.compose.document.templates.cv.v2.data.CvLink;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
@@ -182,24 +182,24 @@ public final class EngineeringResumeLetter {
             }
 
             private DocumentTextStyle nameStyle() {
-                return CvTextStyles.of(theme.typography().headlineFont(),
+                return TextStyles.of(theme.typography().headlineFont(),
                         theme.typography().sizeHeadline(),
                         DocumentTextDecoration.BOLD, DocumentColor.WHITE);
             }
 
             private DocumentTextStyle subtitleStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(), 7.6,
+                return TextStyles.of(theme.typography().bodyFont(), 7.6,
                         DocumentTextDecoration.BOLD, SUBTITLE_COLOR);
             }
 
             private DocumentTextStyle contactMetaStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.DEFAULT, CONTACT_META);
             }
 
             private DocumentTextStyle contactLinkStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.UNDERLINE, CONTACT_LINK);
             }

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/ExecutiveLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/ExecutiveLetter.java
@@ -12,8 +12,8 @@ import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.coverletter.v2.components.LetterBody;
 import com.demcha.compose.document.templates.coverletter.v2.data.CoverLetterDocument;
-import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
-import com.demcha.compose.document.templates.cv.v2.components.TextOrnaments;
+import com.demcha.compose.document.templates.core.text.TextStyles;
+import com.demcha.compose.document.templates.core.text.TextOrnaments;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
 import com.demcha.compose.document.templates.cv.v2.data.CvLink;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
@@ -195,28 +195,28 @@ public final class ExecutiveLetter {
             }
 
             private DocumentTextStyle nameStyle() {
-                return CvTextStyles.of(FontName.POPPINS,
+                return TextStyles.of(FontName.POPPINS,
                         theme.typography().sizeHeadline(),
                         DocumentTextDecoration.BOLD,
                         PRIMARY_NAME);
             }
 
             private DocumentTextStyle metaStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.DEFAULT,
                         theme.palette().ink());
             }
 
             private DocumentTextStyle linkRowBodyStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeBody(),
                         DocumentTextDecoration.DEFAULT,
                         theme.palette().ink());
             }
 
             private DocumentTextStyle linkRowLinkStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeBody(),
                         DocumentTextDecoration.UNDERLINE,
                         ACCENT);

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/MintEditorialLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/MintEditorialLetter.java
@@ -12,8 +12,8 @@ import com.demcha.compose.document.style.*;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.coverletter.v2.components.LetterBody;
 import com.demcha.compose.document.templates.coverletter.v2.data.CoverLetterDocument;
-import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
-import com.demcha.compose.document.templates.cv.v2.components.TextOrnaments;
+import com.demcha.compose.document.templates.core.text.TextStyles;
+import com.demcha.compose.document.templates.core.text.TextOrnaments;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.Headline;
@@ -388,13 +388,13 @@ public final class MintEditorialLetter {
         }
 
         private DocumentTextStyle mastheadNameStyle() {
-            return CvTextStyles.of(theme.typography().headlineFont(),
+            return TextStyles.of(theme.typography().headlineFont(),
                     theme.typography().sizeHeadline(),
                     DocumentTextDecoration.DEFAULT, nameColor);
         }
 
         private DocumentTextStyle taglineStyle() {
-            return CvTextStyles.of(theme.typography().headlineFont(),
+            return TextStyles.of(theme.typography().headlineFont(),
                     theme.typography().sizeContact(),
                     DocumentTextDecoration.BOLD, accent);
         }

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/ModernProfessionalLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/ModernProfessionalLetter.java
@@ -8,7 +8,7 @@ import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.coverletter.v2.components.LetterBody;
 import com.demcha.compose.document.templates.coverletter.v2.data.CoverLetterDocument;
-import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
+import com.demcha.compose.document.templates.core.text.TextStyles;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.ContactLine;
 import com.demcha.compose.document.templates.cv.v2.widgets.Headline;
@@ -102,16 +102,16 @@ public final class ModernProfessionalLetter {
                 Objects.requireNonNull(document, "document");
                 Objects.requireNonNull(doc, "doc");
 
-                DocumentTextStyle nameStyle = CvTextStyles.of(FontName.HELVETICA_BOLD,
+                DocumentTextStyle nameStyle = TextStyles.of(FontName.HELVETICA_BOLD,
                         theme.typography().sizeHeadline(),
                         DocumentTextDecoration.BOLD, NAME_COLOR);
-                DocumentTextStyle contactBodyStyle = CvTextStyles.of(FontName.HELVETICA,
+                DocumentTextStyle contactBodyStyle = TextStyles.of(FontName.HELVETICA,
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.DEFAULT, theme.palette().ink());
-                DocumentTextStyle contactLinkStyle = CvTextStyles.of(FontName.HELVETICA,
+                DocumentTextStyle contactLinkStyle = TextStyles.of(FontName.HELVETICA,
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.UNDERLINE, LINK_COLOR);
-                DocumentTextStyle contactSeparatorStyle = CvTextStyles.of(FontName.HELVETICA,
+                DocumentTextStyle contactSeparatorStyle = TextStyles.of(FontName.HELVETICA,
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.DEFAULT, theme.palette().rule());
 

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/MonogramSidebarLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/MonogramSidebarLetter.java
@@ -10,8 +10,8 @@ import com.demcha.compose.document.style.*;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.coverletter.v2.components.LetterBody;
 import com.demcha.compose.document.templates.coverletter.v2.data.CoverLetterDocument;
-import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
-import com.demcha.compose.document.templates.cv.v2.components.TextOrnaments;
+import com.demcha.compose.document.templates.core.text.TextStyles;
+import com.demcha.compose.document.templates.core.text.TextOrnaments;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
 import com.demcha.compose.document.templates.cv.v2.data.CvName;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
@@ -158,7 +158,7 @@ public final class MonogramSidebarLetter {
                         .layer(new ParagraphBuilder()
                                 .name("CoverLetterV2MonogramSidebarInitials")
                                 .text(initialsText)
-                                .textStyle(CvTextStyles.of(MONOGRAM_FONT, 44.0,
+                                .textStyle(TextStyles.of(MONOGRAM_FONT, 44.0,
                                         DocumentTextDecoration.BOLD, MONOGRAM_RING))
                                 .align(TextAlign.LEFT)
                                 .build(), LayerAlign.CENTER)
@@ -214,31 +214,31 @@ public final class MonogramSidebarLetter {
             }
 
             private DocumentTextStyle nameStyle() {
-                return CvTextStyles.of(theme.typography().headlineFont(),
+                return TextStyles.of(theme.typography().headlineFont(),
                         theme.typography().sizeHeadline(),
                         DocumentTextDecoration.DEFAULT, theme.palette().ink());
             }
 
             private DocumentTextStyle subtitleStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.BOLD, ACCENT);
             }
 
             private DocumentTextStyle contactMetaStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.DEFAULT, theme.palette().muted());
             }
 
             private DocumentTextStyle contactLinkStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.UNDERLINE, ACCENT);
             }
 
             private DocumentTextStyle contactSeparatorStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.DEFAULT, theme.palette().rule());
             }

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/NordicCleanLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/NordicCleanLetter.java
@@ -9,8 +9,8 @@ import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.coverletter.v2.components.LetterBody;
 import com.demcha.compose.document.templates.coverletter.v2.data.CoverLetterDocument;
-import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
-import com.demcha.compose.document.templates.cv.v2.components.MarkdownInline;
+import com.demcha.compose.document.templates.core.text.TextStyles;
+import com.demcha.compose.document.templates.core.text.MarkdownInline;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.ContactLine;
@@ -129,7 +129,7 @@ public final class NordicCleanLetter {
                                 id.addParagraph(paragraph -> paragraph
                                         .text(MarkdownInline.plainText(identity.jobTitle())
                                                 .toUpperCase(Locale.ROOT))
-                                        .textStyle(CvTextStyles.of(
+                                        .textStyle(TextStyles.of(
                                                 theme.typography().bodyFont(), 7.7,
                                                 DocumentTextDecoration.BOLD,
                                                 theme.palette().muted()))
@@ -142,19 +142,19 @@ public final class NordicCleanLetter {
             }
 
             private DocumentTextStyle headlineStyle() {
-                return CvTextStyles.of(theme.typography().headlineFont(),
+                return TextStyles.of(theme.typography().headlineFont(),
                         theme.typography().sizeHeadline(),
                         DocumentTextDecoration.BOLD, theme.palette().ink());
             }
 
             private DocumentTextStyle contactMetaStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.DEFAULT, theme.palette().muted());
             }
 
             private DocumentTextStyle contactLinkStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.UNDERLINE, ACCENT);
             }

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/PanelLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/PanelLetter.java
@@ -9,8 +9,8 @@ import com.demcha.compose.document.style.*;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.coverletter.v2.components.LetterBody;
 import com.demcha.compose.document.templates.coverletter.v2.data.CoverLetterDocument;
-import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
-import com.demcha.compose.document.templates.cv.v2.components.TextOrnaments;
+import com.demcha.compose.document.templates.core.text.TextStyles;
+import com.demcha.compose.document.templates.core.text.TextOrnaments;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
 import com.demcha.compose.document.templates.cv.v2.data.CvLink;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
@@ -212,25 +212,25 @@ public final class PanelLetter {
             }
 
             private DocumentTextStyle nameStyle() {
-                return CvTextStyles.of(FontName.POPPINS,
+                return TextStyles.of(FontName.POPPINS,
                         theme.typography().sizeHeadline(),
                         DocumentTextDecoration.BOLD, HEADER_TEXT);
             }
 
             private DocumentTextStyle headerBodyStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeBody(),
                         DocumentTextDecoration.DEFAULT, theme.palette().ink());
             }
 
             private DocumentTextStyle headerMetaStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.DEFAULT, theme.palette().ink());
             }
 
             private DocumentTextStyle headerLinkStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.UNDERLINE, ACCENT);
             }

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/SidebarPortraitLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/SidebarPortraitLetter.java
@@ -9,8 +9,8 @@ import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.coverletter.v2.components.LetterBody;
 import com.demcha.compose.document.templates.coverletter.v2.data.CoverLetterDocument;
-import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
-import com.demcha.compose.document.templates.cv.v2.components.TextOrnaments;
+import com.demcha.compose.document.templates.core.text.TextStyles;
+import com.demcha.compose.document.templates.core.text.TextOrnaments;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.ContactLine;
@@ -138,25 +138,25 @@ public final class SidebarPortraitLetter {
             }
 
             private DocumentTextStyle nameStyle() {
-                return CvTextStyles.of(theme.typography().headlineFont(),
+                return TextStyles.of(theme.typography().headlineFont(),
                         theme.typography().sizeHeadline(),
                         DocumentTextDecoration.BOLD, theme.palette().ink());
             }
 
             private DocumentTextStyle subtitleStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeEntryDate(),
                         DocumentTextDecoration.DEFAULT, theme.palette().ink());
             }
 
             private DocumentTextStyle contactStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.DEFAULT, theme.palette().ink());
             }
 
             private DocumentTextStyle contactLinkStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.UNDERLINE, theme.palette().muted());
             }

--- a/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/TimelineMinimalLetter.java
+++ b/src/main/java/com/demcha/compose/document/templates/coverletter/v2/presets/TimelineMinimalLetter.java
@@ -13,9 +13,9 @@ import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.coverletter.v2.components.LetterBody;
 import com.demcha.compose.document.templates.coverletter.v2.data.CoverLetterDocument;
-import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
+import com.demcha.compose.document.templates.core.text.TextStyles;
 import com.demcha.compose.document.templates.cv.v2.components.SectionLookup;
-import com.demcha.compose.document.templates.cv.v2.components.TextOrnaments;
+import com.demcha.compose.document.templates.core.text.TextOrnaments;
 import com.demcha.compose.document.templates.cv.v2.data.CvIdentity;
 import com.demcha.compose.document.templates.cv.v2.data.CvLink;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
@@ -210,24 +210,24 @@ public final class TimelineMinimalLetter {
             }
 
             private DocumentTextStyle nameStyle() {
-                return CvTextStyles.of(theme.typography().headlineFont(),
+                return TextStyles.of(theme.typography().headlineFont(),
                         theme.typography().sizeHeadline(),
                         DocumentTextDecoration.DEFAULT, theme.palette().ink());
             }
 
             private DocumentTextStyle jobTitleStyle() {
-                return CvTextStyles.of(theme.typography().headlineFont(), 9.5,
+                return TextStyles.of(theme.typography().headlineFont(), 9.5,
                         DocumentTextDecoration.BOLD, theme.palette().ink());
             }
 
             private DocumentTextStyle contactTextStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.BOLD, theme.palette().muted());
             }
 
             private DocumentTextStyle fallbackIconStyle() {
-                return CvTextStyles.of(theme.typography().headlineFont(), 8.0,
+                return TextStyles.of(theme.typography().headlineFont(), 8.0,
                         DocumentTextDecoration.BOLD, theme.palette().muted());
             }
         }

--- a/src/main/java/com/demcha/compose/document/templates/cv/presets/BlueBanner.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/presets/BlueBanner.java
@@ -20,7 +20,7 @@ import com.demcha.compose.document.templates.blocks.KeyValueBlock;
 import com.demcha.compose.document.templates.blocks.MultiParagraphBlock;
 import com.demcha.compose.document.templates.blocks.NumberedListBlock;
 import com.demcha.compose.document.templates.blocks.ParagraphBlock;
-import com.demcha.compose.document.templates.components.MarkdownText;
+import com.demcha.compose.document.templates.core.text.MarkdownText;
 import com.demcha.compose.document.templates.cv.spec.CvHeader;
 import com.demcha.compose.document.templates.cv.spec.CvModule;
 import com.demcha.compose.document.templates.cv.spec.CvSpec;

--- a/src/main/java/com/demcha/compose/document/templates/cv/presets/BoxedSections.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/presets/BoxedSections.java
@@ -14,7 +14,7 @@ import com.demcha.compose.document.style.DocumentTextIndent;
 import com.demcha.compose.document.style.DocumentTextDecoration;
 import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
-import com.demcha.compose.document.templates.components.MarkdownText;
+import com.demcha.compose.document.templates.core.text.MarkdownText;
 import com.demcha.compose.document.templates.blocks.Block;
 import com.demcha.compose.document.templates.blocks.BulletListBlock;
 import com.demcha.compose.document.templates.blocks.IndentedBlock;

--- a/src/main/java/com/demcha/compose/document/templates/cv/presets/CenteredHeadline.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/presets/CenteredHeadline.java
@@ -21,7 +21,7 @@ import com.demcha.compose.document.templates.blocks.KeyValueBlock;
 import com.demcha.compose.document.templates.blocks.MultiParagraphBlock;
 import com.demcha.compose.document.templates.blocks.NumberedListBlock;
 import com.demcha.compose.document.templates.blocks.ParagraphBlock;
-import com.demcha.compose.document.templates.components.MarkdownText;
+import com.demcha.compose.document.templates.core.text.MarkdownText;
 import com.demcha.compose.document.templates.cv.spec.CvHeader;
 import com.demcha.compose.document.templates.cv.spec.CvModule;
 import com.demcha.compose.document.templates.cv.spec.CvSpec;

--- a/src/main/java/com/demcha/compose/document/templates/cv/presets/EditorialBlue.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/presets/EditorialBlue.java
@@ -22,7 +22,7 @@ import com.demcha.compose.document.templates.blocks.KeyValueBlock;
 import com.demcha.compose.document.templates.blocks.MultiParagraphBlock;
 import com.demcha.compose.document.templates.blocks.NumberedListBlock;
 import com.demcha.compose.document.templates.blocks.ParagraphBlock;
-import com.demcha.compose.document.templates.components.MarkdownText;
+import com.demcha.compose.document.templates.core.text.MarkdownText;
 import com.demcha.compose.document.templates.cv.spec.CvHeader;
 import com.demcha.compose.document.templates.cv.spec.CvModule;
 import com.demcha.compose.document.templates.cv.spec.CvSpec;

--- a/src/main/java/com/demcha/compose/document/templates/cv/presets/MonogramSidebar.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/presets/MonogramSidebar.java
@@ -28,7 +28,7 @@ import com.demcha.compose.document.templates.blocks.KeyValueBlock;
 import com.demcha.compose.document.templates.blocks.MultiParagraphBlock;
 import com.demcha.compose.document.templates.blocks.NumberedListBlock;
 import com.demcha.compose.document.templates.blocks.ParagraphBlock;
-import com.demcha.compose.document.templates.components.MarkdownText;
+import com.demcha.compose.document.templates.core.text.MarkdownText;
 import com.demcha.compose.document.templates.cv.spec.CvHeader;
 import com.demcha.compose.document.templates.cv.spec.CvModule;
 import com.demcha.compose.document.templates.cv.spec.CvSpec;

--- a/src/main/java/com/demcha/compose/document/templates/cv/presets/Panel.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/presets/Panel.java
@@ -21,7 +21,7 @@ import com.demcha.compose.document.templates.blocks.KeyValueBlock;
 import com.demcha.compose.document.templates.blocks.MultiParagraphBlock;
 import com.demcha.compose.document.templates.blocks.NumberedListBlock;
 import com.demcha.compose.document.templates.blocks.ParagraphBlock;
-import com.demcha.compose.document.templates.components.MarkdownText;
+import com.demcha.compose.document.templates.core.text.MarkdownText;
 import com.demcha.compose.document.templates.cv.spec.CvHeader;
 import com.demcha.compose.document.templates.cv.spec.CvModule;
 import com.demcha.compose.document.templates.cv.spec.CvSpec;

--- a/src/main/java/com/demcha/compose/document/templates/cv/presets/SidebarPortrait.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/presets/SidebarPortrait.java
@@ -22,7 +22,7 @@ import com.demcha.compose.document.templates.blocks.KeyValueBlock;
 import com.demcha.compose.document.templates.blocks.MultiParagraphBlock;
 import com.demcha.compose.document.templates.blocks.NumberedListBlock;
 import com.demcha.compose.document.templates.blocks.ParagraphBlock;
-import com.demcha.compose.document.templates.components.MarkdownText;
+import com.demcha.compose.document.templates.core.text.MarkdownText;
 import com.demcha.compose.document.templates.cv.spec.CvHeader;
 import com.demcha.compose.document.templates.cv.spec.CvModule;
 import com.demcha.compose.document.templates.cv.spec.CvSpec;

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/EntryCompactRenderer.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/EntryCompactRenderer.java
@@ -1,5 +1,8 @@
 package com.demcha.compose.document.templates.cv.v2.components;
 
+import com.demcha.compose.document.templates.core.text.MarkdownInline;
+import com.demcha.compose.document.templates.core.text.RichParagraphRenderer;
+
 import com.demcha.compose.document.dsl.SectionBuilder;
 import com.demcha.compose.document.node.TextAlign;
 import com.demcha.compose.document.style.DocumentInsets;

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/LabelValueRenderer.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/LabelValueRenderer.java
@@ -1,5 +1,7 @@
 package com.demcha.compose.document.templates.cv.v2.components;
 
+import com.demcha.compose.document.templates.core.text.MarkdownInline;
+
 import com.demcha.compose.document.dsl.SectionBuilder;
 import com.demcha.compose.document.node.TextAlign;
 import com.demcha.compose.document.style.DocumentInsets;

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/ParagraphPrimitive.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/ParagraphPrimitive.java
@@ -1,5 +1,7 @@
 package com.demcha.compose.document.templates.cv.v2.components;
 
+import com.demcha.compose.document.templates.core.text.MarkdownInline;
+
 import com.demcha.compose.document.dsl.SectionBuilder;
 import com.demcha.compose.document.node.TextAlign;
 import com.demcha.compose.document.style.DocumentInsets;

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/ProjectLabel.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/ProjectLabel.java
@@ -1,5 +1,7 @@
 package com.demcha.compose.document.templates.cv.v2.components;
 
+import com.demcha.compose.document.templates.core.text.MarkdownInline;
+
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/ProjectRenderer.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/ProjectRenderer.java
@@ -1,5 +1,8 @@
 package com.demcha.compose.document.templates.cv.v2.components;
 
+import com.demcha.compose.document.templates.core.text.MarkdownInline;
+import com.demcha.compose.document.templates.core.text.RichParagraphRenderer;
+
 import com.demcha.compose.document.dsl.SectionBuilder;
 import com.demcha.compose.document.node.TextAlign;
 import com.demcha.compose.document.style.DocumentInsets;

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/SkillLineRenderer.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/SkillLineRenderer.java
@@ -1,5 +1,7 @@
 package com.demcha.compose.document.templates.cv.v2.components;
 
+import com.demcha.compose.document.templates.core.text.MarkdownInline;
+
 import com.demcha.compose.document.dsl.SectionBuilder;
 import com.demcha.compose.document.node.TextAlign;
 import com.demcha.compose.document.style.DocumentInsets;

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/package-info.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/package-info.java
@@ -13,9 +13,9 @@
  *       so the same component renders any theme without reflection
  *       or singletons;</li>
  *   <li>own business parsing — specs own the semantic model; shared
- *       adapters may normalize legacy free-form labels or bridge
- *       markdown into rich text, but presets should not duplicate
- *       local parsers;</li>
+ *       adapters may normalize legacy free-form labels, but presets
+ *       should not duplicate local parsers (markdown parsing lives in
+ *       the neutral {@code core.text} layer);</li>
  *   <li>read magic numbers — every value reads from the theme.</li>
  * </ul>
  *

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/package-info.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/package-info.java
@@ -51,9 +51,7 @@
  *   │    ParagraphRenderer │         │    Spacing  (margins)  │
  *   │    SectionDispatcher │         │    Decoration (glyphs) │
  *   │    ParagraphPrimitive│         │    BrandTheme    (bundle)   │
- *   │    MarkdownInline    │         └──────────────────────────┘
- *   │    TextOrnaments     │
- *   └──────────────────────┘
+ *   └──────────────────────┘         └──────────────────────────┘
  *           │ renders
  *           ▼
  *   ┌─────────────────────────────────────────────────────────────┐

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/BlueBanner.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/BlueBanner.java
@@ -1,5 +1,7 @@
 package com.demcha.compose.document.templates.cv.v2.presets;
 
+import com.demcha.compose.document.templates.core.text.TextStyles;
+
 import com.demcha.compose.document.api.DocumentSession;
 import com.demcha.compose.document.dsl.PageFlowBuilder;
 import com.demcha.compose.document.dsl.SectionBuilder;
@@ -108,7 +110,7 @@ public final class BlueBanner {
                 Objects.requireNonNull(document, "document");
                 Objects.requireNonNull(doc, "doc");
 
-                DocumentTextStyle bannerTitleStyle = CvTextStyles.of(
+                DocumentTextStyle bannerTitleStyle = TextStyles.of(
                         theme.typography().bodyFont(),
                         theme.typography().sizeBanner(),
                         DocumentTextDecoration.BOLD,
@@ -191,11 +193,11 @@ public final class BlueBanner {
                                     CvEntry entry,
                                     BrandTheme theme) {
         DocumentTextStyle titleStyle = theme.entryTitleStyle();
-        DocumentTextStyle dateStyle = CvTextStyles.of(theme.typography().bodyFont(),
+        DocumentTextStyle dateStyle = TextStyles.of(theme.typography().bodyFont(),
                 theme.typography().sizeEntryDate(),
                 DocumentTextDecoration.BOLD,
                 theme.palette().ink());
-        DocumentTextStyle subtitleStyle = CvTextStyles.of(theme.typography().bodyFont(),
+        DocumentTextStyle subtitleStyle = TextStyles.of(theme.typography().bodyFont(),
                 theme.typography().sizeEntrySubtitle(),
                 DocumentTextDecoration.DEFAULT,
                 theme.palette().ink());

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/ClassicSerif.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/ClassicSerif.java
@@ -1,5 +1,9 @@
 package com.demcha.compose.document.templates.cv.v2.presets;
 
+import com.demcha.compose.document.templates.core.text.RichParagraphRenderer;
+import com.demcha.compose.document.templates.core.text.TextOrnaments;
+import com.demcha.compose.document.templates.core.text.TextStyles;
+
 import com.demcha.compose.document.api.DocumentSession;
 import com.demcha.compose.document.dsl.PageFlowBuilder;
 import com.demcha.compose.document.dsl.SectionBuilder;
@@ -158,7 +162,7 @@ public final class ClassicSerif {
                             .accentBottom(theme.palette().rule(), 0.45);
                     addCenteredTitle(host, "Professional Profile");
                     RichParagraphRenderer.render(host, summary.body(),
-                            CvTextStyles.of(theme.typography().bodyFont(), 9.8,
+                            TextStyles.of(theme.typography().bodyFont(), 9.8,
                                     DocumentTextDecoration.DEFAULT,
                                     theme.palette().ink()),
                             1.55, DocumentInsets.zero(), TextAlign.CENTER);
@@ -244,7 +248,7 @@ public final class ClassicSerif {
                         "CvV2ClassicSerifEntryHeader",
                         theme.entryTitleStyle(), theme.entryDateStyle(),
                         theme.entrySubtitleStyle(),
-                        CvTextStyles.of(theme.typography().bodyFont(), 8.8,
+                        TextStyles.of(theme.typography().bodyFont(), 8.8,
                                 DocumentTextDecoration.DEFAULT,
                                 theme.palette().ink()),
                         theme.spacing().entryHeaderRowSpacing(),
@@ -272,10 +276,10 @@ public final class ClassicSerif {
 
             private void renderProject(SectionBuilder host, CvRow row) {
                 ProjectRenderer.titleThenBody(host, row, theme.entryTitleStyle(),
-                        CvTextStyles.of(theme.typography().bodyFont(), 8.7,
+                        TextStyles.of(theme.typography().bodyFont(), 8.7,
                                 DocumentTextDecoration.ITALIC,
                                 theme.palette().muted()),
-                        CvTextStyles.of(theme.typography().bodyFont(), 8.8,
+                        TextStyles.of(theme.typography().bodyFont(), 8.8,
                                 DocumentTextDecoration.DEFAULT,
                                 theme.palette().ink()),
                         theme.typography().bodyLineSpacing(),
@@ -306,28 +310,28 @@ public final class ClassicSerif {
             }
 
             private DocumentTextStyle titleStyle() {
-                return CvTextStyles.of(theme.typography().headlineFont(),
+                return TextStyles.of(theme.typography().headlineFont(),
                         theme.typography().sizeBanner(),
                         DocumentTextDecoration.BOLD,
                         ACCENT);
             }
 
             private DocumentTextStyle contactMetaStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.DEFAULT,
                         theme.palette().muted());
             }
 
             private DocumentTextStyle contactLinkStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.UNDERLINE,
                         ACCENT);
             }
 
             private DocumentTextStyle contactSeparatorStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.DEFAULT,
                         theme.palette().rule());

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/CompactMono.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/CompactMono.java
@@ -1,5 +1,8 @@
 package com.demcha.compose.document.templates.cv.v2.presets;
 
+import com.demcha.compose.document.templates.core.text.RichParagraphRenderer;
+import com.demcha.compose.document.templates.core.text.TextStyles;
+
 import com.demcha.compose.document.api.DocumentSession;
 import com.demcha.compose.document.dsl.PageFlowBuilder;
 import com.demcha.compose.document.dsl.SectionBuilder;
@@ -310,52 +313,52 @@ public final class CompactMono {
             }
 
             private DocumentTextStyle headerNameStyle() {
-                return CvTextStyles.of(theme.typography().headlineFont(),
+                return TextStyles.of(theme.typography().headlineFont(),
                         theme.typography().sizeHeadline(),
                         DocumentTextDecoration.BOLD,
                         DocumentColor.rgb(255, 255, 255));
             }
 
             private DocumentTextStyle headerMetaStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.DEFAULT,
                         HEADER_SOFT);
             }
 
             private DocumentTextStyle headerLinkStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.UNDERLINE,
                         LINK_CYAN);
             }
 
             private DocumentTextStyle headerSeparatorStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.DEFAULT,
                         SEPARATOR_GRAY);
             }
 
             private DocumentTextStyle moduleLabelStyle() {
-                return CvTextStyles.of(theme.typography().headlineFont(),
+                return TextStyles.of(theme.typography().headlineFont(),
                         theme.typography().sizeBanner(),
                         DocumentTextDecoration.BOLD,
                         ACCENT);
             }
 
             private DocumentTextStyle bodyStyle(double size, DocumentColor color) {
-                return CvTextStyles.of(theme.typography().bodyFont(), size,
+                return TextStyles.of(theme.typography().bodyFont(), size,
                         DocumentTextDecoration.DEFAULT, color);
             }
 
             private DocumentTextStyle bodyBoldStyle(double size) {
-                return CvTextStyles.of(theme.typography().bodyFont(), size,
+                return TextStyles.of(theme.typography().bodyFont(), size,
                         DocumentTextDecoration.BOLD, theme.palette().ink());
             }
 
             private DocumentTextStyle italicStyle(double size, DocumentColor color) {
-                return CvTextStyles.of(theme.typography().bodyFont(), size,
+                return TextStyles.of(theme.typography().bodyFont(), size,
                         DocumentTextDecoration.ITALIC, color);
             }
         }

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/EditorialBlue.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/EditorialBlue.java
@@ -1,5 +1,8 @@
 package com.demcha.compose.document.templates.cv.v2.presets;
 
+import com.demcha.compose.document.templates.core.text.RichParagraphRenderer;
+import com.demcha.compose.document.templates.core.text.TextStyles;
+
 import com.demcha.compose.document.api.DocumentSession;
 import com.demcha.compose.document.dsl.PageFlowBuilder;
 import com.demcha.compose.document.dsl.SectionBuilder;
@@ -163,11 +166,11 @@ public final class EditorialBlue {
             }
 
             private void renderExperienceEntry(SectionBuilder section, CvEntry entry) {
-                DocumentTextStyle titleStyle = CvTextStyles.of(FontName.HELVETICA_BOLD,
+                DocumentTextStyle titleStyle = TextStyles.of(FontName.HELVETICA_BOLD,
                         11.0, DocumentTextDecoration.BOLD, NAME_COLOR);
-                DocumentTextStyle dateStyle = CvTextStyles.of(FontName.HELVETICA_BOLD,
+                DocumentTextStyle dateStyle = TextStyles.of(FontName.HELVETICA_BOLD,
                         11.0, DocumentTextDecoration.BOLD, theme.palette().rule());
-                DocumentTextStyle subtitleStyle = CvTextStyles.of(FontName.HELVETICA,
+                DocumentTextStyle subtitleStyle = TextStyles.of(FontName.HELVETICA,
                         9.4, DocumentTextDecoration.ITALIC, theme.palette().ink());
 
                 EntryCompactRenderer.titleDateBody(section, entry, titleStyle,
@@ -177,11 +180,11 @@ public final class EditorialBlue {
             }
 
             private void renderEducationEntry(SectionBuilder section, CvEntry entry) {
-                DocumentTextStyle titleStyle = CvTextStyles.of(FontName.HELVETICA_BOLD,
+                DocumentTextStyle titleStyle = TextStyles.of(FontName.HELVETICA_BOLD,
                         10.6, DocumentTextDecoration.BOLD, NAME_COLOR);
-                DocumentTextStyle dateStyle = CvTextStyles.of(FontName.HELVETICA_BOLD,
+                DocumentTextStyle dateStyle = TextStyles.of(FontName.HELVETICA_BOLD,
                         10.0, DocumentTextDecoration.BOLD, theme.palette().rule());
-                DocumentTextStyle subtitleStyle = CvTextStyles.of(FontName.HELVETICA,
+                DocumentTextStyle subtitleStyle = TextStyles.of(FontName.HELVETICA,
                         9.2, DocumentTextDecoration.ITALIC, theme.palette().ink());
 
                 EntryCompactRenderer.titleDateBody(section, entry, titleStyle,
@@ -207,9 +210,9 @@ public final class EditorialBlue {
             }
 
             private void renderProject(SectionBuilder section, CvRow row) {
-                DocumentTextStyle titleStyle = CvTextStyles.of(FontName.HELVETICA_BOLD,
+                DocumentTextStyle titleStyle = TextStyles.of(FontName.HELVETICA_BOLD,
                         10.6, DocumentTextDecoration.BOLD, NAME_COLOR);
-                DocumentTextStyle stackStyle = CvTextStyles.of(FontName.HELVETICA,
+                DocumentTextStyle stackStyle = TextStyles.of(FontName.HELVETICA,
                         9.3, DocumentTextDecoration.ITALIC, theme.palette().rule());
                 ProjectRenderer.titleThenBody(section, row, titleStyle, stackStyle,
                         theme.bodyStyle(), 1.45, DocumentInsets.top(1),
@@ -217,7 +220,7 @@ public final class EditorialBlue {
             }
 
             private void renderKeyValue(SectionBuilder section, CvRow row) {
-                DocumentTextStyle keyStyle = CvTextStyles.of(FontName.HELVETICA_BOLD,
+                DocumentTextStyle keyStyle = TextStyles.of(FontName.HELVETICA_BOLD,
                         theme.typography().sizeBody(),
                         DocumentTextDecoration.BOLD, NAME_COLOR);
                 LabelValueRenderer.render(section, row.label(), row.body(),
@@ -239,7 +242,7 @@ public final class EditorialBlue {
                 if (groups.isEmpty()) {
                     return;
                 }
-                DocumentTextStyle cellStyle = CvTextStyles.of(FontName.HELVETICA,
+                DocumentTextStyle cellStyle = TextStyles.of(FontName.HELVETICA,
                         8.6, DocumentTextDecoration.DEFAULT, theme.palette().ink());
                 TableWidget.Style tableStyle = TableWidget.Style.builder()
                         .name("CvV2EditorialBlueSkillsTable")
@@ -264,7 +267,7 @@ public final class EditorialBlue {
                         .padding(new DocumentInsets(2, 0, 0, 0))
                         .addParagraph(paragraph -> paragraph
                                 .text("References available upon request.")
-                                .textStyle(CvTextStyles.of(FontName.HELVETICA,
+                                .textStyle(TextStyles.of(FontName.HELVETICA,
                                         8.4, DocumentTextDecoration.ITALIC,
                                         theme.palette().muted()))
                                 .align(TextAlign.CENTER)
@@ -297,20 +300,20 @@ public final class EditorialBlue {
             }
 
             private DocumentTextStyle sectionTitleStyle() {
-                return CvTextStyles.of(FontName.HELVETICA_BOLD,
+                return TextStyles.of(FontName.HELVETICA_BOLD,
                         theme.typography().sizeBanner(),
                         DocumentTextDecoration.BOLD,
                         theme.palette().rule());
             }
 
             private Masthead.Style mastheadStyle() {
-                DocumentTextStyle nameStyle = CvTextStyles.of(FontName.HELVETICA_BOLD,
+                DocumentTextStyle nameStyle = TextStyles.of(FontName.HELVETICA_BOLD,
                         theme.typography().sizeHeadline(),
                         DocumentTextDecoration.BOLD, NAME_COLOR);
-                DocumentTextStyle titleStyle = CvTextStyles.of(FontName.HELVETICA,
+                DocumentTextStyle titleStyle = TextStyles.of(FontName.HELVETICA,
                         10.0, DocumentTextDecoration.DEFAULT,
                         theme.palette().ink());
-                DocumentTextStyle linkStyle = CvTextStyles.of(FontName.HELVETICA,
+                DocumentTextStyle linkStyle = TextStyles.of(FontName.HELVETICA,
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.UNDERLINE,
                         theme.palette().rule());

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/EngineeringResume.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/EngineeringResume.java
@@ -7,8 +7,8 @@ import com.demcha.compose.document.node.DocumentLinkOptions;
 import com.demcha.compose.document.node.TextAlign;
 import com.demcha.compose.document.style.*;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
-import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
-import com.demcha.compose.document.templates.cv.v2.components.MarkdownInline;
+import com.demcha.compose.document.templates.core.text.TextStyles;
+import com.demcha.compose.document.templates.core.text.MarkdownInline;
 import com.demcha.compose.document.templates.cv.v2.components.ProjectLabel;
 import com.demcha.compose.document.templates.cv.v2.components.SectionLookup;
 import com.demcha.compose.document.templates.cv.v2.data.*;
@@ -535,133 +535,133 @@ public final class EngineeringResume {
             // -- Style factories ------------------------------------------------
 
             private DocumentTextStyle nameStyle() {
-                return CvTextStyles.of(theme.typography().headlineFont(),
+                return TextStyles.of(theme.typography().headlineFont(),
                         theme.typography().sizeHeadline(),
                         DocumentTextDecoration.BOLD,
                         DocumentColor.WHITE);
             }
 
             private DocumentTextStyle subtitleStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         7.6,
                         DocumentTextDecoration.BOLD,
                         SUBTITLE_COLOR);
             }
 
             private DocumentTextStyle contactMetaStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.DEFAULT,
                         CONTACT_META);
             }
 
             private DocumentTextStyle contactLinkStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.UNDERLINE,
                         CONTACT_LINK);
             }
 
             private DocumentTextStyle railHeadingStyle() {
-                return CvTextStyles.of(theme.typography().headlineFont(),
+                return TextStyles.of(theme.typography().headlineFont(),
                         7.4,
                         DocumentTextDecoration.BOLD,
                         GREEN);
             }
 
             private DocumentTextStyle railBodyStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         6.95,
                         DocumentTextDecoration.DEFAULT,
                         RAIL_TEXT);
             }
 
             private DocumentTextStyle railLabelStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         6.95,
                         DocumentTextDecoration.BOLD,
                         GREEN);
             }
 
             private DocumentTextStyle railTitleStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         6.95,
                         DocumentTextDecoration.BOLD,
                         DocumentColor.WHITE);
             }
 
             private DocumentTextStyle railDateStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         6.7,
                         DocumentTextDecoration.DEFAULT,
                         RAIL_DATE);
             }
 
             private DocumentTextStyle mainHeadingStyle() {
-                return CvTextStyles.of(theme.typography().headlineFont(),
+                return TextStyles.of(theme.typography().headlineFont(),
                         theme.typography().sizeBanner(),
                         DocumentTextDecoration.BOLD,
                         GREEN);
             }
 
             private DocumentTextStyle profileHeadingStyle() {
-                return CvTextStyles.of(theme.typography().headlineFont(),
+                return TextStyles.of(theme.typography().headlineFont(),
                         8.0,
                         DocumentTextDecoration.BOLD,
                         GREEN);
             }
 
             private DocumentTextStyle profileBodyStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         7.75,
                         DocumentTextDecoration.DEFAULT,
                         theme.palette().ink());
             }
 
             private DocumentTextStyle roleTitleStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeEntryTitle(),
                         DocumentTextDecoration.BOLD,
                         theme.palette().ink());
             }
 
             private DocumentTextStyle roleDateStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeEntryDate(),
                         DocumentTextDecoration.BOLD,
                         GREEN);
             }
 
             private DocumentTextStyle subtitleBodyStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeEntrySubtitle(),
                         DocumentTextDecoration.DEFAULT,
                         theme.palette().muted());
             }
 
             private DocumentTextStyle roleBodyStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeBody(),
                         DocumentTextDecoration.DEFAULT,
                         theme.palette().ink());
             }
 
             private DocumentTextStyle projectTitleStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         7.35,
                         DocumentTextDecoration.BOLD,
                         theme.palette().ink());
             }
 
             private DocumentTextStyle projectContextStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         6.85,
                         DocumentTextDecoration.DEFAULT,
                         GREEN);
             }
 
             private DocumentTextStyle projectBodyStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         7.1,
                         DocumentTextDecoration.DEFAULT,
                         theme.palette().ink());

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/Executive.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/Executive.java
@@ -10,7 +10,7 @@ import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.style.DocumentTextDecoration;
 import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
-import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
+import com.demcha.compose.document.templates.core.text.TextStyles;
 import com.demcha.compose.document.templates.cv.v2.components.SectionDispatcher;
 import com.demcha.compose.document.templates.cv.v2.data.*;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
@@ -199,28 +199,28 @@ public final class Executive {
             }
 
             private DocumentTextStyle nameStyle() {
-                return CvTextStyles.of(FontName.POPPINS,
+                return TextStyles.of(FontName.POPPINS,
                         theme.typography().sizeHeadline(),
                         DocumentTextDecoration.BOLD,
                         PRIMARY_NAME);
             }
 
             private DocumentTextStyle metaStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.DEFAULT,
                         theme.palette().ink());
             }
 
             private DocumentTextStyle linkRowBodyStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeBody(),
                         DocumentTextDecoration.DEFAULT,
                         theme.palette().ink());
             }
 
             private DocumentTextStyle linkRowLinkStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeBody(),
                         DocumentTextDecoration.UNDERLINE,
                         ACCENT);

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/MintEditorial.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/MintEditorial.java
@@ -14,10 +14,10 @@ import com.demcha.compose.document.table.DocumentTableCell;
 import com.demcha.compose.document.table.DocumentTableColumn;
 import com.demcha.compose.document.table.DocumentTableStyle;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
-import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
-import com.demcha.compose.document.templates.cv.v2.components.MarkdownInline;
+import com.demcha.compose.document.templates.core.text.TextStyles;
+import com.demcha.compose.document.templates.core.text.MarkdownInline;
 import com.demcha.compose.document.templates.cv.v2.components.SectionLookup;
-import com.demcha.compose.document.templates.cv.v2.components.TextOrnaments;
+import com.demcha.compose.document.templates.core.text.TextOrnaments;
 import com.demcha.compose.document.templates.cv.v2.data.*;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.Headline;
@@ -1074,7 +1074,7 @@ public final class MintEditorial {
                 return gridCell(line, cellStyle);
             }
             DocumentLinkOptions link = new DocumentLinkOptions("mailto:" + email);
-            DocumentTextStyle linkStyle = CvTextStyles.of(
+            DocumentTextStyle linkStyle = TextStyles.of(
                     theme.typography().bodyFont(),
                     theme.typography().sizeEntryDate(),
                     DocumentTextDecoration.UNDERLINE, theme.palette().muted());
@@ -1123,43 +1123,43 @@ public final class MintEditorial {
          * colour differs when a caller overrides {@code nameColor}.
          */
         private DocumentTextStyle mastheadNameStyle() {
-            return CvTextStyles.of(theme.typography().headlineFont(),
+            return TextStyles.of(theme.typography().headlineFont(),
                     theme.typography().sizeHeadline(),
                     DocumentTextDecoration.DEFAULT, nameColor);
         }
 
         private DocumentTextStyle taglineStyle() {
-            return CvTextStyles.of(theme.typography().headlineFont(),
+            return TextStyles.of(theme.typography().headlineFont(),
                     theme.typography().sizeContact(),
                     DocumentTextDecoration.BOLD, accent);
         }
 
         private DocumentTextStyle headingStyle() {
-            return CvTextStyles.of(theme.typography().headlineFont(),
+            return TextStyles.of(theme.typography().headlineFont(),
                     theme.typography().sizeBanner(),
                     DocumentTextDecoration.BOLD, accent);
         }
 
         private DocumentTextStyle labelStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     theme.typography().sizeEntryTitle(),
                     DocumentTextDecoration.BOLD, theme.palette().ink());
         }
 
         private DocumentTextStyle bodyStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     theme.typography().sizeBody(),
                     DocumentTextDecoration.DEFAULT, theme.palette().ink());
         }
 
         private DocumentTextStyle contactStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     theme.typography().sizeContact(),
                     DocumentTextDecoration.DEFAULT, theme.palette().muted());
         }
 
         private DocumentTextStyle smallStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     theme.typography().sizeEntryDate(),
                     DocumentTextDecoration.DEFAULT, theme.palette().muted());
         }

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/MonogramSidebar.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/MonogramSidebar.java
@@ -1,5 +1,9 @@
 package com.demcha.compose.document.templates.cv.v2.presets;
 
+import com.demcha.compose.document.templates.core.text.MarkdownInline;
+import com.demcha.compose.document.templates.core.text.TextOrnaments;
+import com.demcha.compose.document.templates.core.text.TextStyles;
+
 import com.demcha.compose.document.api.DocumentSession;
 import com.demcha.compose.document.api.PageBackgroundFill;
 import com.demcha.compose.document.dsl.EllipseBuilder;
@@ -396,7 +400,7 @@ public final class MonogramSidebar {
                     .layer(new ParagraphBuilder()
                             .name("CvV2MonogramSidebarInitials")
                             .text(initialsText)
-                            .textStyle(CvTextStyles.of(MONOGRAM_FONT, 44.0,
+                            .textStyle(TextStyles.of(MONOGRAM_FONT, 44.0,
                                     DocumentTextDecoration.BOLD, monogramRing))
                             .align(TextAlign.LEFT)
                             .build(), LayerAlign.CENTER)
@@ -725,84 +729,84 @@ public final class MonogramSidebar {
         // -- Style factories ----------------------------------------------
 
         private DocumentTextStyle nameStyle() {
-            return CvTextStyles.of(theme.typography().headlineFont(),
+            return TextStyles.of(theme.typography().headlineFont(),
                     theme.typography().sizeHeadline(),
                     DocumentTextDecoration.DEFAULT,
                     theme.palette().ink());
         }
 
         private DocumentTextStyle subtitleStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     theme.typography().sizeContact(),
                     DocumentTextDecoration.BOLD,
                     accent);
         }
 
         private DocumentTextStyle sidebarHeaderStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     8.0,
                     DocumentTextDecoration.BOLD,
                     theme.palette().ink());
         }
 
         private DocumentTextStyle sidebarBodyStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     theme.typography().sizeContact(),
                     DocumentTextDecoration.DEFAULT,
                     theme.palette().muted());
         }
 
         private DocumentTextStyle sidebarEntryTitleStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     7.6,
                     DocumentTextDecoration.BOLD,
                     theme.palette().ink());
         }
 
         private DocumentTextStyle sidebarEntrySubtitleStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     theme.typography().sizeContact(),
                     DocumentTextDecoration.DEFAULT,
                     theme.palette().ink());
         }
 
         private DocumentTextStyle sidebarEntryDateStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     7.2,
                     DocumentTextDecoration.DEFAULT,
                     accent);
         }
 
         private DocumentTextStyle sidebarSkillStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     theme.typography().sizeContact(),
                     DocumentTextDecoration.DEFAULT,
                     theme.palette().muted());
         }
 
         private DocumentTextStyle mainHeaderStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     theme.typography().sizeBanner(),
                     DocumentTextDecoration.BOLD,
                     theme.palette().ink());
         }
 
         private DocumentTextStyle mainBodyStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     theme.typography().sizeBody(),
                     DocumentTextDecoration.DEFAULT,
                     theme.palette().ink());
         }
 
         private DocumentTextStyle mainEntryTitleStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     theme.typography().sizeEntryTitle(),
                     DocumentTextDecoration.BOLD,
                     theme.palette().ink());
         }
 
         private DocumentTextStyle mainEntryDateStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     theme.typography().sizeEntryDate(),
                     DocumentTextDecoration.BOLD,
                     accent);

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/NordicClean.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/NordicClean.java
@@ -1,5 +1,8 @@
 package com.demcha.compose.document.templates.cv.v2.presets;
 
+import com.demcha.compose.document.templates.core.text.MarkdownInline;
+import com.demcha.compose.document.templates.core.text.TextStyles;
+
 import com.demcha.compose.document.api.DocumentSession;
 import com.demcha.compose.document.dsl.PageFlowBuilder;
 import com.demcha.compose.document.dsl.SectionBuilder;
@@ -307,7 +310,7 @@ public final class NordicClean {
                                         .text(MarkdownInline.plainText(
                                                         doc.identity().jobTitle())
                                                 .toUpperCase(Locale.ROOT))
-                                        .textStyle(CvTextStyles.of(theme.typography().bodyFont(),
+                                        .textStyle(TextStyles.of(theme.typography().bodyFont(),
                                                 7.7,
                                                 DocumentTextDecoration.BOLD,
                                                 theme.palette().muted()))
@@ -402,7 +405,7 @@ public final class NordicClean {
                         options.accentColor(), 82, host -> {
                             for (CvEntry entry : education.entries()) {
                                 EntryCompactRenderer.slashSubtitleDate(host, entry,
-                                        CvTextStyles.of(theme.typography().bodyFont(), 7.05,
+                                        TextStyles.of(theme.typography().bodyFont(), 7.05,
                                                 DocumentTextDecoration.BOLD,
                                                 theme.palette().ink()),
                                         bodyStyle(7.05, theme.palette().muted()),
@@ -460,7 +463,7 @@ public final class NordicClean {
             private void addWorkEntry(SectionBuilder host, CvEntry entry) {
                 EntryCompactRenderer.titleDateBody(host, entry,
                         theme.entryTitleStyle(),
-                        CvTextStyles.of(theme.typography().bodyFont(),
+                        TextStyles.of(theme.typography().bodyFont(),
                                 theme.typography().sizeEntryDate(),
                                 DocumentTextDecoration.BOLD,
                                 options.accentColor()),
@@ -477,7 +480,7 @@ public final class NordicClean {
 
             private void addProject(SectionBuilder host, CvRow row) {
                 ProjectRenderer.inline(host, row,
-                        CvTextStyles.of(theme.typography().bodyFont(), 7.35,
+                        TextStyles.of(theme.typography().bodyFont(), 7.35,
                                 DocumentTextDecoration.BOLD, theme.palette().ink()),
                         bodyStyle(6.95, theme.palette().muted()),
                         bodyStyle(7.2, theme.palette().ink()),
@@ -487,7 +490,7 @@ public final class NordicClean {
             private void addLabelValueLine(SectionBuilder host, String label,
                                            String value, double size,
                                            double lineSpacing) {
-                DocumentTextStyle labelStyle = CvTextStyles.of(theme.typography().bodyFont(),
+                DocumentTextStyle labelStyle = TextStyles.of(theme.typography().bodyFont(),
                         size, DocumentTextDecoration.BOLD, theme.palette().ink());
                 DocumentTextStyle valueStyle = bodyStyle(size,
                         theme.palette().muted());
@@ -497,35 +500,35 @@ public final class NordicClean {
             }
 
             private DocumentTextStyle headlineStyle() {
-                return CvTextStyles.of(theme.typography().headlineFont(),
+                return TextStyles.of(theme.typography().headlineFont(),
                         theme.typography().sizeHeadline(),
                         DocumentTextDecoration.BOLD,
                         theme.palette().ink());
             }
 
             private DocumentTextStyle sectionTitleStyle() {
-                return CvTextStyles.of(theme.typography().headlineFont(),
+                return TextStyles.of(theme.typography().headlineFont(),
                         theme.typography().sizeBanner(),
                         DocumentTextDecoration.BOLD,
                         options.accentColor());
             }
 
             private DocumentTextStyle contactMetaStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.DEFAULT,
                         theme.palette().muted());
             }
 
             private DocumentTextStyle contactLinkStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.UNDERLINE,
                         options.accentColor());
             }
 
             private DocumentTextStyle bodyStyle(double size, DocumentColor color) {
-                return CvTextStyles.of(theme.typography().bodyFont(), size,
+                return TextStyles.of(theme.typography().bodyFont(), size,
                         DocumentTextDecoration.DEFAULT, color);
             }
         }

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/Panel.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/Panel.java
@@ -1,5 +1,7 @@
 package com.demcha.compose.document.templates.cv.v2.presets;
 
+import com.demcha.compose.document.templates.core.text.TextStyles;
+
 import com.demcha.compose.document.api.DocumentSession;
 import com.demcha.compose.document.dsl.PageFlowBuilder;
 import com.demcha.compose.document.dsl.SectionBuilder;
@@ -450,35 +452,35 @@ public final class Panel {
             }
 
             private DocumentTextStyle nameStyle() {
-                return CvTextStyles.of(FontName.POPPINS,
+                return TextStyles.of(FontName.POPPINS,
                         theme.typography().sizeHeadline(),
                         DocumentTextDecoration.BOLD,
                         HEADER_TEXT);
             }
 
             private DocumentTextStyle headerBodyStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeBody(),
                         DocumentTextDecoration.DEFAULT,
                         theme.palette().ink());
             }
 
             private DocumentTextStyle headerMetaStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.DEFAULT,
                         theme.palette().ink());
             }
 
             private DocumentTextStyle headerLinkStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.UNDERLINE,
                         ACCENT);
             }
 
             private DocumentTextStyle moduleTitleStyle() {
-                return CvTextStyles.of(FontName.POPPINS,
+                return TextStyles.of(FontName.POPPINS,
                         theme.typography().sizeBanner(),
                         DocumentTextDecoration.BOLD,
                         ACCENT);

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/SidebarPortrait.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/SidebarPortrait.java
@@ -12,8 +12,8 @@ import com.demcha.compose.document.style.DocumentTextDecoration;
 import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.svg.SvgIcon;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
-import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
-import com.demcha.compose.document.templates.cv.v2.components.MarkdownInline;
+import com.demcha.compose.document.templates.core.text.TextStyles;
+import com.demcha.compose.document.templates.core.text.MarkdownInline;
 import com.demcha.compose.document.templates.cv.v2.components.ProjectLabel;
 import com.demcha.compose.document.templates.cv.v2.components.SectionLookup;
 import com.demcha.compose.document.templates.cv.v2.data.*;
@@ -772,105 +772,105 @@ public final class SidebarPortrait {
         // -- Style factories ------------------------------------------------
 
         private DocumentTextStyle nameStyle() {
-            return CvTextStyles.of(theme.typography().headlineFont(),
+            return TextStyles.of(theme.typography().headlineFont(),
                     theme.typography().sizeHeadline(),
                     DocumentTextDecoration.BOLD,
                     theme.palette().ink());
         }
 
         private DocumentTextStyle subtitleStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     theme.typography().sizeEntryDate(),
                     DocumentTextDecoration.DEFAULT,
                     theme.palette().ink());
         }
 
         private DocumentTextStyle contactStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     theme.typography().sizeContact(),
                     DocumentTextDecoration.DEFAULT,
                     theme.palette().ink());
         }
 
         private DocumentTextStyle sidebarHeaderStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     10.8,
                     DocumentTextDecoration.BOLD,
                     theme.palette().ink());
         }
 
         private DocumentTextStyle sidebarEntryTitleStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     8.4,
                     DocumentTextDecoration.BOLD,
                     theme.palette().ink());
         }
 
         private DocumentTextStyle sidebarEntryMetaStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     7.8,
                     DocumentTextDecoration.DEFAULT,
                     theme.palette().muted());
         }
 
         private DocumentTextStyle sidebarSkillStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     theme.typography().sizeEntrySubtitle(),
                     DocumentTextDecoration.DEFAULT,
                     theme.palette().ink());
         }
 
         private DocumentTextStyle sidebarLanguageNameStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     8.1,
                     DocumentTextDecoration.BOLD,
                     theme.palette().ink());
         }
 
         private DocumentTextStyle sidebarLanguageMetaStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     7.9,
                     DocumentTextDecoration.DEFAULT,
                     theme.palette().muted());
         }
 
         private DocumentTextStyle mainHeaderStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     theme.typography().sizeBanner(),
                     DocumentTextDecoration.BOLD,
                     theme.palette().ink());
         }
 
         private DocumentTextStyle mainBodyStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     theme.typography().sizeBody(),
                     DocumentTextDecoration.DEFAULT,
                     theme.palette().ink());
         }
 
         private DocumentTextStyle mainEntryTitleStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     theme.typography().sizeEntryTitle(),
                     DocumentTextDecoration.BOLD,
                     theme.palette().ink());
         }
 
         private DocumentTextStyle mainEntrySubtitleStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     9.2,
                     DocumentTextDecoration.DEFAULT,
                     theme.palette().ink());
         }
 
         private DocumentTextStyle mainProjectTitleStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     theme.typography().sizeEntryTitle(),
                     DocumentTextDecoration.BOLD,
                     theme.palette().ink());
         }
 
         private DocumentTextStyle mainProjectContextStyle() {
-            return CvTextStyles.of(theme.typography().bodyFont(),
+            return TextStyles.of(theme.typography().bodyFont(),
                     theme.typography().sizeEntryDate(),
                     DocumentTextDecoration.ITALIC,
                     theme.palette().muted());

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/TimelineMinimal.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/presets/TimelineMinimal.java
@@ -12,8 +12,8 @@ import com.demcha.compose.document.style.DocumentStroke;
 import com.demcha.compose.document.style.DocumentTextDecoration;
 import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
-import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
-import com.demcha.compose.document.templates.cv.v2.components.MarkdownInline;
+import com.demcha.compose.document.templates.core.text.TextStyles;
+import com.demcha.compose.document.templates.core.text.MarkdownInline;
 import com.demcha.compose.document.templates.cv.v2.components.SectionLookup;
 import com.demcha.compose.document.templates.cv.v2.data.*;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
@@ -404,63 +404,63 @@ public final class TimelineMinimal {
             // -- style factories ---------------------------------------------
 
             private DocumentTextStyle nameStyle() {
-                return CvTextStyles.of(theme.typography().headlineFont(),
+                return TextStyles.of(theme.typography().headlineFont(),
                         theme.typography().sizeHeadline(),
                         DocumentTextDecoration.DEFAULT,
                         theme.palette().ink());
             }
 
             private DocumentTextStyle jobTitleStyle() {
-                return CvTextStyles.of(theme.typography().headlineFont(),
+                return TextStyles.of(theme.typography().headlineFont(),
                         9.5,
                         DocumentTextDecoration.BOLD,
                         theme.palette().ink());
             }
 
             private DocumentTextStyle contactTextStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeContact(),
                         DocumentTextDecoration.BOLD,
                         theme.palette().muted());
             }
 
             private DocumentTextStyle fallbackIconStyle() {
-                return CvTextStyles.of(theme.typography().headlineFont(),
+                return TextStyles.of(theme.typography().headlineFont(),
                         8.0,
                         DocumentTextDecoration.BOLD,
                         theme.palette().muted());
             }
 
             private DocumentTextStyle sidebarTitleStyle() {
-                return CvTextStyles.of(theme.typography().headlineFont(),
+                return TextStyles.of(theme.typography().headlineFont(),
                         theme.typography().sizeEntryTitle(),
                         DocumentTextDecoration.BOLD,
                         theme.palette().ink());
             }
 
             private DocumentTextStyle sidebarBodyStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeEntrySubtitle(),
                         DocumentTextDecoration.BOLD,
                         theme.palette().ink());
             }
 
             private DocumentTextStyle mainTitleStyle() {
-                return CvTextStyles.of(theme.typography().headlineFont(),
+                return TextStyles.of(theme.typography().headlineFont(),
                         theme.typography().sizeBanner(),
                         DocumentTextDecoration.BOLD,
                         theme.palette().ink());
             }
 
             private DocumentTextStyle mainBulletStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeBody(),
                         DocumentTextDecoration.DEFAULT,
                         theme.palette().ink());
             }
 
             private DocumentTextStyle mainBodyStyle() {
-                return CvTextStyles.of(theme.typography().bodyFont(),
+                return TextStyles.of(theme.typography().bodyFont(),
                         theme.typography().sizeEntryDate(),
                         DocumentTextDecoration.DEFAULT,
                         theme.palette().ink());

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/widgets/Headline.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/widgets/Headline.java
@@ -4,7 +4,7 @@ import com.demcha.compose.document.dsl.SectionBuilder;
 import com.demcha.compose.document.node.TextAlign;
 import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.style.DocumentTextStyle;
-import com.demcha.compose.document.templates.cv.v2.components.TextOrnaments;
+import com.demcha.compose.document.templates.core.text.TextOrnaments;
 import com.demcha.compose.document.templates.cv.v2.data.CvName;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
 

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/widgets/ProfileBand.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/widgets/ProfileBand.java
@@ -7,7 +7,7 @@ import com.demcha.compose.document.style.DocumentColor;
 import com.demcha.compose.document.style.DocumentCornerRadius;
 import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.style.DocumentTextStyle;
-import com.demcha.compose.document.templates.cv.v2.components.MarkdownInline;
+import com.demcha.compose.document.templates.core.text.MarkdownInline;
 
 import java.util.Objects;
 

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/widgets/SectionHeader.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/widgets/SectionHeader.java
@@ -6,7 +6,7 @@ import com.demcha.compose.document.style.DocumentColor;
 import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.style.DocumentTextDecoration;
 import com.demcha.compose.document.style.DocumentTextStyle;
-import com.demcha.compose.document.templates.cv.v2.components.TextOrnaments;
+import com.demcha.compose.document.templates.core.text.TextOrnaments;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
 
 import java.util.Locale;

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/widgets/SkillBar.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/widgets/SkillBar.java
@@ -5,8 +5,8 @@ import com.demcha.compose.document.node.TextAlign;
 import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.style.DocumentTextDecoration;
 import com.demcha.compose.document.style.DocumentTextStyle;
-import com.demcha.compose.document.templates.cv.v2.components.CvTextStyles;
-import com.demcha.compose.document.templates.cv.v2.components.TextOrnaments;
+import com.demcha.compose.document.templates.core.text.TextStyles;
+import com.demcha.compose.document.templates.core.text.TextOrnaments;
 import com.demcha.compose.document.templates.cv.v2.data.CvSkill;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
 
@@ -109,7 +109,7 @@ public final class SkillBar {
         Objects.requireNonNull(theme, "theme");
 
         boolean levelled = skill.level().isPresent();
-        DocumentTextStyle labelStyle = CvTextStyles.of(
+        DocumentTextStyle labelStyle = TextStyles.of(
                 theme.typography().bodyFont(),
                 theme.typography().sizeEntryTitle(),
                 DocumentTextDecoration.BOLD,

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/widgets/Subheadline.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/widgets/Subheadline.java
@@ -4,7 +4,7 @@ import com.demcha.compose.document.dsl.SectionBuilder;
 import com.demcha.compose.document.node.TextAlign;
 import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.style.DocumentTextStyle;
-import com.demcha.compose.document.templates.cv.v2.components.TextOrnaments;
+import com.demcha.compose.document.templates.core.text.TextOrnaments;
 
 /**
  * Secondary headline widget — the small spaced-caps tagline rendered

--- a/src/main/java/com/demcha/compose/document/templates/invoice/builder/InvoiceBuilder.java
+++ b/src/main/java/com/demcha/compose/document/templates/invoice/builder/InvoiceBuilder.java
@@ -8,7 +8,7 @@ import com.demcha.compose.document.node.TextAlign;
 import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
-import com.demcha.compose.document.templates.components.MarkdownText;
+import com.demcha.compose.document.templates.core.text.MarkdownText;
 import com.demcha.compose.document.templates.invoice.spec.InvoiceSpec;
 import com.demcha.compose.document.templates.themes.Spacing;
 

--- a/src/main/java/com/demcha/compose/document/templates/proposal/builder/ProposalBuilder.java
+++ b/src/main/java/com/demcha/compose/document/templates/proposal/builder/ProposalBuilder.java
@@ -8,7 +8,7 @@ import com.demcha.compose.document.node.TextAlign;
 import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
-import com.demcha.compose.document.templates.components.MarkdownText;
+import com.demcha.compose.document.templates.core.text.MarkdownText;
 import com.demcha.compose.document.templates.proposal.spec.ProposalSpec;
 import com.demcha.compose.document.templates.themes.Spacing;
 

--- a/src/test/java/com/demcha/compose/document/templates/core/text/MarkdownInlineTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/core/text/MarkdownInlineTest.java
@@ -1,4 +1,4 @@
-package com.demcha.compose.document.templates.cv.v2.components;
+package com.demcha.compose.document.templates.core.text;
 
 import com.demcha.compose.document.dsl.RichText;
 import com.demcha.compose.document.node.DocumentLinkOptions;

--- a/src/test/java/com/demcha/compose/document/templates/cv/v2/components/CvV2ComponentUtilityTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/v2/components/CvV2ComponentUtilityTest.java
@@ -1,5 +1,7 @@
 package com.demcha.compose.document.templates.cv.v2.components;
 
+import com.demcha.compose.document.templates.core.text.MarkdownInline;
+
 import com.demcha.compose.document.templates.cv.v2.data.CvSection;
 import com.demcha.compose.document.templates.cv.v2.data.ParagraphSection;
 import com.demcha.compose.document.templates.cv.v2.data.RowStyle;

--- a/src/test/java/com/demcha/compose/document/templates/cv/v2/components/ProjectLabelTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/cv/v2/components/ProjectLabelTest.java
@@ -1,5 +1,7 @@
 package com.demcha.compose.document.templates.cv.v2.components;
 
+import com.demcha.compose.document.templates.core.text.MarkdownInline;
+
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;


### PR DESCRIPTION
## Why

The neutral text-rendering primitives — inline markdown parsing, rich-paragraph
rendering, text-style factories, small string ornaments — lived in `cv.v2.components`
(and one in the Gen-2 `templates.components`). They carry no CV data model, yet invoice
and proposal could only reach them through `cv` or the Gen-2 surface. Moving them to a
family-neutral `templates.core.text` lets every family share one text layer. Renaming a
public type is a binary break, so this lands on the 2.0 line.

## What changed

- **Moved to `templates.core.text`:** `MarkdownText` (from `templates.components`); and
  `CvTextStyles` → `TextStyles`, `MarkdownInline`, `RichParagraphRenderer`, `TextOrnaments`
  (from `cv.v2.components`). Added `core/text/package-info.java`.
- **Stayed in `cv.v2.components`:** `ParagraphPrimitive` (package-private) and
  `ParagraphRenderer` — CV-section plumbing used only by the CV section renderers
  (Entry / Row / Skills / Paragraph), not cross-family.
- **Repointed all callers:** `cv.v2`, `coverletter.v2`, the Gen-2 `cv` / `coverletter`
  presets, and the active invoice / proposal builders (which already used `MarkdownText`).
  Relocated `MarkdownInlineTest` → `core.text`.
- **Import note:** several presets already use a wildcard `cv.v2.components.*`; the move
  adds a matching wildcard `core.text.*` to the files that referenced the moved classes
  (consistent with that existing idiom). Can convert to specific imports on request.

**Lane:** templates (canonical). **Target:** `2.0-dev`. Pure move / rename — no logic change.

**Deferred to the docs refresh:** markdown docs that still name the old `cv.v2.components`
text types.

## Verification

- `./mvnw test -pl .` → `Tests run: 1607, Failures: 0, Errors: 0` — zero snapshot updates
  → render is byte-identical.
- `./mvnw -P japicmp verify -pl .` → BUILD SUCCESS; javadoc gate clean; japicmp runs
  report-only and its report documents the move (`core.text.*` added; cv/coverletter
  signatures repointed).
- `examples` test-compile + `GenerateAllExamples` → every example PDF regenerates.
