### PR TITLE
build: drop the unused zxing:javase dependency and decouple two cross-module javadoc refs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,12 +210,6 @@
             <version>${zxing.version}</version>
         </dependency>
 
-        <dependency>
-            <groupId>com.google.zxing</groupId>
-            <artifactId>javase</artifactId>
-            <version>${zxing.version}</version>
-        </dependency>
-
         <!-- Test dependencies -->
         <!--
             The bundled Google fonts (graph-compose-fonts) are NOT a dependency

--- a/src/main/java/com/demcha/compose/engine/debug/LayoutSnapshot.java
+++ b/src/main/java/com/demcha/compose/engine/debug/LayoutSnapshot.java
@@ -6,7 +6,7 @@ import java.util.List;
  * Deterministic, renderer-agnostic snapshot of a fully resolved document.
  *
  * <p>Instances of this record are produced by
- * {@link com.demcha.compose.document.api.DocumentSession#layoutSnapshot()}
+ * {@code DocumentSession#layoutSnapshot()}
  * after layout and pagination have completed, but before the PDF renderer
  * draws anything. The record is intended for debugging, layout-regression
  * tests, and tooling that needs geometry rather than rendered pixels.</p>

--- a/src/main/java/com/demcha/compose/font/FontLibrary.java
+++ b/src/main/java/com/demcha/compose/font/FontLibrary.java
@@ -15,7 +15,7 @@ import java.util.function.Supplier;
  * <p>{@code FontLibrary} maps logical {@link FontName} values to concrete
  * backend font objects. Public authoring code deals only with logical names;
  * measurement and rendering phases resolve those names through typed backend
- * lookups such as {@code getFont(name, PdfFont.class)}.</p>
+ * lookups keyed by the backend's own font {@code Class} token.</p>
  *
  * <p>The library supports both eagerly registered fonts and lazily created
  * fonts through factories.</p>


### PR DESCRIPTION
## Why

The published `graph-compose` jar declares `com.google.zxing:javase`, but nothing in the codebase uses it — it is dead weight in every consumer's transitive tree. Ahead of the 2.0 module split, two javadoc references also reach across the future engine ↔ document boundary and would stop resolving once those packages live in separate modules. This PR is pure hygiene: zero behaviour change.

## What changed

- **Drop `com.google.zxing:javase`.** Only `zxing:core` types are imported anywhere (the barcode/QR render handlers under `document.backend.fixed.pdf.handlers` and the legacy `engine.render.pdf.ecs.handlers`). There are zero `com.google.zxing.client` references in `src`, `examples`, or `benchmarks`. `zxing:core` stays; the `zxing.version` property is retained for it.
- **`engine/debug/LayoutSnapshot.java`** — convert the engine→document `{@link com.demcha.compose.document.api.DocumentSession#layoutSnapshot()}` to `{@code DocumentSession#layoutSnapshot()}`, which reads the same but does not fail to resolve once engine and document are separate modules.
- **`font/FontLibrary.java`** — reword the `getFont(name, PdfFont.class)` javadoc example to be backend-neutral ("keyed by the backend's own `Class` token"), so the core font javadoc stops naming a PDF-backend type.

## Verification

- `./mvnw verify -pl .` — green (full suite). The barcode/QR render tests pass with `javase` **off** the classpath, which is the runtime proof the removal is safe, not just that its imports were unused.
- **Byte-identity:** `target/classes` is byte-for-byte identical to the base branch (960 classes, empty `diff -rq`). Production bytecode is unchanged; only the pom dependency list and javadoc source text differ.
- `./mvnw javadoc:javadoc -pl .` — clean, zero warnings, confirming the `{@code}` conversions don't regress the doclint gate.