### PR TITLE
docs: refresh the release banner, security policy, and roadmap to the 2.0 line

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@
 </p>
 
 > **Release status** &mdash;
-> 🟢 **Latest stable**: [v1.9.0](https://github.com/DemchaAV/GraphCompose/releases/tag/v1.9.0) &mdash; codenamed **"navigable"**: in-document navigation (anchors, internal links, a clickable TOC, page references &amp; bookmarks), multi-section documents, and inline chips / SVG icons / colour emoji. **[What's new in v1.9 &darr;](#whats-new-in-v19)**
+> 🟢 **Latest stable**: [v1.9.1](https://github.com/DemchaAV/GraphCompose/releases/tag/v1.9.1) &mdash; patch on the **"navigable"** line ([v1.9.0](https://github.com/DemchaAV/GraphCompose/releases/tag/v1.9.0)): long inline-code chips (Maven coordinates, FQCNs, URLs) now wrap inside their table column instead of spilling over the neighbour. **[What's new in v1.9 &darr;](#whats-new-in-v19)**
 
-> &nbsp;·&nbsp; 🟡 **In develop**: next cycle — open (see [CHANGELOG](./CHANGELOG.md))
+> &nbsp;·&nbsp; 🟡 **In progress (2.0)**: modular split into per-concern artifacts, with `graph-compose` kept as a drop-in wrapper (see [CHANGELOG](./CHANGELOG.md) and the [2.0 modules migration guide](./docs/migration/v2.0.0-modules.md))
 > &nbsp;·&nbsp; See [API stability policy](./docs/api-stability.md) for tier definitions.
 
 <p align="center">

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,23 +2,24 @@
 
 GraphCompose is solo-maintained. This roadmap is a direction, not a contract. Dates are intentionally omitted. Concrete work is tracked in [issues](https://github.com/DemchaAV/GraphCompose/issues) and shipped work is recorded in [CHANGELOG.md](CHANGELOG.md). For v1.6 phase-level detail, see [docs/roadmaps/v1.6-roadmap.md](docs/roadmaps/v1.6-roadmap.md).
 
-## Now (v1.6.x)
+## Now — 2.0 line
 
-In flight on `main` / `develop`.
+In flight on `2.0-dev`, preparing the 2.0.0 GA. The 2.0 line is about **packaging and internal hygiene**, not new authoring API — binary-breaking by design, with `japicmp` report-only for the cycle.
 
-- v1.6 polish &mdash; documentation, examples, visual baselines, fixes.
-- Open-source hygiene &mdash; security policy, support guidance, dependency automation, security scanning.
-- **Maven Central distribution** &mdash; debuted in v1.6.6 under `io.github.demchaav:graph-compose`. Replaces JitPack as the primary install channel; the JitPack URL stays alive for existing pinned consumers but is no longer documented as a primary option. Shipped per [#7](https://github.com/DemchaAV/GraphCompose/issues/7).
-- **Transitive dependency cleanup** &mdash; shipped in v1.6.7. Kotlin stdlib gone (the library is Java-first), `flexmark-all` aggregator narrowed to the three modules actually consumed by `MarkDownParser`, `jackson-dataformat-yaml` marked optional, unused `jackson-module-jsonSchema` + direct `snakeyaml` dropped, `jcl-over-slf4j` made explicit so PDFBox's commons-logging routes through SLF4J without `flexmark-all`'s transitive bridge. Also fixes a layout-cache staleness bug on `DocumentSession.registry().register(...)`. Zero breaking public API changes (japicmp `semver PATCH`).
-- **CV v2 migration completion + design-token expansion** &mdash; shipped in v1.6.8. Hyperlink-aware project / entry titles: a CV row authored as `"[GraphCompose](https://github.com/x/y) (Java, PDFBox)"` now renders the title as a clickable link with the technology-stack tail intact. `MarkdownInline.append(...)` learned the `[label](url)` form and routes through `RichText.link(...)`; `ProjectRenderer` adopts it transparently. Four new contemporary `BusinessTheme` presets (`nordic()`, `editorial()`, `cinematic()`, `monochrome()`) expand the built-in design-token range to seven. Plus senior-review polish from v1.6.7 (registry symmetry on `DocumentSession`, `target-branch: develop` pinned in Dependabot, `logback-classic` 1.5.34 for CVE-2026-9828). Zero breaking public API changes (japicmp `semver PATCH`).
-- **Showcase site separated from docs** &mdash; the static GitHub Pages site (hero, install snippets, searchable gallery of generated example PDFs) moved out of `docs/` into a top-level `web/` so `docs/` holds documentation only. It now deploys via GitHub Actions (`.github/workflows/deploy-web.yml`), and `cut-release.ps1` keeps its version + `web/examples.json` gallery manifest in lockstep. A Next.js 14 rebuild was briefly prototyped but later removed as unused; the static `web/` site is the one served.
+- **Modular split** &mdash; the single jar is split into `graph-compose-core` plus `graph-compose-render-pdf` / `graph-compose-render-docx` / `graph-compose-render-pptx` / `graph-compose-templates` / `graph-compose-testing`, with render backends discovered through a `ServiceLoader` SPI. `graph-compose` stays a drop-in wrapper (core + render-pdf) so existing PDF callers upgrade unchanged. See the [2.0 modules migration guide](docs/migration/v2.0.0-modules.md) and [ADR 0016](docs/adr/0016-multi-module-packaging.md).
+- **Legacy removal** &mdash; the dead Entity-Component-System execution layer and the deprecated (`forRemoval`) public API are gone; the classic template presets are replaced by the layered `templates.*` stack on `BrandTheme`.
+- **Maintenance** &mdash; the **v1.9.x** line (current stable) receives critical fixes only.
 
-## Next (v1.7)
+Full detail in [CHANGELOG.md](CHANGELOG.md) under `v2.0.0 — Planned`.
 
-Committed direction. Tracked in CHANGELOG (Phase E) and issues.
+## Next — post-2.0 engineering
 
-- **JMH benchmark migration** &mdash; replace the current custom benchmark harness with `org.openjdk.jmh` so the published numbers are credible and machine-comparable.
-- **Templates v2 component refactor** &mdash; 13 of the 14 v2 CV presets are currently hand-coded `DocumentTemplate` subclasses. Route more visual decisions through `CvBuilder` and equivalent component recipes so each preset becomes a thin composition rather than a 400&ndash;700-line class.
+Committed direction for after the 2.0 GA: internal refactors, scale work, and tooling that do **not** change the public authoring API. Tracked in [docs/roadmaps/post-2.0-engineering.md](docs/roadmaps/post-2.0-engineering.md).
+
+- **Decompose the layout hot files** &mdash; split `LayoutCompiler` and `TextFlowSupport` along their natural seams into individually-tested collaborators, with layout output unchanged.
+- **ArchUnit module-boundary guards** &mdash; enforce the canonical / engine / render layering structurally, replacing the path-based greps that can pass vacuously after a move.
+- **Cross-module coverage aggregation** &mdash; a dedicated non-published module that compile-depends on the tested modules so JaCoCo sees the `qa` suites; report-only first, thresholds after a baseline read.
+- **Per-module binary-compatibility baselines** &mdash; once the 2.0 GA artifacts are published, switch `japicmp` to per-module baselines in break-on-incompatible mode.
 
 ## Later (directional)
 
@@ -27,7 +28,6 @@ Not committed. Reflects current thinking; priorities may shift based on user fee
 - **DOCX visibility for unsupported nodes.** Make currently-silent skips (`shape`, `line`, `ellipse`, `barcode`) loud &mdash; minimum a warn log, ideally a strict-mode flag that fails instead of dropping content silently.
 - **Block-level alignment for fixed-size flow children.** Paths, images, layer stacks, shape containers and barcodes currently left-align in a flow; centring one means wrapping it in a full-width `ShapeContainer` just to use its CENTER anchor. Add a per-node horizontal align (left / centre / right &mdash; the `margin: auto` / `align(center)` analogue) so a fixed box can place itself in the flow directly. Surfaced by the v1.8 SVG icon-gallery and feature-catalog work.
 - **Backend-neutral layout measurement.** Decouple measurement from PDFBox-specific resources so non-PDF backends do not pull PDFBox into the dependency graph.
-- **Multi-module Maven layout — shipped in 2.0.** The single jar was split into `graph-compose-core` plus `graph-compose-render-pdf` / `graph-compose-render-docx` / `graph-compose-render-pptx` / `graph-compose-templates` / `graph-compose-testing`, with render backends discovered through a `ServiceLoader` SPI. `graph-compose` is kept as a back-compat wrapper (core + render-pdf) so existing PDF callers upgrade unchanged. See the [modules migration guide](docs/migration/v2.0.0-modules.md).
 - **DOCX maturity.** Either expand DOCX coverage toward PDF parity, or move DOCX behind an explicitly experimental flag.
 - **Property-based testing.** Random table spans, pagination edge cases, deeply nested layouts.
 - **Real PPTX export.** Current state is a manifest skeleton. Will only be built out if there is concrete user demand.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ Security fixes are issued for the latest minor release. Older minors do not rece
 
 | Version | Supported |
 |---------|-----------|
-| 1.6.x   | Yes — actively patched |
-| < 1.6   | No — upgrade required (see [migration guide](docs/roadmaps/migration-v1-5-to-v1-6.md)) |
+| 1.9.x   | Yes — actively patched |
+| < 1.9   | No — upgrade required (see [CHANGELOG.md](CHANGELOG.md) for per-version migration notes) |
 
 ## Reporting a vulnerability
 


### PR DESCRIPTION
## Why

Three top-level, first-contact files had drifted behind the actual release
state, reading as staleness to anyone evaluating the project:

- README release banner: "Latest stable v1.9.0" (tagged release is v1.9.1), and
  the in-progress line labelled "next cycle — open".
- SECURITY.md: supported-versions table listed **1.6.x** — three minors behind.
- ROADMAP.md: headed **"Now (v1.6.x)"** with the already-shipped v1.6/v1.7 items
  described as in flight, while "Later" still listed the multi-module split as
  future work even though it shipped on this line.

## What changed

- **README.md** — banner → v1.9.1 (ported from the accurate `develop` line); the
  in-progress bullet now names the 2.0 modular split and links the
  [modules migration guide](docs/migration/v2.0.0-modules.md).
- **SECURITY.md** — supported-versions table → **1.9.x**; the dangling
  `migration-v1-5-to-v1-6.md` link repointed to `CHANGELOG.md`.
- **ROADMAP.md** — "Now" reframed to the 2.0 packaging/hygiene line (grounded in
  the `v2.0.0 — Planned` CHANGELOG entry and [ADR 0016](docs/adr/0016-multi-module-packaging.md));
  "Next" now points at [post-2.0-engineering.md](docs/roadmaps/post-2.0-engineering.md);
  dropped the duplicate multi-module bullet from "Later".

Docs-only; no code, API, or build changes.

## Verification

`./mvnw -pl . -Dtest=CanonicalSurfaceGuardTest,VersionConsistencyGuardTest,DocumentationCoverageTest,PackageMapGuardTest test` → **24/24 green**.
CanonicalSurfaceGuardTest scans README/docs for retired legacy tokens and
VersionConsistencyGuardTest scans the README install snippets — both pass, and
every relative link target was confirmed to exist.

## Note

SECURITY.md and ROADMAP.md carry the same "1.6.x" staleness on the frozen
`develop`/`main` (1.x) line. Since 2.0.0 will supersede them, this PR fixes only
the active line; a cherry-pick to `develop` would make the corrected security
policy live before 2.0.0 ships if that's preferred.