### PR TITLE
build: consume bundled fonts/emoji as test-scope artifacts instead of sibling source

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,12 @@
         <mockito.version>5.23.0</mockito.version>
         <byteBuddy.version>1.18.10</byteBuddy.version>
 
+        <!-- Bundled fonts / emoji, pulled in at test scope only. Pinned to the
+             independent 1.0.0 line (not bumped in engine lockstep); keep in step
+             with bundle/pom.xml's graphcompose.fonts.version. -->
+        <graphcompose.fonts.version>1.0.0</graphcompose.fonts.version>
+        <graphcompose.emoji.version>1.0.0</graphcompose.emoji.version>
+
         <!-- Build plugins -->
         <central.publishing.plugin.version>0.11.0</central.publishing.plugin.version>
         <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
@@ -212,15 +218,27 @@
 
         <!-- Test dependencies -->
         <!--
-            The bundled Google fonts (graph-compose-fonts) are NOT a dependency
-            of the engine — not even at test scope. The engine's visual /
-            snapshot suite renders with them, but they are placed on the TEST
-            classpath directly from the sibling module's source via the
-            <testResources> entry in <build> below. This keeps the engine fully
-            decoupled from the fonts ARTIFACT (no Maven coordinate to resolve, so
-            an engine-only build never needs the fonts jar published or installed
-            first), while still exercising the real font binaries.
+            The bundled Google fonts and colour-emoji glyphs live in the sibling
+            graph-compose-fonts / graph-compose-emoji modules and are pulled in at
+            TEST scope so the engine's visual / snapshot / emoji suites render with
+            the real binaries. Test scope is not transitive, so the engine's own
+            published jar stays fonts-free — an engine consumer never drags these
+            in. A reactor build satisfies them from the just-built siblings; a
+            standalone `-pl .` build resolves the published 1.0.0 artifacts.
         -->
+        <dependency>
+            <groupId>io.github.demchaav</groupId>
+            <artifactId>graph-compose-fonts</artifactId>
+            <version>${graphcompose.fonts.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.github.demchaav</groupId>
+            <artifactId>graph-compose-emoji</artifactId>
+            <version>${graphcompose.emoji.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
@@ -288,33 +306,16 @@
 
     <build>
         <testResources>
-            <!-- Default test resources. -->
+            <!--
+                Default test resources only. The bundled Google fonts and
+                colour-emoji glyphs are no longer copied in from the sibling
+                source dirs — they reach the test classpath via the
+                graph-compose-fonts / graph-compose-emoji test-scope artifacts
+                (see <dependencies> above), which package the same
+                src/main/resources layout, so classpath lookups are unchanged.
+            -->
             <testResource>
                 <directory>src/test/resources</directory>
-            </testResource>
-            <!--
-                Bundled Google fonts live in the sibling graph-compose-fonts
-                module since v1.8.0. The engine's visual / snapshot suite renders
-                with them, so put that module's resources on the TEST classpath
-                directly from source. This decouples the engine build from the
-                fonts ARTIFACT (no Maven dependency to resolve, so no CI/local
-                bootstrap is needed) while still exercising the real binaries.
-                Test-only: it never reaches the main jar (built from
-                src/main/resources) and is excluded from the tests-jar below.
-            -->
-            <testResource>
-                <directory>${project.basedir}/fonts/src/main/resources</directory>
-            </testResource>
-            <!--
-                Colour-emoji glyphs live in the sibling graph-compose-emoji module
-                (same arrangement as fonts above). EmojiLibrary resolves them from
-                the classpath, so the resolver suite reads that module's resources
-                directly from source — decoupling the engine build from the emoji
-                ARTIFACT (no Maven dependency to resolve). Test-only: never reaches
-                the main jar and is excluded from the tests-jar below.
-            -->
-            <testResource>
-                <directory>${project.basedir}/emoji/src/main/resources</directory>
             </testResource>
         </testResources>
 
@@ -452,20 +453,14 @@
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
-                        <configuration>
-                            <!--
-                                The bundled fonts are on the test classpath via
-                                <testResources> for the engine's own suite; keep
-                                them OUT of the tests-jar. The benchmarks module
-                                (the only consumer of this jar) gets fonts from
-                                the graph-compose-fonts artifact instead. The emoji
-                                glyphs follow the same rule.
-                            -->
-                            <excludes>
-                                <exclude>fonts/**</exclude>
-                                <exclude>emoji/**</exclude>
-                            </excludes>
-                        </configuration>
+                        <!--
+                            No <excludes> needed: the bundled fonts / emoji are no
+                            longer copied into test-classes (they come from the
+                            graph-compose-fonts / graph-compose-emoji test-scope
+                            artifacts), so the tests-jar naturally carries only the
+                            engine's own fixtures (e.g. com.demcha.mock) that the
+                            benchmarks module consumes.
+                        -->
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
## Why

The engine's visual / snapshot / emoji suites render with the bundled Google fonts and colour-emoji glyphs, which live in the sibling `graph-compose-fonts` / `graph-compose-emoji` modules. Until now the root pom put them on the test classpath by pointing `<testResources>` at `${project.basedir}/fonts|emoji/src/main/resources` **by source path**. That form is relative to the root module's basedir and will not survive the 2.0 module split — once render backends and templates become modules at other directory depths, a source-path resource entry can't reach the sibling fonts source. Consuming the published artifact is depth-independent and models the engine as a normal fonts consumer, which is the whole point of the fonts split.

## What changed (root `pom.xml` only)

- Depend on `graph-compose-fonts:1.0.0` and `graph-compose-emoji:1.0.0` at **test** scope (via new `graphcompose.fonts.version` / `graphcompose.emoji.version` properties, pinned to the independent 1.0.0 line and kept in step with `bundle/pom.xml`).
- Remove the two source-path `<testResource>` entries (`fonts|emoji/src/main/resources`); the default `src/test/resources` stays. The artifacts package the same `src/main/resources` layout, so classpath lookups are unchanged.
- Drop the now-moot `fonts/**` / `emoji/**` `attach-test-jar` excludes — nothing is copied into `target/test-classes` any more, so the tests-jar naturally carries only the engine's own fixtures (`com.demcha.mock`) that the benchmarks module consumes.

Test scope is not transitive, so the engine's own published jar stays fonts-free — an engine consumer never drags these in.

## Verification

- `./mvnw clean verify -pl .` — green. Because `clean` wipes `target/test-classes` first, the fonts/emoji can only come from the test-scope artifacts; the visual/emoji suites passing is the proof the decoupling works. This is the same invocation CI's `build-and-test` job runs.
- Aggregator reactor (`-pl :graph-compose -am clean verify`) — build order is `graph-compose-fonts → graph-compose-emoji → graph-compose`, all SUCCESS: the new root→fonts/emoji edge reorders correctly even though the aggregator lists the root first, and the root builds against the reactor-fresh jars.
- `graph-compose-fonts:1.0.0` and `graph-compose-emoji:1.0.0` are on Maven Central and identical to the in-repo source (no commits to `fonts/src` / `emoji/src` since their `-v1.0.0` tags), so a fresh CI build with an empty local repo resolves them from Central without a bootstrap install — closing the gap that made a test-scope fonts dep break CI at the original v1.8.0 split.
- Diff is pom-only; `src/main` is untouched, so the engine's published bytecode is unchanged.