### PR TITLE
test(architecture): add ArchUnit guards for the canonical/engine and font boundaries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <junit.bom.version>6.1.1</junit.bom.version>
         <mockito.version>5.23.0</mockito.version>
         <byteBuddy.version>1.18.11</byteBuddy.version>
+        <archunit.version>1.4.2</archunit.version>
 
         <!-- Bundled fonts / emoji, pulled in at test scope only. Pinned to the
              independent 1.0.0 line (not bumped in engine lockstep); keep in step
@@ -206,6 +207,19 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
             <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!--
+            ArchUnit drives the structural architecture guards (bytecode-level,
+            location-independent) that complement the text-scanning guards in
+            com.demcha.documentation. Test scope only; never on the published
+            engine's compile/runtime classpath.
+        -->
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit</artifactId>
+            <version>${archunit.version}</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/test/java/com/demcha/compose/architecture/ModuleBoundaryArchTest.java
+++ b/src/test/java/com/demcha/compose/architecture/ModuleBoundaryArchTest.java
@@ -1,0 +1,108 @@
+package com.demcha.compose.architecture;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Structural architecture guards enforced at bytecode level, so a
+ * fully-qualified reference or a moved source file cannot slip past the
+ * text-scanning guards in {@code com.demcha.documentation}.
+ *
+ * <p>Complements {@code PublicApiNoEngineLeakTest} and
+ * {@code PdfBackendIsolationGuardTest}: those read source files and only match
+ * {@code import} lines, so a fully-qualified reference is invisible to them;
+ * these assert the same canonical / engine / font boundaries against the
+ * compiled classes and are location-independent.
+ */
+class ModuleBoundaryArchTest {
+
+    // The core module's own classes (document + engine + font + the GraphCompose
+    // facade). DO_NOT_INCLUDE_TESTS drops the test classes — some reside in the
+    // guarded packages and legitimately reach across these boundaries.
+    private static final JavaClasses CORE_CLASSES = new ClassFileImporter()
+            .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+            .importPackages("com.demcha.compose");
+
+    /**
+     * The canonical public surface: the {@code GraphCompose} facade, the session
+     * API, the DSL builders, the node / style value objects, and the chart / svg
+     * / table / image / output / snapshot helpers. These describe what a document
+     * says; the engine reads them, never the reverse.
+     *
+     * <p>{@code document.layout} (the layout compiler) is the sanctioned engine
+     * bridge and is intentionally absent. {@code document.templates} lives in the
+     * separate graph-compose-templates module and is not on this module's
+     * classpath — its boundary is a candidate for a cross-module ArchUnit rule in
+     * the qa suite.
+     */
+    private static final String[] CANONICAL_SURFACE_PACKAGES = {
+            "com.demcha.compose",                          // GraphCompose facade (exact package)
+            "com.demcha.compose.document.api..",
+            "com.demcha.compose.document.dsl..",
+            "com.demcha.compose.document.node..",
+            "com.demcha.compose.document.style..",
+            "com.demcha.compose.document.chart..",
+            "com.demcha.compose.document.svg..",
+            "com.demcha.compose.document.table..",
+            "com.demcha.compose.document.image..",
+            "com.demcha.compose.document.output..",
+            "com.demcha.compose.document.snapshot..",
+            "com.demcha.compose.document.exceptions..",
+            "com.demcha.compose.document.emoji..",
+            "com.demcha.compose.font.."
+    };
+
+    /**
+     * The two session-orchestration classes that still convert canonical insets
+     * to engine value objects by fully-qualified reference
+     * ({@code DocumentSession.toEngineMargin} → {@code engine.components.style.Margin};
+     * {@code DocumentPageBackgrounds} → {@code Margin.zero()} / {@code Padding.zero()}).
+     * They are excluded by name — not by whole-package — so the other public
+     * {@code document.api} types stay guarded. Routing these conversions behind a
+     * public adapter (so the exclusion can be dropped) is tracked as a follow-up.
+     */
+    private static final String KNOWN_ENGINE_BRIDGE_CLASSES =
+            "com\\.demcha\\.compose\\.document\\.api\\.(DocumentSession|DocumentPageBackgrounds)(\\$.+)?";
+
+    @Test
+    void importedTheCoreProductionClasses() {
+        assertThat(CORE_CLASSES.contain("com.demcha.compose.document.api.DocumentSession"))
+                .as("ArchUnit must analyze the compiled core classes; an empty import would let "
+                        + "every rule pass vacuously")
+                .isTrue();
+        assertThat(CORE_CLASSES.contain("com.demcha.compose.document.node.ParagraphNode"))
+                .as("a guarded-package class must be present so the boundary rules have subjects")
+                .isTrue();
+    }
+
+    @Test
+    void canonicalSurfaceDoesNotDependOnTheEngine() {
+        ArchRule rule = noClasses()
+                .that().resideInAnyPackage(CANONICAL_SURFACE_PACKAGES)
+                .and().haveNameNotMatching(KNOWN_ENGINE_BRIDGE_CLASSES)
+                .should().dependOnClassesThat().resideInAPackage("com.demcha.compose.engine..")
+                .because("the canonical public surface must reach the engine only through the "
+                        + "document.layout bridge and the backend ServiceLoader seam, never by "
+                        + "referencing engine.* types directly");
+
+        rule.check(CORE_CLASSES);
+    }
+
+    @Test
+    void fontCatalogDoesNotDependOnTheDocumentLayer() {
+        ArchRule rule = noClasses()
+                .that().resideInAPackage("com.demcha.compose.font..")
+                .should().dependOnClassesThat().resideInAPackage("com.demcha.compose.document..")
+                .because("com.demcha.compose.font is the logical font catalog — it names fonts "
+                        + "and never loads them; a render backend materializes them behind the "
+                        + "FontMetricsProvider seam");
+
+        rule.check(CORE_CLASSES);
+    }
+}


### PR DESCRIPTION
## Why

The architecture guards in `com.demcha.documentation` (e.g. `PublicApiNoEngineLeakTest`,
`PdfBackendIsolationGuardTest`) scan source files and match only lines starting
with `import com.demcha.compose.engine.` — so a **fully-qualified** reference or a
moved file slips past them silently. The 2.0 engineering roadmap
([post-2.0-engineering.md](docs/roadmaps/post-2.0-engineering.md)) calls for ArchUnit
rules that "enforce the layering structurally, replacing the path-based greps that
can pass vacuously after a move."

This lands the first ArchUnit rules — and they immediately earned their keep.

## What changed

- `pom.xml`: `archunit.version=1.4.2` property + `com.tngtech.archunit:archunit`
  **test scope** (never on the published engine's classpath).
- New `ModuleBoundaryArchTest` (core test scope) — bytecode-level, location-independent:
  1. the canonical public surface (`GraphCompose` facade + `document.api` + the
     DSL / node / style / chart / svg / table / image / output / snapshot helpers +
     `font`) must not depend on `com.demcha.compose.engine..`;
  2. the `com.demcha.compose.font` catalog must not depend on `com.demcha.compose.document..`.
  Plus a sanity test that guards against a vacuous (empty-import) pass.

## The finding

The engine rule immediately caught **5 real dependencies the text guard is blind to** —
`DocumentSession.toEngineMargin` returns/constructs `engine.components.style.Margin`,
and `DocumentPageBackgrounds` calls `Margin.zero()` / `Padding.zero()` — all via
**fully-qualified names**, so `PublicApiNoEngineLeakTest`'s empty allowlist is honestly
green while the coupling exists. These two orchestration classes are excluded **by name**
(not by whole package, so the other ~14 `document.api` types stay guarded), pending an
adapter that routes the inset→engine conversion behind the public seam (filed as a
follow-up).

## Verification

Full CI-slice `verify` (core + render-pdf/docx/pptx + templates + testing + qa):
**BUILD SUCCESS**, core 358→361 tests. The rule was proven non-vacuous — an earlier
broader run failed on exactly the 5 violations above before the two bridges were excluded.

## Scope / follow-ups (not in this PR)

- **Additive, not replacing** the text greps yet — retiring them needs the `document.api`
  bridges paid down first.
- `document.templates` isn't guarded here: in the core module it's only empty leftover
  dirs; the real templates live in `graph-compose-templates`, so their boundary belongs
  in a **cross-module ArchUnit rule in the qa suite** (follow-up), together with
  core→render-pdf back-edges.
- Alternative considered: `FreezingArchRule` to keep `document.api` fully in scope by
  freezing the known violations. It's the idiomatic path to eventually retiring the text
  scanners, but commits a baseline store — deferred as a maintainer call.