### PR TITLE
ci(deploy-web): drop the v* tag trigger that fails every release

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -10,19 +10,19 @@ name: Deploy web showcase to GitHub Pages
 # (one-time switch from "Deploy from a branch"). Until that switch is made,
 # this workflow builds the artifact but Pages keeps serving the old source.
 #
-# Triggers: every push to `main` AND every `v*` release tag. The tag trigger
-# is the reliable one for releases — the v1.8.0 release fast-forwarded `main`
-# with 67 changed `web/` files yet the old `paths: web/**` filter silently
-# skipped the deploy, so the live site kept serving the previous release. We
-# dropped the paths filter rather than depend on it: `main` is only pushed at
-# releases / hotfixes, so deploying unconditionally is cheap and correct, and
-# the `v*` tag is a second guaranteed trigger. `concurrency` de-dupes the two
-# triggers a release fires.
+# Triggers: every push to `main` (no `paths` filter). `main` is only pushed at
+# releases / hotfixes, so deploying unconditionally is cheap and correct — the
+# v1.8.0 release fast-forwarded `main` with 67 changed `web/` files yet the old
+# `paths: web/**` filter silently skipped the deploy, leaving the live site on
+# the previous release. A `v*` tag trigger was tried as a backup but removed:
+# GitHub Pages refuses to deploy from a tag ref (the `github-pages` environment
+# only allows `main`), so it failed every release without ever deploying — and
+# via `cancel-in-progress` could even cancel the good `main` run. The
+# unconditional `main` trigger covers releases reliably on its own.
 
 on:
   push:
     branches: [main]
-    tags: ["v*"]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Why

`deploy-web.yml` (GitHub Pages) fired on both the `main` push **and** the `v*` release tag. The tag run **failed every release**: Pages refuses to deploy from a tag ref — the `github-pages` environment only allows `main` — so it produced a red ✗ without ever deploying. Via `concurrency: cancel-in-progress` it could even race-cancel the good `main` run.

## What changed

- Remove `tags: ["v*"]` from `on.push`. The unconditional `push: branches: [main]` trigger (no `paths` filter) already fires on every release/hotfix `main` update, so the tag trigger was redundant. Comment updated to record why.

## Verification

YAML parses; `on.push` is now `{branches: [main]}` only. On the v1.9.0 release the real deploy came from the `[push main]` run (success) — this removes only the parallel failing `[push v1.9.0]` run (e.g. [run 28363823831](https://github.com/DemchaAV/GraphCompose/actions/runs/28363823831)).

**Lane:** build/CI.