### PR TITLE
docs: correct the engine-core retention note and roadmap the session layout-loop extraction

### DIFF
--- a/docs/roadmaps/post-2.0-engineering.md
+++ b/docs/roadmaps/post-2.0-engineering.md
@@ -28,6 +28,24 @@ focused, individually-tested collaborators (the package-private `RowSlots`
 extraction is the pattern to follow), with layout output unchanged and covered
 by the existing snapshot suite. **Status: Planned.**
 
+### Extract the session's layout-resolution loop
+
+`DocumentSession` is a delegating facade — caching, rendering, and document
+chrome already live in dedicated package-private collaborators
+(`DocumentLayoutCache`, `DocumentRenderingFacade`, `DocumentChromeOptions`).
+The one substantive algorithm still inside the class is the coupled fixed
+point in `computeLayout()`: page-reference numbers and per-page margins feed
+layout results back into content and converge over up to five compile passes.
+Extracting that loop into a package-private collaborator (following the
+`DocumentRenderingFacade.Context` pattern) would make the convergence loop
+unit-testable without opening measurement resources; the public surface stays
+unchanged — the session remains the single mutable entry point owning
+lifecycle, authoring state, and the revision-based layout cache. A stricter
+phase-pipeline restructuring (builder → immutable document → renderer) is
+explicitly rejected: cross-references and tables of contents require layout
+results to feed back into content, which a one-way pipeline cannot express.
+**Status: Planned.**
+
 ### Retire the internal `Entity` model
 
 The engine still resolves layout on a legacy `Entity` / `EntityManager` object

--- a/src/main/java/com/demcha/compose/engine/core/package-info.java
+++ b/src/main/java/com/demcha/compose/engine/core/package-info.java
@@ -9,8 +9,8 @@
  * imports nothing from this package directly, and the former
  * {@code GraphCompose.pdf(...)} surface that drove the ECS has been removed. The
  * ECS <em>execution</em> engine — the {@code EntityManager.processSystems()} loop
- * and the layout / pagination / render systems it drives — is dead: it runs only
- * under the legacy engine regression tests.</p>
+ * and the dispatch contracts it drives — is dead code: nothing invokes it, in
+ * production or in tests.</p>
  *
  * <p>The genuinely shared engine packages are elsewhere and are <em>not</em>
  * deprecated: {@code engine.components} (value types), {@code engine.measurement}
@@ -20,9 +20,12 @@
  *
  * @deprecated Legacy ECS engine, superseded by the canonical
  *     {@code com.demcha.compose.document.layout} pipeline. No public entry point
- *     runs it and it is not on the canonical hot path; it is retained only for the
- *     legacy engine regression tests — a candidate for removal. Do not extend it or
- *     spend optimization effort here.
+ *     runs it and it is not on the canonical hot path; it survives only because
+ *     the live {@code Entity} object model and the shared render / pagination /
+ *     debug helpers still compile against these primitives. It goes away when the
+ *     internal {@code Entity} model is retired (see
+ *     {@code docs/roadmaps/post-2.0-engineering.md}). Do not extend it or spend
+ *     optimization effort here.
  */
 @Deprecated
 package com.demcha.compose.engine.core;


### PR DESCRIPTION
## Why

Two doc-accuracy gaps, both in text that steers contributors:

- `engine/core/package-info.java` says the legacy ECS core is *"retained only for the legacy engine regression tests"* — but no test references `EntityManager` or the system contracts anymore. The package actually survives because the live `Entity` object model and the shared render / pagination / debug helpers still compile against its primitives. The stale sentence misleads readers into thinking the package is test-scaffolding that can be dropped by deleting tests.
- `DocumentSession` is a delegating facade (`DocumentLayoutCache` / `DocumentRenderingFacade` / `DocumentChromeOptions` are package-private, so the decomposition is invisible from the public surface), but its one remaining in-class algorithm — the coupled page-reference / per-page-margin fixed point in `computeLayout()` — had no tracked home for its extraction.

## What

- Reword the `engine.core` deprecation note: the execution engine is dead code nothing invokes; the package survives on compile-level coupling from the live `Entity` model and shared helpers, and goes away when the `Entity` model is retired (points at the post-2.0 roadmap).
- Add a "Extract the session's layout-resolution loop" entry to `docs/roadmaps/post-2.0-engineering.md`: move the `computeLayout()` fixed point into a package-private collaborator on the `DocumentRenderingFacade.Context` pattern, public surface unchanged. The entry also records why a one-way builder → immutable document → renderer pipeline is rejected: cross-references and tables of contents need layout results to feed back into content.

## Tests

- `./mvnw verify -pl .` (includes the javadoc gate over the reworded `package-info`): **BUILD SUCCESS**, 358 tests, 0 failures, 0 skipped.
- No guard test asserts the old package-info wording (checked `DocumentationCoverageTest`, `PackageMapGuardTest`, `PublicApiSinceTagCoverageTest`).