### PR TITLE
docs: repoint the guides from the removed template surfaces to the layered presets

### DIFF
--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -91,10 +91,6 @@ need to reach below it.
   (`DocumentTableColumn`, `DocumentTableCell`, `DocumentTableStyle`).
 - **`document.image`** — public image types
   (`DocumentImageData`, `DocumentImageFitMode`).
-- **`document.theme`** — `BusinessTheme` design tokens
-  (`DocumentPalette`, `SpacingScale`, `TextScale`, `TablePreset`). The
-  layered CV theme `BrandTheme` lives separately under
-  `…templates.core.theme`.
 - **`document.output`** — backend-neutral output options
   (`DocumentMetadata`, `DocumentWatermark`, `DocumentProtection`,
   `DocumentHeaderFooter`).
@@ -117,29 +113,26 @@ need to reach below it.
 
 ## Template layer (`com.demcha.compose.document.templates.*`)
 
-Built-in templates compose against the canonical authoring layer using
-the same `DocumentDsl` an application would use directly.
+Templates compose against the canonical authoring layer using the same
+`DocumentDsl` an application would use directly.
 
-- **`...templates.api`** — template-facing contracts
-  (`InvoiceTemplate`, `ProposalTemplate`, `CvTemplate`,
-  `CoverLetterTemplate`, `WeeklyScheduleTemplate`,
-  `CvTemplateRegistry`). Compose-first: every contract takes a
-  `DocumentSession` plus the template-specific data spec.
-- **`...templates.builtins`** — concrete built-ins
-  (`InvoiceTemplateV1`, `InvoiceTemplateV2`, `ProposalTemplateV1`,
-  `ProposalTemplateV2`, `CvTemplateV1`, plus a CV gallery that takes a
-  `BusinessTheme` or `BrandTheme` in their constructor).
-- **`...templates.support`** — backend-neutral scene composers per
-  domain (`...support.cv`, `...support.business`, `...support.schedule`)
-  plus shared composition primitives in `...support.common`.
-- **`...templates.data`** — DTOs (`InvoiceDocumentSpec`,
-  `ProposalDocumentSpec`, etc.).
+- **`...templates.api`** — the `DocumentTemplate<S>` contract every
+  preset factory returns. Compose-first: `compose(DocumentSession, S)`
+  takes an open session plus the template-specific data spec.
+- **`...templates.core`** — the shared, family-neutral layer:
+  `BrandTheme` tokens (`core.theme`), neutral header bricks
+  (`core.identity`), text helpers (`core.text`), and shared widgets
+  (`core.widgets`).
+- **`...templates.<family>`** — the four preset families (`cv`,
+  `coverletter`, `invoice`, `proposal`), each a layered stack
+  (`presets` always; family `data` / `components` / `widgets` where
+  the family needs them). `ModernInvoice`, `ModernProposal`, and the
+  CV / cover-letter preset galleries live here.
+- **`...templates.data`** — family-neutral DTOs (`InvoiceDocumentSpec`,
+  `ProposalDocumentSpec`, the schedule records).
 
-V2 templates (`InvoiceTemplateV2`, `ProposalTemplateV2`) take a
-`BusinessTheme` so the same data renders through any of `classic` /
-`modern` / `executive` (or a custom theme) without touching the call
-site. V1 templates ship side-by-side for callers who want the legacy
-hard-coded look.
+Every preset takes a `BrandTheme` in its `create(...)` factory, so the
+same data renders through any theme without touching the call site.
 
 ## Shared engine foundation (`com.demcha.compose.engine.*`) — internal
 

--- a/docs/architecture/package-map.md
+++ b/docs/architecture/package-map.md
@@ -59,25 +59,15 @@ intended.
 
 | Package | Responsibility | Extension rule |
 | --- | --- | --- |
-| `com.demcha.compose.document.templates.api` | Public template interfaces and registries. | Interfaces compose into `DocumentSession`; do not add legacy composer overloads. |
-| `com.demcha.compose.document.templates.builtins` | Thin built-in template facades. | Facades choose the composer/theme and emit lifecycle logs; composition logic belongs in support packages. |
+| `com.demcha.compose.document.templates.api` | The `DocumentTemplate<S>` compose-first contract. | Templates compose into an open `DocumentSession`; do not add output decisions here. |
 | `com.demcha.compose.document.templates.data.*` | Public template specs and domain data models. | Specs should read like domain data, not layout scripts. |
-| `com.demcha.compose.document.templates.support.common` | Shared template composition primitives, module specs, link helpers, layout policy, and lifecycle logging. | Keep reusable and backend-neutral. |
-| `com.demcha.compose.document.templates.support.cv` | CV-specific scene composers. | CV layout rules belong here, not in generic business helpers. |
-| `com.demcha.compose.document.templates.support.business` | Invoice, proposal, and cover-letter scene composers and policies. | Use shared module/render paths and template layout policy. |
-| `com.demcha.compose.document.templates.support.schedule` | Schedule-specific scene composer. | Keep schedule-specific table/rhythm decisions isolated here. |
-| `com.demcha.compose.document.templates.theme` | Older shared theme *objects* for built-ins (e.g. `WeeklyScheduleTheme`). Distinct from `…templates.themes` (plural) below. | Themes carry styling decisions, not document content. New v2 token work goes in `themes`, not here. |
-| `com.demcha.compose.document.templates.themes` | Templates-v2 theme *token records* — `Spacing`, `Typography` (future `Palette`). Pure value types, no engine / session dependencies. | One source of truth per token group; keep it dependency-free. |
-| `com.demcha.compose.document.templates.components` | Gen-2 composition components — `Header`, `Module` (`MarkdownText` moved to `core.text`). | Stateless after construction; produce `DocumentNode`s. |
-| `com.demcha.compose.document.templates.blocks` | Templates-v2 module-body block kinds — `ParagraphBlock`, `BulletListBlock`, `NumberedListBlock`, `IndentedBlock`, `KeyValueBlock`, `MultiParagraphBlock`, `EducationBlock`, `WorkHistoryBlock`. | A block declares *what* content appears; the renderer expands it per active theme / tokens. |
 | `com.demcha.compose.document.templates.core.theme` | Family-neutral theme tokens — `BrandTheme` + `Palette` / `Typography` / `Spacing` / `Decoration`. | The single token source every family's presets read. |
 | `com.demcha.compose.document.templates.core.text` | Family-neutral text rendering — `MarkdownText`, `MarkdownInline`, `RichParagraphRenderer`, `TextStyles`, `TextOrnaments`. | Markdown → DSL nodes; no family data model. |
 | `com.demcha.compose.document.templates.core.identity` | Family-neutral identity — `PartyIdentity` contract + header widgets (`Headline`, `ContactLine`, `Masthead`, `Subheadline`, `SvgGlyph`) + `Contact` / `Link`. | A masthead is the same shape in every family. |
 | `com.demcha.compose.document.templates.core.widgets` | Family-neutral shared widgets + decoration primitives — `CardWidget`, `TableWidget`, `TimelineAxisWidget`, `Divider`, `AccentStrip`, `Spacer`. | Keep generic (no CV-only assumptions) so any family can reuse them. |
 
-> **Preset families.** Concrete document families live under `…templates.<family>` — `cv`, `coverletter`, `invoice`, `proposal`, `schedule`. CV and cover letter additionally ship a layered v2 surface (`…cv.v2.*` / `…coverletter.v2.*`: `data` / `theme` / `components` / `widgets` / `presets`). These per-family packages are documented by the template guides rather than enumerated here — see [which-template-system.md](../templates/which-template-system.md) for the status matrix and [templates/v2-layered/](../templates/v2-layered/README.md) for the layered architecture.
+> **Preset families.** Concrete document families live under `…templates.<family>` — `cv`, `coverletter`, `invoice`, `proposal` — each a layered stack (family data / components / widgets / presets). These per-family packages are documented by the template guides rather than enumerated here — see [which-template-system.md](../templates/which-template-system.md) for the status matrix and [templates/v2-layered/](../templates/v2-layered/README.md) for the layered architecture.
 
-> **`theme` vs `themes`.** The near-identical names are a known rough edge. `…templates.theme` (singular) is the older shared-theme-object package (built-in `WeeklyScheduleTheme`); `…templates.themes` (plural) is the Templates-v2 token-record package (`Spacing`, `Typography`). Until the two are consolidated, treat `themes` (plural) as the home for new v2 token work. The consolidation itself is a planned **2.0** change (it moves public types, so it is binary-incompatible) — tracked in the [deprecation inventory](../templates/which-template-system.md).
 
 ## Policy
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -18,7 +18,7 @@ tracks what is `Partial` or `Planned`.
 |---|---|---|---|
 | Open a document session | `GraphCompose.document(...)` → `DocumentSession` | Stable | [Your first document](first-document.md) |
 | Describe content in reading order | `pageFlow(...)`, `module(...)`, `addSection(...)` | Stable | [Getting started](getting-started.md) |
-| Maintained document templates | `InvoiceTemplateV2`, `ProposalTemplateV2`, `cv.v2.*`, `coverletter.v2.*` | Stable | [Templates](templates/which-template-system.md) |
+| Maintained document templates | `ModernInvoice`, `ModernProposal`, the `templates.cv.*` / `templates.coverletter.*` preset galleries | Stable | [Templates](templates/which-template-system.md) |
 | Reusable building blocks (helpers) | helper methods / widgets over the DSL | Stable | [Diagrams](diagrams.md#choose-your-authoring-path) |
 | Custom node / backend | `NodeDefinition`, render-handler SPI, `FixedLayoutBackend` | Extension SPI (`@Beta`) | [Extending](recipes/extending.md) |
 

--- a/docs/contributing/implementation-guide.md
+++ b/docs/contributing/implementation-guide.md
@@ -284,30 +284,30 @@ Built-in templates now use a canonical compose-first contract on top of
 Use this split:
 
 1. a public template interface in `com.demcha.compose.document.templates.api` exposes `compose(DocumentSession, ...)`
-2. a canonical built-in class under `com.demcha.compose.document.templates.builtins` exposes stable ids, names, and theme defaults
-3. a dedicated scene composer under a domain support package such as `com.demcha.compose.document.templates.support.cv` or `support.business` owns document composition through `TemplateComposeTarget`
-4. focused canonical tests and examples keep `compose(DocumentSession, ...)` stable while the scene composer owns the reusable document structure
+2. a preset class under `com.demcha.compose.document.templates.<family>.presets` exposes a stable `create(...)` factory and theme defaults
+3. the preset delegates the reusable drawing work to its family's `components` / `widgets` layers and the shared `templates.core` widgets, keeping the preset itself a thin orchestrator
+4. focused canonical tests and examples keep `compose(DocumentSession, ...)` stable while the component layer owns the reusable document structure
 
 Practical rules:
 
 - keep current `render(...): PDDocument` and `render(..., Path)` overloads only as deprecated compatibility adapters
 - keep `GraphCompose.document(...)`, page size selection, margins, `document.buildPdf()`, and `document.toPdfBytes()` in canonical examples and integrations
 - let deprecated bridge adapters call into the canonical `DocumentSession` PDF path rather than owning production layout/render logic
-- put the actual document structure, sections, tables, and paragraph assembly in the scene composer
-- keep scene composers backend-neutral: no `PDDocument`, `PDPage`, `PDRectangle`, or low-level PDF composer imports
+- put the actual document structure, sections, tables, and paragraph assembly in the family's component/widget layer
+- keep components backend-neutral: no `PDDocument`, `PDPage`, `PDRectangle`, or low-level PDF imports
 - keep public examples and integration docs compose-first: show `compose(DocumentSession, ...)` before any deprecated convenience path
-- pass theme or style collaborators into the scene composer constructor instead of hard-wiring backend assumptions into composition code
-- when a built-in template already has a good scene split, extend that pattern instead of reintroducing backend-specific logic into the composition layer
+- pass the `BrandTheme` (or style collaborators) into renderers instead of hard-wiring backend assumptions into composition code
+- when a family already has a good component split, extend that pattern instead of reintroducing backend-specific logic into the composition layer
 
 Current guard rails:
 
-- `CanonicalTemplateComposerPdfBoundaryTest` keeps scene-composition classes free of `PDDocument`, `PDPage`, `PDRectangle`, and low-level PDF composer imports
-- canonical template API tests keep `compose(DocumentSession, ...)` aligned with the built-ins
+- `PublicApiNoEngineLeakTest` keeps the public authoring surface free of engine imports; template components stay backend-neutral by construction
+- the per-family smoke and visual-parity tests keep `compose(DocumentSession, ...)` aligned with the presets
 
 Rule of thumb:
 
-- canonical `*TemplateV1` built-ins should feel like reusable public templates
-- `*TemplateComposer` plus `TemplateComposeTarget` should feel like the reusable document composition core
+- presets should feel like reusable public templates
+- the family component and widget layers (plus `templates.core`) should feel like the reusable document composition core
 
 ## Where rendering hooks in
 
@@ -448,7 +448,7 @@ Do not add a method there if the new object is only an internal helper for templ
 - container:
   [ModuleBuilder.java](./../src/test/java/com/demcha/compose/testsupport/engine/assembly/ModuleBuilder.java)
 - template-level composition helper:
-  [CvTemplateComposer.java](./../src/main/java/com/demcha/compose/document/templates/support/cv/CvTemplateComposer.java)
+  [SectionDispatcher.java](../../src/main/java/com/demcha/compose/document/templates/cv/components/SectionDispatcher.java)
 
 ## Overlay primitive: `LayerStackNode`
 

--- a/docs/first-document.md
+++ b/docs/first-document.md
@@ -83,10 +83,11 @@ hand-build it. A maintained template maps a typed data object into the same
 session, then you render as usual:
 
 ```java
-import com.demcha.compose.document.templates.builtins.InvoiceTemplateV2;
-import com.demcha.compose.document.theme.BusinessTheme;
+import com.demcha.compose.document.templates.api.DocumentTemplate;
+import com.demcha.compose.document.templates.data.invoice.InvoiceDocumentSpec;
+import com.demcha.compose.document.templates.invoice.presets.ModernInvoice;
 
-InvoiceTemplateV2 template = new InvoiceTemplateV2(BusinessTheme.modern());
+DocumentTemplate<InvoiceDocumentSpec> template = ModernInvoice.create();
 
 try (DocumentSession document = GraphCompose.document(Path.of("invoice.pdf")).create()) {
     template.compose(document, invoice);   // invoice = your InvoiceDocumentSpec

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -16,45 +16,53 @@ tree to choose the right one for the document you're rendering.
 
 | Question | Answer | Pick this layer |
 | --- | --- | --- |
-| Is your document one of the built-in shapes (CV, invoice, proposal, weekly schedule, cover letter)? | Yes | **Built-in template.** Skip ahead to "Built-in templates". |
+| Is your document one of the template families (CV, cover letter, invoice, proposal)? | Yes | **Layered template preset.** Skip ahead to "Templates". |
 | Do you need pixel-level control over a one-off PDF? | Yes | **Raw DSL** (`DocumentSession.pageFlow(...)`). |
-| Do you need a re-usable scene for a *new* business document type? | Yes | **Custom template that wraps the DSL.** Implement the `*Template` interface and re-use `BusinessTheme` for visual coherence. |
+| Do you need a re-usable scene for a *new* business document type? | Yes | **Custom template that wraps the DSL.** Implement `DocumentTemplate<S>` and take a `BrandTheme` for visual coherence. |
 
 The DSL and the templates compose against the SAME `DocumentSession`
 — a template can also live alongside hand-written DSL inside one
 session, so you don't have to commit to one layer per document.
 
-Unsure which template surface to target — layered (`cv.v2`), classic
-(`cv.presets`), or a built-in `*TemplateV2`? See
+Arriving from a pre-2.0 surface (classic presets or the built-in
+`*Template` classes)? See
 [Which template system should I use?](templates/which-template-system.md)
-for the authoritative decision tree and status matrix.
+for the naming history and the migration map.
 
 ## Quick start
 
 The shortest path to a real PDF: open a session, drop a soft-panel
-hero on the page, render. The `BusinessTheme` keeps the look
-consistent with the rest of your branded documents.
+hero on the page, render. A couple of inline colour and text-style
+constants keep the look consistent — swap them for your own brand
+values.
 
 ```java
 import com.demcha.compose.GraphCompose;
 import com.demcha.compose.document.api.DocumentSession;
-import com.demcha.compose.document.theme.BusinessTheme;
+import com.demcha.compose.document.style.DocumentColor;
+import com.demcha.compose.document.style.DocumentTextStyle;
+import com.demcha.compose.font.FontName;
 
 import java.nio.file.Path;
 
-BusinessTheme theme = BusinessTheme.modern();   // cream paper + teal/gold
+DocumentColor cream = DocumentColor.rgb(252, 248, 240);   // paper
+DocumentColor panel = DocumentColor.rgb(244, 238, 228);   // soft panel
+DocumentColor accent = DocumentColor.rgb(196, 153, 76);   // gold accent
+DocumentTextStyle h1 = DocumentTextStyle.builder()
+        .fontName(FontName.HELVETICA_BOLD).size(28)
+        .color(DocumentColor.rgb(20, 60, 75)).build();
 
 try (DocumentSession document = GraphCompose.document(Path.of("output.pdf"))
-        .pageBackground(theme.pageBackground())
+        .pageBackground(cream)
         .margin(28, 28, 28, 28)
         .create()) {
     document.pageFlow(page -> page
             .addSection("Hero", section -> section
-                    .softPanel(theme.palette().surfaceMuted(), 10, 14)
-                    .accentLeft(theme.palette().accent(), 4)
+                    .softPanel(panel, 10, 14)
+                    .accentLeft(accent, 4)
                     .addParagraph(p -> p
                             .text("GraphCompose")
-                            .textStyle(theme.text().h1()))
+                            .textStyle(h1))
                     .addParagraph("Quick-start hero block."))
             .module("Summary", module -> module.paragraph(
                     "GraphCompose composes a document graph and renders it twice — "
@@ -196,21 +204,21 @@ without the outline frame and logs a one-time capability warning. See
 [`docs/recipes/shape-as-container.md`](recipes/shape-as-container.md)
 for the full recipe.
 
-## Built-In Templates
+## Templates
 
-Built-ins compose into the same `DocumentSession`. Template data
-lives under `com.demcha.compose.document.templates.data.*`, and the
-current built-in templates live under
-`com.demcha.compose.document.templates.builtins` — `InvoiceTemplateV2`,
-`ProposalTemplateV2`, and the weekly schedule. (For CVs and cover
-letters, prefer the layered `cv.v2` / `coverletter.v2` authoring model —
-see [Templates v2 (layered) quickstart](templates/v2-layered/quickstart.md).)
+Templates compose into the same `DocumentSession`. Data specs live
+under `com.demcha.compose.document.templates.data.*`, and each family
+ships presets under `com.demcha.compose.document.templates.<family>.presets`
+— `ModernInvoice`, `ModernProposal`, and the CV / cover-letter preset
+galleries (see the
+[Templates v2 (layered) quickstart](templates/v2-layered/quickstart.md)).
 
 ```java
-import com.demcha.compose.document.templates.builtins.InvoiceTemplateV2;
-import com.demcha.compose.document.theme.BusinessTheme;
+import com.demcha.compose.document.templates.api.DocumentTemplate;
+import com.demcha.compose.document.templates.data.invoice.InvoiceDocumentSpec;
+import com.demcha.compose.document.templates.invoice.presets.ModernInvoice;
 
-InvoiceTemplateV2 template = new InvoiceTemplateV2(BusinessTheme.modern());
+DocumentTemplate<InvoiceDocumentSpec> template = ModernInvoice.create();
 
 try (DocumentSession document = GraphCompose.document(Path.of("invoice.pdf")).create()) {
     template.compose(document, invoice);   // invoice = your InvoiceDocumentSpec

--- a/docs/operations/layout-snapshot-testing.md
+++ b/docs/operations/layout-snapshot-testing.md
@@ -182,7 +182,7 @@ class InvoiceTemplateSnapshotTest {
 
     @Test
     void shouldKeepInvoiceLayoutStable() throws Exception {
-        InvoiceTemplateV2 template = new InvoiceTemplateV2(BusinessTheme.modern());
+        DocumentTemplate<InvoiceDocumentSpec> template = ModernInvoice.create();
         InvoiceDocumentSpec spec = invoiceFixture();
 
         try (DocumentSession document = GraphCompose.document()
@@ -341,11 +341,10 @@ Prioritize documents that are most sensitive to layout regressions:
 ## Examples in this repository
 
 - `RepositoryShowcaseRenderTest`
-- `SmartPaginationTest`
 - `TablePaginationIntegrationTest`
 - `FontShowcaseLayoutSnapshotTest`
-- `CvTemplateV1LayoutSnapshotTest`
-- `BuiltInTemplateLayoutSnapshotTest`
+- `ChartLayoutSnapshotTest`
+- `ShapeContainerLayoutSnapshotTest`
 - `LayoutSnapshotPublicApiDogfoodTest`
 
 ## Interpreting a mismatch

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -11,7 +11,7 @@ authoring API; public application code should not import
 | --- | --- |
 | [Charts](recipes/charts.md) | Native vector bar / line / area / pie-donut charts: data–spec–style layers, axis & grid toggles, point markers, value-label halos, legend placement, translucent area fills |
 | [Keep-together pagination](recipes/keep-together.md) | `keepTogether()` / `keepEntriesTogether()` — blocks that relocate whole instead of orphaning a heading at a page break |
-| [Themes](recipes/themes.md) | `BusinessTheme.classic / modern / executive`, page background, palette slots, text scale, the `BrandTheme` ↔ `BusinessTheme` bridge |
+| [Themes](recipes/themes.md) | `BrandTheme` token bundle (palette / typography / spacing / decoration), theme factories per family, page background, direct DSL styling |
 | [Shapes and visual primitives](recipes/shapes.md) | Filled cards, dividers, spacers, lines, ellipses, image fit modes, soft panels |
 | [Shape-as-container](recipes/shape-as-container.md) | `addCircle` / `addEllipse` / `addContainer` with `ClipPolicy` (clipped layered children) |
 | [Transforms and z-index](recipes/transforms.md) | `rotate` / `scale` mixin, per-layer `zIndex` for overlays |

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -19,7 +19,7 @@ API, with copy-pasteable snippets verified against the current release.
 | [page-backgrounds.md](page-backgrounds.md) | Per-page fills: sidebars, bands, layered tints |
 | [transforms.md](transforms.md) | Rotation, scaling, skewing |
 | [tables.md](tables.md) | Tabular layouts: columns, headers, zebra rows, composed cells |
-| [themes.md](themes.md) | `BusinessTheme` presets and custom palettes |
+| [themes.md](themes.md) | `BrandTheme` factories and custom token bundles |
 | [barcodes.md](barcodes.md) | QR / Code 128 / Code 39 / EAN / UPC / PDF417 / DataMatrix, tinting, quiet zone, card centring |
 | [images.md](images.md) | Sources (bytes/path), sizing precedence, STRETCH/CONTAIN/COVER fit modes, images in rows and cards |
 | [pdf-chrome.md](pdf-chrome.md) | Metadata, watermarks, running header/footer with `{page}/{pages}/{date}`, protection, links and outline bookmarks |

--- a/docs/recipes/shapes.md
+++ b/docs/recipes/shapes.md
@@ -125,7 +125,7 @@ document.pageFlow(page -> page
 
 ## Soft panel from a theme
 
-When you have a `BusinessTheme`, prefer `softPanel(color, radius,
+When you have a theme palette, prefer `softPanel(color, radius,
 padding)` over hand-rolled `fillColor` + `cornerRadius` + `padding`:
 it keeps the visual identity routed through the theme's palette
 slots. Full discussion in the [themes recipe](themes.md).

--- a/docs/recipes/snapshot-testing.md
+++ b/docs/recipes/snapshot-testing.md
@@ -20,7 +20,7 @@ void invoiceLayoutIsStable() throws Exception {
             .pageSize(DocumentPageSize.A4)
             .margin(DocumentInsets.of(28))
             .create()) {
-        new InvoiceTemplateV2(theme).compose(document, sampleInvoice());
+        ModernInvoice.create().compose(document, sampleInvoice());
 
         LayoutSnapshotAssertions.assertMatches(document, "templates/invoice/invoice_baseline");
     }

--- a/docs/recipes/streaming.md
+++ b/docs/recipes/streaming.md
@@ -36,7 +36,7 @@ void exportInvoice(HttpServletResponse response, InvoiceDocumentSpec invoice) th
     response.setHeader("Content-Disposition", "attachment; filename=invoice.pdf");
 
     try (DocumentSession document = GraphCompose.document().create()) {
-        new InvoiceTemplateV2(BusinessTheme.modern()).compose(document, invoice);
+        ModernInvoice.create().compose(document, invoice);
         document.writePdf(response.getOutputStream());
     }
 }

--- a/docs/recipes/themes.md
+++ b/docs/recipes/themes.md
@@ -1,113 +1,76 @@
 # Themes
 
-`BusinessTheme` bundles a `DocumentPalette`, `SpacingScale`,
-`TextScale`, `TablePreset`, and an optional page background, so
-invoice / proposal / report templates rendered through the same
-theme look like one product instead of three independently styled
-documents.
+GraphCompose has two theming levels:
 
-## Pick a built-in theme
+- **Direct DSL styling** — `DocumentColor`, `DocumentTextStyle`, and the
+  page background, for documents you author yourself on the canonical
+  DSL.
+- **`BrandTheme`** — the template token bundle (a `Palette`, a
+  `Typography`, a `Spacing`, and a `Decoration`) that every layered
+  template family reads, so an invoice, a proposal, and a CV rendered
+  through the same theme look like one product instead of three
+  independently styled documents.
 
-Three built-ins ship with the canonical surface:
+## Theme a template with `BrandTheme`
 
-```java
-import com.demcha.compose.document.theme.BusinessTheme;
-
-BusinessTheme classic   = BusinessTheme.classic();    // crisp blue + white
-BusinessTheme modern    = BusinessTheme.modern();     // cream paper + teal/gold
-BusinessTheme executive = BusinessTheme.executive();  // graphite + warm accent
-```
-
-Each theme exposes a palette, a text scale, a table preset, a
-spacing scale, and an optional page background:
+Each family ships default themes as static factories — the CV presets
+each have a matching factory (`BrandTheme.boxedClassic()`,
+`BrandTheme.nordicClean()`, `BrandTheme.executive()`, …), and the
+invoice / proposal families ship `BrandTheme.invoiceModern()` and
+`BrandTheme.proposalModern()`:
 
 ```java
-document.pageFlow(page -> page
-        .addSection("Hero", section -> section
-                .softPanel(theme.palette().surfaceMuted(), 10, 14)
-                .accentLeft(theme.palette().accent(), 4)
-                .addParagraph(p -> p
-                        .text("GraphCompose")
-                        .textStyle(theme.text().h1()))
-                .addParagraph(p -> p
-                        .text("A theme-driven hero section.")
-                        .textStyle(theme.text().body()))));
+import com.demcha.compose.document.templates.api.DocumentTemplate;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
+import com.demcha.compose.document.templates.data.invoice.InvoiceDocumentSpec;
+import com.demcha.compose.document.templates.invoice.presets.ModernInvoice;
+
+BrandTheme theme = BrandTheme.invoiceModern();
+DocumentTemplate<InvoiceDocumentSpec> template = ModernInvoice.create(theme);
 ```
 
-## Apply the page background
-
-`BusinessTheme.modern()` ships with a cream `pageBackground()`. Apply
-it on the document builder so the entire page paints with the
-theme's paper colour rather than pure white:
-
-```java
-try (DocumentSession document = GraphCompose.document(Path.of("output.pdf"))
-        .pageBackground(theme.pageBackground())
-        .margin(28, 28, 28, 28)
-        .create()) {
-    // ...
-    document.buildPdf();
-}
-```
+The same data spec renders in any theme just by passing a different
+`BrandTheme` to `create(...)` — no need to refactor call sites.
 
 ## Pick the right palette colour by role
 
-Reach for the named slots on `theme.palette()` instead of hard-coding
-hex values — this keeps the document consistent with the rest of the
-theme:
+`theme.palette()` exposes named colour slots. Reach for them instead of
+hard-coding hex values — the slot names stay stable across theme tweaks:
 
 | Slot | Typical use |
 | --- | --- |
-| `palette().accent()` | Brand accent on borders, badges, total rows |
-| `palette().surfaceMuted()` | Soft section backgrounds (`softPanel(...)`) |
-| `palette().textPrimary()` | Body copy |
-| `palette().textMuted()` | Captions, metadata |
+| `palette().ink()` | Body copy, headings |
+| `palette().muted()` | Captions, metadata, secondary text |
+| `palette().rule()` | Dividers, table strokes |
+| `palette().banner()` | Section-header bands, accent fills |
+| `palette().mainFill()` | The page background (`pageBackground(theme.palette().mainFill())`) |
 
-The exact RGB values are an implementation detail of each theme — the
-slot names stay stable across future tweaks.
+## Customize one token bundle, keep the rest
 
-## Reusable text styles via the text scale
-
-`theme.text()` returns a `TextScale` with named slots (`h1`, `h2`,
-`bodyBold`, `body`, `caption`). Use them instead of hand-rolling
-`DocumentTextStyle.builder()...` calls so your headings stay
-consistent.
+`BrandTheme` is a record of four token records — swap any one and keep
+the others:
 
 ```java
-.addParagraph(p -> p.text("Quarterly summary").textStyle(theme.text().h2()))
-.addParagraph(p -> p.text("Generated " + date).textStyle(theme.text().caption()))
+import com.demcha.compose.document.templates.core.theme.*;
+
+BrandTheme base = BrandTheme.boxedClassic();
+BrandTheme custom = new BrandTheme(
+        base.palette(),
+        base.typography(),
+        base.spacing(),
+        new Decoration("▶ ", "  ", "  ·  "));   // ▶ bullets, mid-dot separators
 ```
 
-## Layered themes for invoices and proposals
+- `Palette` — the five colour slots above.
+- `Typography` — headline / body fonts plus the point-size scale
+  (`sizeHeadline`, `sizeBody`, `sizeEntryTitle`, …).
+- `Spacing` — the vertical rhythm between sections and entries.
+- `Decoration` — bullet glyph, stacked indent, contact separator.
 
-`InvoiceTemplateV2` and `ProposalTemplateV2` (Phase E.1 / E.2) take a
-`BusinessTheme` in their constructor:
+## CV and cover-letter themes
 
-```java
-import com.demcha.compose.document.templates.builtins.InvoiceTemplateV2;
-import com.demcha.compose.document.theme.BusinessTheme;
-
-InvoiceTemplateV2 invoice = new InvoiceTemplateV2(BusinessTheme.modern());
-ProposalTemplateV2 proposal = new ProposalTemplateV2(BusinessTheme.modern());
-```
-
-The same business data (`InvoiceDocumentSpec`,
-`ProposalDocumentSpec`) renders in any of the three built-in themes
-just by passing the theme to the constructor — no need to refactor
-the call sites.
-
-The earlier `InvoiceTemplateV1` is hard-coded to a default theme via
-the static `BusinessDocumentSceneStyles`. Both V1 and V2 ship side by
-side; V2 is the cinematic theme-driven path.
-
-## CV themes
-
-CV templates are themed independently of `BusinessTheme`. The layered
-CV presets (`cv.presets.*`) carry their own theme type, `BrandTheme`
-(in `com.demcha.compose.document.templates.core.theme`), so CV tokens
-stay separate from invoice / proposal vocabulary. Each preset ships a
-default theme; render one against a `CvDocument` with its `create()`
-factory:
+CV presets pair with their theme factory by name; render one against a
+`CvDocument` with the preset's `create()` factory:
 
 ```java
 import com.demcha.compose.document.templates.api.DocumentTemplate;
@@ -127,12 +90,41 @@ the per-preset customisation knobs and
 [which template system?](../templates/which-template-system.md) for the
 full preset list.
 
+## Direct DSL styling
+
+Authoring on the canonical DSL directly, define your colours and text
+styles inline (or in a small constants class) and apply the page
+background on the document builder so the entire page paints with your
+paper colour rather than pure white:
+
+```java
+import com.demcha.compose.document.style.DocumentColor;
+import com.demcha.compose.document.style.DocumentTextStyle;
+import com.demcha.compose.font.FontName;
+
+DocumentColor cream = DocumentColor.rgb(252, 248, 240);
+DocumentColor panel = DocumentColor.rgb(244, 238, 228);
+DocumentTextStyle h1 = DocumentTextStyle.builder()
+        .fontName(FontName.HELVETICA_BOLD).size(28)
+        .color(DocumentColor.rgb(20, 60, 75)).build();
+
+try (DocumentSession document = GraphCompose.document(Path.of("output.pdf"))
+        .pageBackground(cream)
+        .margin(28, 28, 28, 28)
+        .create()) {
+    document.pageFlow(page -> page
+            .addSection("Hero", section -> section
+                    .softPanel(panel, 10, 14)
+                    .addParagraph(p -> p.text("GraphCompose").textStyle(h1))));
+    document.buildPdf();
+}
+```
+
 ## See also
 
 - [Shape-as-container](shape-as-container.md) — themed circles + cards.
 - [Tables](tables.md) — the table style overrides used by
   `headerStyle(...)`, `totalRow(...)`, and `zebra(...)` accept full
   `DocumentTableStyle` values, so they pick up theme palettes.
-- [`docs/architecture/canonical-legacy-parity.md`](../architecture/canonical-legacy-parity.md) —
-  the parity matrix lists every theme-aware style override that
-  v1.5 supports.
+- [Business templates](../templates/business-templates.md) — the
+  invoice / proposal presets that consume `BrandTheme`.

--- a/docs/templates/business-templates.md
+++ b/docs/templates/business-templates.md
@@ -1,24 +1,27 @@
-# Built-In Business Templates — Invoice & Proposal
+# Business Templates — Invoice & Proposal
 
 GraphCompose ships maintained templates for two common business
 documents: **invoices** and **proposals**. You supply a typed data
-spec, pick a `BusinessTheme`, and the template renders a consistent,
+spec, pick a `BrandTheme`, and the preset renders a consistent,
 branded document. You never position anything by hand.
 
-> For **CVs and cover letters**, use the layered `cv.v2` / `coverletter.v2`
-> model instead — see the [Templates v2 (layered) quickstart](v2-layered/quickstart.md).
-> Not sure which surface to target? See
+> For **CVs and cover letters**, use the same layered model's CV and
+> cover-letter families — see the
+> [Templates v2 (layered) quickstart](v2-layered/quickstart.md).
+> Arriving from a pre-2.0 surface? See
 > [Which template system should I use?](which-template-system.md).
 
 ## The compose-first contract
 
-Every built-in template follows the same five steps. The template owns
-the document structure; your application owns the data and the output
+Every template follows the same five steps. The preset owns the
+document structure; your application owns the data and the output
 destination.
 
 1. Build a data spec — `InvoiceDocumentSpec` or `ProposalDocumentSpec`.
-2. Choose a `BusinessTheme` (commonly `BusinessTheme.modern()`).
-3. Create the template with the theme.
+2. Choose a `BrandTheme` (each family ships a default —
+   `BrandTheme.invoiceModern()`, `BrandTheme.proposalModern()`).
+3. Ask the preset for a template — `ModernInvoice.create(theme)`
+   returns a `DocumentTemplate<InvoiceDocumentSpec>`.
 4. Open a `DocumentSession`.
 5. `template.compose(document, spec)`, then render.
 
@@ -31,9 +34,10 @@ decides file vs stream vs bytes. The caller does.
 import com.demcha.compose.GraphCompose;
 import com.demcha.compose.document.api.DocumentPageSize;
 import com.demcha.compose.document.api.DocumentSession;
-import com.demcha.compose.document.templates.builtins.InvoiceTemplateV2;
+import com.demcha.compose.document.templates.api.DocumentTemplate;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.data.invoice.InvoiceDocumentSpec;
-import com.demcha.compose.document.theme.BusinessTheme;
+import com.demcha.compose.document.templates.invoice.presets.ModernInvoice;
 
 import java.nio.file.Path;
 
@@ -63,21 +67,22 @@ InvoiceDocumentSpec invoice = InvoiceDocumentSpec.builder()
         .footerNote("Thank you for your business.")
         .build();
 
-BusinessTheme theme = BusinessTheme.modern();
-InvoiceTemplateV2 template = new InvoiceTemplateV2(theme);
+BrandTheme theme = BrandTheme.invoiceModern();
+DocumentTemplate<InvoiceDocumentSpec> template = ModernInvoice.create(theme);
 
+float margin = (float) ModernInvoice.RECOMMENDED_MARGIN;
 try (DocumentSession document = GraphCompose.document(Path.of("invoice.pdf"))
         .pageSize(DocumentPageSize.A4)
-        .pageBackground(theme.pageBackground())
-        .margin(28, 28, 28, 28)
+        .pageBackground(theme.palette().mainFill())
+        .margin(margin, margin, margin, margin)
         .create()) {
     template.compose(document, invoice);
     document.buildPdf();
 }
 ```
 
-The template renders a masthead with the invoice metadata, two-column
-seller / buyer blocks, a zebra-striped line-item table with summary and
+The preset renders a masthead with the invoice metadata, two-column
+seller / buyer blocks, a themed line-item table with summary and
 total rows, and a notes / payment-terms footer.
 
 ## Proposal
@@ -90,9 +95,10 @@ project scope rather than billing. The timeline takes a three-argument
 import com.demcha.compose.GraphCompose;
 import com.demcha.compose.document.api.DocumentPageSize;
 import com.demcha.compose.document.api.DocumentSession;
-import com.demcha.compose.document.templates.builtins.ProposalTemplateV2;
+import com.demcha.compose.document.templates.api.DocumentTemplate;
+import com.demcha.compose.document.templates.core.theme.BrandTheme;
 import com.demcha.compose.document.templates.data.proposal.ProposalDocumentSpec;
-import com.demcha.compose.document.theme.BusinessTheme;
+import com.demcha.compose.document.templates.proposal.presets.ModernProposal;
 
 import java.nio.file.Path;
 
@@ -120,13 +126,14 @@ ProposalDocumentSpec proposal = ProposalDocumentSpec.builder()
         .footerNote("Prepared with GraphCompose.")
         .build();
 
-BusinessTheme theme = BusinessTheme.modern();
-ProposalTemplateV2 template = new ProposalTemplateV2(theme);
+BrandTheme theme = BrandTheme.proposalModern();
+DocumentTemplate<ProposalDocumentSpec> template = ModernProposal.create(theme);
 
+float margin = (float) ModernProposal.RECOMMENDED_MARGIN;
 try (DocumentSession document = GraphCompose.document(Path.of("proposal.pdf"))
         .pageSize(DocumentPageSize.A4)
-        .pageBackground(theme.pageBackground())
-        .margin(28, 28, 28, 28)
+        .pageBackground(theme.palette().mainFill())
+        .margin(margin, margin, margin, margin)
         .create()) {
     template.compose(document, proposal);
     document.buildPdf();
@@ -138,18 +145,19 @@ try (DocumentSession document = GraphCompose.document(Path.of("proposal.pdf"))
 In production the spec usually comes from application data and the
 document is streamed to the caller's stream. The template composes the
 same way before any output method; create one session per request.
+`create()` without arguments uses the family's default theme.
 
 ```java
 import com.demcha.compose.GraphCompose;
 import com.demcha.compose.document.api.DocumentSession;
-import com.demcha.compose.document.templates.builtins.InvoiceTemplateV2;
+import com.demcha.compose.document.templates.api.DocumentTemplate;
 import com.demcha.compose.document.templates.data.invoice.InvoiceDocumentSpec;
-import com.demcha.compose.document.theme.BusinessTheme;
+import com.demcha.compose.document.templates.invoice.presets.ModernInvoice;
 
 import java.io.OutputStream;
 
 void streamInvoice(InvoiceDocumentSpec invoice, OutputStream out) throws Exception {
-    InvoiceTemplateV2 template = new InvoiceTemplateV2(BusinessTheme.modern());
+    DocumentTemplate<InvoiceDocumentSpec> template = ModernInvoice.create();
 
     try (DocumentSession document = GraphCompose.document().create()) {
         template.compose(document, invoice);
@@ -164,16 +172,19 @@ If the built-in structure is close but not exact, prefer these moves in
 order:
 
 1. Check whether the spec already has the field you need.
-2. Change the `BusinessTheme` (or its tokens) for branding.
+2. Change the `BrandTheme` — swap a whole factory, or replace one token
+   bundle (`Palette` / `Typography` / `Spacing` / `Decoration`) and keep
+   the rest. See [Recipes — themes](../recipes/themes.md).
 3. Wrap the template call with session-level PDF chrome — a footer,
    metadata, or protection — see [Getting started](../getting-started.md).
-4. Only fork or write a new template when the document *structure* itself
-   differs. A custom template implements the same `DocumentTemplate<T>`
-   contract and composes into the same session.
+4. Only fork or write a new preset when the document *structure* itself
+   differs. A custom template implements the same `DocumentTemplate<S>`
+   contract and composes into the same session — see
+   [authoring presets](v2-layered/authoring-presets.md).
 
 ## See also
 
-- [Which template system should I use?](which-template-system.md) — the full decision tree.
+- [Which template system should I use?](which-template-system.md) — naming history + the pre-2.0 migration map.
 - [Templates v2 (layered) quickstart](v2-layered/quickstart.md) — CVs and cover letters.
-- [Recipes — themes](../recipes/themes.md) — customizing `BusinessTheme`.
+- [Recipes — themes](../recipes/themes.md) — customizing `BrandTheme`.
 - [Streaming](../recipes/streaming.md) — server output patterns.

--- a/examples/README.md
+++ b/examples/README.md
@@ -56,8 +56,8 @@ are with the canonical DSL, then jump to its detailed section below.
 
 | Example | What it shows | Preview · Source |
 |---|---|---|
-| [CV — single template](#cv-single-template) | One CV via `ModernProfessional.create(BusinessTheme.modern())` (Templates v2) | [PDF](../assets/readme/examples/cv-modern-professional.pdf) · [Source](src/main/java/com/demcha/examples/templates/cv/CvFileExample.java) |
-| [Invoice — cinematic V2](#invoice-cinematic-v2) | `InvoiceTemplateV2 + BusinessTheme.modern()` — the recommended invoice path | [PDF](../assets/readme/examples/invoice-cinematic.pdf) · [Source](src/main/java/com/demcha/examples/templates/invoice/InvoiceCinematicFileExample.java) |
+| [CV — single template](#cv-single-template) | One CV via `ModernProfessional.create()` on a `CvDocument` | [PDF](../assets/readme/examples/cv-modern-professional.pdf) · [Source](src/main/java/com/demcha/examples/templates/cv/CvFileExample.java) |
+| [Invoice — cinematic V2](#invoice-cinematic-v2) | `ModernInvoice + BrandTheme.invoiceModern()` — the recommended invoice path | [PDF](../assets/readme/examples/invoice-cinematic.pdf) · [Source](src/main/java/com/demcha/examples/templates/invoice/InvoiceCinematicFileExample.java) |
 | [Cover Letter](#cover-letter) | One-page `BusinessTheme.modern()` cover letter with section presets | [PDF](../assets/readme/examples/cover-letter.pdf) · [Source](src/main/java/com/demcha/examples/templates/coverletter/CoverLetterFileExample.java) |
 | [Module-first Profile](#module-first-profile) | Authoring directly against `DocumentSession.module(...).paragraph(...)` — DSL-direct, no template | [PDF](../assets/readme/examples/module-first-profile.pdf) · [Source](src/main/java/com/demcha/examples/flagships/ModuleFirstFileExample.java) |
 | **Engine Showcase** | Single-page cinematic brand promo — semantic-graph → polished-PDFs visual metaphor with rounded clip frame, magazine headline lockup, KPI cards, capability columns; source of the README hero image | [Source](src/main/java/com/demcha/examples/flagships/EngineShowcase.java) |
@@ -90,7 +90,7 @@ are with the canonical DSL, then jump to its detailed section below.
 |---|---|---|
 | [CV — template gallery](#cv-template-gallery) | The v2 CV presets in one orchestrated run | [Source](src/main/java/com/demcha/examples/templates/cv/CvTemplateGalleryFileExample.java) |
 | [Cover letter — template gallery](#cover-letter-template-gallery) | All paired v2 cover-letter presets in one orchestrated run | [Source](src/main/java/com/demcha/examples/templates/coverletter/CoverLetterTemplateGalleryFileExample.java) |
-| [Proposal — cinematic V2](#proposal-cinematic-v2) | `ProposalTemplateV2 + BusinessTheme.modern()` | [PDF](../assets/readme/examples/proposal-cinematic.pdf) · [Source](src/main/java/com/demcha/examples/templates/proposal/ProposalCinematicFileExample.java) |
+| [Proposal — cinematic V2](#proposal-cinematic-v2) | `ModernProposal + BrandTheme.proposalModern()` | [PDF](../assets/readme/examples/proposal-cinematic.pdf) · [Source](src/main/java/com/demcha/examples/templates/proposal/ProposalCinematicFileExample.java) |
 
 ### 🔧 Advanced SPI
 
@@ -194,11 +194,10 @@ document.buildPdf();
 
 ### CV — single template
 
-One CV rendered through the Templates v2 surface:
-`ModernProfessional.create(BusinessTheme.modern())` paired with a
-`CvSpec` data shape. The preset is one final class with one
-`create(BusinessTheme)` factory — copy-and-tweak rather than
-fork-a-monolith.
+One CV rendered through the layered template surface:
+`ModernProfessional.create()` paired with a `CvDocument` data shape.
+The preset is one final class with `create()` / `create(BrandTheme)`
+factories — copy-and-tweak rather than fork-a-monolith.
 
 [📄 View PDF](../assets/readme/examples/cv-modern-professional.pdf) ·
 [📜 Full source](src/main/java/com/demcha/examples/templates/cv/CvFileExample.java)
@@ -237,23 +236,24 @@ one-liner factory (`ModernProfessionalLetter.create()`,
 
 ---
 
-## Cinematic templates (v1.5)
+## Cinematic templates
 
 ### Invoice — cinematic V2
 
-`InvoiceTemplateV2(BusinessTheme.modern())` — the cinematic invoice.
-Hero `softPanel` with invoice number / dates / inline rich-text status,
-two-column parties row, themed line-items table with `headerStyle` +
-zebra + totals + `repeatHeader()`, footer row with `accentLeft` strips.
+`ModernInvoice.create(BrandTheme.invoiceModern())` — the cinematic
+invoice. Hero panel with invoice number / dates / status, two-column
+parties row, themed line-items table with header + totals, footer
+notes and payment terms.
 
 ```java
-BusinessTheme theme = BusinessTheme.modern();
-InvoiceTemplateV2 template = new InvoiceTemplateV2(theme);
+BrandTheme theme = BrandTheme.invoiceModern();
+DocumentTemplate<InvoiceDocumentSpec> template = ModernInvoice.create(theme);
 
+float margin = (float) ModernInvoice.RECOMMENDED_MARGIN;
 try (DocumentSession document = GraphCompose.document(outputFile)
         .pageSize(DocumentPageSize.A4)
-        .pageBackground(theme.pageBackground())
-        .margin(28, 28, 28, 28)
+        .pageBackground(theme.palette().mainFill())
+        .margin(margin, margin, margin, margin)
         .create()) {
     template.compose(document, invoice);
     document.buildPdf();
@@ -265,10 +265,10 @@ try (DocumentSession document = GraphCompose.document(outputFile)
 
 ### Proposal — cinematic V2
 
-`ProposalTemplateV2` — same `BusinessTheme`-driven pattern as the
+`ModernProposal` — same `BrandTheme`-driven pattern as the
 invoice. Hero rounded only on the right (`DocumentCornerRadius.right(...)`),
 themed executive-summary panel, sender / recipient parties row,
-`theme.text().h2()` headings, timeline + pricing tables with
+themed headings, timeline + pricing tables with
 `repeatHeader()`, zebra rows, and a `totalRow(...)`.
 
 [📄 View PDF](../assets/readme/examples/proposal-cinematic.pdf) ·
@@ -893,10 +893,9 @@ public ResponseEntity<StreamingResponseBody> invoice(@PathVariable Long id) {
     StreamingResponseBody body = response -> {
         try (DocumentSession document = GraphCompose.document()
                 .pageSize(DocumentPageSize.A4)
-                .pageBackground(BusinessTheme.modern().pageBackground())
                 .margin(28, 28, 28, 28)
                 .create()) {
-            new InvoiceTemplateV2(BusinessTheme.modern()).compose(document, spec);
+            ModernInvoice.create().compose(document, spec);
             document.writePdf(response);   // streams directly, no in-memory PDF
         }
     };
@@ -961,7 +960,7 @@ in-test usage.
 
 ```java
 DocumentSession document = GraphCompose.document(outputFile)…create();
-new InvoiceTemplateV2(theme).compose(document, spec);
+ModernInvoice.create().compose(document, spec);
 
 String snapshot = LayoutSnapshotJson.toJson(document.layoutSnapshot());
 String baseline = Files.readString(baselinePath);


### PR DESCRIPTION
## Why

After the classic/built-in/legacy removals, the how-to and architecture guides still taught the removed surfaces as current — `first-document.md` shipped a live `import …templates.builtins.InvoiceTemplateV2` snippet, `business-templates.md`'s whole body was the built-ins contract, and the examples gallery called the deleted `InvoiceTemplateV2 + BusinessTheme.modern()` "the recommended invoice path". Final 3-13 docs slice: a reader following any guide now lands on the live API.

## What (15 files)

- **`business-templates.md` + `recipes/themes.md`** — rewritten around `ModernInvoice`/`ModernProposal` on `BrandTheme` (data-spec builders were still accurate and stay); themes now covers the `BrandTheme` token bundle (`Palette`/`Typography`/`Spacing`/`Decoration`), per-family factories, and direct DSL styling.
- **`getting-started.md`** — inline-values hero (matching the README hero), Templates section on `ModernInvoice.create()`, decision-table rows on `DocumentTemplate<S>` + `BrandTheme`.
- **`architecture/overview.md` + `package-map.md`** — template layer rebuilt to the actual packages (`api`/`core`/`<family>`/`data`); rows for the nine deleted packages and the theme-vs-themes note removed.
- **`first-document.md`, `capabilities.md`, recipes index rows, `streaming`/`shapes`/`snapshot-testing` recipes, `layout-snapshot-testing.md`, contributing implementation guide** — snippet/prose swaps; dead test names (`SmartPaginationTest`, `CvTemplateV1LayoutSnapshotTest`, `BuiltInTemplateLayoutSnapshotTest`) and dead refs (`TemplateComposeTarget`, `CvTemplateComposer`, `CanonicalTemplateComposerPdfBoundaryTest`) replaced with existing ones.
- **`examples/README.md`** — gallery rows/snippets now match what the linked example sources actually do; mentions of the examples-local `BusinessTheme` styling helper are kept where examples genuinely use it.

Every rewritten snippet was independently fact-checked against the tree (builder methods, factories, token records, DSL calls — all verified to exist); the checker's three prose-leftover findings were fixed in-pass.

## Tests

Docs only. Documentation guards (`DocumentationCoverageTest`, `CanonicalSurfaceGuardTest`, `VersionConsistencyGuardTest`, `PackageMapGuardTest`, `DocumentationExamplesTest`) — 34 tests, 0 failures.

## Follow-up (pre-existing, untouched)

`implementation-guide.md`/`recipes.md` carry ~43 wrong-`../`-depth links to engine sources (predating this change); five public sealed types are missing from the `api-stability.md` §2 list.