### PR TITLE
docs: declare the 2.0 module split in the stability ledger and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,19 @@ for this cycle.
   `invoice`, and `proposal`. Update imports accordingly — behaviour and rendering are
   unchanged; this is a package rename only.
 
+### Packaging
+
+- 2.0 splits the single `graph-compose` jar into modules: a lean core
+  (`graph-compose`), pluggable render backends (`graph-compose-render-pdf`,
+  `graph-compose-render-docx`), `graph-compose-templates`, and
+  `graph-compose-testing`, with render backends discovered via a `ServiceLoader`
+  SPI. The `graph-compose` artifact keeps its coordinate but no longer contains
+  the PDF backend or the templates — add `graph-compose-render-pdf` for PDF
+  output, or depend on `graph-compose-bundle` for a batteries-included coordinate
+  (core + render-pdf + templates + fonts + emoji). The optional
+  `graph-compose-fonts` and `graph-compose-emoji` artifacts are unchanged. Full
+  install guidance ships with 2.0.0.
+
 ## v1.9.0 — 2026-06-29
 
 In-document navigation. Rendered PDFs can now declare named **anchors** and

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -181,6 +181,7 @@ window starts, and its `Status` flips to `deprecated 1.x`.
 | Element | Tier now | Status | Why the 1.x shape is a compromise | 2.0 action | ADR | Issue |
 |---|---|---|---|---|---|---|
 | `DocumentSession.pageMargins(List<PageMarginRule>)` / `PageMarginRule` | Stable | planned | Per-page margins resolve a block's content width by the page it *begins* on (the engine measures each block once, before pagination). A margin that changes the content width therefore does not re-wrap a block mid-flow across a page boundary. | Revisit a page-aware per-line/per-fragment width model so a block can re-wrap when it crosses a margin boundary, if demand warrants. | — | — |
+| `io.github.demchaav:graph-compose` single-jar packaging | Stable | planned | The one published jar bundles the engine, the PDFBox render backend, the POI semantic backend, zxing, and the template families, so an engine-only or bring-your-own-backend consumer still pulls all of them. | Split into a lean `graph-compose` core plus sibling artifacts — `graph-compose-render-pdf`, `graph-compose-render-docx`, `graph-compose-templates`, `graph-compose-testing` — with render backends discovered via a `ServiceLoader` SPI. `graph-compose` keeps its coordinate but no longer contains the PDF backend or templates; add `graph-compose-render-pdf` (or the batteries-included `graph-compose-bundle`) to keep PDF output. | — | — |
 
 ---
 

--- a/web/index.html
+++ b/web/index.html
@@ -59,7 +59,7 @@
         "programmingLanguage": "Java",
         "softwareVersion": "2.0.0",
         "url": "https://demchaav.github.io/GraphCompose/",
-        "downloadUrl": "https://central.sonatype.com/artifact/io.github.demchaav/graph-compose/1.9.0",
+        "downloadUrl": "https://central.sonatype.com/artifact/io.github.demchaav/graph-compose/2.0.0",
         "image": "https://demchaav.github.io/GraphCompose/assets/logo/graphcompose-logo.png",
         "license": "https://github.com/DemchaAV/GraphCompose/blob/main/LICENSE",
         "author": {


### PR DESCRIPTION
## Why

First step of the 2.0 modularization (Maven module split) — **declare it publicly before any code moves**, so the breaking change is on record for the migration guide.

## What

- **`docs/api-stability.md` §3** (2.0 breaking-changes ledger) — a row for the `graph-compose` single-jar → multi-module split: lean core keeps the coordinate but sheds the PDF backend / templates; add `graph-compose-render-pdf` (or `graph-compose-bundle`) for PDF output.
- **`CHANGELOG.md` v2.0.0 Planned** — a `### Packaging` note describing the module set (`graph-compose`, `-render-pdf`, `-render-docx`, `-templates`, `-testing`, `-bundle`) and the ServiceLoader backend discovery.
- **`web/index.html`** — align the schema `downloadUrl` with the `2.0.0` `softwareVersion` it sits next to (was a stale `1.9.0`).

No production code. This is PR-A0 of the modularization phase plan.

## Tests

Doc guards — `VersionConsistencyGuardTest`, `CanonicalSurfaceGuardTest`, `DocumentationCoverageTest`, `DocumentationSnippetCompileTest`, `PackageMapGuardTest` — 26 tests, 0 failures.