### PR TITLE
ci: add concurrency guards to the CI, publish, and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,15 @@ on:
 permissions:
   contents: read
 
+# Collapse superseded runs. On a pull request, a new push cancels the still-
+# running CI for the previous commit on the same PR — the common case where
+# rapid iteration would otherwise queue several full matrix builds. Pushes to
+# the integration branches (main / develop / 2.0-dev) are never cancelled, so
+# every merged commit keeps a complete, recorded CI run.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   architecture-and-documentation-guards:
     name: Architecture and Documentation Guards

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,15 @@ on:
 permissions:
   contents: read
 
+# Serialize Maven Central publishes. A publish is a global, non-atomic sequence
+# of eight module uploads, so two runs must never overlap — a constant group
+# name funnels every tag / dispatch through one lane. cancel-in-progress is
+# false so a re-tag or dispatch never aborts a publish already mid-upload; the
+# second run queues behind it instead.
+concurrency:
+  group: publish-maven-central
+  cancel-in-progress: false
+
 jobs:
   publish:
     name: Publish ${{ github.ref_name }} to Maven Central

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,14 @@ on:
 permissions:
   contents: write
 
+# One GitHub Release per tag. A re-pushed tag queues behind the in-flight run
+# for that same tag rather than racing it; cancel-in-progress is false so a
+# release is never aborted mid-creation. Distinct tags carry distinct refs and
+# still proceed in parallel.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   release:
     name: Verify and publish GitHub Release


### PR DESCRIPTION
## Why

None of the three tag- or PR-triggered workflows declared a `concurrency`
block, so two overlapping runs could proceed in parallel. The consequential
case is `publish.yml`: its deploy is a **non-atomic sequence of eight module
uploads** to Maven Central, so two runs racing (e.g. a re-pushed tag, or a tag
push plus a `workflow_dispatch` re-publish) could interleave uploads.

## What changed

- **ci.yml** — `cancel-in-progress` scoped to pull requests only
  (`${{ github.event_name == 'pull_request' }}`): rapid PR iteration collapses
  to the latest commit's run, while pushes to `main` / `develop` / `2.0-dev`
  are never cancelled, so every merged commit keeps a complete recorded run.
- **publish.yml** — a constant group (`publish-maven-central`) serializes every
  Central publish through one lane; `cancel-in-progress: false` so a re-tag or
  dispatch never aborts an upload already in flight — it queues behind it.
- **release.yml** — group per tag (`release-${{ github.ref }}`),
  `cancel-in-progress: false`: one GitHub Release per tag, never cancelled
  mid-creation; distinct tags still proceed in parallel.

Additive only — 26 lines, no job logic changed.

## Verification

All three files parse as valid YAML with the `concurrency` blocks present
(`yaml.safe_load`), and GitHub parses the updated `ci.yml` when it runs this
PR's own CI — a syntax error would surface as a workflow error here.

## Note

`publish-fonts.yml` / `publish-emoji.yml` also deploy to Central (single
artifact each, so lower race risk). They could take the same guard in a
follow-up if you want full symmetry; left out here to keep this PR to the three
files the audit flagged.