### PR TITLE
docs: document the LTR-only text limitation and consolidate the 2.0 API changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -113,6 +113,15 @@ for this cycle.
   of the engine is driven from qa at test scope). CI publishes the HTML/XML report as an
   artifact; no coverage threshold is enforced yet.
 
+### Documentation
+
+- Documented that text is laid out left-to-right only: bidirectional (RTL) reordering
+  and complex-script shaping (Arabic joining, Indic reordering) are not performed. Added
+  to the README support matrix.
+- The 2.0 module migration guide now lists the API changes it previously delegated to the
+  changelog — the `.v2` package rename, the `BusinessTheme` removal, the retired classic
+  presets, and `Font.adjustFontSizeToFit` — each with its migration action.
+
 ## v1.9.1 — 2026-07-06
 
 Table columns now contain long inline-code content instead of letting it spill

--- a/README.md
+++ b/README.md
@@ -205,6 +205,11 @@ For a Spring Boot `@RestController` streaming the PDF straight to the response, 
 | DOCX | Partial | Semantic export via Apache POI. Unsupported nodes (`shape`, `line`, `ellipse`, `barcode`) are dropped silently &mdash; layout fidelity is best-effort for paragraph / list / table content. |
 | PPTX | Skeleton | Validates supported node types and emits a manifest. **Not a real PowerPoint export yet** &mdash; planned only if there is demand. |
 
+### Text &amp; internationalization
+
+- Text is laid out **left-to-right**. Bidirectional (RTL) reordering and complex-script shaping &mdash; Arabic contextual joining, Indic reordering &mdash; are **not** performed, so Arabic / Hebrew text renders in logical order without correct visual ordering.
+- A glyph the active font does not cover renders as `?` (with a warning logged); load a font that covers the script you need.
+
 ### When to use GraphCompose
 
 - **Server-side PDF generation in Java** &mdash; invoices, CVs, reports, proposals, statements, schedules.

--- a/docs/migration/v2.0.0-modules.md
+++ b/docs/migration/v2.0.0-modules.md
@@ -2,9 +2,10 @@
 
 GraphCompose 2.0 splits the single `graph-compose` jar into per-concern modules so an
 engine-only consumer no longer pulls PDFBox, POI, zxing, and the template families. This
-guide covers the **dependency** change. For API-level removals (retired classes, the
-`.v2` package rename, `BusinessTheme`), see the [`### Removed` / `### Public API` sections
-of the changelog](../../CHANGELOG.md); the rationale is [ADR 0016](../adr/0016-multi-module-packaging.md).
+guide covers the **dependency** change and the **API changes** 2.0 makes — the retired
+deprecated APIs, the `.v2` package rename, and the `BusinessTheme` removal are all listed
+below. The [`### Removed` / `### Public API` sections of the changelog](../../CHANGELOG.md)
+carry the exhaustive detail; the rationale is [ADR 0016](../adr/0016-multi-module-packaging.md).
 
 ## TL;DR — rendering PDF? Nothing changes
 
@@ -98,6 +99,18 @@ sites before you upgrade:
 
 The PDF option types (`PdfMetadataOptions` and friends) still exist for advanced
 `PdfFixedLayoutBackend.builder()` configuration — only the session-level shortcuts are gone.
+
+## Other 2.0 API changes
+
+Beyond the deprecated surface above, 2.0 makes the breaking changes below. None affects
+plain PDF rendering; they touch template authoring and one package rename.
+
+| Change | Migration |
+|---|---|
+| **The layered template packages dropped their `.v2` suffix** — `…document.templates.<family>.v2.*` → `…document.templates.<family>.*` for `cv`, `coverletter`, `invoice`, `proposal`. | Update imports only; behaviour and rendering are unchanged. |
+| **`BusinessTheme` removed**, with its `DocumentPalette` / `SpacingScale` / `TextScale` / `TablePreset` companions. | Author with explicit `DocumentColor` / `DocumentTextStyle` values, or a template `BrandTheme`. The token bundle lives on only as a styling helper inside the examples module. |
+| **The classic (pre-layered) CV and cover-letter presets removed.** | Use the layered `templates.cv.*` / `templates.coverletter.*` stack on `BrandTheme` — the single template surface now. |
+| **`Font.adjustFontSizeToFit(...)` removed** (engine-internal). | No action — text auto-sizing is resolved by the layout compiler. |
 
 ## Reference
 


### PR DESCRIPTION
## Why

Two honesty/completeness gaps in the docs:

- **RTL/bidi is unsupported but undocumented.** The engine lays text out left-to-right
  and performs no bidirectional reordering or complex-script shaping, so Arabic/Hebrew
  render in logical (visually wrong) order — a silent surprise with nothing in the docs
  warning about it.
- **The 2.0 migration guide was incomplete.** It covered the `@Deprecated(forRemoval)`
  removals but *delegated* the other 2.0 breaking API changes (the `.v2` package rename,
  `BusinessTheme`, the classic presets) to the changelog, so a migrating reader had to
  reconstruct the full break list from two documents.

## What changed

- **README** → new **Text &amp; internationalization** note under the output-support
  matrix: LTR-only, no RTL reordering / complex-script shaping, and an uncovered glyph
  renders as `?` (logged).
- **`docs/migration/v2.0.0-modules.md`** → a new **Other 2.0 API changes** table (the
  `.v2` rename, `BusinessTheme` + companions, the retired classic CV/cover-letter presets,
  `Font.adjustFontSizeToFit`), each with its migration action; the intro no longer punts
  those to the changelog.
- **CHANGELOG** → a `### Documentation` entry.

Docs-only; no code, API, or build changes.

## Verification

`./mvnw -pl . -Dtest=CanonicalSurfaceGuardTest,VersionConsistencyGuardTest,DocumentationCoverageTest test`
→ **22/22 green**. `CanonicalSurfaceGuardTest` scans README/docs for retired legacy
tokens and passes — the `.v2`-rename wording uses `document.templates.<family>.v2.*`, not
the banned `com.demcha.compose.v2`. No new or broken links; the migration facts are taken
verbatim from the changelog's `### Removed` / `### Public API` sections.