### PR TITLE
docs(readme): list graph-compose-markdown under Companion projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ Full detail: [architecture overview](./docs/architecture/overview.md) &middot; [
 
 ## Companion projects
 
+- [**graph-compose-markdown**](https://central.sonatype.com/artifact/io.github.demchaav/graph-compose-markdown) &mdash; a Markdown &rarr; PDF path built on the GraphCompose engine. Hand it a Markdown document and it renders through the same layout, theme, and PDFBox pipeline as the Java DSL &mdash; a companion **input surface** for teams who would rather author in Markdown than call the DSL directly. Published on Maven Central as `io.github.demchaav:graph-compose-markdown`; independent lifecycle, consumes the engine as a dependency.
 - [**graphcompose-ai-flow**](https://github.com/DemchaAV/graphcompose-ai-flow) &mdash; experimental sister project exploring an AI-assisted authoring flow on top of GraphCompose. Independent codebase, separate lifecycle &mdash; nothing in this repo depends on it. Track it if you are interested in agentic document composition driven by the same semantic node model.
 
 ## License


### PR DESCRIPTION
## Why

The 2.0 README's **Companion projects** section listed only `graphcompose-ai-flow`. The `graph-compose-markdown` companion — a Markdown → PDF input surface built on the engine, published on Maven Central — landed in the README on `main` (#314) but was never carried onto the 2.0 line, so the two companion surfaces were discoverable from different branches.

## What

Add one bullet to the Companion projects list (above the existing `graphcompose-ai-flow` entry), matching the wording already on `main`: `graph-compose-markdown` as an independent-lifecycle Markdown input surface that renders through the same layout/theme/PDFBox pipeline, linked to its Maven Central artifact page. Description is version-neutral (it describes an external companion), so no 2.0-specific rewording was needed.

## Tests

- `./mvnw test -pl . -Dtest=CanonicalSurfaceGuardTest,DocumentationCoverageTest,PackageMapGuardTest,VersionConsistencyGuardTest`: **BUILD SUCCESS**, 24 tests, 0 failures — the guards that scan `README.md` for legacy-surface tokens and version drift stay green.