### PR TITLE
docs(readme): v1.9.1 release status + graph-compose-markdown companion

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </p>
 
 > **Release status** &mdash;
-> 🟢 **Latest stable**: [v1.9.0](https://github.com/DemchaAV/GraphCompose/releases/tag/v1.9.0) &mdash; codenamed **"navigable"**: in-document navigation (anchors, internal links, a clickable TOC, page references &amp; bookmarks), multi-section documents, and inline chips / SVG icons / colour emoji. **[What's new in v1.9 &darr;](#whats-new-in-v19)**
+> 🟢 **Latest stable**: [v1.9.1](https://github.com/DemchaAV/GraphCompose/releases/tag/v1.9.1) &mdash; patch on the **"navigable"** line ([v1.9.0](https://github.com/DemchaAV/GraphCompose/releases/tag/v1.9.0)): long inline-code chips (Maven coordinates, FQCNs, URLs) now wrap inside their table column instead of spilling over the neighbour. **[What's new in v1.9 &darr;](#whats-new-in-v19)**
 
 > &nbsp;·&nbsp; 🟡 **In develop**: next cycle — open (see [CHANGELOG](./CHANGELOG.md))
 > &nbsp;·&nbsp; See [API stability policy](./docs/api-stability.md) for tier definitions.
@@ -284,6 +284,7 @@ Full detail: [architecture overview](./docs/architecture/overview.md) &middot; [
 
 ## Companion projects
 
+- [**graph-compose-markdown**](https://central.sonatype.com/artifact/io.github.demchaav/graph-compose-markdown) &mdash; a Markdown &rarr; PDF path built on the GraphCompose engine. Hand it a Markdown document and it renders through the same layout, theme, and PDFBox pipeline as the Java DSL &mdash; a companion **input surface** for teams who would rather author in Markdown than call the DSL directly. Published on Maven Central as `io.github.demchaav:graph-compose-markdown`; independent lifecycle, consumes the engine as a dependency.
 - [**graphcompose-ai-flow**](https://github.com/DemchaAV/graphcompose-ai-flow) &mdash; experimental sister project exploring an AI-assisted authoring flow on top of GraphCompose. Independent codebase, separate lifecycle &mdash; nothing in this repo depends on it. Track it if you are interested in agentic document composition driven by the same semantic node model.
 
 ## License


### PR DESCRIPTION
## Why

Pre-release documentation for **v1.9.1** (the inline-code column-wrap fix, already on `develop`). Two by-hand docs the release script does not touch: the "Release status" prose block (which must reach `main` via the release commit — process gate 2.8 / the v1.6.9 lesson) and surfacing the `graph-compose-markdown` companion as a Markdown input path.

## What changed

- **README "Release status"** blockquote → names **v1.9.1** as latest stable with the fix one-liner. `cut-release.ps1` only rewrites the install snippets, not this block, so it must land on `develop` pre-cut so the release commit carries it to `main`.
- **Companion projects** → add **graph-compose-markdown**: a Markdown → PDF input surface built on the engine, published on Maven Central (`io.github.demchaav:graph-compose-markdown:0.3.0`). Linked to the Central artifact page — the parser has no public GitHub repo, so a GitHub link would 404.

## Verification

Release-readiness audit on `develop` + this change: `./mvnw -B -ntp clean verify -pl .` → **BUILD SUCCESS, 1634 tests**, 0 failures (guard suite incl. `VersionConsistencyGuardTest` / `DocumentationCoverageTest` / `CanonicalSurfaceGuardTest`; install snippets untouched, stay `1.9.0`). `GenerateAllExamples` → 87 generated, no layout errors. `develop` current with `main`; tag `v1.9.1` absent; README relative links resolve.

**Lane:** docs — pre-release prep, no code/API change. Merge on `develop` **before** running `cut-release.ps1 -Version 1.9.1`.