### PR TITLE
test(architecture): guard the templates module boundaries with ArchUnit

### DIFF
--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -44,6 +44,10 @@
         <logback.version>1.5.37</logback.version>
         <pdfbox.version>3.0.7</pdfbox.version>
         <javafx.version>21.0.2</javafx.version>
+        <!-- ArchUnit for the cross-module boundary guards below. Roughly in step
+             with the engine pom's archunit.version; a drift is harmless (test-only,
+             each module runs its own test JVM), so it is not version-guarded. -->
+        <archunit.version>1.4.2</archunit.version>
         <!-- graphcompose.fonts.version / graphcompose.emoji.version and
              maven.deploy.skip=true are inherited from the aggregator parent. -->
     </properties>
@@ -169,6 +173,17 @@
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-swing</artifactId>
             <version>${javafx.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!--
+            Cross-module architecture guards. Only qa has the engine, render-pdf, and
+            templates artifacts on one classpath, so the boundaries between them can
+            only be asserted structurally from here.
+        -->
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit</artifactId>
+            <version>${archunit.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/qa/src/test/java/com/demcha/compose/architecture/CrossModuleBoundaryArchTest.java
+++ b/qa/src/test/java/com/demcha/compose/architecture/CrossModuleBoundaryArchTest.java
@@ -1,0 +1,83 @@
+package com.demcha.compose.architecture;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Cross-module architecture guards, enforced at bytecode level. The engine
+ * ({@code graph-compose-core}), the PDF backend ({@code graph-compose-render-pdf}),
+ * and the built-in templates ({@code graph-compose-templates}) only meet on one
+ * classpath here in the qa module, so the boundaries <em>between</em> them can
+ * only be asserted from here.
+ *
+ * <p>These complement the intra-core {@code ModuleBoundaryArchTest} in the engine
+ * module. In particular the templates &rarr; engine boundary went unguarded when
+ * the templates left the engine jar: {@code PublicApiNoEngineLeakTest} and
+ * {@code PdfBackendIsolationGuardTest} scan the engine's own sources only.
+ */
+class CrossModuleBoundaryArchTest {
+
+    // Every module's production classes on the qa classpath (engine + render-pdf +
+    // templates + testing). DO_NOT_INCLUDE_TESTS drops qa's own test classes, which
+    // legitimately depend on all of them.
+    private static final JavaClasses MODULE_CLASSES = new ClassFileImporter()
+            .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+            .importPackages("com.demcha.compose");
+
+    private static final String TEMPLATES = "com.demcha.compose.document.templates..";
+    private static final String[] PDF_BACKEND = {
+            "com.demcha.compose.document.backend.fixed.pdf..",
+            "com.demcha.compose.engine.render.pdf.."
+    };
+
+    @Test
+    void importedTheTemplatesAndEngineModuleClasses() {
+        assertThat(MODULE_CLASSES.contain("com.demcha.compose.document.api.DocumentSession"))
+                .as("the engine classes must be on the qa classpath")
+                .isTrue();
+        assertThat(MODULE_CLASSES.stream()
+                .anyMatch(c -> c.getPackageName().startsWith("com.demcha.compose.document.templates")))
+                .as("the templates classes must be on the qa classpath so the boundary rules have subjects")
+                .isTrue();
+    }
+
+    @Test
+    void templatesDoNotDependOnTheEngine() {
+        ArchRule rule = noClasses()
+                .that().resideInAPackage(TEMPLATES)
+                .should().dependOnClassesThat().resideInAPackage("com.demcha.compose.engine..")
+                .because("the built-in templates compose over the canonical DSL only — they must "
+                        + "reach the engine through the public document.* API, never by referencing "
+                        + "engine.* internals directly");
+
+        rule.check(MODULE_CLASSES);
+    }
+
+    @Test
+    void templatesStayBackendNeutral() {
+        ArchRule rule = noClasses()
+                .that().resideInAPackage(TEMPLATES)
+                .should().dependOnClassesThat().resideInAPackage("org.apache.pdfbox..")
+                .because("templates are pure authoring code over the canonical DSL; PDFBox lives "
+                        + "behind the graph-compose-render-pdf backend seam, not in a preset");
+
+        rule.check(MODULE_CLASSES);
+    }
+
+    @Test
+    void thePdfBackendDoesNotDependOnTemplates() {
+        ArchRule rule = noClasses()
+                .that().resideInAnyPackage(PDF_BACKEND)
+                .should().dependOnClassesThat().resideInAPackage(TEMPLATES)
+                .because("the render backend is template-agnostic — it renders the resolved layout "
+                        + "graph and knows nothing about the built-in presets");
+
+        rule.check(MODULE_CLASSES);
+    }
+}


### PR DESCRIPTION
## Why

When the built-in templates left the engine jar for `graph-compose-templates`, the
guards that kept them off engine internals and PDFBox stopped covering them:
`PublicApiNoEngineLeakTest` and `PdfBackendIsolationGuardTest` scan **the engine's
own sources only**. So `templates → engine` — the one boundary Maven does *not*
enforce (templates depends on core, and core *contains* `engine.*`) — has been
unguarded on the 2.0 line.

Only the qa module has the engine, render-pdf, and templates artifacts on one
classpath, so the cross-module boundaries can only be asserted from here. This
completes the ArchUnit story started by the intra-core `ModuleBoundaryArchTest`.

## What changed

- `qa/pom.xml`: ArchUnit at test scope (drift from the engine pom's copy is harmless —
  test-only, separate JVMs — so it is not version-guarded, and the comment says so).
- New `CrossModuleBoundaryArchTest` (bytecode-level, so it catches fully-qualified
  references and survives file moves):
  1. **templates must not depend on `com.demcha.compose.engine..`** — the real gap;
     templates compose over the canonical DSL, never engine internals.
  2. **templates must not depend on `org.apache.pdfbox..`** — stay backend-neutral.
  3. **the PDF backend must not depend on the templates** — it is template-agnostic.

  Plus a sanity test that the engine and templates classes are both imported (so the
  rules have subjects and can't pass vacuously).

## Verification

Full CI-slice `verify`: **BUILD SUCCESS**, qa 638 → **642** tests. All three rules are
green on the current tree — templates is genuinely engine- and PDFBox-clean at the
bytecode level (no hidden fully-qualified leak, unlike the `document.api` bridges the
intra-core rule surfaced).

## Notes

- Rules 2 and 3 are also enforced by the Maven dependency graph (templates has no PDFBox
  or render-pdf on its classpath); they are kept as cheap structural documentation of the
  intended module DAG and a guard against a future dependency being added.
- render-docx / render-pptx are not on qa's classpath, so their boundaries aren't checked
  here — a follow-up if wanted.