### PR TITLE
build: extract the semantic DOCX/PPTX backend into graph-compose-render-docx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,12 @@ jobs:
       - name: Install root artifact
         run: ./mvnw -B -ntp -DskipTests install -pl .
 
+      - name: Install graph-compose-render-docx (consumed by the examples module)
+        # The DOCX export example depends on the render-docx backend module, which
+        # is not on Central. Install it after the engine (its graph-compose
+        # dependency) so the examples build resolves it.
+        run: ./mvnw -B -ntp -f render-docx/pom.xml -DskipTests install
+
       - name: Compile examples module
         run: ./mvnw -B -ntp -f examples/pom.xml clean compile
 
@@ -136,34 +142,6 @@ jobs:
           name: examples-pdfs-${{ github.run_id }}
           path: examples/target/generated-pdfs/**
           if-no-files-found: error
-
-  no-poi-suite:
-    name: Test suite without poi-ooxml (optional-deps regression)
-    if: github.event_name == 'pull_request'
-    needs: architecture-and-documentation-guards
-    runs-on: ubuntu-latest
-    env:
-      JAVA_TOOL_OPTIONS: -Djava.awt.headless=true
-
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v7
-
-      - name: Set up Temurin JDK 17
-        uses: actions/setup-java@v5
-        with:
-          distribution: temurin
-          java-version: '17'
-          cache: maven
-
-      - name: Run suite under -P no-poi
-        # poi-ooxml is declared <optional>true</optional>; this job
-        # validates that callers who don't render DOCX still get a
-        # green suite without the POI footprint. Tests that require
-        # poi (DocxSemanticBackend output) carry
-        # @DisabledIfSystemProperty(named = "no.poi", matches = "true")
-        # and skip cleanly. See Track I1 in the readiness taskboard.
-        run: ./mvnw -B -ntp test -pl . -P no-poi
 
   binary-compat:
     name: Binary Compatibility (japicmp vs pom baseline)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,6 +99,16 @@ jobs:
           CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
+      - name: Publish render-docx to Maven Central
+        # The semantic DOCX/PPTX backend, lockstep-versioned with the engine
+        # (ships on the same v* tag). graph-compose resolves from the local repo
+        # installed by the engine deploy above.
+        run: ./mvnw -B -ntp -f render-docx/pom.xml -P release -DskipTests -Dgpg.skip=false deploy
+        env:
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+
       - name: Publish bundle to Maven Central
         # The graph-compose-bundle convenience aggregate pins this engine
         # version + a compatible graph-compose-fonts version. It tracks the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ for this cycle.
   (core + render-pdf + templates + fonts + emoji). The optional
   `graph-compose-fonts` and `graph-compose-emoji` artifacts are unchanged. Full
   install guidance ships with 2.0.0.
+- `graph-compose-render-docx` is now a separate artifact: the semantic DOCX/PPTX
+  backend and Apache POI leave the `graph-compose` jar. `DocxSemanticBackend` moves
+  to `com.demcha.compose.document.backend.semantic.docx` and `PptxSemanticBackend`
+  to `com.demcha.compose.document.backend.semantic.pptx`; add
+  `graph-compose-render-docx` (it brings POI transitively) to export DOCX. The
+  `no-poi` build profile is retired.
 
 ## v1.9.0 — 2026-06-29
 

--- a/aggregator/pom.xml
+++ b/aggregator/pom.xml
@@ -60,6 +60,7 @@
         <module>..</module>
         <module>../fonts</module>
         <module>../emoji</module>
+        <module>../render-docx</module>
         <module>../bundle</module>
         <module>../examples</module>
         <module>../benchmarks</module>

--- a/docs/recipes/docx-export.md
+++ b/docs/recipes/docx-export.md
@@ -9,7 +9,7 @@ the recipient needs to *edit* the document; use PDF when pixels must match.
 ## Exporting a session
 
 ```java
-import com.demcha.compose.document.backend.semantic.DocxSemanticBackend;
+import com.demcha.compose.document.backend.semantic.docx.DocxSemanticBackend;
 
 try (DocumentSession document = GraphCompose.document()
         .pageSize(595, 842)
@@ -32,10 +32,10 @@ try (DocumentSession document = GraphCompose.document()
 default output file when one was given to `GraphCompose.document(path)`;
 the two-argument overload targets an explicit path.
 
-**Dependency note:** the backend requires `org.apache.poi:poi-ooxml` on
-the classpath. GraphCompose declares it **optional** in its POM, so
-consumers who export DOCX must add it explicitly — consumers who only
-render PDF carry no POI footprint.
+**Dependency note:** the DOCX backend ships in the
+`io.github.demchaav:graph-compose-render-docx` artifact, which brings Apache POI
+transitively. Add that one dependency to export DOCX — consumers who only render
+PDF never pull POI.
 
 ## What maps 1:1
 
@@ -77,4 +77,4 @@ designs, precise placement — export PDF for the reader and DOCX only as
 an editable companion.
 
 Round-trip coverage (paragraphs, tables, metadata, chart fallback) lives in
-[`DocxSemanticBackendTest`](../../src/test/java/com/demcha/compose/document/backend/semantic/DocxSemanticBackendTest.java).
+[`DocxSemanticBackendTest`](../../render-docx/src/test/java/com/demcha/compose/document/backend/semantic/docx/DocxSemanticBackendTest.java).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -43,14 +43,14 @@ GraphCompose marks one heavy, rarely-needed dependency **optional** so
 PDF-only consumers don't pay for it. If you use DOCX export, add the
 dependency to **your** project.
 
-**DOCX export** — `document.export(new DocxSemanticBackend())` needs
-Apache POI on your classpath:
+**DOCX export** — `document.export(new DocxSemanticBackend())` ships in the
+`graph-compose-render-docx` artifact, which brings Apache POI transitively:
 
 ```xml
 <dependency>
-  <groupId>org.apache.poi</groupId>
-  <artifactId>poi-ooxml</artifactId>
-  <version>5.5.1</version>
+  <groupId>io.github.demchaav</groupId>
+  <artifactId>graph-compose-render-docx</artifactId>
+  <version>2.0.0</version>
 </dependency>
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -943,8 +943,8 @@ images, spacers, and page breaks map 1:1; session metadata lands in the
 Word core properties. Charts export as their categories-by-series data
 table (one capability warning per export), shape containers flatten to
 inline layers, and pure geometry — dividers, shapes, barcodes — stays
-PDF-only by design. Requires `org.apache.poi:poi-ooxml` on the
-classpath (the dependency is optional in the GraphCompose POM).
+PDF-only by design. Requires the `graph-compose-render-docx` artifact
+on the classpath (it brings Apache POI transitively).
 
 [📄 View PDF](../assets/readme/examples/word-export-companion.pdf) ·
 [📝 Word file](../assets/readme/examples/word-export-companion.docx) ·

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -67,13 +67,13 @@
             <version>${graphcompose.emoji.version}</version>
         </dependency>
 
-        <!-- DOCX export (WordExportExample): poi-ooxml is optional in the
-             GraphCompose POM, so consumers add it explicitly.
-             Keep in lockstep with the root pom's poi.version. -->
+        <!-- DOCX export (WordExportExample): the semantic DOCX backend ships in
+             graph-compose-render-docx since 2.0, which brings Apache POI
+             transitively. -->
         <dependency>
-            <groupId>org.apache.poi</groupId>
-            <artifactId>poi-ooxml</artifactId>
-            <version>5.5.1</version>
+            <groupId>io.github.demchaav</groupId>
+            <artifactId>graph-compose-render-docx</artifactId>
+            <version>${graphcompose.version}</version>
         </dependency>
 
         <dependency>

--- a/examples/src/main/java/com/demcha/examples/features/docx/WordExportExample.java
+++ b/examples/src/main/java/com/demcha/examples/features/docx/WordExportExample.java
@@ -2,7 +2,7 @@ package com.demcha.examples.features.docx;
 
 import com.demcha.compose.GraphCompose;
 import com.demcha.compose.document.api.DocumentSession;
-import com.demcha.compose.document.backend.semantic.DocxSemanticBackend;
+import com.demcha.compose.document.backend.semantic.docx.DocxSemanticBackend;
 import com.demcha.compose.document.chart.ChartData;
 import com.demcha.compose.document.chart.ChartSpec;
 import com.demcha.compose.document.image.DocumentImageData;

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,6 @@
         <logback.version>1.5.37</logback.version>
         <lombok.version>1.18.46</lombok.version>
         <pdfbox.version>3.0.7</pdfbox.version>
-        <poi.version>5.5.1</poi.version>
         <javafx.version>21.0.2</javafx.version>
         <slf4j.version>2.0.18</slf4j.version>
         <zxing.version>3.5.4</zxing.version>
@@ -630,39 +629,6 @@
                             <publishingServerId>central</publishingServerId>
                             <autoPublish>false</autoPublish>
                             <waitUntil>validated</waitUntil>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-
-        <!--
-            Optional-deps regression: runs the canonical suite with
-            `poi-ooxml` (and its transitives) excluded from the test
-            classpath, so callers that don't render DOCX validate that
-            our DocxSemanticBackend is genuinely optional. Tests that
-            require POI carry @DisabledIfSystemProperty(named = "no.poi",
-            matches = "true") and skip cleanly under this profile.
-            Activate with `-P no-poi`. Tracked in v1.6.6 stabilization
-            (Track I1).
-        -->
-        <profile>
-            <id>no-poi</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${maven.surefire.plugin.version}</version>
-                        <configuration>
-                            <classpathDependencyExcludes>
-                                <classpathDependencyExclude>org.apache.poi:poi-ooxml</classpathDependencyExclude>
-                                <classpathDependencyExclude>org.apache.poi:poi</classpathDependencyExclude>
-                                <classpathDependencyExclude>org.apache.poi:poi-ooxml-lite</classpathDependencyExclude>
-                            </classpathDependencyExcludes>
-                            <systemPropertyVariables>
-                                <no.poi>true</no.poi>
-                            </systemPropertyVariables>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -182,19 +182,6 @@
             <version>${flexmark.version}</version>
         </dependency>
 
-        <!--
-            Apache POI powers the canonical DOCX semantic backend. Marked
-            optional so library consumers that only render PDFs do not pull
-            in ~10MB of POI runtime; apps that call DocumentSession.export(new
-            DocxSemanticBackend()) must add poi-ooxml to their own classpath.
-        -->
-        <dependency>
-            <groupId>org.apache.poi</groupId>
-            <artifactId>poi-ooxml</artifactId>
-            <version>${poi.version}</version>
-            <optional>true</optional>
-        </dependency>
-
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>

--- a/render-docx/pom.xml
+++ b/render-docx/pom.xml
@@ -1,0 +1,228 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <!--
+        Semantic office export backend (DOCX today, a PPTX skeleton) split out of
+        the engine jar in the 2.0 module line. Apache POI (~10 MB) lives here, not
+        in the lean core: a consumer that only renders PDF never pulls POI, and an
+        app that wants Word output adds this one artifact (it brings the core
+        transitively). SemanticBackend / SemanticExportContext / manifest — the SPI
+        — stay in the core `document.backend.semantic` package.
+
+        Standalone pom (no aggregator parent, like fonts/); its version tracks the
+        engine line in lockstep (bumped by cut-release.ps1), and the `release`
+        profile is copy-pasted from the engine pom.
+    -->
+    <groupId>io.github.demchaav</groupId>
+    <artifactId>graph-compose-render-docx</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+
+    <name>GraphCompose Render — DOCX</name>
+    <description>Semantic DOCX / PPTX export backend for GraphCompose, backed by Apache POI.</description>
+    <url>https://github.com/DemchaAV/GraphCompose</url>
+
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>https://opensource.org/licenses/MIT</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <id>DemchaAV</id>
+            <name>Artem Demchyshyn</name>
+            <email>demchishynartem@gmail.com</email>
+            <url>https://github.com/DemchaAV</url>
+            <roles>
+                <role>Lead Developer</role>
+                <role>Architect</role>
+            </roles>
+            <timezone>UTC 0</timezone>
+        </developer>
+    </developers>
+
+    <scm>
+        <connection>scm:git:https://github.com/DemchaAV/GraphCompose.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/DemchaAV/GraphCompose.git</developerConnection>
+        <url>https://github.com/DemchaAV/GraphCompose/tree/main</url>
+    </scm>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>17</maven.compiler.release>
+
+        <poi.version>5.5.1</poi.version>
+        <junit.bom.version>6.1.1</junit.bom.version>
+        <assertj.version>3.27.7</assertj.version>
+        <logback.version>1.5.37</logback.version>
+        <graphcompose.fonts.version>1.0.0</graphcompose.fonts.version>
+        <graphcompose.emoji.version>1.0.0</graphcompose.emoji.version>
+
+        <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
+        <maven.jar.plugin.version>3.5.0</maven.jar.plugin.version>
+        <maven.surefire.plugin.version>3.5.6</maven.surefire.plugin.version>
+        <maven.source.plugin.version>3.4.0</maven.source.plugin.version>
+        <maven.javadoc.plugin.version>3.12.0</maven.javadoc.plugin.version>
+        <maven.gpg.plugin.version>3.2.8</maven.gpg.plugin.version>
+        <central.publishing.plugin.version>0.11.0</central.publishing.plugin.version>
+
+        <!-- See the engine pom: opted in via -Dgpg.skip=false on the publish workflow. -->
+        <gpg.skip>true</gpg.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.github.demchaav</groupId>
+            <artifactId>graph-compose</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>${poi.version}</version>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.bom.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!--
+            The docx tests build a DocumentSession, which lays out text through the
+            font metrics seam; the bundled families come from the published fonts /
+            emoji artifacts (same as the engine's own test suite since v2.0).
+        -->
+        <dependency>
+            <groupId>io.github.demchaav</groupId>
+            <artifactId>graph-compose-fonts</artifactId>
+            <version>${graphcompose.fonts.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.github.demchaav</groupId>
+            <artifactId>graph-compose-emoji</artifactId>
+            <version>${graphcompose.emoji.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven.compiler.plugin.version}</version>
+                <configuration>
+                    <release>${maven.compiler.release}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven.jar.plugin.version}</version>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <!-- Maven Central release artefacts — mirrors the engine pom's `release`
+             profile (sources + javadoc + GPG + central-publishing). Standalone by
+             design, so the configuration is duplicated rather than inherited. -->
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>${maven.source.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>${maven.javadoc.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                                <configuration>
+                                    <doclint>none</doclint>
+                                    <failOnError>false</failOnError>
+                                    <quiet>true</quiet>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${maven.gpg.plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <skip>${gpg.skip}</skip>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>${central.publishing.plugin.version}</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <publishingServerId>central</publishingServerId>
+                            <autoPublish>false</autoPublish>
+                            <waitUntil>validated</waitUntil>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/render-docx/src/main/java/com/demcha/compose/document/backend/semantic/docx/DocxSemanticBackend.java
+++ b/render-docx/src/main/java/com/demcha/compose/document/backend/semantic/docx/DocxSemanticBackend.java
@@ -1,5 +1,7 @@
-package com.demcha.compose.document.backend.semantic;
+package com.demcha.compose.document.backend.semantic.docx;
 
+import com.demcha.compose.document.backend.semantic.SemanticBackend;
+import com.demcha.compose.document.backend.semantic.SemanticExportContext;
 import com.demcha.compose.document.chart.ChartData;
 import com.demcha.compose.document.chart.NumberFormatSpec;
 import com.demcha.compose.document.dsl.TableBuilder;

--- a/render-docx/src/main/java/com/demcha/compose/document/backend/semantic/docx/DocxSemanticBackend.java
+++ b/render-docx/src/main/java/com/demcha/compose/document/backend/semantic/docx/DocxSemanticBackend.java
@@ -58,9 +58,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * containers. It deliberately ignores fixed-layout concerns (no per-page
  * pagination, no PDF chrome) since semantic exports target editing tools.</p>
  *
- * <p><b>Dependencies:</b> requires {@code org.apache.poi:poi-ooxml} on the
- * classpath. Library consumers must add it explicitly because the dependency is
- * declared optional in the GraphCompose POM.</p>
+ * <p><b>Dependencies:</b> this backend ships in
+ * {@code io.github.demchaav:graph-compose-render-docx}, which brings
+ * {@code org.apache.poi:poi-ooxml} transitively — adding that one artifact is
+ * all a DOCX consumer needs.</p>
  *
  * @author Artem Demchyshyn
  */

--- a/render-docx/src/main/java/com/demcha/compose/document/backend/semantic/pptx/PptxSemanticBackend.java
+++ b/render-docx/src/main/java/com/demcha/compose/document/backend/semantic/pptx/PptxSemanticBackend.java
@@ -1,5 +1,8 @@
-package com.demcha.compose.document.backend.semantic;
+package com.demcha.compose.document.backend.semantic.pptx;
 
+import com.demcha.compose.document.backend.semantic.SemanticBackend;
+import com.demcha.compose.document.backend.semantic.SemanticExportContext;
+import com.demcha.compose.document.backend.semantic.SemanticExportManifest;
 import com.demcha.compose.document.layout.DocumentGraph;
 import com.demcha.compose.document.exceptions.UnsupportedNodeCapabilityException;
 import com.demcha.compose.document.node.ContainerNode;

--- a/render-docx/src/test/java/com/demcha/compose/document/backend/semantic/docx/DocxGeometryDropTest.java
+++ b/render-docx/src/test/java/com/demcha/compose/document/backend/semantic/docx/DocxGeometryDropTest.java
@@ -8,7 +8,6 @@ import com.demcha.compose.document.style.DocumentStroke;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.apache.poi.xwpf.usermodel.XWPFParagraph;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import java.io.ByteArrayInputStream;
 import java.util.List;
@@ -22,8 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * geometry leaves (paths, polygons) are dropped without throwing — the
  * fixed-layout PDF backend is the path for pixel-perfect geometry.
  */
-@DisabledIfSystemProperty(named = "no.poi", matches = "true",
-        disabledReason = "DocxSemanticBackend requires poi-ooxml")
 class DocxGeometryDropTest {
 
     @Test

--- a/render-docx/src/test/java/com/demcha/compose/document/backend/semantic/docx/DocxGeometryDropTest.java
+++ b/render-docx/src/test/java/com/demcha/compose/document/backend/semantic/docx/DocxGeometryDropTest.java
@@ -1,4 +1,4 @@
-package com.demcha.compose.document.backend.semantic;
+package com.demcha.compose.document.backend.semantic.docx;
 
 import com.demcha.compose.GraphCompose;
 import com.demcha.compose.document.api.DocumentSession;

--- a/render-docx/src/test/java/com/demcha/compose/document/backend/semantic/docx/DocxListParityTest.java
+++ b/render-docx/src/test/java/com/demcha/compose/document/backend/semantic/docx/DocxListParityTest.java
@@ -1,4 +1,4 @@
-package com.demcha.compose.document.backend.semantic;
+package com.demcha.compose.document.backend.semantic.docx;
 
 import com.demcha.compose.GraphCompose;
 import com.demcha.compose.document.api.DocumentSession;

--- a/render-docx/src/test/java/com/demcha/compose/document/backend/semantic/docx/DocxListParityTest.java
+++ b/render-docx/src/test/java/com/demcha/compose/document/backend/semantic/docx/DocxListParityTest.java
@@ -7,7 +7,6 @@ import com.demcha.compose.document.style.DocumentInsets;
 import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.apache.poi.xwpf.usermodel.XWPFParagraph;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import java.io.ByteArrayInputStream;
 import java.util.List;
@@ -22,8 +21,6 @@ import static org.assertj.core.api.Assertions.assertThat;
  * {@link ListMarker#normalizeItemText(String, boolean)} for flat items —
  * so both outputs of one session agree.
  */
-@DisabledIfSystemProperty(named = "no.poi", matches = "true",
-        disabledReason = "DocxSemanticBackend requires poi-ooxml; the no-poi profile validates the rest of the suite without it")
 class DocxListParityTest {
 
     @Test

--- a/render-docx/src/test/java/com/demcha/compose/document/backend/semantic/docx/DocxSemanticBackendTest.java
+++ b/render-docx/src/test/java/com/demcha/compose/document/backend/semantic/docx/DocxSemanticBackendTest.java
@@ -1,4 +1,4 @@
-package com.demcha.compose.document.backend.semantic;
+package com.demcha.compose.document.backend.semantic.docx;
 
 import com.demcha.compose.GraphCompose;
 import com.demcha.compose.document.api.DocumentSession;

--- a/render-docx/src/test/java/com/demcha/compose/document/backend/semantic/docx/DocxSemanticBackendTest.java
+++ b/render-docx/src/test/java/com/demcha/compose/document/backend/semantic/docx/DocxSemanticBackendTest.java
@@ -15,7 +15,6 @@ import org.apache.poi.xwpf.usermodel.XWPFDocument;
 import org.apache.poi.xwpf.usermodel.XWPFParagraph;
 import org.apache.poi.xwpf.usermodel.XWPFTable;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 
 import java.io.ByteArrayInputStream;
 import java.util.List;
@@ -23,14 +22,8 @@ import java.util.List;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * DOCX semantic backend output. Skipped under the {@code -P no-poi}
- * profile, where {@code poi-ooxml} is intentionally absent from the
- * test classpath to validate that consumers who don't render DOCX can
- * still build and run the canonical suite without the optional POI
- * footprint (Track I1).
+ * DOCX semantic backend output.
  */
-@DisabledIfSystemProperty(named = "no.poi", matches = "true",
-        disabledReason = "DocxSemanticBackend requires poi-ooxml; the no-poi profile validates the rest of the suite without it")
 class DocxSemanticBackendTest {
 
     @Test

--- a/render-docx/src/test/java/com/demcha/compose/document/backend/semantic/docx/SessionSemanticExportTest.java
+++ b/render-docx/src/test/java/com/demcha/compose/document/backend/semantic/docx/SessionSemanticExportTest.java
@@ -1,0 +1,70 @@
+package com.demcha.compose.document.backend.semantic.docx;
+
+import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.api.DocumentSession;
+import com.demcha.compose.document.backend.semantic.SemanticExportManifest;
+import com.demcha.compose.document.backend.semantic.pptx.PptxSemanticBackend;
+import com.demcha.compose.document.node.ContainerNode;
+import com.demcha.compose.document.node.ParagraphNode;
+import com.demcha.compose.document.node.ShapeNode;
+import com.demcha.compose.document.node.TextAlign;
+import com.demcha.compose.document.style.DocumentColor;
+import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.document.style.DocumentStroke;
+import com.demcha.compose.document.style.DocumentTextStyle;
+import org.junit.jupiter.api.Test;
+
+import java.awt.Color;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Exercises {@code DocumentSession.export(...)} with the semantic office backends
+ * from their new home. Moved out of the engine's {@code DocumentSessionTest} when
+ * the DOCX/PPTX backends were extracted to graph-compose-render-docx (the engine
+ * test scope can no longer see them). POI is always present in this module, so the
+ * old no-poi guard is dropped.
+ */
+class SessionSemanticExportTest {
+
+    @Test
+    void semanticBackendsShouldExportManifestsFromDocumentGraph() throws Exception {
+        try (DocumentSession session = GraphCompose.document()
+                .pageSize(200, 200)
+                .margin(DocumentInsets.of(10))
+                .create()) {
+
+            session.add(new ContainerNode(
+                    "DocxRoot",
+                    List.of(new ParagraphNode("P", "Hello world", DocumentTextStyle.DEFAULT, TextAlign.LEFT, 0, DocumentInsets.zero(), DocumentInsets.zero())),
+                    8,
+                    DocumentInsets.zero(),
+                    DocumentInsets.zero(),
+                    null,
+                    null));
+
+            byte[] docx = session.export(new DocxSemanticBackend());
+
+            assertThat(docx).isNotEmpty();
+            // DOCX files are ZIP-archived OOXML packages; the first two bytes
+            // of any ZIP container are the local-file-header signature.
+            assertThat(docx[0]).isEqualTo((byte) 'P');
+            assertThat(docx[1]).isEqualTo((byte) 'K');
+
+            session.clear();
+            session.add(new ContainerNode(
+                    "PptxRoot",
+                    List.of(new ShapeNode("Box", 40, 20, Color.BLUE, DocumentStroke.of(DocumentColor.BLACK, 1), DocumentInsets.zero(), DocumentInsets.zero())),
+                    8,
+                    DocumentInsets.zero(),
+                    DocumentInsets.zero(),
+                    null,
+                    null));
+
+            SemanticExportManifest pptx = session.export(new PptxSemanticBackend());
+            assertThat(pptx.backendName()).isEqualTo("pptx-semantic");
+            assertThat(pptx.nodeKinds()).contains("ContainerNode", "ShapeNode");
+        }
+    }
+}

--- a/scripts/cut-release.ps1
+++ b/scripts/cut-release.ps1
@@ -479,6 +479,9 @@ try {
     Update-PomVersion (Join-Path $repoRoot 'aggregator/pom.xml') $Version
     Update-PomVersion (Join-Path $repoRoot 'examples/pom.xml') $Version
     Update-PomVersion (Join-Path $repoRoot 'benchmarks/pom.xml') $Version
+    # render-docx tracks the engine line (lockstep): its <version> bumps here and
+    # its graph-compose dep is ${project.version} (follows automatically).
+    Update-PomVersion (Join-Path $repoRoot 'render-docx/pom.xml') $Version
     # Bundle tracks the engine line: its project <version> bumps here; its
     # graph-compose dep is ${project.version} (follows automatically) and its
     # graph-compose-fonts dep is ${graphcompose.fonts.version} (stays pinned —
@@ -547,6 +550,7 @@ try {
         'pom.xml',
         'aggregator/pom.xml',
         'bundle/pom.xml',
+        'render-docx/pom.xml',
         'examples/pom.xml',
         'benchmarks/pom.xml',
         'README.md',

--- a/src/test/java/com/demcha/compose/document/api/DocumentSessionTest.java
+++ b/src/test/java/com/demcha/compose/document/api/DocumentSessionTest.java
@@ -19,10 +19,7 @@ import com.demcha.compose.engine.measurement.TextMeasurementSystem;
 import com.demcha.compose.engine.measurement.FontLibraryTextMeasurementSystem;
 import com.demcha.compose.document.backend.fixed.FixedLayoutBackend;
 import com.demcha.compose.document.backend.fixed.FixedLayoutRenderContext;
-import com.demcha.compose.document.backend.semantic.DocxSemanticBackend;
 import com.demcha.compose.document.backend.fixed.pdf.PdfFixedLayoutBackend;
-import com.demcha.compose.document.backend.semantic.PptxSemanticBackend;
-import com.demcha.compose.document.backend.semantic.SemanticExportManifest;
 import com.demcha.compose.document.exceptions.AtomicNodeTooLargeException;
 import com.demcha.compose.document.image.DocumentImageFitMode;
 import com.demcha.compose.document.layout.BoxConstraints;
@@ -74,7 +71,6 @@ import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPage;
 import org.apache.pdfbox.pdmodel.common.PDRectangle;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
 import org.apache.pdfbox.rendering.PDFRenderer;
 import org.apache.pdfbox.text.PDFTextStripper;
 
@@ -785,48 +781,6 @@ class DocumentSessionTest {
         assertThatThrownBy(() -> session.registry()
                 .register(new BadgeNodeDefinition()))
                 .isInstanceOf(IllegalStateException.class);
-    }
-
-    @Test
-    @DisabledIfSystemProperty(named = "no.poi", matches = "true",
-            disabledReason = "Exercises DocxSemanticBackend; skipped under the no-poi profile that excludes poi-ooxml from the test classpath")
-    void semanticBackendsShouldExportManifestsFromDocumentGraph() throws Exception {
-        try (DocumentSession session = GraphCompose.document()
-                .pageSize(200, 200)
-                .margin(DocumentInsets.of(10))
-                .create()) {
-
-            session.add(new ContainerNode(
-                    "DocxRoot",
-                    List.of(new ParagraphNode("P", "Hello world", DocumentTextStyle.DEFAULT, TextAlign.LEFT, 0, DocumentInsets.zero(), DocumentInsets.zero())),
-                    8,
-                    DocumentInsets.zero(),
-                    DocumentInsets.zero(),
-                    null,
-                    null));
-
-            byte[] docx = session.export(new DocxSemanticBackend());
-
-            assertThat(docx).isNotEmpty();
-            // DOCX files are ZIP-archived OOXML packages; the first two bytes
-            // of any ZIP container are the local-file-header signature.
-            assertThat(docx[0]).isEqualTo((byte) 'P');
-            assertThat(docx[1]).isEqualTo((byte) 'K');
-
-            session.clear();
-            session.add(new ContainerNode(
-                    "PptxRoot",
-                    List.of(new ShapeNode("Box", 40, 20, Color.BLUE, DocumentStroke.of(DocumentColor.BLACK, 1), DocumentInsets.zero(), DocumentInsets.zero())),
-                    8,
-                    DocumentInsets.zero(),
-                    DocumentInsets.zero(),
-                    null,
-                    null));
-
-            SemanticExportManifest pptx = session.export(new PptxSemanticBackend());
-            assertThat(pptx.backendName()).isEqualTo("pptx-semantic");
-            assertThat(pptx.nodeKinds()).contains("ContainerNode", "ShapeNode");
-        }
     }
 
     @Test


### PR DESCRIPTION
## Why

A 2.0 lean-core goal: a consumer that only renders PDF should not pull Apache POI (~10 MB). This extracts the semantic office backend into its own artifact so POI leaves the core entirely — and, being the smallest extraction, it proves the multi-module publish/reactor/release pipeline before the larger render-pdf and templates moves.

## What changed

- **New `graph-compose-render-docx` module** (standalone pom, lockstep-versioned with the engine). `DocxSemanticBackend` → `document.backend.semantic.docx`; the `PptxSemanticBackend` stub → `document.backend.semantic.pptx`. The SPI (`SemanticBackend`, `SemanticExportContext`, `SemanticExportManifest`) **stays** in the core `document.backend.semantic` package — the backends move to format sub-packages so there is no split package. `poi-ooxml` is a plain compile dependency of this module.
- **Core drops POI:** the root pom's `<optional>` `poi-ooxml` dependency, the now-unused `poi.version` property, and the `no-poi` profile are removed; the `no-poi` CI job is retired. The one `DocumentSession` export test that exercised both backends moves to render-docx as `SessionSemanticExportTest` (the engine test scope can no longer see the backends; its no-poi guard is dropped because POI is always present in this module).
- **Pipeline wiring (this PR):** `aggregator` gains the module; `publish.yml` deploys it on the `v*` tag after the engine (its `graph-compose` dependency); `cut-release.ps1` bumps it in lockstep and adds it to the commit staging allow-list; the examples-generation CI job installs it; `examples` depends on `graph-compose-render-docx` (bringing POI transitively) and `WordExportExample` imports the new FQN.

`DocxSemanticBackend` / `PptxSemanticBackend` change public FQN — a documented 2.0 move; the old→new mapping lands in the 2.0 migration guide.

## Verification

- **Standalone** `./mvnw clean verify -pl .` — green. The engine builds **POI-free**; there is zero `org.apache.poi` anywhere in the root sources.
- **Reactor** `./mvnw -f aggregator/pom.xml verify` — green across all modules, including render-docx (its four DOCX tests pass) and `examples` (which resolves render-docx from the reactor).