### PR TITLE
chore(api): close v1.9.0 engine-leak guard and metadata gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to GraphCompose are documented here. Versions
 follow semantic versioning; release dates are ISO 8601.
 
-## v1.9.0 — unreleased
+## v1.9.0 — Planned
 
 In-document navigation. Rendered PDFs can now declare named **anchors** and
 **internal links** that jump to them — clickable tables of contents,

--- a/src/main/java/com/demcha/compose/document/api/DocumentSession.java
+++ b/src/main/java/com/demcha/compose/document/api/DocumentSession.java
@@ -475,6 +475,7 @@ public final class DocumentSession implements AutoCloseable {
      * @param rules ordered list of per-page margin overrides, or {@code null}/empty to clear
      * @return this session
      * @throws IllegalStateException if this session has already been closed
+     * @since 1.9.0
      */
     public DocumentSession pageMargins(List<PageMarginRule> rules) {
         ensureOpen();

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/BannerRenderer.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/BannerRenderer.java
@@ -5,7 +5,7 @@ import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.SectionHeader;
 
 /**
- * @deprecated Use
+ * @deprecated since 1.9.0; removed in 2.0. Use
  * {@link com.demcha.compose.document.templates.cv.v2.widgets.SectionHeader#banner}
  * instead — the widget groups the banner alongside its sibling
  * variants ({@code underlined}, {@code flat}) so picking a section-
@@ -13,7 +13,7 @@ import com.demcha.compose.document.templates.cv.v2.widgets.SectionHeader;
  * delegating shim so v2 code written before the widgets layer keeps
  * compiling unchanged.
  */
-@Deprecated(forRemoval = true)
+@Deprecated(since = "1.9.0", forRemoval = true)
 public final class BannerRenderer {
 
     private BannerRenderer() {

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/ContactRenderer.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/ContactRenderer.java
@@ -6,14 +6,14 @@ import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.ContactLine;
 
 /**
- * @deprecated Use
+ * @deprecated since 1.9.0; removed in 2.0. Use
  * {@link com.demcha.compose.document.templates.cv.v2.widgets.ContactLine#centered}
  * instead — the widget gives you named centred/right-aligned
  * variants plus a configurable field order. Kept as a thin
  * delegating shim so v2 code written before the widgets layer keeps
  * compiling unchanged.
  */
-@Deprecated(forRemoval = true)
+@Deprecated(since = "1.9.0", forRemoval = true)
 public final class ContactRenderer {
 
     private ContactRenderer() {

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/components/HeadlineRenderer.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/components/HeadlineRenderer.java
@@ -6,14 +6,14 @@ import com.demcha.compose.document.templates.cv.v2.theme.CvTheme;
 import com.demcha.compose.document.templates.cv.v2.widgets.Headline;
 
 /**
- * @deprecated Use
+ * @deprecated since 1.9.0; removed in 2.0. Use
  * {@link com.demcha.compose.document.templates.cv.v2.widgets.Headline#spacedCentered}
  * instead — the widget gives you a named API plus alignment +
  * spaced-caps variants, while this class only ever did the
  * centred-spaced-caps form. Kept as a thin delegating shim so v2
  * code written before the widgets layer keeps compiling unchanged.
  */
-@Deprecated(forRemoval = true)
+@Deprecated(since = "1.9.0", forRemoval = true)
 public final class HeadlineRenderer {
 
     private HeadlineRenderer() {

--- a/src/test/java/com/demcha/documentation/PublicApiNoEngineLeakTest.java
+++ b/src/test/java/com/demcha/documentation/PublicApiNoEngineLeakTest.java
@@ -41,6 +41,11 @@ class PublicApiNoEngineLeakTest {
             PROJECT_ROOT.resolve("src/main/java/com/demcha/compose/document/style"),
             PROJECT_ROOT.resolve("src/main/java/com/demcha/compose/document/table"),
             PROJECT_ROOT.resolve("src/main/java/com/demcha/compose/document/image"),
+            PROJECT_ROOT.resolve("src/main/java/com/demcha/compose/document/output"),
+            PROJECT_ROOT.resolve("src/main/java/com/demcha/compose/document/snapshot"),
+            PROJECT_ROOT.resolve("src/main/java/com/demcha/compose/document/theme"),
+            PROJECT_ROOT.resolve("src/main/java/com/demcha/compose/document/exceptions"),
+            PROJECT_ROOT.resolve("src/main/java/com/demcha/compose/document/emoji"),
             PROJECT_ROOT.resolve("src/main/java/com/demcha/compose/font"));
 
     /**


### PR DESCRIPTION
## Why

Two gaps in the public-API surface of the in-progress v1.9.0 release.

`PublicApiNoEngineLeakTest` documents itself as pinning "every
`com.demcha.compose.engine.*` import leaking into the public API surface", but
`PUBLIC_API_ROOTS` listed only eight `document.*` packages — `output`,
`snapshot`, `theme`, `exceptions`, and `emoji` were never scanned. All five are
public (each carries a `package-info`), and three gained new public types this
cycle (`DocumentViewerPreferences`/`DocumentPageNumbering` in `output`,
`PageIndex`/`PageReference` in `snapshot`, `EmojiLibrary` in `emoji`), so an
engine import into any of them would land in Stable public API undetected.

Separately, three pieces of 1.9.0 metadata were inconsistent:
`DocumentSession.pageMargins(...)` shipped without the `@since 1.9.0` its six
sibling new methods carry; the three deprecated CV-renderer shims carried
`@Deprecated(forRemoval = true)` without the `since` that their sibling
`CoverLetterTemplate` and `docs/api-stability.md` §3 both require; and the
in-progress CHANGELOG header read `— unreleased`, which the release tooling does
not match (it dates `## v<ver> — Planned`), so the shipped CHANGELOG would have
stayed undated.

## What changed

- `PublicApiNoEngineLeakTest.PUBLIC_API_ROOTS` now also scans
  `document/{output,snapshot,theme,exceptions,emoji}`. All five are already
  engine-import-free, so the guard passes immediately and locks the property in.
  The engine-adjacent internal trees (`layout`, `backend`, `templates`, `debug`)
  stay excluded by design — they legitimately depend on the engine.
- `DocumentSession.pageMargins(List<PageMarginRule>)` gains `@since 1.9.0`,
  matching `viewerPreferences` / `pageIndex` / `toImage(s)`.
- `HeadlineRenderer` / `ContactRenderer` / `BannerRenderer` become
  `@Deprecated(since = "1.9.0", forRemoval = true)`, and their `@deprecated`
  Javadoc leads with `since 1.9.0; removed in 2.0.` — the `since` marks when the
  deprecation took effect, matching `CoverLetterTemplate` and the §3 ledger.
- CHANGELOG in-progress header `## v1.9.0 — unreleased` → `## v1.9.0 — Planned`
  so the release tooling rewrites it to the ISO date at cut time.

## Verification

`./mvnw -B -ntp clean verify -pl .` → **BUILD SUCCESS**, **1607 tests**, 0
failures, 0 javadoc warnings. The widened `PublicApiNoEngineLeakTest` stays green
(all five added packages are engine-clean); `VersionConsistencyGuardTest` stays
green with the `Planned` header. No runtime code changed — a test allow-list,
Javadoc `@since`, deprecation annotations, and a CHANGELOG header only; no public
API surface added or altered.

**Lane:** test + canonical (docs/metadata) — guard coverage plus 1.9.0
public-API metadata, no behavioural change.
