### PR TITLE
docs: retire the classic template surface from the guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ For a Spring Boot `@RestController` streaming the PDF straight to the response, 
 ### When to use GraphCompose
 
 - **Server-side PDF generation in Java** &mdash; invoices, CVs, reports, proposals, statements, schedules.
-- **Templated documents from data** &mdash; themed presets (`ModernProfessional`, `InvoiceTemplateV2`, &hellip;) you parameterise instead of re-styling every time.
+- **Templated documents from data** &mdash; themed presets (`ModernProfessional`, `ModernInvoice`, &hellip;) you parameterise instead of re-styling every time.
 - **Regression-tested layouts** &mdash; `DocumentSession#layoutSnapshot()` makes layout changes visible in PRs before any byte ships; `PdfVisualRegression` adds a pixel-level gate for font and colour fidelity.
 - **Streaming PDFs from web backends** &mdash; Spring Boot `@RestController` writing straight to the response ([`HttpStreamingExample`](./examples/src/main/java/com/demcha/examples/features/streaming/HttpStreamingExample.java)).
 - **Higher-level than PDFBox, lighter than JasperReports** &mdash; Java DSL describes semantics; no XML templates, no manual coordinates.
@@ -281,8 +281,8 @@ Full detail: [architecture overview](./docs/architecture/overview.md) &middot; [
 📚 **[Full docs index](./docs/README.md)** &mdash; categorised map of every doc, ADR, and recipe. Start there to navigate the documentation.
 
 ### Templates
-- 🆕 [**Templates — v2 layered architecture**](./docs/templates/v2-layered/README.md) &mdash; the canonical going-forward pattern for new template families (CV v2 is the reference implementation). Personas: [quickstart](./docs/templates/v2-layered/quickstart.md) · [using templates](./docs/templates/v2-layered/using-templates.md) · [authoring presets](./docs/templates/v2-layered/authoring-presets.md) · [contributing a new family](./docs/templates/v2-layered/contributor-guide.md).
-- [Templates v1-classic landing](./docs/templates/v1-classic/README.md) &mdash; the older `BusinessTheme` / `CvSpec` CV / cover-letter / invoice / proposal preset library (**deprecated** — CV + cover letter are superseded by [v2-layered](./docs/templates/v2-layered/README.md); invoice / proposal / schedule are not yet ported). Cheat sheet: [authoring](./docs/templates/v1-classic/authoring.md).
+- [**Templates — layered architecture**](./docs/templates/v2-layered/README.md) &mdash; the template surface: CV, cover-letter, invoice, and proposal preset families on `BrandTheme`. Personas: [quickstart](./docs/templates/v2-layered/quickstart.md) · [using templates](./docs/templates/v2-layered/using-templates.md) · [authoring presets](./docs/templates/v2-layered/authoring-presets.md) · [contributing a new family](./docs/templates/v2-layered/contributor-guide.md).
+- [Which template system?](./docs/templates/which-template-system.md) &mdash; the template naming history and the migration map for callers arriving from a pre-2.0 surface (classic presets, built-in `*Template` classes, the legacy PDF API). The retired classic docs are archived at [v1-classic](./docs/templates/v1-classic/README.md).
 
 ### Architecture & operations
 - [Architecture overview](./docs/architecture/overview.md) · [Lifecycle](./docs/architecture/lifecycle.md) · [Production rendering](./docs/operations/production-rendering.md) · [Layout snapshot testing](./docs/operations/layout-snapshot-testing.md) · [Troubleshooting](./docs/troubleshooting.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,10 +14,10 @@ back here.
 | You are… | Read |
 |---|---|
 | **New to GraphCompose** — what is it, how do I render my first PDF | [Your first document](first-document.md) → [Getting started](getting-started.md) |
-| **Author rendering an invoice or proposal** | [Built-in business templates](templates/business-templates.md) |
+| **Author rendering an invoice or proposal** | [Templates v2 (layered) — using templates](templates/v2-layered/using-templates.md) |
 | **Author rendering a CV** with your own data | [Templates v2 (layered) — quickstart](templates/v2-layered/quickstart.md) |
 | **Designer / author** wanting a custom visual style for CVs | [Templates v2 (layered) — authoring presets](templates/v2-layered/authoring-presets.md) |
-| **Author using legacy v1.6 templates** (CV / cover-letter / invoice / proposal still using `*Spec` + builders) | [Templates v1-classic — landing](templates/v1-classic/README.md) |
+| **Maintainer of a pre-2.0 caller** (classic `*Spec` + builder templates, removed in 2.0) | [Which template system? — migration map](templates/which-template-system.md) |
 | **Contributor adding a new template family** to the library | [Templates v2 (layered) — contributor guide](templates/v2-layered/contributor-guide.md) |
 | **Contributor extending the engine** (new node type, new backend handler) | [Extension guide](contributing/extension-guide.md) → [Implementation guide](contributing/implementation-guide.md) |
 | **Operator** running GraphCompose in production | [Production rendering](operations/production-rendering.md) → [Performance](operations/performance.md) → [Logging](operations/logging.md) |
@@ -34,9 +34,9 @@ back here.
 - **[troubleshooting.md](troubleshooting.md)** — symptom-first fixes for common gotchas: stray `?` glyphs, silent DOCX drops, optional-dependency `NoClassDefFoundError`, running the bundled examples.
 
 ### Templates
-- **[templates/business-templates.md](templates/business-templates.md)** — built-in invoice & proposal templates: the compose-first contract, end to end.
-- **[templates/v2-layered/](templates/v2-layered/)** — 🆕 canonical going-forward pattern (CV is the reference implementation): `data` / `theme` / `components` / `widgets` / `presets`.
-- **[templates/v1-classic/](templates/v1-classic/)** — the spec/builder/presets surface used by v1.6 CV, cover-letter, invoice, proposal templates. Still ships, still supported.
+- **[templates/business-templates.md](templates/business-templates.md)** — invoice & proposal templates: the compose-first contract, end to end. ⚠️ Being reworked for the layered `ModernInvoice` / `ModernProposal` surface.
+- **[templates/v2-layered/](templates/v2-layered/)** — the template surface (CV is the reference implementation): `data` / `theme` / `components` / `widgets` / `presets`.
+- **[templates/v1-classic/](templates/v1-classic/)** — 🗄️ archived: the classic spec/builder/presets surface removed in 2.0; kept for pre-2.0 callers.
 
 ### Architecture
 - **[architecture/overview.md](architecture/overview.md)** — high-level system architecture (engine + DSL + templates + backends).

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -28,12 +28,12 @@ matrix.
 
 | Tier | Marker | Used for | Breaking changes allowed in |
 |---|---|---|---|
-| **Stable** | _(default — no annotation)_ | The canonical authoring surface that user code is meant to call: `GraphCompose.document(...)`, `DocumentSession`, `DocumentDsl`, `RowBuilder` / `SectionBuilder` / `ParagraphBuilder` and friends, `DocumentInsets` / `DocumentColor` / `DocumentTextStyle`, the `BusinessTheme` and `BrandTheme` factories, the recommended template presets in `cv.v2.*` and `coverletter.v2.*`. | **Major releases only.** |
-| **Supported** | _(no annotation; called out in the page's Javadoc)_ | A canonical surface that ships through 1.x but won't be in 2.0 — its replacement is already the Stable path. The `cv.presets.*` "classic" CV preset surface is the only Supported tier in 1.x today (replaced by `cv.v2.*` per [`which-template-system.md`](templates/which-template-system.md)). Bug fixes + behaviour-preserving refactors only. | **Minor releases for behaviour-preserving refactors; removed wholesale in 2.0.** |
+| **Stable** | _(default — no annotation)_ | The canonical authoring surface that user code is meant to call: `GraphCompose.document(...)`, `DocumentSession`, `DocumentDsl`, `RowBuilder` / `SectionBuilder` / `ParagraphBuilder` and friends, `DocumentInsets` / `DocumentColor` / `DocumentTextStyle`, the `BrandTheme` factories, and the layered template presets (`templates.cv.*`, `templates.coverletter.*`, `templates.invoice.*`, `templates.proposal.*`). | **Major releases only.** |
+| **Supported** | _(no annotation; called out in the page's Javadoc)_ | A canonical surface that ships through a major line but won't be in the next one — its replacement is already the Stable path. Bug fixes + behaviour-preserving refactors only. *(No package holds this tier on the 2.0 line; the classic `cv.presets.*` CV surface held it through 1.x and was removed in 2.0 per [`which-template-system.md`](templates/which-template-system.md).)* | **Minor releases for behaviour-preserving refactors; removed wholesale in the next major.** |
 | **Extension SPI** | [`@Beta`](../src/main/java/com/demcha/compose/document/api/Beta.java) | Public extension points that authors are expected to **implement**, not only call: render-handler interfaces, [`NodeDefinition`](../src/main/java/com/demcha/compose/document/layout/NodeDefinition.java), custom `Theme` subtype contracts, fragment payload interfaces designed for extension. | Minor releases, with a one-minor deprecation window where possible. |
 | **Experimental** | [`@Beta`](../src/main/java/com/demcha/compose/document/api/Beta.java) _(same annotation as Extension SPI; the distinction lives in the docstring on the annotated element)_ | A brand-new public type shipping in its first minor release before its contract has stabilised. The contract is in active flux. | Any minor release, including removal. No deprecation window. |
 | **Internal** | [`@Internal`](../src/main/java/com/demcha/compose/document/api/Internal.java) (per-element or per-package) | Engine surface: everything in `com.demcha.compose.document.layout.*`, `com.demcha.compose.engine.*`, render-pipeline payload records, `LayoutCompiler`, `NodeDefinitionSupport`, the placement / measure / split contracts. Technically `public` for cross-package collaboration; not part of the contract. Canonical list lives in [ADR-0003](adr/0003-api-stability-and-internal-marker.md) § *Coverage*. | **Any release.** No deprecation window, no CHANGELOG entry required. |
-| **Legacy** | _(no annotation today; flagged in [`which-template-system.md`](templates/which-template-system.md) § 4 and in CHANGELOG `### Deprecations`)_ | Pre-rebuild surface kept only so downstream callers from before the v1.6 rebuild keep compiling: `com.demcha.templates.*` (the original `MainPageCV` / `MainPageCvDTO` / `ModuleYml` / `TemplateBuilder` family), `com.demcha.compose.v2.*` (the original engine-direct builders). Frozen — bug fixes only. | **Removed in 2.0**; no patch / minor changes other than security fixes. |
+| **Legacy** | _(no annotation; flagged in [`which-template-system.md`](templates/which-template-system.md) and in CHANGELOG `### Deprecations`)_ | Pre-rebuild surface kept only so callers from before a major rebuild keep compiling. Frozen — bug fixes only. *(No package holds this tier on the 2.0 line; `com.demcha.templates.*` and `com.demcha.compose.v2.*` held it through 1.x and were removed in 2.0 — the migration target is the canonical DSL.)* | **Removed in the next major**; no patch / minor changes other than security fixes. |
 
 > Both marker annotations
 > ([`@Internal`](../src/main/java/com/demcha/compose/document/api/Internal.java)
@@ -62,11 +62,9 @@ GraphCompose uses sealed interfaces in several places to keep visitor
 code exhaustive. The public ones — the ones this policy actually covers —
 are:
 
-- [`Block`](../src/main/java/com/demcha/compose/document/templates/blocks/Block.java) (Stable)
-- [`CvSection`](../src/main/java/com/demcha/compose/document/templates/cv/v2/data/CvSection.java) (Stable)
+- [`CvSection`](../src/main/java/com/demcha/compose/document/templates/cv/data/CvSection.java) (Stable)
 - [`InlineRun`](../src/main/java/com/demcha/compose/document/node/InlineRun.java) (Stable)
 - [`ShapeOutline`](../src/main/java/com/demcha/compose/document/style/ShapeOutline.java) (Stable)
-- [`TemplateModuleBlock`](../src/main/java/com/demcha/compose/document/templates/support/common/TemplateModuleBlock.java) (Extension SPI)
 
 Sealed types under `@Internal` packages — `ParagraphSpan` and
 `PlacementContext` — are outside this policy by definition; their permit
@@ -84,10 +82,10 @@ though it's purely additive at the source level.
 1. **Stable sealed hierarchies are additive in minor releases only when
    the new variant carries a sensible default rendering for callers
    that did not switch on it.** Concretely: if a caller pattern-matches
-   on `Block` and hits a `NewlyAddedBlock` it didn't expect, the
-   default rendering must visually degrade gracefully — typically by
-   delegating to the closest stable variant (often `ParagraphBlock`)
-   rather than throwing.
+   on `CvSection` and hits a newly added section variant it didn't
+   expect, the default rendering must visually degrade gracefully —
+   typically by delegating to the closest stable variant (often
+   `ParagraphSection`) rather than throwing.
 2. **The CHANGELOG entry for the minor release names the new permit
    explicitly** under `### Public API` so callers know to audit their
    visitor code. Example wording, from the v1.6.4 cut:
@@ -149,12 +147,13 @@ deprecation is *"this will simply go away in 2.0 and there is no
 replacement because the problem itself moved,"* say so explicitly in
 prose so the reader knows not to look for one.
 
-### Currently slated for removal in 2.0
+### Currently slated for removal in the next major
 
 Two inventories track what is deferred to the next major:
 
-- **Template surfaces and pre-rebuild aliases** —
-  [`docs/templates/which-template-system.md` § 4](templates/which-template-system.md#4-deprecation-inventory--1x--20).
+- **Template surfaces and pre-rebuild aliases** — the 1.x → 2.0 removals
+  are done on the 2.0 line; the migration map lives in
+  [`docs/templates/which-template-system.md` § 3](templates/which-template-system.md#3-migrating-a-pre-20-caller).
 - **Every other public-API rework, simplification, or deprecation** — the ledger below.
 
 #### 2.0 breaking-changes ledger
@@ -192,15 +191,15 @@ Javadoc per element.
 | `com.demcha.compose.document.dsl` | **Stable** | All builder types (`RowBuilder`, `SectionBuilder`, `ParagraphBuilder`, etc.). |
 | `com.demcha.compose.document.node` | **Stable** | Node records (`RowNode`, `SectionNode`, `ParagraphNode`, ...). Sealed where relevant — see § 2. |
 | `com.demcha.compose.document.style` | **Stable** | `DocumentColor`, `DocumentInsets`, `DocumentTextStyle`, `DocumentTransform`, ... |
-| `com.demcha.compose.document.templates.cv.*` | **Stable** | Layered CV presets, `CvDocument`, `BrandTheme`. Recommended template surface. |
-| `com.demcha.compose.document.templates.coverletter.v2.*` | **Stable** | Layered cover-letter presets. |
-| `com.demcha.compose.document.templates.builtins` | **Stable** | `InvoiceTemplateV2`, `ProposalTemplateV2`, `BusinessTheme`. |
-| `com.demcha.compose.document.templates.cv.presets.*` | **Stable but Supported** | The "classic" v1.6 rebuild surface. See [`which-template-system.md`](templates/which-template-system.md). Supported through 1.x; removed in 2.0. |
-| `com.demcha.compose.document.templates.support.common` | **Extension SPI** | Helpers template authors build new presets against. `@Beta` arrives in Track H2. |
+| `com.demcha.compose.document.templates.api` | **Stable** | The `DocumentTemplate<S>` seam every preset factory returns. |
+| `com.demcha.compose.document.templates.core.*` | **Stable** | The shared, family-neutral template layer — `BrandTheme` tokens (`core.theme`), neutral header bricks (`core.identity`), text helpers (`core.text`), shared widgets (`core.widgets`). |
+| `com.demcha.compose.document.templates.cv.*` | **Stable** | Layered CV family — `CvDocument` data, components, widgets, presets. |
+| `com.demcha.compose.document.templates.coverletter.*` | **Stable** | Layered cover-letter family. |
+| `com.demcha.compose.document.templates.invoice.*` | **Stable** | Layered invoice family — `ModernInvoice` on `InvoiceDocumentSpec`. |
+| `com.demcha.compose.document.templates.proposal.*` | **Stable** | Layered proposal family — `ModernProposal` on `ProposalDocumentSpec`. |
+| `com.demcha.compose.document.templates.data.*` | **Stable** | Family-neutral document data records (invoice / proposal / schedule specs). |
 | `com.demcha.compose.document.layout.*` | **Internal** | Marked `@Internal` at the package level. Engine surface. |
 | `com.demcha.compose.engine.*` | **Internal** | Engine surface; not part of the public contract regardless of `public` keyword. |
-| `com.demcha.templates.*` | **Legacy** | Pre-rebuild surface; removed in 2.0. See [`which-template-system.md`](templates/which-template-system.md). |
-| `com.demcha.compose.v2.*` | **Legacy** | Pre-rebuild engine-direct surface; removed in 2.0. |
 
 ---
 
@@ -219,9 +218,9 @@ Javadoc per element.
   output is visually identical. Compare semantically, not by file hash.
 - **Internal package shape across releases.** See § 1, tier Internal.
 - **Sealed hierarchy permits' exhaustiveness across minor releases for
-  Stable hierarchies.** See § 2. Switching on a sealed `Block` without
-  a `default` branch *will* fail to compile cleanly on the next minor
-  release that adds a new permit — by design.
+  Stable hierarchies.** See § 2. Switching on a sealed `CvSection`
+  without a `default` branch *will* fail to compile cleanly on the next
+  minor release that adds a new permit — by design.
 
 ---
 
@@ -232,14 +231,14 @@ Javadoc per element.
   guards that enforce it).
 - [ADR-0004 — PDF fragment render handler SPI is public](adr/0004-pdf-handler-spi-extension.md)
   — a worked example of opening an Extension SPI seam.
-- [ADR-0011 — Templates v2 architecture](adr/0011-templates-v2-architecture.md)
-  and [ADR-0015 — Layered template architecture](adr/0015-layered-template-architecture.md)
-  — the architectural justification for the `classic` / `layered`
-  template tiers in § 4.
+- [ADR-0015 — Layered template architecture](adr/0015-layered-template-architecture.md)
+  — the architectural justification for the layered template packages in
+  § 4 ([ADR-0011](adr/0011-templates-v2-architecture.md) documents the
+  removed classic predecessor).
 - [`docs/templates/which-template-system.md`](templates/which-template-system.md)
-  — the recommended-vs-legacy decision guide for template surfaces;
-  this stability policy lives one level up and covers all packages,
-  not just templates.
+  — the template naming history and the migration map for pre-2.0
+  callers; this stability policy lives one level up and covers all
+  packages, not just templates.
 - [`InternalAnnotationCoverageTest`](../src/test/java/com/demcha/documentation/InternalAnnotationCoverageTest.java)
   and [`InternalAnnotationDocumentationTest`](../src/test/java/com/demcha/compose/document/api/InternalAnnotationDocumentationTest.java)
   — the architecture guards that fail the build if the package-level

--- a/docs/templates/v1-classic/README.md
+++ b/docs/templates/v1-classic/README.md
@@ -1,18 +1,15 @@
 # Templates v1-classic &mdash; CV, cover letter, invoice, proposal
 
-> ⚠️ **Naming clarification.** This page describes the **v1.6
-> "Templates v2"** surface — the rebuilt canonical templates that
-> shipped in v1.6 with `*Spec` records + `*Builder` + presets. The
-> codebase still calls this layer "Templates v2" internally (see
-> [ADR 0011](../../adr/0011-templates-v2-architecture.md)).
->
-> The **newer layered architecture** for v2 templates (data /
-> theme / components / widgets / presets, with `CvDocument` rather
-> than `CvSpec`) lives at
-> **[templates/v2-layered/](../v2-layered/README.md)** and is the
-> recommended path for new template families going forward.
->
-> Both surfaces coexist today; neither is deprecated yet.
+> 🗄️ **Archived.** This page documents the classic template surface
+> (`*Spec` records + `*Builder` + presets + `BusinessTheme`, introduced
+> by [ADR 0011](../../adr/0011-templates-v2-architecture.md)) that
+> shipped through the 1.x line and was **removed in GraphCompose 2.0**.
+> It is kept for readers maintaining a pre-2.0 caller. The current
+> template surface is the layered stack at
+> **[templates/v2-layered/](../v2-layered/README.md)**; the migration
+> map is in
+> [which-template-system.md § 3](../which-template-system.md#3-migrating-a-pre-20-caller).
+> Nothing below is updated anymore.
 
 GraphCompose v1.6 ships a rebuilt canonical template surface for the four
 business document shapes: **CV, cover letter, invoice, proposal**. Every

--- a/docs/templates/v1-classic/authoring.md
+++ b/docs/templates/v1-classic/authoring.md
@@ -1,15 +1,13 @@
 # Template authoring — v1-classic cheatsheet
 
-> ⚠️ **For the v1.6 "Templates v2" surface** (`CvSpec`, `CvBuilder`,
-> `*Presets` with `BusinessTheme`). Still shipped and maintained.
->
-> **Writing a new template family from scratch?** The newer layered
-> architecture is the canonical going-forward path —
-> [templates/v2-layered/authoring-presets.md](../v2-layered/authoring-presets.md)
-> shows the widget-composition pattern (much shorter presets, fewer
-> classes to maintain).
->
-> **Authoring against existing v1-classic templates?** Keep reading.
+> 🗄️ **Archived.** This cheatsheet covers the classic surface
+> (`CvSpec`, `CvBuilder`, `*Presets` with `BusinessTheme`) that was
+> **removed in GraphCompose 2.0**. It is kept for readers maintaining a
+> pre-2.0 caller. The live authoring cheatsheet is
+> [templates/v2-layered/authoring-presets.md](../v2-layered/authoring-presets.md);
+> the migration map is in
+> [which-template-system.md § 3](../which-template-system.md#3-migrating-a-pre-20-caller).
+> Nothing below is updated anymore.
 
 This page is the single reference for writing new templates and DSL
 code without boilerplate. Read it once before starting a template;

--- a/docs/templates/v2-layered/README.md
+++ b/docs/templates/v2-layered/README.md
@@ -1,20 +1,20 @@
 # Templates — Layered Architecture
 
 > ⚠️ **Naming clarification.** This is the **layered** template
-> architecture (data / theme / components / widgets / presets), the
-> going-forward canonical pattern. Package:
+> architecture (data / theme / components / widgets / presets) — the
+> template surface. Reference package:
 > `com.demcha.compose.document.templates.cv`.
 >
-> **Not to be confused with** the older v1.6 "Templates v2" surface
-> (`CvSpec`, `CvBuilder`, presets with `BusinessTheme`) — that lives
-> in [templates/v1-classic/](../v1-classic/README.md) and still ships
-> alongside this one.
+> **Naming note:** through 1.x an older surface also called
+> "Templates v2" (`CvSpec`, `CvBuilder`, presets with `BusinessTheme`)
+> shipped alongside this one; it was removed in 2.0 and its docs are
+> archived at [templates/v1-classic/](../v1-classic/README.md).
 
-The **canonical going-forward pattern** for building business documents
-on GraphCompose. CV is the reference implementation today
-(`com.demcha.compose.document.templates.cv`); invoice, cover-letter,
-proposal, and any new template family will follow the same shape as
-they're migrated.
+The **template surface** for building business documents on
+GraphCompose. All four families ship on it — CV (the reference
+implementation, `com.demcha.compose.document.templates.cv`),
+cover-letter, invoice, and proposal — and any new template family
+follows the same shape.
 
 This is the entry point. Pick the doc that matches your goal.
 
@@ -122,7 +122,7 @@ The detailed contract for each layer is in
 - **Examples**:
   [`examples/cv/v2/`](../../examples/src/main/java/com/demcha/examples/templates/cv/v2)
   has runnable rendering examples for the shipped presets.
-- **Legacy v1 surface**:
+- **Archived classic surface**:
   [`docs/templates/v1-classic/README.md`](../v1-classic/README.md) describes the older
-  spec / preset / theme split used by the v1 templates. Still valid
-  for the v1 packages; superseded by this guide for v2 work.
+  spec / preset / theme split that was removed in 2.0; kept for
+  pre-2.0 callers.

--- a/docs/templates/which-template-system.md
+++ b/docs/templates/which-template-system.md
@@ -1,238 +1,130 @@
 # Which template system should I use?
 
-**Short answer.** For any **new** code on GraphCompose 1.6.x and later, use
-the [**layered**](v2-layered/README.md) template surface
-(`com.demcha.compose.document.templates.cv.*`, paired with
-`*Letter` cover-letter presets in `…coverletter.v2.*`). The older
-[**classic**](v1-classic/README.md) surface still ships, still works,
-and stays supported through the 1.x line, but **the layered surface is
-the path forward** and is the only template family that will be in
-GraphCompose 2.0.
+**Short answer.** There is one: the [**layered**](v2-layered/README.md)
+template surface — `com.demcha.compose.document.templates.{cv, coverletter,
+invoice, proposal}`, every preset a final class with a
+`create(BrandTheme)` factory returning a `DocumentTemplate<…>`. GraphCompose
+2.0 ships no other template system.
 
-This page is the decision guide. It exists because the project ships
-**two parallel canonical template surfaces** today, with confusingly
-similar names, and a new contributor needs to know which one to read
-and which one to write against.
+Through the 1.x line this page was a decision guide between two parallel
+surfaces. On the 2.0 line the decision is gone; what remains here is the
+naming history (so old commit messages and ADRs still make sense) and the
+migration map for callers arriving from a pre-2.0 surface.
 
 ---
 
-## 0. The naming, once
+## 1. The naming, once
 
-The two surfaces have collided naming because the *codebase* and the
-*docs* labelled them at different points in time:
+Two template generations coexisted through 1.x, with confusingly similar
+names. Both older labels refer to surfaces that **no longer exist in 2.0**:
 
-| What you'll see | Where it lives | What it actually is |
+| Historical label | What it was | Fate |
 |---|---|---|
-| **"Templates v2" (in commit messages, ADR 0011, package names like `cv.v2`)** | `com.demcha.compose.document.templates.cv.*` | The **layered** architecture — *data / theme / components / widgets / presets*, paired with `CvDocument` builder. Recommended. |
-| **"Templates v1.6" / "templates rebuild"** | `com.demcha.compose.document.templates.cv.presets.*` | The 1.6 rebuilt canonical surface — `CvSpec` + `CvBuilder` + presets + `BusinessTheme`. Still supported. |
-| **Folder `docs/templates/v1-classic/`** | docs only | Documents the **non-layered** surface (`cv.presets.*`). The doc folder name is *not* the same axis as the package's `v2` suffix. |
-| **Folder `docs/templates/v2-layered/`** | docs only | Documents the layered surface (`cv.v2.*`). |
+| **"classic"** / "Templates v1.6" / "templates rebuild" (`cv.presets.*`, `CvSpec` + `CvBuilder` + `BusinessTheme`) | The 1.6 rebuilt canonical surface, documented in [`v1-classic/`](v1-classic/README.md) (now archived). | Removed in 2.0. Same-named layered presets replace it (§ 3). |
+| **"Templates v2"** / "layered" (package suffix `cv.v2` etc.) | The layered architecture — *data / theme / components / widgets / presets* on `BrandTheme`, introduced by [ADR-0015](../adr/0015-layered-template-architecture.md). | **This is the 2.0 surface.** The `.v2` package suffix was dropped in 2.0 (`templates.cv.v2.*` → `templates.cv.*`); the docs folder keeps its historical [`v2-layered/`](v2-layered/README.md) name. |
+| **Built-in `*TemplateV1` / `*TemplateV2`** (Invoice / Proposal / WeeklySchedule) | Standalone one-class templates on `BusinessTheme`, predating the layered families. | Removed in 2.0. Invoice / proposal are layered families now (§ 3); weekly schedule has no 2.0 template yet. |
+| **Legacy PDF API** (`GraphCompose.pdf(...)`, `PdfComposer`, `com.demcha.compose.v2.*`, `com.demcha.templates.*`) | The original pre-1.6, PDF-direct authoring path. | Removed in 2.0. Migration target is the canonical DSL directly (§ 3). |
 
-From here, this page uses one name per surface, consistently:
-
-- **`classic`** → `cv.presets.*`, documented in `docs/templates/v1-classic/` — pre-layered, still supported.
-- **`layered`** → `cv.v2.*` + `coverletter.v2.*`, documented in `docs/templates/v2-layered/` — recommended.
-
-ADR references: [ADR-0011 templates-v2-architecture](../adr/0011-templates-v2-architecture.md) introduces the `classic` surface;
-[ADR-0015 layered-template-architecture](../adr/0015-layered-template-architecture.md) introduces the `layered` one and supersedes 0011 for new template families.
+ADR references: [ADR-0011](../adr/0011-templates-v2-architecture.md)
+introduced the classic surface; [ADR-0015](../adr/0015-layered-template-architecture.md)
+introduced the layered one and superseded 0011.
 
 ---
 
-## 1. Status matrix
+## 2. Status matrix
 
-| Surface | Status | Stability | Use for new code? | Will exist in 2.0? | First read |
-|---|---|---|---|---|---|
-| **Layered** (`cv.v2.*`, `coverletter.v2.*`) | **Recommended** | Stable (additive changes only) | ✅ Yes | ✅ Yes (canonical) | [v2-layered/quickstart](v2-layered/quickstart.md) |
-| **Classic** (`cv.presets.*`, paired classic letter presets) | **Supported** | Stable, no new features | 🟡 Only if migrating an existing v1.5-era caller | ❌ Removed (full migration to layered) | [v1-classic/README](v1-classic/README.md) |
-| **Built-in `*TemplateV2`** (Invoice / Proposal) | **Recommended** | Stable | ✅ Yes | ✅ Yes | [v1-classic/README](v1-classic/README.md) — InvoiceTemplateV2 / ProposalTemplateV2 sections (documented historically inside the v1-classic folder; pending a dedicated `built-ins/` section) |
-| **Built-in `*TemplateV1`** (Invoice / Proposal / WeeklySchedule) | **Legacy** | Stable, no new features | ❌ No (use V2 versions; WeeklySchedule has no V2 yet) | ❌ Removed | (no top-level doc — see source Javadoc) |
-| **Canonical DSL** (`GraphCompose.document()` + `DocumentSession` + `DocumentDsl`) | **Recommended** | Stable | ✅ Yes — required substrate for both template surfaces and direct authoring | ✅ Yes | [Main README — Hello world](../../README.md) |
-| **Legacy PDF API** (`GraphCompose.pdf(...)`, `PdfComposer`, `com.demcha.compose.v2.*`, `com.demcha.templates.*`) | **Legacy** | Frozen — bug fixes only | ❌ No | ❌ Removed | `graphcompose-legacy-architect` skill (internal Claude / Codex artifact, not a repo page) |
-| **Engine surface** (`com.demcha.compose.document.layout.*`, `com.demcha.compose.engine.*`, render handlers) | **Internal** | Stable in practice, not part of the public contract; can change in any minor release without a CHANGELOG entry | ❌ No | 🟡 Mostly — package boundaries will tighten further behind `@Internal` | `graphcompose-shared-engine-architect` skill (internal Claude / Codex artifact); [ADR-0015](../adr/0015-layered-template-architecture.md) for the canonical/engine seam |
-
-> **Status definitions.** *Recommended* = the path GraphCompose 2.0 will
-> ship; new code targets it. *Supported* = bug fixes + behaviour-preserving
-> refactors only, no new features; exists through 1.x. *Internal* = engine
-> surface, not part of the public contract; can change in any minor
-> release without a CHANGELOG entry. *Legacy* = bug fixes only, removed
-> in 2.0; do not start new code here.
-
----
-
-## 2. Decision tree
-
-```
-I want to render a business document on GraphCompose.
-
-├─ Is it a CV or cover letter?
-│   ├─ Yes → use a `layered` preset (cv.v2 / coverletter.v2).
-│   │       See [v2-layered/using-templates.md](v2-layered/using-templates.md).
-│   │       Existing `classic` (cv.presets.*) caller? Read § 3 below; the
-│   │       layered preset with the same name is a drop-in replacement
-│   │       for almost every case.
-│   │
-│   └─ No → continue.
-│
-├─ Is it an invoice or proposal?
-│   └─ Use `InvoiceTemplateV2` or `ProposalTemplateV2` (the `V2` variants).
-│       The `V1` variants exist for backward compatibility; do not start
-│       new code on them.
-│
-├─ Is it a weekly schedule?
-│   └─ Use `WeeklyScheduleTemplateV1`. There is no V2 yet — the V1 API
-│       will be re-shaped before 2.0 (no concrete plan yet); track in
-│       the public release roadmap before adopting it long-term.
-│
-└─ It's something else (custom shape, brochure, report)?
-    └─ Author directly on the canonical DSL: `GraphCompose.document()`
-       + `pageFlow(...)` or `dsl().pageFlow(...)`. Reuse `BusinessTheme`
-       and layered widgets (`SectionDispatcher`, `EntryCompactRenderer`,
-       `RichParagraphRenderer`, `CardWidget`) wherever they fit; lift
-       new reusable widgets into the `cv.v2/components` and
-       `cv.v2/widgets` packages so the next template family can share
-       them.
-```
-
----
-
-## 3. Migration table — `classic` → `layered`
-
-Every CV preset that shipped in `cv.presets.*` has a same-named drop-in
-replacement in `cv.v2.presets.*`. Migrating a caller is the import swap
-plus a theme + data-record swap (introduced below):
-
-```diff
--import com.demcha.compose.document.templates.cv.presets.NordicClean;
-+import com.demcha.compose.document.templates.cv.presets.NordicClean;
-
--// before: CvSpec + BusinessTheme
--NordicClean.create(BusinessTheme.nordicClean()).render(session, cvSpec);
-+// after:  CvDocument + BrandTheme — see the two shape changes below
-+NordicClean.create(cvTheme).render(session, cvDocument);
-```
-
-Two real shape changes accompany the swap:
-
-1. **Theme.** `BusinessTheme.X()` → `BrandTheme.X()`. The CV-specific
-   tokens (palette / typography / spacing) are split out so `cv.v2`
-   themes don't carry invoice / proposal vocabulary they don't use.
-2. **Data record.** `CvSpec` → `CvDocument`. The data shape becomes
-   strongly-typed sections (`SectionGroup`, `EntryGroup`, `SkillGroup`,
-   …) instead of a flat `Block` permit list. The
-   [contributor-guide](v2-layered/contributor-guide.md) walks through
-   the section types end-to-end.
-
-### CV presets — one-to-one mapping
-
-| `classic` (`cv.presets.*`) | `layered` (`cv.v2.presets.*`) | Cover letter (`coverletter.v2.presets.*`) | Notes |
+| Surface | Status | Use for new code? | First read |
 |---|---|---|---|
-| `BlueBanner` | `BlueBanner` | `BlueBannerLetter` | |
-| `BoxedSections` | `BoxedSections` | `BoxedSectionsLetter` | Reference preset for the layered architecture. |
-| `CenteredHeadline` | `CenteredHeadline` | `CenteredHeadlineLetter` | Layered-only in 1.6.5+; classic version is the rebuilt one. |
-| `ClassicSerif` | `ClassicSerif` | `ClassicSerifLetter` | |
-| `CompactMono` | `CompactMono` | `CompactMonoLetter` | |
-| `EditorialBlue` | `EditorialBlue` | `EditorialBlueLetter` | |
-| `EngineeringResume` | `EngineeringResume` | `EngineeringResumeLetter` | |
-| `Executive` | `Executive` | `ExecutiveLetter` | |
-| `ModernProfessional` | `ModernProfessional` | `ModernProfessionalLetter` | |
-| `MonogramSidebar` | `MonogramSidebar` | `MonogramSidebarLetter` | Layered version uses `pageBackgrounds(...)` for sidebar chrome (multi-page-safe). |
-| `NordicClean` | `NordicClean` | `NordicCleanLetter` | Layered version ships public `NordicClean.Options`. |
-| `Panel` | `Panel` | `PanelLetter` | |
-| `SidebarPortrait` | `SidebarPortrait` | `SidebarPortraitLetter` | Layered version uses `pageBackgrounds(...)`. |
-| `TimelineMinimal` | `TimelineMinimal` | `TimelineMinimalLetter` | |
-| _(no classic)_ | `MinimalUnderlined` | _(no letter yet)_ | Layered-only. |
-| _(no classic)_ | `MintEditorial` | `MintEditorialLetter` | Layered-only (shipped in v1.6.5). |
+| **Layered templates** (`templates.cv.*`, `templates.coverletter.*`, `templates.invoice.*`, `templates.proposal.*` on `BrandTheme`) | **Stable** — the template surface | ✅ Yes | [v2-layered/quickstart](v2-layered/quickstart.md) |
+| **Canonical DSL** (`GraphCompose.document()` + `DocumentSession` + builders) | **Stable** — the authoring substrate under the templates, and the direct path for custom shapes | ✅ Yes | [Main README — Hello world](../../README.md) |
+| **Engine surface** (`com.demcha.compose.document.layout.*`, `com.demcha.compose.engine.*`, render handlers) | **Internal** — not part of the public contract; can change in any release | ❌ No | [ADR-0015](../adr/0015-layered-template-architecture.md) for the canonical/engine seam |
 
-If your caller uses a name on the left, the row tells you what to import
-on the right and which cover-letter preset pairs with it.
-
-### Built-ins (Invoice / Proposal / WeeklySchedule)
-
-| V1 | V2 | Migration |
-|---|---|---|
-| `InvoiceTemplateV1` | `InvoiceTemplateV2` | Same data record (`InvoiceSpec`), same `BusinessTheme`. Renderer rewrite uses layered widgets; output is visually equivalent and snapshot-tested. |
-| `ProposalTemplateV1` | `ProposalTemplateV2` | Same data record (`ProposalSpec`), same `BusinessTheme`. Same migration pattern as invoice. |
-| `WeeklyScheduleTemplateV1` | _(no V2 yet)_ | Stay on V1 until a V2 ships. |
-
-### Things that are **not** in either canonical surface (still legacy)
-
-These live under `com.demcha.compose.v2.*`, `com.demcha.templates.*`, or
-the `GraphCompose.pdf(...)` factory. They are the original (pre-1.6)
-PDF-direct authoring path. They will be removed in 2.0:
-
-- `GraphCompose.pdf(outputFile)` and `PdfComposer`.
-- `com.demcha.templates.MainPageCV`, `MainPageCvDTO`, `ModuleYml`,
-  `TemplateBuilder` and friends.
-- `com.demcha.compose.v2.*` (engine-direct builders predating the
-  canonical DSL).
-
-If a caller still imports any of these, the migration target is
-**directly the canonical DSL** (`GraphCompose.document()`) — there is no
-1:1 equivalent in the template surfaces, because these classes were
-never canonical templates, they were a PDF authoring shortcut. The
-[migration-v1-5-to-v1-6 roadmap](../roadmaps/migration-v1-5-to-v1-6.md)
-walks through the swap for the common shapes.
+Choosing is simple: rendering a CV, cover letter, invoice, or proposal →
+pick a layered preset. Anything else (report, brochure, custom shape) →
+author directly on the canonical DSL, reusing `templates.core` widgets
+where they fit.
 
 ---
 
-## 4. Deprecation inventory — 1.x → 2.0
+## 3. Migrating a pre-2.0 caller
 
-Read this when planning long-lived code or when auditing dependencies
-that may already use one of the slated-for-removal types. None of these
-are deleted in 1.x; the work below is anti-roadmap and lives in the
-private taskboard.
+### Classic CV / cover-letter presets → layered
 
-### Removed in 2.0
+Every classic CV preset has a **same-named** layered replacement; the
+migration is the theme + data-record swap:
 
-| Item | Reason | Replacement |
+1. **Theme.** `BusinessTheme.X()` → `BrandTheme.X()` (per-family factories,
+   e.g. `BrandTheme.boxedClassic()`, `BrandTheme.invoiceModern()`).
+2. **Data record.** `CvSpec` → `CvDocument` — strongly-typed sections
+   (`ParagraphSection`, `SkillsSection`, `EntriesSection`, …) instead of a
+   flat block list. The [contributor guide](v2-layered/contributor-guide.md)
+   walks the section types end-to-end.
+
+| Classic preset (removed) | Layered CV preset | Paired cover letter |
 |---|---|---|
-| `GraphCompose.pdf(...)` factory + `PdfComposer` | PDF-direct path predates the canonical DSL; bypasses layout and rendering invariants. | `GraphCompose.document(...)` + `DocumentSession.buildPdf()`. |
-| `com.demcha.compose.v2.*` (the entire package) | Engine-direct builders predating canonical DSL. Mixes layout vocabulary with rendering vocabulary. | Canonical DSL surface (`document.api`, `document.dsl`, `document.node`, `document.style`). |
-| `com.demcha.templates.MainPageCV`, `MainPageCvDTO`, `ModuleYml`, `TemplateBuilder` | The original CV template pre-rebuild. Replaced by `cv.presets.*` (classic) in 1.6, now slated to be replaced again by `cv.v2.*` (layered). | A `cv.v2.presets.*` preset, or direct canonical DSL authoring. |
-| Entire `cv.presets.*` package (the `classic` surface) | Superseded by `cv.v2.presets.*` (layered). Every preset on the left has a same-named layered replacement (see § 3). | `cv.v2.presets.*`. |
-| `DocumentSession.builder()` (deprecated alias) | Pre-rebuild builder entry point. | `GraphCompose.document()`. |
-| `DocumentDsl.text(...)` (deprecated alias) | Pre-rebuild text shortcut. | `paragraph(...)` builders inside `pageFlow`. |
-| `DocumentPalette.of(...)` (deprecated alias) | Pre-rebuild palette factory. | `DocumentPalette.from(...)` (or theme-specific factories). |
-| PDF-specific chrome overloads on `BusinessTheme` | Coupled CV-specific tokens with PDF-specific decisions. | Layered `BrandTheme` + render-time `pageBackgrounds(...)`. |
-| `templates.theme` + `templates.themes` (two near-identical packages) | Confusingly similar names: `theme` (singular) holds built-in theme objects (`WeeklyScheduleTheme`); `themes` (plural) holds v2 token records (`Spacing`, `Typography`). | Merge into one **singular** `templates.theme` (matching `document.theme` / `core.theme`). Deferred to 2.0 because these are public types — the package move is binary-incompatible and would fail the japicmp gate. |
+| `BlueBanner` | `BlueBanner` | `BlueBannerLetter` |
+| `BoxedSections` | `BoxedSections` | `BoxedSectionsLetter` |
+| `CenteredHeadline` | `CenteredHeadline` | `CenteredHeadlineLetter` |
+| `ClassicSerif` | `ClassicSerif` | `ClassicSerifLetter` |
+| `CompactMono` | `CompactMono` | `CompactMonoLetter` |
+| `EditorialBlue` | `EditorialBlue` | `EditorialBlueLetter` |
+| `EngineeringResume` | `EngineeringResume` | `EngineeringResumeLetter` |
+| `Executive` | `Executive` | `ExecutiveLetter` |
+| `ModernProfessional` | `ModernProfessional` | `ModernProfessionalLetter` |
+| `MonogramSidebar` | `MonogramSidebar` | `MonogramSidebarLetter` |
+| `NordicClean` | `NordicClean` | `NordicCleanLetter` |
+| `Panel` | `Panel` | `PanelLetter` |
+| `SidebarPortrait` | `SidebarPortrait` | `SidebarPortraitLetter` |
+| `TimelineMinimal` | `TimelineMinimal` | `TimelineMinimalLetter` |
+| _(layered-only)_ | `MinimalUnderlined`, `MintEditorial` | `MintEditorialLetter` |
 
-### Open questions for 2.0 (no decision yet)
+### Built-in templates → layered families
 
-- `WeeklyScheduleTemplateV1` — whether to ship a V2 along the layered
-  architecture or to deprecate weekly schedule entirely.
-- `InlineRow` / `SplittableRow` / `GridNode` decisions deferred from
-  1.7 — may unblock magazine-style multi-column flow without needing a
-  `GridNode` primitive. Tracked in the maintainers' internal release-
-  readiness notes; will surface here once a public 1.8 engine-refactor
-  roadmap is published.
+| Removed built-in | 2.0 replacement |
+|---|---|
+| `InvoiceTemplateV1` / `InvoiceTemplateV2` | `templates.invoice.presets.ModernInvoice` — `create()` or `create(BrandTheme)`, data record `InvoiceDocumentSpec`. |
+| `ProposalTemplateV1` / `ProposalTemplateV2` | `templates.proposal.presets.ModernProposal` — same shape, data record `ProposalDocumentSpec`. |
+| `WeeklyScheduleTemplateV1` | No 2.0 template yet. The `templates.data.schedule` records still ship; author the rendering on the canonical DSL. |
+
+### Legacy PDF API → canonical DSL
+
+`GraphCompose.pdf(...)`, `PdfComposer`, `com.demcha.templates.*`, and
+`com.demcha.compose.v2.*` have no 1:1 template equivalent — they were a
+PDF-authoring shortcut, not templates. The migration target is the
+canonical DSL directly: `GraphCompose.document(...)` + `pageFlow(...)` +
+`DocumentSession.buildPdf()`. The
+[v1.5 → v1.6 migration roadmap](../roadmaps/migration-v1-5-to-v1-6.md)
+walks through the swap for the common shapes.
 
 ### Maven coordinates do **not** change in 2.0
 
-The library `pom.xml` artifact id stays `graph-compose`. The Maven Central
-coordinates introduced in 1.6.6 (`io.github.demchaav:graph-compose:<X>`)
-carry through to 2.0 unchanged. The legacy JitPack URL
-(`com.github.DemchaAV:GraphCompose:v<X>`) remains resolvable for callers
-pinned to v1.6.5 and earlier but is not the documented install channel.
+The artifact stays `io.github.demchaav:graph-compose:<X>` on Maven
+Central. The legacy JitPack URL (`com.github.DemchaAV:GraphCompose:v<X>`)
+remains resolvable for callers pinned to v1.6.5 and earlier but is not
+the documented install channel.
 
 ---
 
-## 5. Cross-links
+## 4. Cross-links
 
-- **First-class architecture references**
-  - [ADR-0011 Templates v2 architecture](../adr/0011-templates-v2-architecture.md) (the `classic` surface)
-  - [ADR-0015 Layered template architecture](../adr/0015-layered-template-architecture.md) (the `layered` surface; supersedes 0011 for new families)
-- **Layered (recommended) docs**
-  - [README](v2-layered/README.md) · [Quickstart](v2-layered/quickstart.md) · [Using templates](v2-layered/using-templates.md) · [Authoring presets](v2-layered/authoring-presets.md) · [Contributor guide](v2-layered/contributor-guide.md)
-- **Classic (supported) docs**
-  - [README](v1-classic/README.md) · [Authoring](v1-classic/authoring.md)
-- **Migration roadmaps**
-  - [v1.4 → v1.5](../roadmaps/migration-v1-4-to-v1-5.md)
-  - [v1.5 → v1.6](../roadmaps/migration-v1-5-to-v1-6.md)
+- **Layered (current) docs** —
+  [README](v2-layered/README.md) · [Quickstart](v2-layered/quickstart.md) ·
+  [Using templates](v2-layered/using-templates.md) ·
+  [Authoring presets](v2-layered/authoring-presets.md) ·
+  [Contributor guide](v2-layered/contributor-guide.md)
+- **Architecture** —
+  [ADR-0015 Layered template architecture](../adr/0015-layered-template-architecture.md) ·
+  [API stability policy](../api-stability.md)
+- **Historical (archived)** —
+  [v1-classic README](v1-classic/README.md) · [v1-classic authoring](v1-classic/authoring.md) ·
+  [ADR-0011 Templates v2 architecture](../adr/0011-templates-v2-architecture.md)
+- **Migration roadmaps** —
+  [v1.4 → v1.5](../roadmaps/migration-v1-4-to-v1-5.md) ·
+  [v1.5 → v1.6](../roadmaps/migration-v1-5-to-v1-6.md)
 
 ---
 
-*This page is maintained alongside the templates surfaces. When a new
-preset, built-in, or deprecation lands, update §1 (status matrix) and
-§3 (migration table) in the same commit. The `CanonicalSurfaceGuardTest`
-documentation-coverage check enforces that no legacy API token leaks
-into this doc.*
+*When a new preset or family lands, update § 2 (status matrix) and § 3
+(migration table) in the same commit. This page is allowlisted in
+`CanonicalSurfaceGuardTest` so it may name retired API tokens — keep
+such mentions scoped to the migration guidance above.*

--- a/examples/README.md
+++ b/examples/README.md
@@ -1125,10 +1125,10 @@ from `GenerateAllExamples`** (`generate()` returns the output path),
 and **deterministic** — the same data + same code always produces the
 same bytes (verified by `LayoutSnapshotRegressionExample`).
 
-For the canonical authoring patterns — builder hierarchy, theme
-tokens, table presets, golden / anti-patterns, and a 40-line skeleton
-for new templates — read
-[**`docs/templates/v1-classic/authoring.md`**](../docs/templates/v1-classic/authoring.md)
+For the canonical authoring patterns — the layered data / theme /
+components / widgets / presets split, golden / anti-patterns, and the
+preset skeleton — read
+[**`docs/templates/v2-layered/authoring-presets.md`**](../docs/templates/v2-layered/authoring-presets.md)
 once before writing your own.
 
 ## Where things live
@@ -1139,5 +1139,5 @@ once before writing your own.
 | `examples/src/main/java/com/demcha/examples/support/` | Reusable helpers (`ExampleOutputPaths`, `WeeklyScheduleRenderer`) |
 | `examples/target/generated-pdfs/` | Output of running the examples (gitignored) |
 | `assets/readme/examples/` | Committed PDF previews linked from this gallery |
-| `docs/templates/v1-classic/authoring.md` | Template authoring cheatsheet |
+| `docs/templates/v2-layered/authoring-presets.md` | Template authoring cheatsheet |
 | `CHANGELOG.md` | Per-version surface changes (every example link is current to v1.6) |

--- a/src/test/java/com/demcha/documentation/DocumentationCoverageTest.java
+++ b/src/test/java/com/demcha/documentation/DocumentationCoverageTest.java
@@ -139,12 +139,13 @@ class DocumentationCoverageTest {
     void readmeShouldUseCanonicalDslAndAvoidLegacyApis() throws IOException {
         String readme = Files.readString(PROJECT_ROOT.resolve("README.md"));
 
-        // Canonical-DSL fingerprints — the slim v1.5 landing README must
-        // surface at least one example using the canonical authoring path.
+        // Canonical-DSL fingerprints — the slim landing README must
+        // surface at least one example using the canonical authoring path,
+        // including styled text (the hero snippet).
         assertThat(readme).contains("GraphCompose.document(");
         assertThat(readme).contains("DocumentSession");
         assertThat(readme).contains("document.pageFlow(");
-        assertThat(readme).contains("BusinessTheme");
+        assertThat(readme).contains("DocumentTextStyle");
 
         // Legacy-API guard — the README may not advertise any retired
         // entry point, builder shape, or pre-canonical field-based CV


### PR DESCRIPTION
## Why

The 2.0 line removed the classic template presets, the built-in `*Template` classes, `BusinessTheme`, and the legacy PDF API — but the guides still described them as shipping, supported, and in places "recommended". Third 3-13 docs slice: the conceptual/ledger docs.

## What (9 files)

- **`which-template-system.md`** — rewritten slim (238 → 130 lines): the naming history ("classic" / "Templates v2" / built-ins / legacy PDF API, all with their 2.0 fate) + a migration map for pre-2.0 callers — classic presets → same-named layered presets (full 16-row table kept), built-ins → `ModernInvoice`/`ModernProposal`, legacy PDF API → canonical DSL. Every named class/factory/package fact-checked against the tree by an independent pass.
- **`api-stability.md`** — §1 Supported + Legacy tiers reworded (no package holds them on the 2.0 line; policy definitions kept); §2 sealed examples re-anchored from the deleted `Block`/`TemplateModuleBlock` to `CvSection` (+ its post-rename path); §4 tier map rebuilt to the actual packages (`templates.api`/`core`/`cv`/`coverletter`/`invoice`/`proposal`/`data`).
- **`v1-classic/{README,authoring}.md`** — 🗄️ archived banners (removed in 2.0, kept for pre-2.0 callers, nothing below updated) replacing the false "still ships / neither is deprecated" notes.
- **`README.md`** — Templates section now leads with the layered surface + the migration map; retired `InvoiceTemplateV2` mention → `ModernInvoice`. Zero `BusinessTheme` tokens remain, so the `DocumentationCoverageTest` README fingerprint follows the hero snippet (`BusinessTheme` → `DocumentTextStyle`).
- **`docs/README.md` / `v2-layered/README.md` / `examples/README.md`** — invoice/proposal author routing, "still ships, still supported", and the authoring-cheatsheet pointers fixed to the live surface.

## Follow-ups (next docs slice — bodies not touched here)

`docs/templates/business-templates.md` (whole body teaches the removed built-ins — flagged ⚠️ in the docs index for now), `capabilities.md`, `getting-started.md`, `first-document.md`, `architecture/{overview,package-map}.md`, contributing guides, and the examples/README invoice gallery prose. Also pre-existing: five public sealed types absent from the api-stability §2 list (`DocumentPaint`, `DocumentPathSegment`, `DocumentLinkTarget`, `ChartSize`, `ChartSpec`).

## Tests

`./mvnw verify javadoc:javadoc -pl .` — 1378 tests, 0 failures, javadoc clean (includes the updated `DocumentationCoverageTest`). All links in touched docs verified to resolve (295 OK; the only broken ones are inside the archived v1-classic body, pointing at deleted source — covered by the archive banner).