### PR TITLE
build(coverage): extend the aggregate to render-pdf and templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,11 +107,12 @@ for this cycle.
 ### Build
 
 - Added report-only cross-module code coverage. A new non-published
-  `graph-compose-coverage` module runs JaCoCo `report-aggregate` over the engine plus
-  the `graph-compose-qa` cross-module suites, so the canonical core's coverage counts
-  the tests that actually exercise it (a single-module report undercounts, because most
-  of the engine is driven from qa at test scope). CI publishes the HTML/XML report as an
-  artifact; no coverage threshold is enforced yet.
+  `graph-compose-coverage` module runs JaCoCo `report-aggregate` over the engine, the
+  PDF backend, and the built-in templates plus the `graph-compose-qa` cross-module
+  suites, so each module's coverage counts the tests that actually exercise it (a
+  single-module report undercounts, because much of the production code is driven from
+  qa at test scope). CI publishes the HTML/XML report as an artifact; no coverage
+  threshold is enforced yet.
 
 ### Documentation
 

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -7,7 +7,7 @@
     <!--
         Non-published cross-module coverage aggregator (2.0 module line). JaCoCo's
         report-aggregate builds one report from the jacoco.exec of every module it
-        depends on, so the canonical engine's coverage counts BOTH its own tests
+        depends on, so each measured module's coverage counts BOTH its own tests
         and the graph-compose-qa cross-module suites that exercise it at test scope
         — which a single-module report undercounts (report-aggregate does not
         traverse test-scope dependencies, hence this dedicated module that
@@ -18,9 +18,10 @@
         last in the aggregator) so every measured module's exec exists first, and
         never publishes (maven.deploy.skip=true, inherited from the parent).
 
-        Scope: the canonical engine (graph-compose-core). The render-pdf / templates
-        backends measure their own coverage once they gain prepare-agent — a
-        follow-up — so they are intentionally not aggregated here yet.
+        Scope: the engine (graph-compose-core), the PDF backend
+        (graph-compose-render-pdf), and the built-in templates
+        (graph-compose-templates) — each reported from its own tests plus the qa
+        suites' exec.
     -->
     <parent>
         <groupId>io.github.demchaav</groupId>
@@ -35,10 +36,20 @@
     <description>Non-published cross-module JaCoCo coverage aggregation for GraphCompose.</description>
 
     <dependencies>
-        <!-- Classes to report on (the canonical engine). -->
+        <!-- Classes to report on (the production modules). -->
         <dependency>
             <groupId>io.github.demchaav</groupId>
             <artifactId>graph-compose-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.demchaav</groupId>
+            <artifactId>graph-compose-render-pdf</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.github.demchaav</groupId>
+            <artifactId>graph-compose-templates</artifactId>
             <version>${project.version}</version>
         </dependency>
         <!--

--- a/render-pdf/pom.xml
+++ b/render-pdf/pom.xml
@@ -77,6 +77,9 @@
         <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
         <maven.jar.plugin.version>3.5.0</maven.jar.plugin.version>
         <maven.surefire.plugin.version>3.5.6</maven.surefire.plugin.version>
+        <!-- Keep in lockstep with the engine pom's jacoco.plugin.version
+             (VersionConsistencyGuardTest enforces the equality). -->
+        <jacoco.plugin.version>0.8.12</jacoco.plugin.version>
         <maven.source.plugin.version>3.4.0</maven.source.plugin.version>
         <maven.javadoc.plugin.version>3.12.0</maven.javadoc.plugin.version>
         <maven.gpg.plugin.version>3.2.8</maven.gpg.plugin.version>
@@ -207,6 +210,24 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.plugin.version}</version>
+            </plugin>
+            <!--
+                Coverage agent (prepare-agent only — no <argLine> here, so surefire
+                picks up the property it writes). This module's exec feeds the
+                report-aggregate in graph-compose-coverage.
+            -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>jacoco-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/src/test/java/com/demcha/documentation/VersionConsistencyGuardTest.java
+++ b/src/test/java/com/demcha/documentation/VersionConsistencyGuardTest.java
@@ -126,6 +126,30 @@ class VersionConsistencyGuardTest {
         assertThat(declaresOwnVersion(PROJECT_ROOT.resolve("qa/pom.xml")))
                 .describedAs("qa/pom.xml must inherit <version> from the aggregator parent, not declare its own")
                 .isFalse();
+        assertThat(declaresOwnVersion(PROJECT_ROOT.resolve("coverage/pom.xml")))
+                .describedAs("coverage/pom.xml must inherit <version> from the aggregator parent, not declare its own")
+                .isFalse();
+    }
+
+    @Test
+    void jacocoPluginVersionAgreesAcrossModules() throws Exception {
+        // The coverage agent (which writes each module's exec) and report-aggregate
+        // (which reads them) must run the same JaCoCo version — a mismatch can break
+        // the exec-format read. The version is pinned as a literal in each standalone
+        // module that measures coverage (engine, render-pdf, templates) plus the
+        // aggregator that the qa + coverage children inherit, so guard the four
+        // against drift.
+        String core = pinnedVersionProperty(PROJECT_ROOT.resolve("pom.xml"), "jacoco.plugin.version");
+
+        assertThat(pinnedVersionProperty(PROJECT_ROOT.resolve("aggregator/pom.xml"), "jacoco.plugin.version"))
+                .describedAs("aggregator jacoco.plugin.version must match the engine pom's (%s)", core)
+                .isEqualTo(core);
+        assertThat(pinnedVersionProperty(PROJECT_ROOT.resolve("render-pdf/pom.xml"), "jacoco.plugin.version"))
+                .describedAs("render-pdf jacoco.plugin.version must match the engine pom's (%s)", core)
+                .isEqualTo(core);
+        assertThat(pinnedVersionProperty(PROJECT_ROOT.resolve("templates/pom.xml"), "jacoco.plugin.version"))
+                .describedAs("templates jacoco.plugin.version must match the engine pom's (%s)", core)
+                .isEqualTo(core);
     }
 
     @Test

--- a/templates/pom.xml
+++ b/templates/pom.xml
@@ -63,6 +63,9 @@
         <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
         <maven.jar.plugin.version>3.5.0</maven.jar.plugin.version>
         <maven.surefire.plugin.version>3.5.6</maven.surefire.plugin.version>
+        <!-- Keep in lockstep with the engine pom's jacoco.plugin.version
+             (VersionConsistencyGuardTest enforces the equality). -->
+        <jacoco.plugin.version>0.8.12</jacoco.plugin.version>
         <maven.source.plugin.version>3.4.0</maven.source.plugin.version>
         <maven.javadoc.plugin.version>3.12.0</maven.javadoc.plugin.version>
         <maven.gpg.plugin.version>3.2.8</maven.gpg.plugin.version>
@@ -129,6 +132,24 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven.surefire.plugin.version}</version>
+            </plugin>
+            <!--
+                Coverage agent (prepare-agent only — no <argLine> here, so surefire
+                picks up the property it writes). This module's exec feeds the
+                report-aggregate in graph-compose-coverage.
+            -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>jacoco-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <!--
                 Build a tests-classifier jar so graph-compose-qa and the benchmarks


### PR DESCRIPTION
## Why

The report-only coverage aggregate added in the last cycle covered **only the engine**.
render-pdf (44 classes) and templates (135 classes) are significant production code whose
coverage was invisible. Aggregating them *without* their own `prepare-agent` would
undercount them (they'd show only qa-driven coverage), so this adds the agent to both and
folds them into the report — the follow-up flagged when the first increment shipped.

## What changed

- **`render-pdf/pom.xml`, `templates/pom.xml`**: `jacoco:prepare-agent` (prepare-agent
  only — no `<argLine>`, so surefire picks up the property; no Mockito-agent merge like
  core needs), plus a pinned `jacoco.plugin.version`.
- **`coverage/pom.xml`**: now also depends on `graph-compose-render-pdf` and
  `graph-compose-templates`, so their classes join the `report-aggregate` bundle; Javadoc
  updated to the three-module scope.
- **`VersionConsistencyGuardTest`**: `jacoco.plugin.version` is now pinned in four
  standalone spots (engine / aggregator / render-pdf / templates); a new
  `jacocoPluginVersionAgreesAcrossModules` asserts the four are equal (a mismatched
  agent-writer vs report-reader JaCoCo version can break the exec read), and the
  `coverage` module joins the inherit-version guard.

## Verification

Full CI-slice `verify`: **BUILD SUCCESS**. The aggregate grows from the engine's 443
classes to **695** — TOTAL 83.9% instruction, split **core 79% / render-pdf 85% /
templates 92%**. Those per-module numbers reflect each module's own tests **plus** the qa
suites (JaCoCo OR-merges the execs, no double-count). The new version guard passes.

japicmp-safe: jacoco is a build plugin on render-pdf/templates, never a dependency — the
published jars are unaffected.