### PR TITLE
refactor(templates): drop the v2 suffix from the invoice package

### DIFF
--- a/benchmarks/src/main/java/com/demcha/compose/AllocationRateProbe.java
+++ b/benchmarks/src/main/java/com/demcha/compose/AllocationRateProbe.java
@@ -5,7 +5,7 @@ import com.demcha.compose.document.api.DocumentSession;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.data.invoice.InvoiceDocumentSpec;
 import com.demcha.compose.document.templates.data.proposal.ProposalDocumentSpec;
-import com.demcha.compose.document.templates.invoice.v2.presets.ModernInvoice;
+import com.demcha.compose.document.templates.invoice.presets.ModernInvoice;
 import com.demcha.compose.document.templates.proposal.v2.presets.ModernProposal;
 
 import java.lang.management.GarbageCollectorMXBean;

--- a/benchmarks/src/main/java/com/demcha/compose/CurrentSpeedBenchmark.java
+++ b/benchmarks/src/main/java/com/demcha/compose/CurrentSpeedBenchmark.java
@@ -17,7 +17,7 @@ import com.demcha.compose.document.templates.cv.v2.data.CvDocument;
 import com.demcha.compose.document.templates.cv.v2.presets.ModernProfessional;
 import com.demcha.compose.document.templates.data.invoice.InvoiceDocumentSpec;
 import com.demcha.compose.document.templates.data.proposal.ProposalDocumentSpec;
-import com.demcha.compose.document.templates.invoice.v2.presets.ModernInvoice;
+import com.demcha.compose.document.templates.invoice.presets.ModernInvoice;
 import com.demcha.compose.document.templates.proposal.v2.presets.ModernProposal;
 import com.demcha.compose.engine.components.style.Margin;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;

--- a/benchmarks/src/main/java/com/demcha/compose/jmh/ColdStartJmhBenchmark.java
+++ b/benchmarks/src/main/java/com/demcha/compose/jmh/ColdStartJmhBenchmark.java
@@ -8,7 +8,7 @@ import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.templates.cv.v2.data.CvDocument;
 import com.demcha.compose.document.templates.cv.v2.presets.ModernProfessional;
 import com.demcha.compose.document.templates.data.invoice.InvoiceDocumentSpec;
-import com.demcha.compose.document.templates.invoice.v2.presets.ModernInvoice;
+import com.demcha.compose.document.templates.invoice.presets.ModernInvoice;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;

--- a/examples/src/main/java/com/demcha/examples/GenerateAllExamples.java
+++ b/examples/src/main/java/com/demcha/examples/GenerateAllExamples.java
@@ -79,7 +79,7 @@ import com.demcha.examples.templates.cv.v2.CvPanelExample;
 import com.demcha.examples.templates.cv.v2.CvSidebarPortraitExample;
 import com.demcha.examples.templates.cv.v2.CvTimelineMinimalExample;
 import com.demcha.examples.templates.invoice.InvoiceCinematicFileExample;
-import com.demcha.examples.templates.invoice.v2.ModernInvoiceV2Example;
+import com.demcha.examples.templates.invoice.ModernInvoiceV2Example;
 import com.demcha.examples.templates.proposal.CinematicProposalFileExample;
 import com.demcha.examples.templates.proposal.ProposalCinematicFileExample;
 import com.demcha.examples.templates.proposal.v2.ModernProposalV2Example;

--- a/examples/src/main/java/com/demcha/examples/features/snapshots/LayoutSnapshotRegressionExample.java
+++ b/examples/src/main/java/com/demcha/examples/features/snapshots/LayoutSnapshotRegressionExample.java
@@ -6,7 +6,7 @@ import com.demcha.compose.document.api.DocumentSession;
 import com.demcha.compose.document.snapshot.LayoutSnapshot;
 import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
-import com.demcha.compose.document.templates.invoice.v2.presets.ModernInvoice;
+import com.demcha.compose.document.templates.invoice.presets.ModernInvoice;
 import com.demcha.compose.testing.layout.LayoutSnapshotJson;
 import com.demcha.examples.support.ExampleDataFactory;
 import com.demcha.examples.support.ExampleOutputPaths;

--- a/examples/src/main/java/com/demcha/examples/features/streaming/HttpStreamingExample.java
+++ b/examples/src/main/java/com/demcha/examples/features/streaming/HttpStreamingExample.java
@@ -7,7 +7,7 @@ import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.data.invoice.InvoiceDocumentSpec;
-import com.demcha.compose.document.templates.invoice.v2.presets.ModernInvoice;
+import com.demcha.compose.document.templates.invoice.presets.ModernInvoice;
 import com.demcha.examples.support.ExampleDataFactory;
 import com.demcha.examples.support.ExampleOutputPaths;
 

--- a/examples/src/main/java/com/demcha/examples/templates/invoice/InvoiceCinematicFileExample.java
+++ b/examples/src/main/java/com/demcha/examples/templates/invoice/InvoiceCinematicFileExample.java
@@ -6,7 +6,7 @@ import com.demcha.compose.document.api.DocumentSession;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.data.invoice.InvoiceDocumentSpec;
-import com.demcha.compose.document.templates.invoice.v2.presets.ModernInvoice;
+import com.demcha.compose.document.templates.invoice.presets.ModernInvoice;
 import com.demcha.examples.support.ExampleDataFactory;
 import com.demcha.examples.support.ExampleOutputPaths;
 
@@ -14,7 +14,7 @@ import java.nio.file.Path;
 
 /**
  * Runnable showcase for the cinematic invoice look on the layered
- * {@code invoice.v2} surface — {@link ModernInvoice} on
+ * layered invoice surface — {@link ModernInvoice} on
  * {@link BrandTheme#invoiceModern()}, rendering the shared
  * {@link InvoiceDocumentSpec} sample on the cream page background.
  *

--- a/examples/src/main/java/com/demcha/examples/templates/invoice/v2/ModernInvoiceV2Example.java
+++ b/examples/src/main/java/com/demcha/examples/templates/invoice/v2/ModernInvoiceV2Example.java
@@ -1,4 +1,4 @@
-package com.demcha.examples.templates.invoice.v2;
+package com.demcha.examples.templates.invoice;
 
 import com.demcha.compose.GraphCompose;
 import com.demcha.compose.document.api.DocumentPageSize;
@@ -6,7 +6,7 @@ import com.demcha.compose.document.api.DocumentSession;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.data.invoice.InvoiceDocumentSpec;
-import com.demcha.compose.document.templates.invoice.v2.presets.ModernInvoice;
+import com.demcha.compose.document.templates.invoice.presets.ModernInvoice;
 import com.demcha.examples.support.ExampleDataFactory;
 import com.demcha.examples.support.ExampleOutputPaths;
 

--- a/src/main/java/com/demcha/compose/document/templates/data/invoice/package-info.java
+++ b/src/main/java/com/demcha/compose/document/templates/data/invoice/package-info.java
@@ -1,5 +1,5 @@
 /**
  * Shared, render-neutral invoice document specs and supporting data
- * records, consumed by the layered {@code invoice.v2} presets.
+ * records, consumed by the layered {@code invoice.presets} presets.
  */
 package com.demcha.compose.document.templates.data.invoice;

--- a/src/main/java/com/demcha/compose/document/templates/invoice/package-info.java
+++ b/src/main/java/com/demcha/compose/document/templates/invoice/package-info.java
@@ -1,10 +1,9 @@
 /**
  * Invoice template family.
  *
- * <p>The shipping invoice surface is the layered preset stack under
- * {@code invoice.v2}, built on the shared {@code templates.core} layer and a
- * {@code BrandTheme}. {@code invoice.v2.presets.ModernInvoice} is the
- * reference preset.</p>
+ * <p>The invoice surface is a layered preset stack built on the shared
+ * {@code templates.core} layer and a {@code BrandTheme}.
+ * {@code invoice.presets.ModernInvoice} is the reference preset.</p>
  *
  * @since 1.6.0
  */

--- a/src/main/java/com/demcha/compose/document/templates/invoice/presets/ModernInvoice.java
+++ b/src/main/java/com/demcha/compose/document/templates/invoice/presets/ModernInvoice.java
@@ -1,4 +1,4 @@
-package com.demcha.compose.document.templates.invoice.v2.presets;
+package com.demcha.compose.document.templates.invoice.presets;
 
 import com.demcha.compose.document.api.DocumentSession;
 import com.demcha.compose.document.dsl.TableBuilder;

--- a/src/main/java/com/demcha/compose/document/templates/invoice/presets/package-info.java
+++ b/src/main/java/com/demcha/compose/document/templates/invoice/presets/package-info.java
@@ -14,4 +14,4 @@
  *
  * @since 2.0.0
  */
-package com.demcha.compose.document.templates.invoice.v2.presets;
+package com.demcha.compose.document.templates.invoice.presets;

--- a/src/main/java/com/demcha/compose/document/templates/proposal/v2/presets/ModernProposal.java
+++ b/src/main/java/com/demcha/compose/document/templates/proposal/v2/presets/ModernProposal.java
@@ -27,7 +27,7 @@ import java.util.Objects;
  *
  * <p>It composes a proposal on a
  * {@link com.demcha.compose.document.templates.core.theme.BrandTheme}
- * plus the canonical DSL, mirroring the {@code invoice.v2} preset shape:
+ * plus the canonical DSL, mirroring the {@code invoice.presets} preset shape:
  * a {@code create(BrandTheme)} factory returns a thin
  * {@link DocumentTemplate} whose {@code compose} sequences a hero panel,
  * an executive-summary panel, the FROM / TO parties, the body sections,

--- a/src/main/java/com/demcha/compose/document/templates/proposal/v2/presets/package-info.java
+++ b/src/main/java/com/demcha/compose/document/templates/proposal/v2/presets/package-info.java
@@ -3,7 +3,7 @@
  * on a {@link com.demcha.compose.document.templates.core.theme.BrandTheme}
  * plus the canonical DSL.
  *
- * <p>This package mirrors {@code invoice.v2.presets}: each preset is a
+ * <p>This package mirrors {@code invoice.presets}: each preset is a
  * {@code final} class with a {@code create(BrandTheme)} factory returning
  * a {@link com.demcha.compose.document.templates.api.DocumentTemplate}
  * parameterised on

--- a/src/test/java/com/demcha/compose/document/templates/invoice/presets/InvoiceV2VisualParityTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/invoice/presets/InvoiceV2VisualParityTest.java
@@ -1,4 +1,4 @@
-package com.demcha.compose.document.templates.invoice.v2.presets;
+package com.demcha.compose.document.templates.invoice.presets;
 
 import com.demcha.compose.GraphCompose;
 import com.demcha.compose.document.api.DocumentPageSize;

--- a/src/test/java/com/demcha/compose/document/templates/invoice/presets/ModernInvoiceSmokeTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/invoice/presets/ModernInvoiceSmokeTest.java
@@ -1,4 +1,4 @@
-package com.demcha.compose.document.templates.invoice.v2.presets;
+package com.demcha.compose.document.templates.invoice.presets;
 
 import com.demcha.compose.GraphCompose;
 import com.demcha.compose.document.api.DocumentPageSize;
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Smoke test for the layered {@code invoice.v2} pipeline through
+ * Smoke test for the layered invoice pipeline through
  * {@link ModernInvoice} — proves the preset renders an
  * {@link InvoiceDocumentSpec} end-to-end on a {@link BrandTheme}, via
  * both factory variants, with any theme, and on an empty invoice.

--- a/src/test/java/com/demcha/documentation/DocumentationExamplesTest.java
+++ b/src/test/java/com/demcha/documentation/DocumentationExamplesTest.java
@@ -6,7 +6,7 @@ import com.demcha.compose.document.api.DocumentSession;
 import com.demcha.compose.document.image.DocumentImageFitMode;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.data.invoice.InvoiceDocumentSpec;
-import com.demcha.compose.document.templates.invoice.v2.presets.ModernInvoice;
+import com.demcha.compose.document.templates.invoice.presets.ModernInvoice;
 import com.demcha.compose.document.style.DocumentColor;
 import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.style.DocumentStroke;

--- a/src/test/java/com/demcha/testing/visual/HttpStreamingDemoTest.java
+++ b/src/test/java/com/demcha/testing/visual/HttpStreamingDemoTest.java
@@ -6,7 +6,7 @@ import com.demcha.compose.document.api.DocumentSession;
 import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.data.invoice.InvoiceDocumentSpec;
-import com.demcha.compose.document.templates.invoice.v2.presets.ModernInvoice;
+import com.demcha.compose.document.templates.invoice.presets.ModernInvoice;
 import com.demcha.testing.VisualTestOutputs;
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/com/demcha/testing/visual/LayoutSnapshotRegressionDemoTest.java
+++ b/src/test/java/com/demcha/testing/visual/LayoutSnapshotRegressionDemoTest.java
@@ -7,7 +7,7 @@ import com.demcha.compose.document.snapshot.LayoutSnapshot;
 import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.data.invoice.InvoiceDocumentSpec;
-import com.demcha.compose.document.templates.invoice.v2.presets.ModernInvoice;
+import com.demcha.compose.document.templates.invoice.presets.ModernInvoice;
 import com.demcha.compose.testing.layout.LayoutSnapshotJson;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
## Why

With the classic invoice stack removed, the layered presets no longer need the `v2` package segment — first of the four per-family suffix drops (invoice → proposal → cover-letter → cv), smallest family first to prove the rename mechanics.

## What

- `git mv templates/invoice/v2/presets` → `templates/invoice/presets` (main + test); rewrite `templates.invoice.v2` → `templates.invoice` across all 15 referencing files (engine, tests, examples, benchmarks).
- Fix the prose `{@code invoice.v2}` mentions in surviving javadoc (incl. two in `proposal/v2` that named the now-gone package) and the invoice parent package-info.
- Pure rename: `InvoiceV2VisualParityTest` passes against the **unchanged** committed baseline — the render is identical.

Deferred: `docs/templates/v2-layered/contributor-guide.md` walkthrough (one coherent docs pass in 3-13 after all suffixes drop); the examples' own `examples/templates/invoice/v2/` directory name (examples-internal, cosmetic).

## Tests

`./mvnw verify javadoc:javadoc -pl .` — 1378 tests, 0 failures, javadoc clean. Examples + benchmarks compile; perf-smoke + examples-generation smoke (85) green. japicmp report-only on this line.