### PR TITLE
docs(readme): add the graph-compose-emoji install snippet for the v1.9.0 emoji feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,23 @@ dependencies { implementation("io.github.demchaav:graph-compose:1.8.0") }
 > above) to pull the engine + fonts together. Full details and upgrade steps:
 > the [v1.8.0 fonts migration note](./docs/migration/v1.8.0-fonts.md).
 
+> **Colour emoji (from v1.9.0).** `RichText.emoji(":star:", size)` resolves
+> GitHub-style shortcodes to inline vector glyphs from an independently-versioned
+> companion artifact (the same split model as the fonts above). Text without
+> emoji needs nothing extra; to render colour emoji, add:
+>
+> ```xml
+> <dependency>
+>     <groupId>io.github.demchaav</groupId>
+>     <artifactId>graph-compose-emoji</artifactId>
+>     <version>1.0.0</version>
+> </dependency>
+> ```
+>
+> An unknown shortcode falls back to its literal text, so a document that uses no
+> emoji &mdash; or runs without the artifact &mdash; renders unchanged. The
+> `graph-compose-bundle` stays fonts-only; emoji is opt-in.
+
 > **Distribution** &mdash; Maven Central is the canonical channel from **v1.6.6** onwards
 > (`io.github.demchaav:graph-compose:<version>`). Hosted Javadocs auto-publish to
 > [javadoc.io/doc/io.github.demchaav/graph-compose](https://javadoc.io/doc/io.github.demchaav/graph-compose)


### PR DESCRIPTION
## Why

The README's "What's new in v1.9" names colour emoji "via the new
independently-versioned `graph-compose-emoji` module", but the install section
had no coordinate for it — only the fonts companion artifact ships a copy-paste
`<dependency>` block. A reader who wants the headline emoji feature has nothing
to add, and the glyphs are what make `RichText.emoji(...)` render.

## What changed

- README install section: a `graph-compose-emoji` (`1.0.0`) install snippet that
  mirrors the fonts block — noting emoji is **opt-in** (the
  `graph-compose-bundle` stays fonts-only) and that an unknown shortcode falls
  back to its literal text, so a document without emoji renders unchanged.

## Verification

`./mvnw -B -ntp test -pl . -Dtest=CanonicalSurfaceGuardTest,DocumentationCoverageTest,DocumentationExamplesTest,VersionConsistencyGuardTest`
→ **BUILD SUCCESS, 32 green**. The `graph-compose-emoji` coordinate is **not**
mistaken for the engine install snippet by `VersionConsistencyGuardTest`
(`graph-compose</artifactId>` ≠ `graph-compose-emoji</artifactId>`).

**Lane:** docs.

## Release sequencing (important)

This snippet pins `graph-compose-emoji:1.0.0`, which is **not yet on Maven
Central**. It must be published there via the `emoji-v1.0.0` tag
(`publish-emoji.yml`) **before** this README reaches `main` — i.e. before the
v1.9.0 engine cut — so no one copies a coordinate that 404s (the v1.5.0
README-window lesson). Runbook: `docs/contributing/release-process.md` §2.E.
