### PR TITLE
docs: rework the README hero off BusinessTheme, log the 2.0 template changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,25 @@ follow semantic versioning; release dates are ISO 8601.
 The 2.0 development line. Binary-breaking by design — japicmp runs report-only
 for this cycle.
 
-### Build
-- Move the 2.0 line to `2.0.0-SNAPSHOT`. The README and showcase install
-  snippets now advertise the planned `2.0.0` coordinate.
+### Removed
+
+- The classic (pre-layered) CV and cover-letter template presets have been removed.
+  The layered template stack — `templates.cv.*`, `templates.coverletter.*`,
+  `templates.invoice.*`, and `templates.proposal.*`, all on `BrandTheme` — is now the
+  single template surface.
+- The standalone `BusinessTheme` design-token bundle (and its `DocumentPalette` /
+  `SpacingScale` / `TextScale` / `TablePreset` companions) is no longer part of the
+  library. It lives on only as a styling helper inside the examples module; author
+  documents with explicit `DocumentColor` / `DocumentTextStyle` values or a template
+  `BrandTheme`.
+
+### Public API
+
+- The layered template packages dropped their `.v2` suffix:
+  `com.demcha.compose.document.templates.<family>.v2.*` →
+  `com.demcha.compose.document.templates.<family>.*` for `cv`, `coverletter`,
+  `invoice`, and `proposal`. Update imports accordingly — behaviour and rendering are
+  unchanged; this is a package rename only.
 
 ## v1.9.0 — 2026-06-29
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 
 - **Author intent, not coordinates.** Fluent DSL for sections, paragraphs, tables, lists, layer stacks, themes &mdash; the engine handles measurement, pagination, and rendering.
 - **Deterministic by design.** Two-pass layout. Snapshots are stable across machines, so layout regressions are catchable in tests before any byte ships.
-- **Cinematic by default.** `BusinessTheme`, soft panels, accent strips, transforms, native vector charts, and gradients are first-class primitives, not workarounds.
+- **Cinematic by default.** Soft panels, accent strips, transforms, native vector charts, and gradients are first-class primitives, not workarounds.
 - **PDFBox isolated, DOCX optional.** Single backend interface. Apache POI&ndash;backed DOCX export is available for compatible semantic content &mdash; see [support matrix](#output-support) for limitations.
 
 Sits between **iText** (low-level page primitives) and **JasperReports** (XML-template-driven layout): a Java DSL describes the document semantically, the engine renders.
@@ -132,27 +132,40 @@ dependencies { implementation("io.github.demchaav:graph-compose:2.0.0") }
 import com.demcha.compose.GraphCompose;
 import com.demcha.compose.document.api.DocumentPageSize;
 import com.demcha.compose.document.api.DocumentSession;
-import com.demcha.compose.document.theme.BusinessTheme;
+import com.demcha.compose.document.style.DocumentColor;
+import com.demcha.compose.document.style.DocumentTextDecoration;
+import com.demcha.compose.document.style.DocumentTextStyle;
+import com.demcha.compose.font.FontName;
 
 import java.nio.file.Path;
 
 class Hello {
     public static void main(String[] args) throws Exception {
-        BusinessTheme theme = BusinessTheme.modern();
+        // A small inline palette — swap these for your own brand colours.
+        DocumentColor cream = DocumentColor.rgb(252, 248, 240);
+        DocumentColor panel = DocumentColor.rgb(244, 238, 228);
+        DocumentColor accent = DocumentColor.rgb(196, 153, 76);
+        DocumentTextStyle h1 = DocumentTextStyle.builder()
+                .fontName(FontName.HELVETICA_BOLD).size(28)
+                .decoration(DocumentTextDecoration.BOLD)
+                .color(DocumentColor.rgb(20, 60, 75)).build();
+        DocumentTextStyle body = DocumentTextStyle.builder()
+                .fontName(FontName.HELVETICA).size(11)
+                .color(DocumentColor.rgb(34, 38, 50)).build();
 
         try (DocumentSession document = GraphCompose.document(Path.of("hello.pdf"))
                 .pageSize(DocumentPageSize.A4)
-                .pageBackground(theme.pageBackground())
+                .pageBackground(cream)
                 .margin(28, 28, 28, 28)
                 .create()) {
 
             document.pageFlow(page -> page
                     .addSection("Hero", section -> section
-                            .softPanel(theme.palette().surfaceMuted(), 10, 14)
-                            .accentLeft(theme.palette().accent(), 4)
-                            .addParagraph(p -> p.text("GraphCompose").textStyle(theme.text().h1()))
-                            .addParagraph(p -> p.text("A theme-driven hero, no manual coordinates.")
-                                    .textStyle(theme.text().body()))));
+                            .softPanel(panel, 10, 14)
+                            .accentLeft(accent, 4)
+                            .addParagraph(p -> p.text("GraphCompose").textStyle(h1))
+                            .addParagraph(p -> p.text("A cinematic hero, no manual coordinates.")
+                                    .textStyle(body))));
 
             document.buildPdf();
         }


### PR DESCRIPTION
## Why

`BusinessTheme` moved to the examples module (#279), so the README "Hello world" hero no longer compiled (it imported `com.demcha.compose.document.theme.BusinessTheme`). Second 3-13 docs slice — the README + CHANGELOG.

## What

- **Hero snippet:** replace `BusinessTheme.modern()` + `theme.*()` with the same palette and text styles as direct `DocumentColor.rgb(...)` / `DocumentTextStyle.builder(...)` values. The rendered hero is **identical** (same cream page, tan soft panel, gold accent strip, h1/body) — just self-contained. Verified: the snippet **compiles** against the engine.
- **Feature bullet:** drop `BusinessTheme` from "Cinematic by default." (soft panels, accent strips, transforms, charts, gradients remain first-class engine primitives).
- **CHANGELOG:** extend the `## v2.0.0 — Planned` entry with the classic-preset + `BusinessTheme` removals and the layered-package `.v2`-suffix drop, in reader-first terms.

## Out of scope (next 3-13 slice)

`api-stability.md` retier, `which-template-system.md` slim rewrite, and the `v1-classic/` docs archive — including the README's remaining `v1-classic` landing link (line 285), which is why the README still mentions `BusinessTheme` and `DocumentationCoverageTest` is untouched here.

## Tests

Docs only. Hero snippet compiles (`javac` against the engine classpath). `DocumentationCoverageTest` + `VersionConsistencyGuardTest` + `CanonicalSurfaceGuardTest` + `PackageMapGuardTest` + `DocumentationExamplesTest` — 34 tests, 0 failures.