### PR TITLE
build(coverage): add report-only cross-module JaCoCo aggregation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,11 +125,12 @@ jobs:
 
       - name: Build and run tests
         # Reactor slice: the engine, the render-docx / render-pptx semantic backends,
-        # the extracted graph-compose-testing module, and the graph-compose-qa
+        # the extracted graph-compose-testing module, the graph-compose-qa
         # cross-module suites (which need the testing module + the engine test-jar on
-        # the classpath and so cannot live in the engine's own test scope). -am pulls
-        # the fonts / emoji upstreams; bundle / examples / benchmarks are excluded.
-        run: ./mvnw -B -ntp -f aggregator/pom.xml clean verify -pl :graph-compose-core,:graph-compose-render-pdf,:graph-compose-render-docx,:graph-compose-render-pptx,:graph-compose-templates,:graph-compose-testing,:graph-compose-qa -am
+        # the classpath and so cannot live in the engine's own test scope), and the
+        # graph-compose-coverage aggregator (report-only JaCoCo over core + qa exec).
+        # -am pulls the fonts / emoji upstreams; bundle / examples / benchmarks are excluded.
+        run: ./mvnw -B -ntp -f aggregator/pom.xml clean verify -pl :graph-compose-core,:graph-compose-render-pdf,:graph-compose-render-docx,:graph-compose-render-pptx,:graph-compose-templates,:graph-compose-testing,:graph-compose-qa,:graph-compose-coverage -am
 
       - name: Generate Javadoc
         # Run only on the baseline JDK — Javadoc output is identical
@@ -137,6 +138,19 @@ jobs:
         # references.
         if: matrix.java == '17'
         run: ./mvnw -B -ntp javadoc:javadoc
+
+      - name: Upload aggregate coverage report
+        # Report-only: the cross-module JaCoCo report (core coverage counting the
+        # qa suites) is published as an artifact for inspection; no threshold gate.
+        # One JDK is enough — coverage is identical across JVMs.
+        if: matrix.java == '17'
+        uses: actions/upload-artifact@v7
+        with:
+          # Core-scope aggregate (engine coverage counting the qa suites);
+          # render-pdf / templates are a follow-up, so the name is explicit.
+          name: coverage-core-aggregate-${{ github.run_id }}
+          path: coverage/target/site/jacoco-aggregate/**
+          if-no-files-found: error
 
   examples-generation:
     name: Examples Generation Smoke Test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,15 @@ for this cycle.
   accumulates image data indefinitely. Single documents are unaffected: the caps sit
   far above any realistic distinct-image count, so a render never evicts or re-decodes.
 
+### Build
+
+- Added report-only cross-module code coverage. A new non-published
+  `graph-compose-coverage` module runs JaCoCo `report-aggregate` over the engine plus
+  the `graph-compose-qa` cross-module suites, so the canonical core's coverage counts
+  the tests that actually exercise it (a single-module report undercounts, because most
+  of the engine is driven from qa at test scope). CI publishes the HTML/XML report as an
+  artifact; no coverage threshold is enforced yet.
+
 ## v1.9.1 — 2026-07-06
 
 Table columns now contain long inline-code content instead of letting it spill

--- a/aggregator/pom.xml
+++ b/aggregator/pom.xml
@@ -45,6 +45,12 @@
             fonts; bump only when the emoji set changes.
         -->
         <graphcompose.emoji.version>1.0.0</graphcompose.emoji.version>
+        <!--
+            Coverage plugin version for the aggregator children that measure
+            coverage (qa) and aggregate it (coverage). Keep in lockstep with the
+            standalone engine pom's jacoco.plugin.version.
+        -->
+        <jacoco.plugin.version>0.8.12</jacoco.plugin.version>
     </properties>
 
     <!--
@@ -70,5 +76,10 @@
         <module>../examples</module>
         <module>../benchmarks</module>
         <module>../qa</module>
+        <!--
+            Coverage aggregation. Listed last so every measured module's
+            jacoco.exec exists before report-aggregate runs. Non-published.
+        -->
+        <module>../coverage</module>
     </modules>
 </project>

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <!--
+        Non-published cross-module coverage aggregator (2.0 module line). JaCoCo's
+        report-aggregate builds one report from the jacoco.exec of every module it
+        depends on, so the canonical engine's coverage counts BOTH its own tests
+        and the graph-compose-qa cross-module suites that exercise it at test scope
+        — which a single-module report undercounts (report-aggregate does not
+        traverse test-scope dependencies, hence this dedicated module that
+        compile-depends on the measured modules).
+
+        Report-only: no coverage threshold is enforced yet. The aggregate HTML/XML
+        lands in target/site/jacoco-aggregate/. Sits at the reactor tail (listed
+        last in the aggregator) so every measured module's exec exists first, and
+        never publishes (maven.deploy.skip=true, inherited from the parent).
+
+        Scope: the canonical engine (graph-compose-core). The render-pdf / templates
+        backends measure their own coverage once they gain prepare-agent — a
+        follow-up — so they are intentionally not aggregated here yet.
+    -->
+    <parent>
+        <groupId>io.github.demchaav</groupId>
+        <artifactId>graph-compose-build</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+        <relativePath>../aggregator/pom.xml</relativePath>
+    </parent>
+
+    <artifactId>graph-compose-coverage</artifactId>
+    <packaging>pom</packaging>
+    <name>GraphCompose Coverage</name>
+    <description>Non-published cross-module JaCoCo coverage aggregation for GraphCompose.</description>
+
+    <dependencies>
+        <!-- Classes to report on (the canonical engine). -->
+        <dependency>
+            <groupId>io.github.demchaav</groupId>
+            <artifactId>graph-compose-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!--
+            The cross-module suites whose jacoco.exec carries most of the engine's
+            real coverage. It has no main classes of its own; it is here so
+            report-aggregate reads its exec.
+        -->
+        <dependency>
+            <groupId>io.github.demchaav</groupId>
+            <artifactId>graph-compose-qa</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>report-aggregate</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>report-aggregate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,16 @@
         <maven.javadoc.plugin.version>3.12.0</maven.javadoc.plugin.version>
         <maven.source.plugin.version>3.4.0</maven.source.plugin.version>
         <maven.surefire.plugin.version>3.5.6</maven.surefire.plugin.version>
+        <jacoco.plugin.version>0.8.12</jacoco.plugin.version>
+
+        <!--
+            Empty default for the surefire argLine. JaCoCo's prepare-agent
+            prepends its javaagent to this property; declaring it empty here means
+            surefire's `@{argLine}` resolves to empty (not the literal `@{argLine}`,
+            which the JVM would treat as an argfile) when coverage is skipped
+            (-Djacoco.skip=true) or prepare-agent otherwise does not run.
+        -->
+        <argLine></argLine>
 
         <!-- Minimum toolchain (enforced by maven-enforcer-plugin) -->
         <enforcer.requireMavenVersion>3.8.0</enforcer.requireMavenVersion>
@@ -358,8 +368,44 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.plugin.version}</version>
                 <configuration>
-                    <argLine>-javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
+                    <!--
+                        @{argLine} is the late-evaluated `argLine` property JaCoCo's
+                        prepare-agent prepends its javaagent to; keeping it here (rather
+                        than a bare literal) lets the coverage agent attach alongside the
+                        Mockito inline-mock agent instead of one clobbering the other. It
+                        resolves to the empty <argLine> default in <properties> when
+                        coverage is skipped, so the Mockito-only run still works.
+                    -->
+                    <argLine>@{argLine} -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito.version}/mockito-core-${mockito.version}.jar</argLine>
                 </configuration>
+            </plugin>
+
+            <!--
+                Coverage agent. prepare-agent sets the `argLine` property (picked
+                up by surefire above) so each test run writes target/jacoco.exec;
+                the per-module HTML report is a convenience. The cross-module
+                aggregate that counts the qa suites' coverage of the engine lives
+                in the dedicated `graph-compose-coverage` module (report-aggregate).
+            -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>jacoco-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>jacoco-report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <!--

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -188,6 +188,26 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.plugin.version}</version>
             </plugin>
+            <!--
+                Coverage agent. qa's cross-module suites exercise the engine at
+                test scope, so their jacoco.exec is where most of the canonical
+                core's coverage actually lands. The graph-compose-coverage module
+                reads this exec via report-aggregate. (No <argLine> is set here,
+                so surefire picks up the property prepare-agent writes.)
+            -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>jacoco-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
## Why

The canonical engine is exercised mostly by the **`graph-compose-qa`** cross-module
suites, which depend on it at **test scope** — so a single-module JaCoCo report
undercounts the core, and `report-aggregate` does not traverse test-scope
dependencies. Per [post-2.0-engineering.md](docs/roadmaps/post-2.0-engineering.md)
("a dedicated non-published aggregation module that compile-depends on the tested
modules … report-only first"), this adds that module.

## What changed

- **`graph-compose-coverage`** (new, non-published, `packaging=pom`, parent = aggregator):
  compile-depends on `graph-compose-core` (its classes become the report bundle) and
  `graph-compose-qa` (0 main classes — contributes its `jacoco.exec` only), and runs
  `jacoco:report-aggregate` at `verify`. Report-only; no threshold gate.
- **core + qa**: `jacoco:prepare-agent`. Core merges the coverage agent into its
  surefire `argLine` alongside the Mockito inline-mock agent via `@{argLine}`, with an
  **empty `argLine` property default** so a `-Djacoco.skip=true` run still starts.
- **CI**: the coverage module joins the reactor slice; the aggregate HTML/XML is
  uploaded as an artifact on JDK 17 (`if-no-files-found: error`).

## Verification

Full CI-slice `verify` (11 modules incl. coverage): **BUILD SUCCESS**. The aggregate
is accurate — core **78.0%** instruction / 63.7% branch, with `document.layout` **88%**,
`layout.definitions` 96%, `document.api` 83%. Those layout numbers are only that high
*because* qa's exec is aggregated onto core's classes — exactly the undercount this
fixes. JaCoCo OR-merges execs per probe, so there is no double-counting. Confirmed
`-Djacoco.skip=true` and a normal (jacoco-on) run both pass on core.

japicmp-safe: `prepare-agent` is on-the-fly `-javaagent` instrumentation and never
rewrites `target/classes`, so the published jar and the binary-compat gate are unaffected.

## Scope / follow-ups

- **Core only** by design: render-pdf / templates would *undercount* without their own
  `prepare-agent`, so aggregating them now would mislead — they join in a follow-up.
- Recommend extending `VersionConsistencyGuardTest` to assert `jacoco.plugin.version`
  is equal across the core pom and the aggregator (it is dual-sourced — standalone core
  can't inherit the aggregator property), and to enumerate the new `coverage` module.