### PR TITLE
build(version): move the 2.0 line to 2.0.0-SNAPSHOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to GraphCompose are documented here. Versions
 follow semantic versioning; release dates are ISO 8601.
 
+## v2.0.0 — Planned
+
+The 2.0 development line. Binary-breaking by design — japicmp runs report-only
+for this cycle.
+
+### Build
+- Move the 2.0 line to `2.0.0-SNAPSHOT`. The README and showcase install
+  snippets now advertise the planned `2.0.0` coordinate.
+
 ## v1.9.0 — 2026-06-29
 
 In-document navigation. Rendered PDFs can now declare named **anchors** and

--- a/README.md
+++ b/README.md
@@ -73,12 +73,12 @@ Core document APIs stay source- and binary-compatible with v1.8 &mdash; v1.9 is 
 <dependency>
     <groupId>io.github.demchaav</groupId>
     <artifactId>graph-compose</artifactId>
-    <version>1.9.0</version>
+    <version>2.0.0</version>
 </dependency>
 ```
 
 ```kotlin
-dependencies { implementation("io.github.demchaav:graph-compose:1.9.0") }
+dependencies { implementation("io.github.demchaav:graph-compose:2.0.0") }
 ```
 
 > **Bundled fonts (from v1.8.0).** The curated Google fonts no longer ship

--- a/aggregator/pom.xml
+++ b/aggregator/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.demchaav</groupId>
     <artifactId>graph-compose-build</artifactId>
-    <version>1.9.0</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>GraphCompose Build Aggregator</name>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.demchaav</groupId>
         <artifactId>graph-compose-build</artifactId>
-        <version>1.9.0</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../aggregator/pom.xml</relativePath>
     </parent>
 

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -25,7 +25,7 @@
         line. The graph-compose dependency below uses ${project.version}, so it
         follows automatically.
     -->
-    <version>1.9.0</version>
+    <version>2.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>GraphCompose Bundle</name>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.demchaav</groupId>
         <artifactId>graph-compose-build</artifactId>
-        <version>1.9.0</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../aggregator/pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.demchaav</groupId>
     <artifactId>graph-compose</artifactId>
-    <version>1.9.0</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <name>GraphCompose</name>
     <description>A declarative layout engine for programmatic document generation, implemented primarily in Java.</description>

--- a/web/index.html
+++ b/web/index.html
@@ -57,7 +57,7 @@
         "applicationSubCategory": "Library",
         "operatingSystem": "Cross-platform (JVM 21+)",
         "programmingLanguage": "Java",
-        "softwareVersion": "1.9.0",
+        "softwareVersion": "2.0.0",
         "url": "https://demchaav.github.io/GraphCompose/",
         "downloadUrl": "https://central.sonatype.com/artifact/io.github.demchaav/graph-compose/1.9.0",
         "image": "https://demchaav.github.io/GraphCompose/assets/logo/graphcompose-logo.png",
@@ -168,7 +168,7 @@
   <main id="top">
     <section class="hero section-shell" aria-labelledby="hero-title">
       <div class="hero-copy">
-        <p class="eyebrow">Java &middot; v1.9.0 &middot; MIT</p>
+        <p class="eyebrow">Java &middot; v2.0.0 &middot; MIT</p>
         <h1 id="hero-title">Java PDF layout engine for structured business documents.</h1>
         <p class="hero-lead">Describe documents. Render polished PDFs. A semantic layout engine for Java services that need <b>structured, paginated, theme-driven</b> output &mdash; CVs, invoices, proposals, reports.</p>
         <p class="hero-text">No drawing API. No pixel arithmetic. You compose <code>ParagraphNode</code>, <code>TableNode</code>, <code>SectionNode</code>; GraphCompose handles measurement, pagination, fonts, and PDFBox rendering.</p>
@@ -233,14 +233,14 @@
 <pre class="language-xml"><code class="language-xml">&lt;dependency&gt;
   &lt;groupId&gt;io.github.demchaav&lt;/groupId&gt;
   &lt;artifactId&gt;graph-compose&lt;/artifactId&gt;
-  &lt;version&gt;1.9.0&lt;/version&gt;
+  &lt;version&gt;2.0.0&lt;/version&gt;
 &lt;/dependency&gt;</code></pre>
         </div>
         <div class="install-block">
           <h4>Gradle</h4>
 <pre class="language-groovy"><code class="language-groovy">dependencies {
   implementation(
-    'io.github.demchaav:graph-compose:1.9.0'
+    'io.github.demchaav:graph-compose:2.0.0'
   )
 }</code></pre>
         </div>


### PR DESCRIPTION
## Why

The `2.0-dev` line still carried the `1.9.0` release version across every
module, so a snapshot build resolved against the previous release instead of
the in-development 2.0 line.

## What

- Bump the engine, aggregator, examples, benchmarks, and bundle poms to
  `2.0.0-SNAPSHOT`. `graph-compose-fonts` keeps its independent version line.
- Add the `v2.0.0 — Planned` changelog entry and point the README and showcase
  (`web/index.html`) install snippets at the planned `2.0.0` coordinate. The
  "Latest stable" badge stays on `1.9.0` (the current release).

## Tests

`./mvnw install javadoc:javadoc -pl .` — 1625 tests, 0 failures,
`VersionConsistencyGuardTest` green. Examples, benchmarks, and bundle all
compile/resolve against the new `2.0.0-SNAPSHOT`.