### PR TITLE
test: guard the layered template surface against PDFBox and engine leaks

### DIFF
--- a/src/test/java/com/demcha/documentation/PdfBackendIsolationGuardTest.java
+++ b/src/test/java/com/demcha/documentation/PdfBackendIsolationGuardTest.java
@@ -15,8 +15,10 @@ import java.util.TreeSet;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Architectural guard that keeps PDFBox out of the canonical document API and
- * non-PDF fixed-layout contracts.
+ * Architectural guard that keeps PDFBox out of the canonical document API, the
+ * layered template surface, and non-PDF fixed-layout contracts. Templates
+ * compose against the canonical DSL and must stay backend-neutral, so a preset
+ * or component that reached for a PDFBox type would fail here.
  */
 class PdfBackendIsolationGuardTest {
 
@@ -34,6 +36,7 @@ class PdfBackendIsolationGuardTest {
             PROJECT_ROOT.resolve("src/main/java/com/demcha/compose/document/image"),
             PROJECT_ROOT.resolve("src/main/java/com/demcha/compose/document/layout"),
             PROJECT_ROOT.resolve("src/main/java/com/demcha/compose/document/snapshot"),
+            PROJECT_ROOT.resolve("src/main/java/com/demcha/compose/document/templates"),
             PROJECT_ROOT.resolve("src/main/java/com/demcha/compose/document/backend/fixed"));
 
     @Test

--- a/src/test/java/com/demcha/documentation/PublicApiNoEngineLeakTest.java
+++ b/src/test/java/com/demcha/documentation/PublicApiNoEngineLeakTest.java
@@ -45,6 +45,7 @@ class PublicApiNoEngineLeakTest {
             PROJECT_ROOT.resolve("src/main/java/com/demcha/compose/document/snapshot"),
             PROJECT_ROOT.resolve("src/main/java/com/demcha/compose/document/exceptions"),
             PROJECT_ROOT.resolve("src/main/java/com/demcha/compose/document/emoji"),
+            PROJECT_ROOT.resolve("src/main/java/com/demcha/compose/document/templates"),
             PROJECT_ROOT.resolve("src/main/java/com/demcha/compose/font"));
 
     /**


### PR DESCRIPTION
## Why

The layered template packages (`templates.{core,cv,coverletter,invoice,proposal,data}`) are backend-neutral and engine-clean by construction — but nothing enforced it. Both architectural guards scanned the rest of the public surface while **skipping `document.templates`**, which is exactly how the old `CanonicalTemplateComposerPdfBoundaryTest` (it only covered the now-removed `templates.support` composers, #278) vanished with no replacement.

## What

Extend the two **existing** guards with `document/templates` as a scanned root (no new near-duplicate test):

- **`PdfBackendIsolationGuardTest`** — no `org.apache.pdfbox.*` imports or references. Javadoc updated to name the template surface.
- **`PublicApiNoEngineLeakTest`** — no `import com.demcha.compose.engine.*`.

The surface is clean today, so both pass. A preset or component that reached for a PDFBox or engine type would now fail the build, naming the offending file.

## Tests

`./mvnw verify -pl .` — 1378 tests, 0 failures. **Negatively verified**: injecting `org.apache.pdfbox.*` into `ModernInvoice` makes `PdfBackendIsolationGuardTest` fail and report the file; reverted.