### PR TITLE
refactor(examples): render invoice/proposal examples via the layered presets

### DIFF
--- a/examples/src/main/java/com/demcha/examples/features/snapshots/LayoutSnapshotRegressionExample.java
+++ b/examples/src/main/java/com/demcha/examples/features/snapshots/LayoutSnapshotRegressionExample.java
@@ -5,8 +5,8 @@ import com.demcha.compose.document.api.DocumentPageSize;
 import com.demcha.compose.document.api.DocumentSession;
 import com.demcha.compose.document.snapshot.LayoutSnapshot;
 import com.demcha.compose.document.style.DocumentInsets;
-import com.demcha.compose.document.templates.builtins.InvoiceTemplateV2;
-import com.demcha.compose.document.theme.BusinessTheme;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
+import com.demcha.compose.document.templates.invoice.v2.presets.ModernInvoice;
 import com.demcha.compose.testing.layout.LayoutSnapshotJson;
 import com.demcha.examples.support.ExampleDataFactory;
 import com.demcha.examples.support.ExampleOutputPaths;
@@ -56,7 +56,7 @@ public final class LayoutSnapshotRegressionExample {
     }
 
     /**
-     * Composes the sample invoice through {@link InvoiceTemplateV2},
+     * Composes the sample invoice through {@code ModernInvoice},
      * extracts the layout snapshot, writes (or verifies) a JSON
      * baseline alongside the PDF, and renders the PDF for visual
      * inspection.
@@ -65,16 +65,16 @@ public final class LayoutSnapshotRegressionExample {
      * @throws Exception if rendering, snapshot extraction, or baseline IO fails
      */
     public static Path generate() throws Exception {
-        BusinessTheme theme = BusinessTheme.modern();
+        BrandTheme theme = BrandTheme.invoiceModern();
         Path pdfFile = ExampleOutputPaths.prepare("features/snapshots", "invoice-snapshot-regression.pdf");
         Path baselineFile = ExampleOutputPaths.prepare("features/snapshots", "invoice-snapshot-regression.layout.json");
 
         try (DocumentSession document = GraphCompose.document()
                 .pageSize(DocumentPageSize.A4)
-                .pageBackground(theme.pageBackground())
+                .pageBackground(theme.palette().mainFill())
                 .margin(DocumentInsets.of(28))
                 .create()) {
-            new InvoiceTemplateV2(theme).compose(document, ExampleDataFactory.sampleInvoice());
+            ModernInvoice.create(theme).compose(document, ExampleDataFactory.sampleInvoice());
 
             // Step 1: extract the deterministic post-layout snapshot.
             LayoutSnapshot snapshot = document.layoutSnapshot();

--- a/examples/src/main/java/com/demcha/examples/features/streaming/HttpStreamingExample.java
+++ b/examples/src/main/java/com/demcha/examples/features/streaming/HttpStreamingExample.java
@@ -4,9 +4,10 @@ import com.demcha.compose.GraphCompose;
 import com.demcha.compose.document.api.DocumentPageSize;
 import com.demcha.compose.document.api.DocumentSession;
 import com.demcha.compose.document.style.DocumentInsets;
-import com.demcha.compose.document.templates.builtins.InvoiceTemplateV2;
+import com.demcha.compose.document.templates.api.DocumentTemplate;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.data.invoice.InvoiceDocumentSpec;
-import com.demcha.compose.document.theme.BusinessTheme;
+import com.demcha.compose.document.templates.invoice.v2.presets.ModernInvoice;
 import com.demcha.examples.support.ExampleDataFactory;
 import com.demcha.examples.support.ExampleOutputPaths;
 
@@ -74,7 +75,7 @@ public final class HttpStreamingExample {
 
     /**
      * Renders the supplied invoice into the supplied output stream
-     * via {@code InvoiceTemplateV2} on {@link BusinessTheme#modern()}.
+     * via {@code ModernInvoice} on {@link BrandTheme#invoiceModern()}.
      *
      * <p>The stream is intentionally <strong>not closed</strong> by
      * this method — that lets the same code be used from a Servlet,
@@ -87,12 +88,12 @@ public final class HttpStreamingExample {
      * @throws Exception if PDF rendering fails
      */
     public static void streamInvoiceTo(InvoiceDocumentSpec invoice, OutputStream sink) throws Exception {
-        BusinessTheme theme = BusinessTheme.modern();
-        InvoiceTemplateV2 template = new InvoiceTemplateV2(theme);
+        BrandTheme theme = BrandTheme.invoiceModern();
+        DocumentTemplate<InvoiceDocumentSpec> template = ModernInvoice.create(theme);
 
         try (DocumentSession document = GraphCompose.document()
                 .pageSize(DocumentPageSize.A4)
-                .pageBackground(theme.pageBackground())
+                .pageBackground(theme.palette().mainFill())
                 .margin(DocumentInsets.of(28))
                 .create()) {
             template.compose(document, invoice);

--- a/examples/src/main/java/com/demcha/examples/templates/invoice/InvoiceCinematicFileExample.java
+++ b/examples/src/main/java/com/demcha/examples/templates/invoice/InvoiceCinematicFileExample.java
@@ -3,19 +3,20 @@ package com.demcha.examples.templates.invoice;
 import com.demcha.compose.GraphCompose;
 import com.demcha.compose.document.api.DocumentPageSize;
 import com.demcha.compose.document.api.DocumentSession;
-import com.demcha.compose.document.templates.builtins.InvoiceTemplateV2;
-import com.demcha.compose.document.theme.BusinessTheme;
+import com.demcha.compose.document.templates.api.DocumentTemplate;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
+import com.demcha.compose.document.templates.data.invoice.InvoiceDocumentSpec;
+import com.demcha.compose.document.templates.invoice.v2.presets.ModernInvoice;
 import com.demcha.examples.support.ExampleDataFactory;
 import com.demcha.examples.support.ExampleOutputPaths;
 
 import java.nio.file.Path;
 
 /**
- * Phase E.1 — runnable showcase for {@code InvoiceTemplateV2}, the
- * cinematic theme-driven invoice template. Renders the same
- * {@link com.demcha.compose.document.templates.data.invoice.InvoiceDocumentSpec}
- * as the v1 template through the modern business theme so reviewers can
- * compare the two outputs side by side.
+ * Runnable showcase for the cinematic invoice look on the layered
+ * {@code invoice.v2} surface — {@link ModernInvoice} on
+ * {@link BrandTheme#invoiceModern()}, rendering the shared
+ * {@link InvoiceDocumentSpec} sample on the cream page background.
  *
  * @author Artem Demchyshyn
  */
@@ -26,12 +27,12 @@ public final class InvoiceCinematicFileExample {
 
     public static Path generate() throws Exception {
         Path outputFile = ExampleOutputPaths.prepare("templates/invoice", "invoice-cinematic.pdf");
-        BusinessTheme theme = BusinessTheme.modern();
-        InvoiceTemplateV2 template = new InvoiceTemplateV2(theme);
+        BrandTheme theme = BrandTheme.invoiceModern();
+        DocumentTemplate<InvoiceDocumentSpec> template = ModernInvoice.create(theme);
 
         try (DocumentSession document = GraphCompose.document(outputFile)
                 .pageSize(DocumentPageSize.A4)
-                .pageBackground(theme.pageBackground())
+                .pageBackground(theme.palette().mainFill())
                 .margin(28, 28, 28, 28)
                 .create()) {
             template.compose(document, ExampleDataFactory.sampleInvoice());

--- a/examples/src/main/java/com/demcha/examples/templates/proposal/ProposalCinematicFileExample.java
+++ b/examples/src/main/java/com/demcha/examples/templates/proposal/ProposalCinematicFileExample.java
@@ -3,16 +3,20 @@ package com.demcha.examples.templates.proposal;
 import com.demcha.compose.GraphCompose;
 import com.demcha.compose.document.api.DocumentPageSize;
 import com.demcha.compose.document.api.DocumentSession;
-import com.demcha.compose.document.templates.builtins.ProposalTemplateV2;
-import com.demcha.compose.document.theme.BusinessTheme;
+import com.demcha.compose.document.templates.api.DocumentTemplate;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
+import com.demcha.compose.document.templates.data.proposal.ProposalDocumentSpec;
+import com.demcha.compose.document.templates.proposal.v2.presets.ModernProposal;
 import com.demcha.examples.support.ExampleDataFactory;
 import com.demcha.examples.support.ExampleOutputPaths;
 
 import java.nio.file.Path;
 
 /**
- * Phase E.2 — runnable showcase for {@code ProposalTemplateV2}, the
- * cinematic theme-driven proposal template.
+ * Runnable showcase for the cinematic proposal look on the layered
+ * {@code proposal.v2} surface — {@link ModernProposal} on
+ * {@link BrandTheme#proposalModern()}, rendering the shared
+ * {@link ProposalDocumentSpec} sample on the cream page background.
  *
  * @author Artem Demchyshyn
  */
@@ -23,12 +27,12 @@ public final class ProposalCinematicFileExample {
 
     public static Path generate() throws Exception {
         Path outputFile = ExampleOutputPaths.prepare("templates/proposal", "proposal-cinematic.pdf");
-        BusinessTheme theme = BusinessTheme.modern();
-        ProposalTemplateV2 template = new ProposalTemplateV2(theme);
+        BrandTheme theme = BrandTheme.proposalModern();
+        DocumentTemplate<ProposalDocumentSpec> template = ModernProposal.create(theme);
 
         try (DocumentSession document = GraphCompose.document(outputFile)
                 .pageSize(DocumentPageSize.A4)
-                .pageBackground(theme.pageBackground())
+                .pageBackground(theme.palette().mainFill())
                 .margin(28, 28, 28, 28)
                 .create()) {
             template.compose(document, ExampleDataFactory.sampleProposal());

--- a/src/test/java/com/demcha/testing/visual/HttpStreamingDemoTest.java
+++ b/src/test/java/com/demcha/testing/visual/HttpStreamingDemoTest.java
@@ -4,9 +4,9 @@ import com.demcha.compose.GraphCompose;
 import com.demcha.compose.document.api.DocumentPageSize;
 import com.demcha.compose.document.api.DocumentSession;
 import com.demcha.compose.document.style.DocumentInsets;
-import com.demcha.compose.document.templates.builtins.InvoiceTemplateV2;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.data.invoice.InvoiceDocumentSpec;
-import com.demcha.compose.document.theme.BusinessTheme;
+import com.demcha.compose.document.templates.invoice.v2.presets.ModernInvoice;
 import com.demcha.testing.VisualTestOutputs;
 import org.junit.jupiter.api.Test;
 
@@ -63,7 +63,7 @@ class HttpStreamingDemoTest {
 
         byte[] bufferedBytes;
         try (DocumentSession document = newSession()) {
-            new InvoiceTemplateV2(BusinessTheme.modern())
+            ModernInvoice.create()
                     .compose(document, sampleInvoice());
             bufferedBytes = document.toPdfBytes();
         }
@@ -86,17 +86,16 @@ class HttpStreamingDemoTest {
 
     private static void renderInvoice(OutputStream sink) throws Exception {
         try (DocumentSession document = newSession()) {
-            new InvoiceTemplateV2(BusinessTheme.modern())
+            ModernInvoice.create()
                     .compose(document, sampleInvoice());
             document.writePdf(sink);
         }
     }
 
     private static DocumentSession newSession() {
-        BusinessTheme theme = BusinessTheme.modern();
         return GraphCompose.document()
                 .pageSize(DocumentPageSize.A4)
-                .pageBackground(theme.pageBackground())
+                .pageBackground(BrandTheme.invoiceModern().palette().mainFill())
                 .margin(DocumentInsets.of(28))
                 .create();
     }

--- a/src/test/java/com/demcha/testing/visual/LayoutSnapshotRegressionDemoTest.java
+++ b/src/test/java/com/demcha/testing/visual/LayoutSnapshotRegressionDemoTest.java
@@ -5,9 +5,9 @@ import com.demcha.compose.document.api.DocumentPageSize;
 import com.demcha.compose.document.api.DocumentSession;
 import com.demcha.compose.document.snapshot.LayoutSnapshot;
 import com.demcha.compose.document.style.DocumentInsets;
-import com.demcha.compose.document.templates.builtins.InvoiceTemplateV2;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.data.invoice.InvoiceDocumentSpec;
-import com.demcha.compose.document.theme.BusinessTheme;
+import com.demcha.compose.document.templates.invoice.v2.presets.ModernInvoice;
 import com.demcha.compose.testing.layout.LayoutSnapshotJson;
 import org.junit.jupiter.api.Test;
 
@@ -42,11 +42,11 @@ class LayoutSnapshotRegressionDemoTest {
         String firstJson;
         String secondJson;
         try (DocumentSession a = newSession()) {
-            new InvoiceTemplateV2(BusinessTheme.modern()).compose(a, sampleInvoice(1));
+            ModernInvoice.create().compose(a, sampleInvoice(1));
             firstJson = LayoutSnapshotJson.toJson(a.layoutSnapshot());
         }
         try (DocumentSession b = newSession()) {
-            new InvoiceTemplateV2(BusinessTheme.modern()).compose(b, sampleInvoice(1));
+            ModernInvoice.create().compose(b, sampleInvoice(1));
             secondJson = LayoutSnapshotJson.toJson(b.layoutSnapshot());
         }
         assertThat(secondJson)
@@ -63,11 +63,11 @@ class LayoutSnapshotRegressionDemoTest {
         String oneRow;
         String tenRows;
         try (DocumentSession a = newSession()) {
-            new InvoiceTemplateV2(BusinessTheme.modern()).compose(a, sampleInvoice(1));
+            ModernInvoice.create().compose(a, sampleInvoice(1));
             oneRow = LayoutSnapshotJson.toJson(a.layoutSnapshot());
         }
         try (DocumentSession b = newSession()) {
-            new InvoiceTemplateV2(BusinessTheme.modern()).compose(b, sampleInvoice(20));
+            ModernInvoice.create().compose(b, sampleInvoice(20));
             tenRows = LayoutSnapshotJson.toJson(b.layoutSnapshot());
         }
         assertThat(tenRows)
@@ -78,7 +78,7 @@ class LayoutSnapshotRegressionDemoTest {
     @Test
     void snapshotReportsPagesAndNodes() throws Exception {
         try (DocumentSession document = newSession()) {
-            new InvoiceTemplateV2(BusinessTheme.modern()).compose(document, sampleInvoice(1));
+            ModernInvoice.create().compose(document, sampleInvoice(1));
             LayoutSnapshot snapshot = document.layoutSnapshot();
             assertThat(snapshot.totalPages()).isPositive();
             assertThat(snapshot.nodes()).isNotEmpty();
@@ -87,10 +87,9 @@ class LayoutSnapshotRegressionDemoTest {
     }
 
     private static DocumentSession newSession() {
-        BusinessTheme theme = BusinessTheme.modern();
         return GraphCompose.document()
                 .pageSize(DocumentPageSize.A4)
-                .pageBackground(theme.pageBackground())
+                .pageBackground(BrandTheme.invoiceModern().palette().mainFill())
                 .margin(DocumentInsets.of(28))
                 .create();
     }


### PR DESCRIPTION
## Why

Stage-2 stood up the layered `invoice/v2` (`ModernInvoice`) and `proposal/v2` (`ModernProposal`) families (#257/#264/#269). This PR moves the **example + demo-test consumers** off the cinematic builtins `InvoiceTemplateV2` / `ProposalTemplateV2`, so those builtins keep no example consumer — only their own unit tests, which retire with them in the 2.0 cleanup.

## What

- **`InvoiceCinematicFileExample` / `ProposalCinematicFileExample`** — render `ModernInvoice` / `ModernProposal` on a `BrandTheme` (same class names + output paths `invoice-cinematic.pdf` / `proposal-cinematic.pdf`, so showcase/README keys are unchanged). The proposal output now includes its header — `ModernProposal` fixes the builtin's dropped-header bug.
- **`HttpStreamingExample` / `LayoutSnapshotRegressionExample`** — swap the invoice fixture to `ModernInvoice`; the snapshot baseline lives in the generated (gitignored) dir and regenerates.
- **`HttpStreamingDemoTest` / `LayoutSnapshotRegressionDemoTest`** — follow their examples onto `ModernInvoice` (assertions unchanged: stream-not-closed / size-parity; deterministic-snapshot / structural-diff).

No engine (`src/main`) change.

### Intentionally left (out of scope)
- `CustomBusinessThemeExample` + `CustomBusinessThemeDemoTest` — demo the 2.0-removed `BusinessTheme`; `ModernInvoice`'s accent is preset-local so a custom `BrandTheme` can't fully vary it. Deferred to the Phase-3 cleanup (delete with `BusinessTheme`).
- The builtins' own tests (`InvoiceTemplateV2Test` / `ProposalTemplateV2Test` / `*DemoTest`) — retire with the builtins in 2.0.
- Doc repointing — a separate coherent pass (getting-started / first-document / recipes + the interlinked `which-template-system` "Recommended" matrix), so the docs don't go inconsistent piecemeal.

`MasterShowcaseExample` and `CinematicProposalFileExample` were false positives (prose-only / hand-authored) — untouched.

## Tests

`./mvnw verify javadoc:javadoc -pl .` → BUILD SUCCESS, 1625 tests, 0 failures; javadoc clean. All 4 migrated examples render valid PDFs (proposal-cinematic now shows its header).