### PR TITLE
refactor(templates): drop the v2 suffix from the proposal package

### DIFF
--- a/benchmarks/src/main/java/com/demcha/compose/AllocationRateProbe.java
+++ b/benchmarks/src/main/java/com/demcha/compose/AllocationRateProbe.java
@@ -6,7 +6,7 @@ import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.data.invoice.InvoiceDocumentSpec;
 import com.demcha.compose.document.templates.data.proposal.ProposalDocumentSpec;
 import com.demcha.compose.document.templates.invoice.presets.ModernInvoice;
-import com.demcha.compose.document.templates.proposal.v2.presets.ModernProposal;
+import com.demcha.compose.document.templates.proposal.presets.ModernProposal;
 
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;

--- a/benchmarks/src/main/java/com/demcha/compose/CurrentSpeedBenchmark.java
+++ b/benchmarks/src/main/java/com/demcha/compose/CurrentSpeedBenchmark.java
@@ -18,7 +18,7 @@ import com.demcha.compose.document.templates.cv.v2.presets.ModernProfessional;
 import com.demcha.compose.document.templates.data.invoice.InvoiceDocumentSpec;
 import com.demcha.compose.document.templates.data.proposal.ProposalDocumentSpec;
 import com.demcha.compose.document.templates.invoice.presets.ModernInvoice;
-import com.demcha.compose.document.templates.proposal.v2.presets.ModernProposal;
+import com.demcha.compose.document.templates.proposal.presets.ModernProposal;
 import com.demcha.compose.engine.components.style.Margin;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
 

--- a/examples/src/main/java/com/demcha/examples/GenerateAllExamples.java
+++ b/examples/src/main/java/com/demcha/examples/GenerateAllExamples.java
@@ -82,7 +82,7 @@ import com.demcha.examples.templates.invoice.InvoiceCinematicFileExample;
 import com.demcha.examples.templates.invoice.ModernInvoiceV2Example;
 import com.demcha.examples.templates.proposal.CinematicProposalFileExample;
 import com.demcha.examples.templates.proposal.ProposalCinematicFileExample;
-import com.demcha.examples.templates.proposal.v2.ModernProposalV2Example;
+import com.demcha.examples.templates.proposal.ModernProposalV2Example;
 import com.demcha.examples.templates.schedule.WeeklyScheduleFileExample;
 
 /**

--- a/examples/src/main/java/com/demcha/examples/templates/proposal/ProposalCinematicFileExample.java
+++ b/examples/src/main/java/com/demcha/examples/templates/proposal/ProposalCinematicFileExample.java
@@ -6,7 +6,7 @@ import com.demcha.compose.document.api.DocumentSession;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.data.proposal.ProposalDocumentSpec;
-import com.demcha.compose.document.templates.proposal.v2.presets.ModernProposal;
+import com.demcha.compose.document.templates.proposal.presets.ModernProposal;
 import com.demcha.examples.support.ExampleDataFactory;
 import com.demcha.examples.support.ExampleOutputPaths;
 
@@ -14,7 +14,7 @@ import java.nio.file.Path;
 
 /**
  * Runnable showcase for the cinematic proposal look on the layered
- * {@code proposal.v2} surface — {@link ModernProposal} on
+ * layered proposal surface — {@link ModernProposal} on
  * {@link BrandTheme#proposalModern()}, rendering the shared
  * {@link ProposalDocumentSpec} sample on the cream page background.
  *

--- a/examples/src/main/java/com/demcha/examples/templates/proposal/v2/ModernProposalV2Example.java
+++ b/examples/src/main/java/com/demcha/examples/templates/proposal/v2/ModernProposalV2Example.java
@@ -1,4 +1,4 @@
-package com.demcha.examples.templates.proposal.v2;
+package com.demcha.examples.templates.proposal;
 
 import com.demcha.compose.GraphCompose;
 import com.demcha.compose.document.api.DocumentPageSize;
@@ -6,7 +6,7 @@ import com.demcha.compose.document.api.DocumentSession;
 import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.data.proposal.ProposalDocumentSpec;
-import com.demcha.compose.document.templates.proposal.v2.presets.ModernProposal;
+import com.demcha.compose.document.templates.proposal.presets.ModernProposal;
 import com.demcha.examples.support.ExampleDataFactory;
 import com.demcha.examples.support.ExampleOutputPaths;
 

--- a/src/main/java/com/demcha/compose/document/templates/data/proposal/package-info.java
+++ b/src/main/java/com/demcha/compose/document/templates/data/proposal/package-info.java
@@ -1,5 +1,5 @@
 /**
  * Shared, render-neutral proposal document specs and supporting data
- * records, consumed by the layered {@code proposal.v2} presets.
+ * records, consumed by the layered {@code proposal.presets} presets.
  */
 package com.demcha.compose.document.templates.data.proposal;

--- a/src/main/java/com/demcha/compose/document/templates/proposal/package-info.java
+++ b/src/main/java/com/demcha/compose/document/templates/proposal/package-info.java
@@ -1,10 +1,9 @@
 /**
  * Proposal / statement-of-work template family.
  *
- * <p>The shipping proposal surface is the layered preset stack under
- * {@code proposal.v2}, built on the shared {@code templates.core} layer and a
- * {@code BrandTheme}. {@code proposal.v2.presets.ModernProposal} is the
- * reference preset.</p>
+ * <p>The proposal surface is a layered preset stack built on the shared
+ * {@code templates.core} layer and a {@code BrandTheme}.
+ * {@code proposal.presets.ModernProposal} is the reference preset.</p>
  *
  * @since 1.6.0
  */

--- a/src/main/java/com/demcha/compose/document/templates/proposal/presets/ModernProposal.java
+++ b/src/main/java/com/demcha/compose/document/templates/proposal/presets/ModernProposal.java
@@ -1,4 +1,4 @@
-package com.demcha.compose.document.templates.proposal.v2.presets;
+package com.demcha.compose.document.templates.proposal.presets;
 
 import com.demcha.compose.document.api.DocumentSession;
 import com.demcha.compose.document.dsl.TableBuilder;

--- a/src/main/java/com/demcha/compose/document/templates/proposal/presets/package-info.java
+++ b/src/main/java/com/demcha/compose/document/templates/proposal/presets/package-info.java
@@ -14,4 +14,4 @@
  *
  * @since 2.0.0
  */
-package com.demcha.compose.document.templates.proposal.v2.presets;
+package com.demcha.compose.document.templates.proposal.presets;

--- a/src/test/java/com/demcha/compose/document/templates/proposal/presets/ModernProposalSmokeTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/proposal/presets/ModernProposalSmokeTest.java
@@ -1,4 +1,4 @@
-package com.demcha.compose.document.templates.proposal.v2.presets;
+package com.demcha.compose.document.templates.proposal.presets;
 
 import com.demcha.compose.GraphCompose;
 import com.demcha.compose.document.api.DocumentPageSize;
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Smoke test for the layered {@code proposal.v2} pipeline through
+ * Smoke test for the layered proposal pipeline through
  * {@link ModernProposal} — proves the preset renders a
  * {@link ProposalDocumentSpec} end-to-end on a {@link BrandTheme}, via
  * both factory variants, with any theme, and on an empty proposal.

--- a/src/test/java/com/demcha/compose/document/templates/proposal/presets/ProposalV2VisualParityTest.java
+++ b/src/test/java/com/demcha/compose/document/templates/proposal/presets/ProposalV2VisualParityTest.java
@@ -1,4 +1,4 @@
-package com.demcha.compose.document.templates.proposal.v2.presets;
+package com.demcha.compose.document.templates.proposal.presets;
 
 import com.demcha.compose.GraphCompose;
 import com.demcha.compose.document.api.DocumentPageSize;


### PR DESCRIPTION
## Why

Second of the four per-family suffix drops (invoice ✅ → **proposal** → cover-letter → cv), same mechanics as #280.

## What

- `git mv templates/proposal/v2/presets` → `templates/proposal/presets` (main + test); rewrite `templates.proposal.v2` → `templates.proposal` across all 9 referencing files (engine, tests, examples, benchmarks).
- Fix the prose `{@code proposal.v2}` mentions (data package-info, smoke test, cinematic example) and the proposal parent package-info.
- Pure rename: `ProposalV2VisualParityTest` passes against the **unchanged** committed 2-page baseline — the render is identical.

Deferred (as in #280): the `v2-layered` docs walkthrough (3-13) and the examples-own `examples/templates/proposal/v2/` dir name.

## Tests

`./mvnw verify javadoc:javadoc -pl .` — 1378 tests, 0 failures, javadoc clean. Examples + benchmarks compile; perf-smoke + examples-generation smoke (85) green. japicmp report-only on this line.