### PR TITLE
build: add graph-compose-core; keep graph-compose as a drop-in wrapper

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         # testing module + the engine test-jar on the classpath and so cannot
         # live in the engine's own test scope). -am pulls the fonts / emoji
         # upstreams; render-docx / bundle / examples / benchmarks are excluded.
-        run: ./mvnw -B -ntp -f aggregator/pom.xml clean verify -pl :graph-compose,:graph-compose-testing,:graph-compose-qa -am
+        run: ./mvnw -B -ntp -f aggregator/pom.xml clean verify -pl :graph-compose-core,:graph-compose-testing,:graph-compose-qa -am
 
       - name: Generate Javadoc
         # Run only on the baseline JDK — Javadoc output is identical
@@ -116,8 +116,14 @@ jobs:
         # Central, so install it into the local repo before building examples.
         run: ./mvnw -B -ntp -f emoji/pom.xml -DskipTests install
 
-      - name: Install root artifact
+      - name: Install root artifact (graph-compose-core)
         run: ./mvnw -B -ntp -DskipTests install -pl .
+
+      - name: Install graph-compose (the compat wrapper, consumed by the examples module)
+        # examples depends on the graph-compose coordinate — the empty jar wrapper
+        # over graph-compose-core. Install it after the core so the examples build
+        # resolves it (and the engine classes transitively).
+        run: ./mvnw -B -ntp -f wrapper/pom.xml -DskipTests install
 
       - name: Install graph-compose-render-docx (consumed by the examples module)
         # The DOCX export example depends on the render-docx backend module, which

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,6 +99,16 @@ jobs:
           CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
+      - name: Publish graph-compose (compat wrapper) to Maven Central
+        # The empty jar that keeps the `graph-compose` coordinate a drop-in: it
+        # depends on graph-compose-core, resolved from the local repo installed by
+        # the engine (core) deploy above. Ships on the same v* tag, lockstep.
+        run: ./mvnw -B -ntp -f wrapper/pom.xml -P release -DskipTests -Dgpg.skip=false deploy
+        env:
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
+
       - name: Publish render-docx to Maven Central
         # The semantic DOCX/PPTX backend, lockstep-versioned with the engine
         # (ships on the same v* tag). graph-compose resolves from the local repo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,16 +30,17 @@ for this cycle.
 
 ### Packaging
 
-- 2.0 splits the single `graph-compose` jar into modules: a lean core
-  (`graph-compose`), pluggable render backends (`graph-compose-render-pdf`,
-  `graph-compose-render-docx`), `graph-compose-templates`, and
-  `graph-compose-testing`, with render backends discovered via a `ServiceLoader`
-  SPI. The `graph-compose` artifact keeps its coordinate but no longer contains
-  the PDF backend or the templates — add `graph-compose-render-pdf` for PDF
-  output, or depend on `graph-compose-bundle` for a batteries-included coordinate
-  (core + render-pdf + templates + fonts + emoji). The optional
-  `graph-compose-fonts` and `graph-compose-emoji` artifacts are unchanged. Full
-  install guidance ships with 2.0.0.
+- 2.0 splits the monolithic engine into modules. The engine now builds under a new
+  **`graph-compose-core`** coordinate, and the original **`graph-compose` coordinate
+  becomes a thin drop-in aggregator** that depends on `graph-compose-core` — so an
+  existing `graph-compose` dependency keeps compiling and rendering PDF unchanged.
+  Consumer-testing support (`graph-compose-testing`) and the semantic DOCX/PPTX
+  backend (`graph-compose-render-docx`) are already separate artifacts; the PDF
+  render backend and the built-in templates move into their own modules over the
+  rest of the 2.0 cycle, at which point `graph-compose` aggregates the PDF backend
+  and `graph-compose-core` becomes the lean, bring-your-own-backend coordinate. The
+  optional `graph-compose-fonts` / `graph-compose-emoji` artifacts are unchanged.
+  Full install guidance ships with 2.0.0.
 - `graph-compose-render-docx` is now a separate artifact: the semantic DOCX/PPTX
   backend and Apache POI leave the `graph-compose` jar. `DocxSemanticBackend` moves
   to `com.demcha.compose.document.backend.semantic.docx` and `PptxSemanticBackend`

--- a/aggregator/pom.xml
+++ b/aggregator/pom.xml
@@ -58,6 +58,7 @@
     -->
     <modules>
         <module>..</module>
+        <module>../wrapper</module>
         <module>../fonts</module>
         <module>../emoji</module>
         <module>../render-docx</module>

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -50,7 +50,7 @@
         <!-- The library under benchmark. -->
         <dependency>
             <groupId>io.github.demchaav</groupId>
-            <artifactId>graph-compose</artifactId>
+            <artifactId>graph-compose-core</artifactId>
             <version>${graphcompose.version}</version>
         </dependency>
 
@@ -74,7 +74,7 @@
         -->
         <dependency>
             <groupId>io.github.demchaav</groupId>
-            <artifactId>graph-compose</artifactId>
+            <artifactId>graph-compose-core</artifactId>
             <version>${graphcompose.version}</version>
             <type>test-jar</type>
             <classifier>tests</classifier>

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -7,7 +7,7 @@
 # validates, not a drifting newer one.
 #
 # install is scoped to the two published coordinates — graph-compose-core (the
-# engine, at the root pom) and graph-compose (the drop-in wrapper in dist/) — so
+# engine, at the root pom) and graph-compose (the drop-in wrapper in wrapper/) — so
 # JitPack serves both, never the examples/benchmarks reactor siblings.
 jdk:
   - openjdk17

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,14 +1,15 @@
-# JitPack builds the published library artifact
-# (com.github.DemchaAV:GraphCompose) from the standalone root pom.xml.
+# JitPack builds the published library coordinates
+# (com.github.DemchaAV:GraphCompose) from the standalone poms.
 #
 # JDK is pinned to 17 — the project's compile baseline
 # (maven.compiler.release=17) and the JDK the release verify/javadoc gate
 # runs on — so the jar consumers download is built on the same JDK CI
 # validates, not a drifting newer one.
 #
-# install is scoped to the root module (-pl .) so JitPack builds only the
-# library, never the examples/benchmarks reactor siblings.
+# install is scoped to the two published coordinates — graph-compose-core (the
+# engine, at the root pom) and graph-compose (the drop-in wrapper in dist/) — so
+# JitPack serves both, never the examples/benchmarks reactor siblings.
 jdk:
   - openjdk17
 install:
-  - ./mvnw -DskipTests install -pl .
+  - ./mvnw -DskipTests -f aggregator/pom.xml install -pl :graph-compose-core,:graph-compose

--- a/pom.xml
+++ b/pom.xml
@@ -5,11 +5,11 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.github.demchaav</groupId>
-    <artifactId>graph-compose</artifactId>
+    <artifactId>graph-compose-core</artifactId>
     <version>2.0.0-SNAPSHOT</version>
 
-    <name>GraphCompose</name>
-    <description>A declarative layout engine for programmatic document generation, implemented primarily in Java.</description>
+    <name>GraphCompose Core</name>
+    <description>A declarative layout engine for programmatic document generation, implemented primarily in Java. This is the lean engine coordinate; depend on the `graph-compose` artifact for the drop-in, PDF-capable install.</description>
     <url>https://github.com/DemchaAV/GraphCompose</url>
 
     <licenses>
@@ -400,7 +400,7 @@
                 Build a tests-classifier jar so the sibling `benchmarks/`
                 module can reuse the test-only fixtures (com.demcha.mock.*,
                 etc.) without duplicating them. The artifact is
-                graph-compose-${version}-tests.jar in the local repository
+                graph-compose-core-${version}-tests.jar in the local repository
                 after `mvn install`. It is a LOCAL build aid only: the
                 `release` profile disables this execution (phase=none) so the
                 tests jar is never attached and therefore never deployed to
@@ -463,7 +463,7 @@
                     <!--
                         Keep the tests-classifier jar OUT of the published
                         artifact set. The default build attaches a
-                        graph-compose-${version}-tests.jar (for the local
+                        graph-compose-core-${version}-tests.jar (for the local
                         benchmarks module); on a release `deploy` that jar
                         would otherwise be uploaded to Maven Central, where it
                         is pure dead weight (test classes + heavy golden

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -50,7 +50,7 @@
     <dependencies>
         <dependency>
             <groupId>io.github.demchaav</groupId>
-            <artifactId>graph-compose</artifactId>
+            <artifactId>graph-compose-core</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
@@ -64,7 +64,7 @@
         -->
         <dependency>
             <groupId>io.github.demchaav</groupId>
-            <artifactId>graph-compose</artifactId>
+            <artifactId>graph-compose-core</artifactId>
             <version>${project.version}</version>
             <type>test-jar</type>
             <classifier>tests</classifier>

--- a/render-docx/pom.xml
+++ b/render-docx/pom.xml
@@ -78,7 +78,7 @@
     <dependencies>
         <dependency>
             <groupId>io.github.demchaav</groupId>
-            <artifactId>graph-compose</artifactId>
+            <artifactId>graph-compose-core</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/scripts/cut-release.ps1
+++ b/scripts/cut-release.ps1
@@ -304,7 +304,7 @@ function Run-ShowcaseSync {
     $execProp = '"-Dexec.mainClass=com.demcha.examples.support.ShowcaseSync"'
     # The examples module depends on these bumped SNAPSHOT siblings (not on
     # Central); each must be installed before exec:java can resolve them.
-    $exampleSnapshotSiblings = @('render-docx/pom.xml', 'testing/pom.xml')
+    $exampleSnapshotSiblings = @('wrapper/pom.xml', 'render-docx/pom.xml', 'testing/pom.xml')
     if ($DryRun) {
         Write-Host "    [DRY RUN] $mvnw -B -ntp -DskipTests install -pl ." -ForegroundColor Yellow
         foreach ($modulePom in $exampleSnapshotSiblings) {
@@ -504,6 +504,9 @@ try {
     # automatically). graph-compose-qa is an aggregator child (its version is
     # inherited) and is never published, so it needs no explicit bump.
     Update-PomVersion (Join-Path $repoRoot 'testing/pom.xml') $Version
+    # graph-compose (the graph-compose compat wrapper (wrapper/)) tracks the engine line lockstep;
+    # its graph-compose-core dep is ${project.version} (follows automatically).
+    Update-PomVersion (Join-Path $repoRoot 'wrapper/pom.xml') $Version
     # Bundle tracks the engine line: its project <version> bumps here; its
     # graph-compose dep is ${project.version} (follows automatically) and its
     # graph-compose-fonts dep is ${graphcompose.fonts.version} (stays pinned —
@@ -574,6 +577,7 @@ try {
         'bundle/pom.xml',
         'render-docx/pom.xml',
         'testing/pom.xml',
+        'wrapper/pom.xml',
         'examples/pom.xml',
         'benchmarks/pom.xml',
         'README.md',

--- a/src/test/java/com/demcha/documentation/VersionConsistencyGuardTest.java
+++ b/src/test/java/com/demcha/documentation/VersionConsistencyGuardTest.java
@@ -107,6 +107,25 @@ class VersionConsistencyGuardTest {
     }
 
     @Test
+    void graphComposeWrapperStaysAJarOverCore() throws Exception {
+        Element project = parse(PROJECT_ROOT.resolve("wrapper/pom.xml")).getDocumentElement();
+
+        // Packaging MUST stay jar (the default when <packaging> is absent). A pom
+        // would force every existing graph-compose consumer to add <type>pom</type>
+        // and break their build — the entire point of the wrapper is a drop-in jar.
+        Element packaging = directChild(project, "packaging");
+        assertThat(packaging == null ? "jar" : packaging.getTextContent().trim())
+                .describedAs("wrapper/pom.xml (the graph-compose coordinate) must stay a jar, never pom — a pom would force consumers to add <type>pom</type>")
+                .isEqualTo("jar");
+
+        // And it must aggregate the engine: the dependency on graph-compose-core is
+        // what makes a bare `graph-compose` bring the engine transitively.
+        assertThat(declaresDependencyOn(project, "graph-compose-core"))
+                .describedAs("wrapper/pom.xml must depend on graph-compose-core so `graph-compose` still brings the engine")
+                .isTrue();
+    }
+
+    @Test
     void benchmarksDependencyDerivesVersionAndIsNotHardcoded() throws IOException {
         String pom = Files.readString(PROJECT_ROOT.resolve("benchmarks/pom.xml"));
 
@@ -284,6 +303,24 @@ class VersionConsistencyGuardTest {
             }
         }
         throw new IllegalStateException("No <project>/<version> or inherited <parent>/<version> in " + pom);
+    }
+
+    private static boolean declaresDependencyOn(Element project, String artifactId) {
+        Element deps = directChild(project, "dependencies");
+        if (deps == null) {
+            return false;
+        }
+        NodeList children = deps.getChildNodes();
+        for (int i = 0; i < children.getLength(); i++) {
+            Node node = children.item(i);
+            if (node.getNodeType() == Node.ELEMENT_NODE && node.getNodeName().equals("dependency")) {
+                Element aid = directChild((Element) node, "artifactId");
+                if (aid != null && artifactId.equals(aid.getTextContent().trim())) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private static Element directChild(Element parent, String name) {

--- a/src/test/java/com/demcha/documentation/VersionConsistencyGuardTest.java
+++ b/src/test/java/com/demcha/documentation/VersionConsistencyGuardTest.java
@@ -67,6 +67,9 @@ class VersionConsistencyGuardTest {
         assertThat(effectiveVersion(PROJECT_ROOT.resolve("testing/pom.xml")))
                 .describedAs("testing (graph-compose-testing) tracks the engine line and must equal the root version (%s)", root)
                 .isEqualTo(root);
+        assertThat(effectiveVersion(PROJECT_ROOT.resolve("wrapper/pom.xml")))
+                .describedAs("wrapper (the graph-compose compat wrapper) tracks the engine line and must equal the root version (%s)", root)
+                .isEqualTo(root);
 
         // NOTE: fonts/pom.xml (graph-compose-fonts) is intentionally NOT checked
         // here. It carries an independent version line (it ships on its own

--- a/wrapper/pom.xml
+++ b/wrapper/pom.xml
@@ -5,24 +5,27 @@
     <modelVersion>4.0.0</modelVersion>
 
     <!--
-        Published consumer-testing support split out of the engine jar in the 2.0
-        module line: LayoutSnapshotAssertions (deterministic layout-snapshot
-        regression) and PdfVisualRegression (pixel-diff of rendered pages). It
-        carries the jackson (snapshot JSON) and PDFBox (page rasterization)
-        dependencies so the lean core does not. Consumers add it at TEST scope to
-        pin their own document layouts.
+        The `graph-compose` coordinate as a back-compat aggregator. In the 2.0
+        module split the engine code moved to graph-compose-core; this empty jar
+        keeps the original `graph-compose` coordinate working as a drop-in for
+        existing consumers by depending on graph-compose-core. As render backends
+        are extracted it also depends on graph-compose-render-pdf, so a bare
+        `graph-compose` dependency keeps rendering PDF exactly as in 1.x — classes
+        arrive transitively from core, the PDF backend provider from render-pdf.
 
-        Standalone pom (no aggregator parent, like fonts/render-docx); its version
-        tracks the engine line in lockstep. PDFBox is a direct dependency here and
-        becomes a graph-compose-render-pdf dependency once that module is extracted
-        (B3), keeping the visual-regression rasterizer behind the backend seam.
+        Packaging is `jar` (an empty one), NOT `pom`: a `pom` would force every
+        existing consumer to add `<type>pom</type>` and break their build. A jar
+        that carries only <dependencies> resolves as a normal artifact.
+
+        Standalone pom (no aggregator parent, like fonts/render-docx/testing);
+        its version tracks the engine line in lockstep.
     -->
     <groupId>io.github.demchaav</groupId>
-    <artifactId>graph-compose-testing</artifactId>
+    <artifactId>graph-compose</artifactId>
     <version>2.0.0-SNAPSHOT</version>
 
-    <name>GraphCompose Testing</name>
-    <description>Consumer testing support for GraphCompose: layout-snapshot assertions and PDF visual regression.</description>
+    <name>GraphCompose</name>
+    <description>The graph-compose coordinate: a drop-in aggregator over graph-compose-core for a PDF-capable install.</description>
     <url>https://github.com/DemchaAV/GraphCompose</url>
 
     <licenses>
@@ -57,15 +60,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
 
-        <pdfbox.version>3.0.7</pdfbox.version>
-        <jackson.bom.version>2.21.4</jackson.bom.version>
-        <junit.bom.version>6.1.1</junit.bom.version>
-        <assertj.version>3.27.7</assertj.version>
-        <logback.version>1.5.37</logback.version>
-
         <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
         <maven.jar.plugin.version>3.5.0</maven.jar.plugin.version>
-        <maven.surefire.plugin.version>3.5.6</maven.surefire.plugin.version>
         <maven.source.plugin.version>3.4.0</maven.source.plugin.version>
         <maven.javadoc.plugin.version>3.12.0</maven.javadoc.plugin.version>
         <maven.gpg.plugin.version>3.2.8</maven.gpg.plugin.version>
@@ -76,40 +72,12 @@
     </properties>
 
     <dependencies>
+        <!-- The engine. As backends are extracted, graph-compose-render-pdf joins
+             this list so a bare `graph-compose` dependency still renders PDF. -->
         <dependency>
             <groupId>io.github.demchaav</groupId>
             <artifactId>graph-compose-core</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson.bom.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.pdfbox</groupId>
-            <artifactId>pdfbox</artifactId>
-            <version>${pdfbox.version}</version>
-        </dependency>
-
-        <!-- Test dependencies -->
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>${junit.bom.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <version>${assertj.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -125,44 +93,17 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${maven.surefire.plugin.version}</version>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>${maven.jar.plugin.version}</version>
-            </plugin>
-            <!--
-                Public API javadoc gate for the testing surface — relocated here
-                from the engine pom's `subpackages` config when this module was
-                extracted. doclint=all keeps the published assertions/visual API
-                documented.
-            -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${maven.javadoc.plugin.version}</version>
-                <configuration>
-                    <subpackages>com.demcha.compose.testing</subpackages>
-                    <doclint>all</doclint>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>validate-public-api-javadoc</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>javadoc</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>
 
     <profiles>
         <!-- Maven Central release artefacts — mirrors the engine pom's `release`
-             profile. Standalone by design, so the configuration is duplicated. -->
+             profile. This module carries no sources, so the source/javadoc jars
+             are empty (failOnError=false keeps javadoc from aborting on the empty
+             source set); Central only requires the jars to be present. -->
         <profile>
             <id>release</id>
             <build>
@@ -193,8 +134,7 @@
                                     <goal>jar</goal>
                                 </goals>
                                 <configuration>
-                                    <subpackages>com.demcha.compose.testing</subpackages>
-                                    <doclint>all</doclint>
+                                    <failOnError>false</failOnError>
                                     <quiet>true</quiet>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
## Why

The 2.0 module split originally aimed to make bare `graph-compose` the lean core —
which would make every existing consumer's `.buildPdf()` throw
`MissingBackendException` at **runtime** after upgrading to 2.0. This reverses that:
the engine gets its own `graph-compose-core` coordinate, and `graph-compose` stays a
**drop-in** that keeps rendering PDF, so existing consumers upgrade with zero changes.

## What

- Rename the root artifact `graph-compose` → **`graph-compose-core`** — the engine
  sources stay at the root dir, only the coordinate string changes.
- New **`wrapper/`** module publishes the `graph-compose` coordinate as an empty
  **jar** (jar, not pom — a pom would force consumers to add `<type>pom</type>` and
  break their build) that depends on `graph-compose-core`. A `graph-compose`
  dependency now brings the engine transitively and renders PDF unchanged.
- Repoint the engine-internal modules that need the engine classes directly
  (render-docx, testing, qa, benchmarks — incl. the tests-classifier jar) to
  `graph-compose-core`. **bundle and examples stay on `graph-compose`** (the wrapper),
  dogfooding the consumer path.
- Wire the aggregator (+`wrapper`), CI (build gate targets `graph-compose-core`; the
  examples job installs the wrapper), publish (deploy the wrapper after the core),
  `cut-release.ps1` (bump/commit/install the wrapper), jitpack (build both
  coordinates), and `VersionConsistencyGuardTest` (wrapper tracks the engine version).
- Core still carries the PDF backend and the templates; those move into their own
  modules over the rest of the 2.0 cycle. Consumer imports are unchanged.

## Tests

- Full reactor `./mvnw -f aggregator/pom.xml clean verify` → BUILD SUCCESS, all 11
  modules, all tests green (incl. the wrapper-aware version guard).
- **Back-compat proof:** `graph-compose` dependency tree resolves to
  `graph-compose → graph-compose-core (compile)`; the examples module (which depends
  on the `graph-compose` wrapper) renders **85 example PDFs**.
