### PR TITLE
docs(templates): redraw the cv.v2 layer diagrams for the extracted core

### DIFF
--- a/docs/templates/v2-layered/quickstart.md
+++ b/docs/templates/v2-layered/quickstart.md
@@ -14,14 +14,15 @@ GraphCompose's templates v2 (layered) gives you:
 - **Themes describing visuals** — `BrandTheme` (palette + typography +
   spacing + decoration). Swap a theme to change colours, fonts,
   bullet glyphs without touching renderers.
-- **Widgets as visual LEGO bricks** — `Headline`, `Subheadline`,
-  `ContactLine`, `SectionHeader`. Each one is a named visual decision
-  you can drop into a preset.
+- **Widgets as visual LEGO bricks** — the neutral header bricks
+  (`Headline`, `Subheadline`, `ContactLine`) live in the shared
+  `templates.core.identity`; CV-specific ones (`SectionHeader` and
+  friends) in `cv.v2.widgets`. Each is a named visual decision you
+  drop into a preset.
 - **Presets as compositions** — a preset orchestrates widgets in a
-  page flow. `BoxedSections`, `MinimalUnderlined`,
-  `ModernProfessional`, `CenteredHeadline`, `BlueBanner`,
-  `EditorialBlue`, `ClassicSerif`, `NordicClean`, and `CompactMono`
-  ship today; writing your own is ~150 lines.
+  page flow. Sixteen ship today (`BoxedSections`, `ModernProfessional`,
+  `NordicClean`, `EditorialBlue`, `Executive`, `EngineeringResume`,
+  `TimelineMinimal`, …); writing your own is ~150 lines.
 
 You hand a `CvDocument` to a preset, you get a PDF. The preset
 internally composes widgets that read theme tokens that ultimately
@@ -84,42 +85,42 @@ Same data, different visual. That's the layering.
 
 ---
 
-## The 5 layers
+## The layers
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│  presets/   BoxedSections, MinimalUnderlined,               │
-│             ModernProfessional, CenteredHeadline,           │
-│             BlueBanner, EditorialBlue, ClassicSerif,         │
-│             NordicClean, CompactMono                         │
-│             — composition of widgets in a page flow         │
-└─────────────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────────────────────┐
+│  presets/    16 CV compositions                                            │
+│    BoxedSections, ModernProfessional, NordicClean, ...                     │
+│    -- widgets composed in a page flow                                      │
+└────────────────────────────────────────────────────────────────────────────┘
         │ compose from widgets
         ▼
-┌─────────────────────────────────────────────────────────────┐
-│  widgets/   Headline, Subheadline, ContactLine,             │
-│             SectionHeader                                   │
-│             — named visual LEGO bricks                      │
-└─────────────────────────────────────────────────────────────┘
-        │ delegate to ↓    │ read tokens from ↓
-        ▼                  ▼
-┌─────────────────────┐  ┌──────────────────────────────────┐
-│  components/         │  │  theme/                          │
-│    SectionDispatcher │  │    Palette  (colours)          │
-│    EntryRenderer     │  │    Typography (fonts + sizes)  │
-│    RowRenderer       │  │    Spacing  (margins + gaps)   │
-│    ParagraphRenderer │  │    Decoration (bullet, sep)    │
-│    + primitives      │  │    BrandTheme (bundle + factories)  │
-└─────────────────────┘  └──────────────────────────────────┘
-        │ renders into DSL
+┌────────────────────────────────────────────────────────────────────────────┐
+│  widgets/    CV-specific visual bricks                                     │
+│    SectionHeader, FlowSectionHeader, SkillBar, SectionModule, ...          │
+│    (neutral header bricks -- Headline, Subheadline, ContactLine,           │
+│     Masthead, SvgGlyph -- live in core.identity)                           │
+└────────────────────────────────────────────────────────────────────────────┘
+        │ delegate to
         ▼
-┌─────────────────────────────────────────────────────────────┐
-│  data/      CvDocument, CvIdentity, CvSection (sealed),     │
-│             ParagraphSection / SkillsSection / RowsSection  │
-│             / EntriesSection,                               │
-│             CvRow, CvEntry, Slot                            │
-│             — pure records, zero rendering deps             │
-└─────────────────────────────────────────────────────────────┘
+┌────────────────────────────────────────────────────────────────────────────┐
+│  components/    CV section renderers                                       │
+│    SectionDispatcher, EntryRenderer, RowRenderer, ParagraphRenderer        │
+└────────────────────────────────────────────────────────────────────────────┘
+        │ render into
+        ▼
+┌────────────────────────────────────────────────────────────────────────────┐
+│  data/    CvDocument, CvIdentity, CvSection (sealed),                      │
+│    ParagraphSection / SkillsSection / RowsSection / EntriesSection,        │
+│    CvRow, CvEntry, Slot  -- pure records, zero rendering deps              │
+└────────────────────────────────────────────────────────────────────────────┘
+
+  ...all built on the shared, family-neutral core (templates.core.*):
+┌────────────────────────────────────────────────────────────────────────────┐
+│  core.theme       BrandTheme = Palette / Typography / Spacing / Decoration │
+│  core.identity    Headline, Subheadline, ContactLine, Masthead, SvgGlyph   │
+│  core.text        MarkdownText, RichParagraphRenderer, TextStyles          │
+└────────────────────────────────────────────────────────────────────────────┘
 ```
 
 **What each layer is for** (in plain English):
@@ -127,7 +128,7 @@ Same data, different visual. That's the layering.
 | Layer | "Answers the question…" |
 |---|---|
 | `data/` | "What goes on the page?" — content, no styling. |
-| `theme/` | "How does it look?" — colours, fonts, glyphs. |
+| `core.theme` | "How does it look?" — colours, fonts, glyphs (shared `BrandTheme`). |
 | `components/` | "How is one element drawn?" — paragraph, row, entry primitives. |
 | `widgets/` | "Which visual building block do I want here?" — named LEGO bricks. |
 | `presets/` | "In what order, with which widgets, on which page flow?" — composition. |

--- a/src/main/java/com/demcha/compose/document/templates/api/DocumentTemplate.java
+++ b/src/main/java/com/demcha/compose/document/templates/api/DocumentTemplate.java
@@ -10,12 +10,14 @@ import com.demcha.compose.document.api.DocumentSession;
  * {@link DocumentSession}. The interface is intentionally minimal — just
  * identity (for registry lookup) and one composition seam.</p>
  *
- * <p><strong>Templates v2 contract</strong> (introduced in v1.6 alongside
- * the templates restructure):</p>
+ * <p>Implementation contract:</p>
  * <ul>
- *   <li>Implementations should be plain factory-style classes whose
- *       {@code create(BusinessTheme)} method returns a configured
- *       {@code DocumentTemplate<S>}.</li>
+ *   <li>Implementations are plain factory-style classes — a static
+ *       {@code create(theme)} method returns a configured
+ *       {@code DocumentTemplate<S>}. The theme type is the family's own:
+ *       the layered cv / cover-letter presets take a {@code BrandTheme};
+ *       the layered invoice / proposal presets take a
+ *       {@code BusinessTheme}.</li>
  *   <li>Implementations are stateless after construction — composing the
  *       same spec twice produces the same output.</li>
  *   <li>Implementations do not call {@code session.buildPdf()}; the caller
@@ -23,12 +25,7 @@ import com.demcha.compose.document.api.DocumentSession;
  *       session DSL.</li>
  * </ul>
  *
- * <p>Domain-specific interfaces ({@code CvTemplate}, {@code InvoiceTemplate},
- * etc.) remain in this package during the v1.6 migration window for
- * backward compatibility. New templates should implement
- * {@code DocumentTemplate<S>} directly.</p>
- *
- * @param <S> the spec type rendered by this template (e.g. {@code CvSpec},
+ * @param <S> the spec type rendered by this template (e.g. {@code CvDocument},
  *            {@code InvoiceSpec}, {@code ProposalSpec})
  */
 public interface DocumentTemplate<S> {

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/AUTHORS.md
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/AUTHORS.md
@@ -5,8 +5,9 @@ on top of the v2 surface. It complements the JavaDoc in
 `package-info.java` with longer, copy-pasteable recipes.
 
 If you have never used this package before, read
-[the package overview](./package-info.java) first. The four layers
-(`data/` · `theme/` · `components/` · `presets/`) and what each is for
+[the package overview](./package-info.java) first. The four CV layers
+(`data/` · `components/` · `widgets/` · `presets/`) — plus the shared
+theme / text / identity in `templates.core.*` — and what each is for
 are explained there.
 
 This guide answers the **"how do I…"** questions.

--- a/src/main/java/com/demcha/compose/document/templates/cv/v2/package-info.java
+++ b/src/main/java/com/demcha/compose/document/templates/cv/v2/package-info.java
@@ -13,54 +13,42 @@
  * section titles are free strings and links are optional. See
  * {@code AUTHORS.md} for a non-IT example.</p>
  *
- * <h2>Four layers, one responsibility each</h2>
+ * <h2>Four CV layers, built on the shared core</h2>
  *
  * <pre>
- *   ┌─────────────────────────────────────────────────────────────┐
- *   │  presets/                                                   │
- *   │    BoxedSections      ← composition: data + theme + render  │
- *   │    MinimalUnderlined  ← another composition, same pieces    │
- *   │    ModernProfessional ← corporate composition variant       │
- *   │    CenteredHeadline   ← classic centred headline variant    │
- *   │    BlueBanner         ← full-width banner composition       │
- *   │    EditorialBlue      ← compact editorial composition       │
- *   │    ClassicSerif       ← serif cover/detail preset           │
- *   │    NordicClean        ← teal two-column rail preset         │
- *   │    CompactMono        ← dark header + rail/card preset      │
- *   └─────────────────────────────────────────────────────────────┘
+ *
+ *   ┌───────────────────────────────────────────────────────────────────────┐
+ *   │  presets/    16 CV compositions                                       │
+ *   │    BoxedSections, ModernProfessional, NordicClean, EditorialBlue, ... │
+ *   └───────────────────────────────────────────────────────────────────────┘
  *           │ compose from
  *           ▼
- *   ┌─────────────────────────────────────────────────────────────┐
- *   │  widgets/  ← named visual building blocks (LEGO bricks)    │
- *   │    Headline       .spacedCentered | .uppercaseCentered      │
- *   │                   | .uppercaseLeftAligned | .rightAligned  │
- *   │    Subheadline    .centeredSpacedCaps                       │
- *   │    ContactLine    .centered | .centered(...styles)          │
- *   │                   .rightAligned | .leftAligned              │
- *   │                   .rightAlignedStacked                      │
- *   │                   .twoRowRightAligned                       │
- *   │    SectionHeader  .banner | .fullWidthBanner | .underlined  │
- *   │                   .flat | .flatSpacedCaps | .tickLabel      │
- *   └─────────────────────────────────────────────────────────────┘
- *           │ delegate to                       │ read tokens from
- *           ▼                                   ▼
- *   ┌──────────────────────┐         ┌──────────────────────────┐
- *   │  components/         │         │  theme/                  │
- *   │    RowRenderer       │ reads   │    Palette  (colours)  │
- *   │    EntryRenderer     │◀────────│    Typography (fonts)  │
- *   │    ParagraphRenderer │         │    Spacing  (margins)  │
- *   │    SectionDispatcher │         │    Decoration (glyphs) │
- *   │    ParagraphPrimitive│         │    BrandTheme    (bundle)   │
- *   └──────────────────────┘         └──────────────────────────┘
- *           │ renders
+ *   ┌───────────────────────────────────────────────────────────────────────┐
+ *   │  widgets/    CV-specific visual bricks                                │
+ *   │    SectionHeader, FlowSectionHeader, SkillBar,                        │
+ *   │    SectionModule, ProfileBand, IconTextRow                            │
+ *   └───────────────────────────────────────────────────────────────────────┘
+ *           │ delegate to
  *           ▼
- *   ┌─────────────────────────────────────────────────────────────┐
- *   │  data/                                                      │
- *   │    CvIdentity   ← name, optional job title, contact, links  │
- *   │    CvSection    ← sealed: Paragraph | Rows | Entries | Skills│
- *   │    CvDocument   ← identity + Placement(slot, section)       │
- *   │    Slot         ← MAIN | SIDEBAR | FOOTER                   │
- *   └─────────────────────────────────────────────────────────────┘
+ *   ┌───────────────────────────────────────────────────────────────────────┐
+ *   │  components/    CV section renderers                                  │
+ *   │    SectionDispatcher, EntryRenderer, RowRenderer,                     │
+ *   │    ParagraphRenderer, ParagraphPrimitive                              │
+ *   └───────────────────────────────────────────────────────────────────────┘
+ *           │ render into
+ *           ▼
+ *   ┌───────────────────────────────────────────────────────────────────────┐
+ *   │  data/    CvIdentity, CvSection (sealed), CvDocument, Slot            │
+ *   └───────────────────────────────────────────────────────────────────────┘
+ *
+ *     ...built on the shared, family-neutral core in templates.core.* :
+ *   ┌───────────────────────────────────────────────────────────────────────┐
+ *   │  core.theme       BrandTheme = Palette / Typography /                 │
+ *   │                   Spacing / Decoration tokens                         │
+ *   │  core.identity    Headline, Subheadline, ContactLine, Masthead,       │
+ *   │                   SvgGlyph  (neutral header bricks)                   │
+ *   │  core.text        MarkdownText, RichParagraphRenderer, TextStyles     │
+ *   └───────────────────────────────────────────────────────────────────────┘
  * </pre>
  *
  * <h2>What goes where — when you write your own template</h2>
@@ -71,20 +59,23 @@
  *       No colours, no fonts, no sizes. Pure records. If you're
  *       describing a person's job history, this is where you live.</dd>
  *
- *   <dt><b>{@code theme/}</b></dt>
+ *   <dt><b>{@code templates.core.theme}</b></dt>
  *   <dd>The cosmetic decisions. <em>"How does it look?"</em>
- *       Colours, fonts, sizes, margins, glyphs. Swap-able without
- *       touching renderers. If you want a navy theme or a different
- *       bullet character, this is where you live.</dd>
+ *       Colours, fonts, sizes, margins, glyphs — the family-neutral
+ *       {@code BrandTheme} bundle, shared by every template family.
+ *       Swap-able without touching renderers. If you want a navy theme
+ *       or a different bullet character, this is where you live.</dd>
  *
  *   <dt><b>{@code widgets/}</b></dt>
  *   <dd>The LEGO bricks. <em>"Which visual building block do I
  *       want here — a banner, an underlined title, a right-aligned
- *       headline?"</em> Each widget has a small set of named
- *       variants and, where useful, a lower-level entry for ad-hoc
- *       parameter combinations. This
- *       is where most preset code lives — picking widgets and
- *       composing them.</dd>
+ *       headline?"</em> CV-specific bricks ({@code SectionHeader}
+ *       and friends) live here; the neutral header bricks
+ *       ({@code Headline}, {@code Subheadline}, {@code ContactLine},
+ *       {@code Masthead}, {@code SvgGlyph}) live in
+ *       {@code templates.core.identity}. Each widget has a small set
+ *       of named variants — this is where most preset code lives,
+ *       picking widgets and composing them.</dd>
  *
  *   <dt><b>{@code components/}</b></dt>
  *   <dd>The reusable drawing primitives. <em>"How is a section

--- a/src/main/java/com/demcha/compose/document/templates/themes/Spacing.java
+++ b/src/main/java/com/demcha/compose/document/templates/themes/Spacing.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 /**
  * One source of truth for all template spacing tokens.
  *
- * <p>Replaces the historical {@code BrandTheme.spacing}/{@code BrandTheme.spacingModuleName}
+ * <p>Replaces the historical per-theme {@code spacing} / {@code spacingModuleName}
  * fields plus the hard-coded {@code MINIMUM_TOP_LEVEL_MODULE_SPACING}
  * constant scattered throughout the legacy composers. Templates v2 presets
  * read every spacing decision from a {@code Spacing} instance and pass it

--- a/src/main/java/com/demcha/compose/document/templates/themes/Typography.java
+++ b/src/main/java/com/demcha/compose/document/templates/themes/Typography.java
@@ -55,7 +55,7 @@ public record Typography(
 
     /**
      * Returns the default Helvetica-based typography matching the historical
-     * {@code BrandTheme.defaultTheme()} sizing.
+     * default-theme sizing.
      *
      * @return Helvetica typography preset
      */


### PR DESCRIPTION
## Why

After the core extraction (#248–#252), the cv.v2 author docs still drew the pre-extraction structure — ASCII "layer" diagrams that put theme and the neutral header widgets inside cv.v2, a "5 layers" framing, a 9-preset list, and javadoc referencing a phantom `CvTemplate` and a `create(BusinessTheme)` factory that no longer matches the per-family theme types.

## What

- **cv/v2/package-info + quickstart**: redraw the ASCII layer diagrams as "four CV layers (data / components / widgets / presets), built on the shared `templates.core.*`"; header bricks (`Headline`, `ContactLine`, …) shown in `core.identity`, preset count corrected to 16, theme/text in `core.theme` / `core.text`. Boxes are width-padded so borders align.
- **AUTHORS.md**: layer list corrected to the four CV layers + shared core.
- **DocumentTemplate.java**: dropped the v1.6 migration-window wording + phantom `CvTemplate`; the `create(theme)` factory's theme type is per-family — `BrandTheme` for the cv / cover-letter presets and the layered invoice / proposal presets.
- **themes/Spacing + Typography**: reworded the dangling historical `BrandTheme.spacing` / `.defaultTheme()` `{@code}` references.

Docs/javadoc only — no code or behaviour change.

## Tests

`./mvnw verify javadoc:javadoc -pl .` → BUILD SUCCESS, 1612 tests, 0 failures; javadoc report clean.