### PR TITLE
docs(templates): fix engine source links after the v2-suffix drop

### DIFF
--- a/docs/operations/test-your-document.md
+++ b/docs/operations/test-your-document.md
@@ -258,6 +258,6 @@ about, at near-zero cost per run.
 - [`LayoutSnapshotPublicApiDogfoodTest`](../../src/test/java/com/demcha/testing/layout/LayoutSnapshotPublicApiDogfoodTest.java)
   — a working integration test that drives the snapshot API
   entirely through the published surface. Copyable starting point.
-- [`CvV2VisualParityTest`](../../src/test/java/com/demcha/compose/document/templates/cv/v2/presets/CvV2VisualParityTest.java)
+- [`CvV2VisualParityTest`](../../src/test/java/com/demcha/compose/document/templates/cv/presets/CvV2VisualParityTest.java)
   — example of the pixel-level pattern (currently test-only;
   becoming public via Track N).

--- a/docs/recipes/themes.md
+++ b/docs/recipes/themes.md
@@ -103,7 +103,7 @@ side; V2 is the cinematic theme-driven path.
 ## CV themes
 
 CV templates are themed independently of `BusinessTheme`. The layered
-CV presets (`cv.v2.presets.*`) carry their own theme type, `BrandTheme`
+CV presets (`cv.presets.*`) carry their own theme type, `BrandTheme`
 (in `com.demcha.compose.document.templates.core.theme`), so CV tokens
 stay separate from invoice / proposal vocabulary. Each preset ships a
 default theme; render one against a `CvDocument` with its `create()`

--- a/docs/templates/v2-layered/README.md
+++ b/docs/templates/v2-layered/README.md
@@ -113,10 +113,10 @@ The detailed contract for each layer is in
 ## See also
 
 - **Per-package JavaDocs**:
-  [`cv/v2/package-info.java`](../../../src/main/java/com/demcha/compose/document/templates/cv/v2/package-info.java)
+  [`cv/package-info.java`](../../../src/main/java/com/demcha/compose/document/templates/cv/package-info.java)
   has the ASCII diagram and 4-step author walkthrough.
 - **AUTHORS.md**:
-  [`cv/v2/AUTHORS.md`](../../../src/main/java/com/demcha/compose/document/templates/cv/v2/AUTHORS.md)
+  [`cv/AUTHORS.md`](../../../src/main/java/com/demcha/compose/document/templates/cv/AUTHORS.md)
   is the recipe cookbook — 7 hands-on recipes from "change a bullet
   glyph" to "add a new section subtype".
 - **Examples**:

--- a/docs/templates/v2-layered/authoring-presets.md
+++ b/docs/templates/v2-layered/authoring-presets.md
@@ -358,14 +358,14 @@ not, try Layer 2. If still not, go inline. That's the design.
 |---|---|
 | 1 preset only | Inline. Don't extract. |
 | 2 presets | Add a new factory method to an existing widget, OR add a parameter to `.render(...)`. |
-| 3+ presets | It's its own widget — new class in `cv/v2/widgets/`. |
+| 3+ presets | It's its own widget — new class in `cv/widgets/`. |
 
 Don't predict — extract. Premature widgets are noise; they add API
 surface that nobody calls.
 
 When you do add a new widget:
 
-1. **One file per widget** in `cv/v2/widgets/`.
+1. **One file per widget** in `cv/widgets/`.
 2. **`public final class`** with a private constructor.
 3. **1-3 named factories** + a lower-level `.render(...)` when useful.
 4. **First parameter is always `SectionBuilder host`**.
@@ -383,7 +383,7 @@ When you do add a new widget:
 
 A new preset needs at least:
 
-1. **Smoke test** in `src/test/.../cv/v2/presets/MyPresetSmokeTest.java`:
+1. **Smoke test** in `src/test/.../cv/presets/MyPresetSmokeTest.java`:
    - `exposes_stable_identity` — checks `id()` and `displayName()`
    - `default_factory_renders` — calls `create().compose(...)` with
      a full sample document, asserts `session.roots()` is non-empty
@@ -412,4 +412,4 @@ cover-letter-v2) following the same layered shape?
 
 → The full recipe cookbook (with code for every customisation
 combo):
-[`cv/v2/AUTHORS.md`](../../../src/main/java/com/demcha/compose/document/templates/cv/v2/AUTHORS.md)
+[`cv/AUTHORS.md`](../../../src/main/java/com/demcha/compose/document/templates/cv/AUTHORS.md)

--- a/docs/templates/v2-layered/contributor-guide.md
+++ b/docs/templates/v2-layered/contributor-guide.md
@@ -16,7 +16,7 @@ the layered pattern looks the way it does.
 1. [The 5-layer convention](#the-5-layer-convention)
 2. [Package map for a new family](#package-map-for-a-new-family)
 3. [Naming rules](#naming-rules)
-4. [Worked walkthrough — `invoice/v2`](#worked-walkthrough)
+4. [Worked walkthrough — `invoice`](#worked-walkthrough)
 5. [Required deliverables](#required-deliverables)
 6. [Test checklist](#test-checklist)
 7. [Doc checklist](#doc-checklist)
@@ -64,7 +64,7 @@ data differs; the *layering* is identical.
 Mirror the CV v2 layout. Concrete example for invoice:
 
 ```
-src/main/java/com/demcha/compose/document/templates/invoice/v2/
+src/main/java/com/demcha/compose/document/templates/invoice/
 ├── package-info.java                   ← ASCII diagram + 4-step walkthrough
 ├── AUTHORS.md                          ← recipe cookbook
 ├── data/
@@ -106,7 +106,7 @@ src/main/java/com/demcha/compose/document/templates/invoice/v2/
     └── (more as added)
 ```
 
-The structure is **identical** to cv/v2 — only the records inside
+The structure is **identical** to cv — only the records inside
 differ.
 
 ---
@@ -135,7 +135,7 @@ differ.
 ---
 
 <a id="worked-walkthrough"></a>
-## Worked walkthrough — `invoice/v2`
+## Worked walkthrough — `invoice`
 
 Order to write things in:
 
@@ -253,7 +253,7 @@ A new template family PR ships with:
 - [ ] **5 packages** under `<family>/v2/` populated per convention
 - [ ] **At least 1 reference preset** that renders a sample document
 - [ ] **`AUTHORS.md`** in the family root (recipe cookbook — copy
-      the cv/v2 one as starting structure)
+      the cv one as starting structure)
 - [ ] **`package-info.java`** at family root + each sub-package
 - [ ] **Sample fixture** in `ExampleDataFactory.sample<Family>DocumentV2()`
 - [ ] **Example runner** in `examples/.../templates/<family>/v2/`
@@ -331,7 +331,7 @@ baseline so a reviewer can see exactly what changed before deciding
 to re-bless or fix.
 
 **Reference**: see
-`src/test/java/com/demcha/compose/document/templates/cv/v2/presets/CvV2VisualParityTest.java`
+`src/test/java/com/demcha/compose/document/templates/cv/presets/CvV2VisualParityTest.java`
 — a 200-line drop-in template you can copy for a new family.
 
 ---
@@ -341,7 +341,7 @@ to re-bless or fix.
 
 - [ ] `<family>/v2/package-info.java` — ASCII diagram of the 5
       layers, plus a 4-step "how to author a document" walkthrough
-      (copy the cv/v2 one's structure).
+      (copy the cv one's structure).
 - [ ] `<family>/v2/AUTHORS.md` — recipe cookbook. At least:
       change a glyph, change colours, add a new section subtype,
       conditional sections.
@@ -363,7 +363,7 @@ to re-bless or fix.
   Mark v1 `@Deprecated` only after the v2 surface is feature-complete
   and shipped — that's a follow-up PR.
 - ❌ **Don't fork widgets across families.** If invoice needs a
-  `Headline`, write `templates/invoice/v2/widgets/Letterhead.java`
+  `Headline`, write `templates/invoice/widgets/Letterhead.java`
   — an invoice letterhead has different needs from a CV name
   headline. Don't try to share the same widget class across
   domains.
@@ -398,7 +398,7 @@ A new template family PR is reviewed against:
 5. **No engine / v1 edits** — additive only.
 
 Expected size: ~1500-2500 lines of new code for a fresh family.
-Compare to cv/v2 baseline (PR #45) which was 2082 lines including
+Compare to cv baseline (PR #45) which was 2082 lines including
 35 files.
 
 ---

--- a/docs/templates/v2-layered/quickstart.md
+++ b/docs/templates/v2-layered/quickstart.md
@@ -17,7 +17,7 @@ GraphCompose's templates v2 (layered) gives you:
 - **Widgets as visual LEGO bricks** — the neutral header bricks
   (`Headline`, `Subheadline`, `ContactLine`) live in the shared
   `templates.core.identity`; CV-specific ones (`SectionHeader` and
-  friends) in `cv.v2.widgets`. Each is a named visual decision you
+  friends) in `cv.widgets`. Each is a named visual decision you
   drop into a preset.
 - **Presets as compositions** — a preset orchestrates widgets in a
   page flow. Sixteen ship today (`BoxedSections`, `ModernProfessional`,
@@ -145,5 +145,5 @@ touch a renderer. A new widget doesn't touch the data model.
 | Render your own CV with your data | [using-templates.md](using-templates.md) |
 | Make a new visual style | [authoring-presets.md](authoring-presets.md) |
 | Add a new template family to the library (invoice, cover-letter) | [contributor-guide.md](contributor-guide.md) |
-| See hands-on recipes (change a bullet, swap colours, …) | [`cv/v2/AUTHORS.md`](../../../src/main/java/com/demcha/compose/document/templates/cv/v2/AUTHORS.md) |
+| See hands-on recipes (change a bullet, swap colours, …) | [`cv/AUTHORS.md`](../../../src/main/java/com/demcha/compose/document/templates/cv/AUTHORS.md) |
 | Run the shipped examples | [`examples/cv/v2/`](../../examples/src/main/java/com/demcha/examples/templates/cv/v2) |

--- a/docs/templates/v2-layered/using-templates.md
+++ b/docs/templates/v2-layered/using-templates.md
@@ -287,7 +287,7 @@ BrandTheme theme = new BrandTheme(
 ```
 
 For more recipes (compact spacing, alternative typography scales,
-etc.) see [`cv/v2/AUTHORS.md`](../../../src/main/java/com/demcha/compose/document/templates/cv/v2/AUTHORS.md).
+etc.) see [`cv/AUTHORS.md`](../../../src/main/java/com/demcha/compose/document/templates/cv/AUTHORS.md).
 
 ---
 
@@ -387,4 +387,4 @@ No GitHub, no Projects, no Tech Skills — and the API doesn't notice.
 [**authoring-presets.md**](authoring-presets.md)
 
 → Reference for every recipe (change bullet, swap colours, …)
-[`cv/v2/AUTHORS.md`](../../../src/main/java/com/demcha/compose/document/templates/cv/v2/AUTHORS.md)
+[`cv/AUTHORS.md`](../../../src/main/java/com/demcha/compose/document/templates/cv/AUTHORS.md)


### PR DESCRIPTION
## Why

The four per-family suffix drops (#280–#283) moved `templates.<fam>.v2.*` up to `templates.<fam>.*`, leaving the how-to docs with broken source-path links and imports pointing at packages that no longer exist. First of the 3-13 docs slices — the purely mechanical link/import fixes.

## What (7 how-to docs)

- Repoint engine source links, file paths, and import snippets `templates/<fam>/v2/` → `templates/<fam>/` and `templates.<fam>.v2` → `templates.<fam>` in: `v2-layered/{README,quickstart,authoring-presets,contributor-guide,using-templates}.md`, `recipes/themes.md`, `operations/test-your-document.md`.
- **Example-source links left untouched** (`examples/templates/<fam>/v2/` — those directories are deliberately unchanged).
- All 13 fixed engine links verified to resolve to real files post-rename.

## Out of scope (later 3-13 slices)

The conceptual/ledger docs (`which-template-system.md`, `api-stability.md` §3/§4), the BusinessTheme README rework, and the CHANGELOG v2.0.0 entry get a narrative pass separately.

## Tests

Docs-only. `DocumentationExamplesTest` + `CanonicalSurfaceGuardTest` + `DocumentationCoverageTest` + `PackageMapGuardTest` + `VersionConsistencyGuardTest` — 34 tests, 0 failures.

## Follow-up

Two example dir-links in `quickstart.md`/`README.md` use `../../examples/` (resolves to `docs/examples/`) — a pre-existing `../`-depth typo, unrelated to this rename; fold into the later docs pass.