### PR TITLE
docs(install): document the 2.0 module install matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,24 @@ Core document APIs stay source- and binary-compatible with v1.8 &mdash; v1.9 is 
 dependencies { implementation("io.github.demchaav:graph-compose:2.0.0") }
 ```
 
+> **Which artifact? (2.0 module split).** `graph-compose` above is the drop-in default —
+> it renders PDF out of the box because it aggregates the lean `graph-compose-core` engine
+> plus the `graph-compose-render-pdf` backend, so existing 1.x callers upgrade with **no
+> code change**. Reach for a different coordinate only to take less or more:
+>
+> | Goal | Depend on |
+> |---|---|
+> | **PDF — the 1.x default** | `graph-compose` |
+> | **Batteries-included** (PDF + templates + fonts + emoji) | `graph-compose-bundle` |
+> | **Lean core, bring your own backend** | `graph-compose-core` |
+> | **Built-in CV / cover-letter / invoice / proposal templates** | add `graph-compose-templates` |
+> | **DOCX / PPTX export** | add `graph-compose-render-docx` / `graph-compose-render-pptx` |
+>
+> Every 2.0 coordinate shares the `graph-compose` version (the fonts and emoji companions
+> keep their own lines). A bare `graph-compose-core` renders nothing until a backend is on
+> the classpath — asking it to build a PDF throws `MissingBackendException`, which names the
+> artifact to add (`graph-compose-render-pdf`, already included in `graph-compose`).
+
 > **Bundled fonts (from v1.8.0).** The curated Google fonts no longer ship
 > inside the engine jar &mdash; they live in an independently-versioned
 > companion artifact so an engine upgrade never re-downloads ~18&nbsp;MB of

--- a/docs/templates/v2-layered/quickstart.md
+++ b/docs/templates/v2-layered/quickstart.md
@@ -3,6 +3,11 @@
 **5 minutes.** What it is, why it's structured this way, and a working
 example that renders a CV PDF.
 
+> **Dependency.** The ready-made presets ship in the opt-in
+> `graph-compose-templates` artifact — they are **not** bundled in `graph-compose`. Add it
+> next to `graph-compose` (or depend on `graph-compose-bundle`, which includes both). See
+> the [README install matrix](../../../README.md#installation).
+
 ---
 
 ## What you get

--- a/docs/templates/v2-layered/using-templates.md
+++ b/docs/templates/v2-layered/using-templates.md
@@ -8,6 +8,10 @@ theme variants.
 If you haven't read [quickstart.md](quickstart.md), do that first —
 it sets up the conceptual model in 5 minutes.
 
+> **Dependency.** These presets ship in the opt-in `graph-compose-templates` artifact (not
+> bundled in `graph-compose`); add it, or use `graph-compose-bundle`. See the
+> [README install matrix](../../../README.md#installation).
+
 ---
 
 ## Table of contents

--- a/docs/templates/which-template-system.md
+++ b/docs/templates/which-template-system.md
@@ -6,6 +6,10 @@ invoice, proposal}`, every preset a final class with a
 `create(BrandTheme)` factory returning a `DocumentTemplate<…>`. GraphCompose
 2.0 ships no other template system.
 
+> **Dependency.** These presets ship in the opt-in `graph-compose-templates` artifact — not
+> bundled in `graph-compose`. Add it, or depend on `graph-compose-bundle`. See the
+> [README install matrix](../../README.md#installation).
+
 Through the 1.x line this page was a decision guide between two parallel
 surfaces. On the 2.0 line the decision is gone; what remains here is the
 naming history (so old commit messages and ADRs still make sense) and the

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -37,10 +37,32 @@ fall back to inline content with a one-time capability warning.
 Use DOCX only for paragraph / list / table / image / section content.
 Per-feature mapping: [canonical ↔ legacy parity matrix](architecture/canonical-legacy-parity.md).
 
+## `MissingBackendException` when rendering
+
+**Cause.** You depend on `graph-compose-core` (the lean 2.0 engine) but no render
+backend is on the classpath. The core carries the `DocumentSession` authoring API and a
+`ServiceLoader` seam, but the actual renderer ships separately — so `document.buildPdf()`
+/ `toPdfBytes()` / `toImages()` throws `MissingBackendException` until a backend is
+discoverable.
+
+**Fix.** Add the PDF backend, or depend on `graph-compose` (which already bundles it):
+
+```xml
+<dependency>
+  <groupId>io.github.demchaav</groupId>
+  <artifactId>graph-compose-render-pdf</artifactId>
+  <version>2.0.0</version>
+</dependency>
+```
+
+The exception message names the exact artifact to add. Plain `graph-compose` and
+`graph-compose-bundle` both include the PDF backend out of the box — only a deliberately
+lean `graph-compose-core` needs this.
+
 ## `NoClassDefFoundError` at runtime
 
-GraphCompose marks one heavy, rarely-needed dependency **optional** so
-PDF-only consumers don't pay for it. If you use DOCX export, add the
+GraphCompose keeps the heavier office backends in **separate** artifacts so
+PDF-only consumers don't pay for them. If you use DOCX export, add the
 dependency to **your** project.
 
 **DOCX export** — `document.export(new DocxSemanticBackend())` ships in the


### PR DESCRIPTION
## Why

The 2.0 module split gives consumers several coordinates (`graph-compose`,
`graph-compose-core`, the render backends, `graph-compose-templates`,
`graph-compose-bundle`), but the install docs still described the pre-split single
artifact — so a reader couldn't tell which one they need, and a lean-core user had no
pointer when rendering threw.

## What

- **README install section** gains a "which artifact?" matrix: `graph-compose` for PDF
  out of the box (the 1.x default), `graph-compose-bundle` for batteries-included,
  `graph-compose-core` for a lean bring-your-own-backend engine, and the opt-in
  templates / DOCX / PPTX coordinates. The primary `graph-compose:2.0.0` snippet stays the
  version anchor; the matrix carries no per-module version literals (single source of truth).
- **Troubleshooting** gains a `MissingBackendException` entry — the lean-core failure mode
  (render without a backend), with the one-line fix.
- The layered-template guides (`quickstart`, `using-templates`, `which-template-system`)
  gain a dependency callout: the presets ship in the opt-in `graph-compose-templates`
  artifact, not bundled in `graph-compose`.

## Tests

- Documentation guards green (`CanonicalSurfaceGuardTest`, `DocumentationCoverageTest`,
  `PackageMapGuardTest`, `VersionConsistencyGuardTest`, POI/PDF isolation) — 27 tests, 0
  failures. New relative links resolve; README carries no legacy-API tokens.
