### PR TITLE
fix(engine): bound the process-wide image caches with LRU eviction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,14 @@ for this cycle.
   (`graph-compose-render-docx` / `graph-compose-render-pptx`) stay opt-in and are not
   bundled.
 
+### Internal
+
+- The process-wide image caches (decoded source bytes and image metadata) are now
+  bounded with LRU eviction instead of growing without limit. A long-lived JVM that
+  renders many distinct images — a rendering service, a batch job — no longer
+  accumulates image data indefinitely. Single documents are unaffected: the caps sit
+  far above any realistic distinct-image count, so a render never evicts or re-decodes.
+
 ## v1.9.1 — 2026-07-06
 
 Table columns now contain long inline-code content instead of letting it spill

--- a/src/main/java/com/demcha/compose/engine/components/content/BoundedLruCache.java
+++ b/src/main/java/com/demcha/compose/engine/components/content/BoundedLruCache.java
@@ -1,0 +1,72 @@
+package com.demcha.compose.engine.components.content;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Fixed-capacity, thread-safe memoization cache with access-order (LRU)
+ * eviction. Once {@code maxEntries} distinct keys are held, the next insertion
+ * evicts the least-recently-used entry, so a long-lived JVM that keeps
+ * accumulating unrelated keys cannot grow the cache without bound.
+ *
+ * <p>Unlike the per-thread font caches in the PDF backend, the image caches are
+ * shared across render threads on purpose: a decoded image should be reused by
+ * every thread and its (potentially large) bytes held once, not duplicated per
+ * thread. Sharing an access-order map needs synchronization — a cache hit
+ * mutates the recency order — but the value function runs <em>outside</em> the
+ * lock, so a slow file read or image decode never blocks another thread's cache
+ * access. Two threads racing on the same absent key may both compute it; because
+ * the cache memoizes a deterministic function, the duplicate compute is wasted
+ * work only, and every caller ends up sharing the first stored value.
+ */
+final class BoundedLruCache<K, V> {
+
+    private final int maxEntries;
+    private final Map<K, V> entries;
+
+    BoundedLruCache(int maxEntries) {
+        if (maxEntries < 1) {
+            throw new IllegalArgumentException("maxEntries must be >= 1, got " + maxEntries);
+        }
+        this.maxEntries = maxEntries;
+        this.entries = new LinkedHashMap<>(16, 0.75f, true) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<K, V> eldest) {
+                return size() > BoundedLruCache.this.maxEntries;
+            }
+        };
+    }
+
+    /**
+     * Returns the value cached under {@code key}, computing and storing it with
+     * {@code mappingFunction} on a miss. The mapping function must not return
+     * {@code null} and runs outside the cache lock.
+     */
+    V getOrCompute(K key, Function<? super K, ? extends V> mappingFunction) {
+        synchronized (entries) {
+            V cached = entries.get(key);
+            if (cached != null) {
+                return cached;
+            }
+        }
+        V computed = Objects.requireNonNull(mappingFunction.apply(key), "mappingFunction must not return null");
+        synchronized (entries) {
+            V raced = entries.putIfAbsent(key, computed);
+            return raced != null ? raced : computed;
+        }
+    }
+
+    int size() {
+        synchronized (entries) {
+            return entries.size();
+        }
+    }
+
+    void clear() {
+        synchronized (entries) {
+            entries.clear();
+        }
+    }
+}

--- a/src/main/java/com/demcha/compose/engine/components/content/ImageSourceCache.java
+++ b/src/main/java/com/demcha/compose/engine/components/content/ImageSourceCache.java
@@ -14,14 +14,23 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.HexFormat;
 import java.util.Iterator;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @Slf4j
 final class ImageSourceCache {
-    private static final Map<String, CachedImageSource> SOURCE_CACHE = new ConcurrentHashMap<>();
-    private static final Map<String, ImageMetadata> METADATA_CACHE = new ConcurrentHashMap<>();
+    /**
+     * Entry caps for the process-wide image caches. The source cache holds raw
+     * image bytes, so it is bounded tighter than the metadata cache, which holds
+     * tiny width/height/format records. Both caps sit well above any single
+     * realistic document's distinct-image count — real renders never evict; the
+     * bound only protects a long-lived JVM (e.g. a rendering service) from
+     * accumulating unrelated images without limit.
+     */
+    private static final int MAX_SOURCE_ENTRIES = 128;
+    private static final int MAX_METADATA_ENTRIES = 512;
+
+    private static final BoundedLruCache<String, CachedImageSource> SOURCE_CACHE = new BoundedLruCache<>(MAX_SOURCE_ENTRIES);
+    private static final BoundedLruCache<String, ImageMetadata> METADATA_CACHE = new BoundedLruCache<>(MAX_METADATA_ENTRIES);
     private static final AtomicInteger METADATA_DECODE_COUNT = new AtomicInteger();
 
     private ImageSourceCache() {
@@ -30,7 +39,7 @@ final class ImageSourceCache {
     static ImageData fromPath(Path path) {
         Path absolutePath = path.toAbsolutePath().normalize();
         String sourceKey = absolutePath.toString();
-        CachedImageSource source = SOURCE_CACHE.computeIfAbsent(sourceKey, key -> loadFromPath(absolutePath));
+        CachedImageSource source = SOURCE_CACHE.getOrCompute(sourceKey, key -> loadFromPath(absolutePath));
         return new ImageData(source.bytes(), sourceKey, source.fingerprint(), source.metadata());
     }
 
@@ -40,7 +49,7 @@ final class ImageSourceCache {
         }
         byte[] safeCopy = Arrays.copyOf(bytes, bytes.length);
         String fingerprint = fingerprint(safeCopy);
-        ImageMetadata metadata = METADATA_CACHE.computeIfAbsent(fingerprint, key -> decodeMetadata(safeCopy));
+        ImageMetadata metadata = METADATA_CACHE.getOrCompute(fingerprint, key -> decodeMetadata(safeCopy));
         return new ImageData(safeCopy, "memory:" + fingerprint, fingerprint, metadata);
     }
 
@@ -66,7 +75,7 @@ final class ImageSourceCache {
         try {
             byte[] bytes = Files.readAllBytes(absolutePath);
             String fingerprint = fingerprint(bytes);
-            ImageMetadata metadata = METADATA_CACHE.computeIfAbsent(fingerprint, key -> decodeMetadata(bytes));
+            ImageMetadata metadata = METADATA_CACHE.getOrCompute(fingerprint, key -> decodeMetadata(bytes));
             return new CachedImageSource(bytes, fingerprint, metadata);
         } catch (IOException e) {
             log.error("Failed to read image bytes from {}", absolutePath, e);

--- a/src/test/java/com/demcha/compose/engine/components/content/BoundedLruCacheTest.java
+++ b/src/test/java/com/demcha/compose/engine/components/content/BoundedLruCacheTest.java
@@ -1,0 +1,150 @@
+package com.demcha.compose.engine.components.content;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit coverage for {@link BoundedLruCache}: memoization on a hit, access-order
+ * (LRU) eviction once over capacity, argument validation, and the shared
+ * single-value guarantee under concurrent misses on the same key.
+ */
+class BoundedLruCacheTest {
+
+    @Test
+    void computesOnceThenReturnsTheCachedValueOnRepeat() {
+        BoundedLruCache<String, String> cache = new BoundedLruCache<>(4);
+        Map<String, Integer> computeCounts = new HashMap<>();
+        Function<String, String> compute = key -> {
+            computeCounts.merge(key, 1, Integer::sum);
+            return key.toUpperCase();
+        };
+
+        assertThat(cache.getOrCompute("a", compute)).isEqualTo("A");
+        assertThat(cache.getOrCompute("a", compute)).isEqualTo("A");
+
+        assertThat(computeCounts).containsEntry("a", 1);
+        assertThat(cache.size()).isEqualTo(1);
+    }
+
+    @Test
+    void evictsLeastRecentlyUsedAndKeepsRecentlyAccessedOverCapacity() {
+        BoundedLruCache<String, String> cache = new BoundedLruCache<>(2);
+        Map<String, Integer> computeCounts = new HashMap<>();
+        Function<String, String> compute = key -> {
+            computeCounts.merge(key, 1, Integer::sum);
+            return key.toUpperCase();
+        };
+
+        cache.getOrCompute("a", compute);          // {a}
+        cache.getOrCompute("b", compute);          // {a, b}
+        cache.getOrCompute("a", compute);          // hit — touches a, so b is now least-recently-used
+        cache.getOrCompute("c", compute);          // inserting c evicts b, not a
+        cache.getOrCompute("a", compute);          // still a hit — a was never evicted
+        cache.getOrCompute("b", compute);          // b was evicted — recomputed
+
+        assertThat(cache.size()).isEqualTo(2);
+        assertThat(computeCounts)
+                .containsEntry("a", 1)   // computed once, kept hot by the access touch
+                .containsEntry("b", 2)   // evicted then recomputed
+                .containsEntry("c", 1);
+    }
+
+    @Test
+    void constructorRejectsNonPositiveCapacity() {
+        assertThatThrownBy(() -> new BoundedLruCache<String, String>(0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("maxEntries");
+        assertThatThrownBy(() -> new BoundedLruCache<String, String>(-1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("maxEntries");
+    }
+
+    @Test
+    void getOrComputeRejectsNullFromTheMappingFunction() {
+        BoundedLruCache<String, String> cache = new BoundedLruCache<>(4);
+
+        assertThatThrownBy(() -> cache.getOrCompute("a", key -> null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessageContaining("mappingFunction");
+    }
+
+    @Test
+    void clearEmptiesTheCache() {
+        BoundedLruCache<String, String> cache = new BoundedLruCache<>(4);
+        cache.getOrCompute("a", String::toUpperCase);
+
+        cache.clear();
+
+        assertThat(cache.size()).isZero();
+    }
+
+    @Test
+    void concurrentMissesOnTheSameKeyAllShareOneStoredValue() throws Exception {
+        BoundedLruCache<String, Object> cache = new BoundedLruCache<>(4);
+        int threads = 16;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        try {
+            List<Future<Object>> results = new ArrayList<>();
+            for (int i = 0; i < threads; i++) {
+                results.add(pool.submit(() -> {
+                    start.await();
+                    // Every call returns a fresh Object; only a shared cache can
+                    // hand every thread the same instance back.
+                    return cache.getOrCompute("k", key -> new Object());
+                }));
+            }
+            start.countDown();
+
+            Object shared = results.get(0).get(5, TimeUnit.SECONDS);
+            for (Future<Object> result : results) {
+                assertThat(result.get(5, TimeUnit.SECONDS)).isSameAs(shared);
+            }
+            assertThat(cache.size()).isEqualTo(1);
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+
+    @Test
+    void distinctKeysStayBoundedByCapacityUnderConcurrency() throws Exception {
+        int capacity = 8;
+        BoundedLruCache<Integer, Integer> cache = new BoundedLruCache<>(capacity);
+        int threads = 12;
+        int keysPerThread = 50;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        try {
+            List<Future<?>> done = new ArrayList<>();
+            for (int t = 0; t < threads; t++) {
+                done.add(pool.submit(() -> {
+                    start.await();
+                    for (int k = 0; k < keysPerThread; k++) {
+                        cache.getOrCompute(k, key -> key * key);
+                    }
+                    return null;
+                }));
+            }
+            start.countDown();
+            for (Future<?> f : done) {
+                f.get(5, TimeUnit.SECONDS);
+            }
+            assertThat(cache.size()).isLessThanOrEqualTo(capacity);
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+}


### PR DESCRIPTION
## Why

`ImageSourceCache` holds two **static, process-wide** caches — decoded source
bytes keyed by absolute path, and image metadata keyed by content hash — both
plain unbounded `ConcurrentHashMap`s. A long-lived JVM that renders many
distinct images (a rendering service, a batch job) accumulates image data
indefinitely: a latent memory-growth path with no ceiling.

## What changed

- New package-private `BoundedLruCache<K,V>`: fixed-capacity, thread-safe,
  access-order (LRU) eviction. The value function runs **outside** the cache
  lock, so a slow `Files.readAllBytes` / `ImageIO` decode never blocks another
  render thread; only the brief get / `putIfAbsent` bookkeeping is synchronized.
- `ImageSourceCache` rewired onto it: `MAX_SOURCE_ENTRIES = 128` (raw bytes,
  bounded tighter) and `MAX_METADATA_ENTRIES = 512` (tiny records).
- It remains a pure memoization of a deterministic function (path→bytes,
  hash→metadata), so **output is unchanged** and eviction only ever causes a
  re-decode yielding the same result.

Shared + synchronized (not ThreadLocal like the font caches in `PdfFontLoader`):
images are large and arbitrary, so per-thread duplication would multiply memory
and defeat cross-thread dedup — the opposite of the goal.

## Verification

- Full CI-slice `verify` (core + render-pdf/docx/pptx + templates + testing +
  qa): **BUILD SUCCESS**. Core 358→365 tests, qa 638, javadoc gate green, and
  the 32-thread `DocumentSessionParallelStressTest` passes.
- New `BoundedLruCacheTest` (8 cases): proves access-order eviction (not FIFO),
  capacity validation, the concurrent single-value guarantee, and `size ≤ cap`
  under 12-thread contention. Existing `ImageDataCacheTest` unchanged and green
  (`sourceCacheSize==1`, `metadataCacheSize==1`, `metadataDecodeCount==1`).
- Reviewed for concurrency (compute-outside-lock, no lock nesting on the
  SOURCE→METADATA path, safe publication), LRU semantics, and determinism.

## Notes / accepted tradeoffs

- **Source cap 128** targets the real risk (cross-document accumulation in a
  long-lived JVM). A single document with >128 *distinct* raster images would
  evict-and-re-read within that render — correctness preserved, LRU + render
  locality mitigate. No repo example/template comes close; easy to bump the
  constant if a target document is image-heavy.
- Concurrent first-touch of the *same* key may decode it twice (deterministic →
  harmless), vs `computeIfAbsent`'s exactly-once. Documented in the helper's
  Javadoc.
- Out of scope (pre-existing, unchanged by this diff): `ImageData` exposes the
  shared cached `byte[]` by reference — a follow-up candidate.