### PR TITLE
refactor(engine): route the document.api insets conversion through the layout bridge

### DIFF
--- a/src/main/java/com/demcha/compose/document/api/DocumentPageBackgrounds.java
+++ b/src/main/java/com/demcha/compose/document/api/DocumentPageBackgrounds.java
@@ -57,7 +57,7 @@ final class DocumentPageBackgrounds {
                 // fills are unaffected.
                 double fragmentY =
                         (1.0 - fill.yRatio() - fill.heightRatio()) * pageHeight;
-                combined.add(new PlacedFragment(
+                combined.add(PlacedFragment.withZeroInsets(
                         "@page-background[" + page + "][" + i + "]",
                         0,
                         page,
@@ -65,8 +65,6 @@ final class DocumentPageBackgrounds {
                         fragmentY,
                         fill.widthRatio() * pageWidth,
                         fill.heightRatio() * pageHeight,
-                        com.demcha.compose.engine.components.style.Margin.zero(),
-                        com.demcha.compose.engine.components.style.Padding.zero(),
                         new ShapeFragmentPayload(fill.color().color(),
                                 null, 0.0, null, null, null)));
             }

--- a/src/main/java/com/demcha/compose/document/api/DocumentSession.java
+++ b/src/main/java/com/demcha/compose/document/api/DocumentSession.java
@@ -110,7 +110,7 @@ public final class DocumentSession implements AutoCloseable {
         this.defaultOutputFile = defaultOutputFile;
         this.pageSize = Objects.requireNonNull(pageSize, "pageSize");
         this.margin = margin == null ? DocumentInsets.zero() : requireNonNegativePageMargin(margin);
-        this.canvas = LayoutCanvas.from(pageSize.width(), pageSize.height(), toEngineMargin(this.margin));
+        this.canvas = LayoutCanvas.from(pageSize.width(), pageSize.height(), this.margin);
         this.markdown = markdown;
         this.debug = DocumentDebugOptions.none().withGuides(guideLines);
         this.registry = BuiltInNodeDefinitions.registerDefaults(new InvalidatingNodeRegistry());
@@ -271,7 +271,7 @@ public final class DocumentSession implements AutoCloseable {
     public DocumentSession pageSize(DocumentPageSize pageSize) {
         ensureOpen();
         this.pageSize = Objects.requireNonNull(pageSize, "pageSize");
-        this.canvas = LayoutCanvas.from(this.pageSize.width(), this.pageSize.height(), toEngineMargin(margin));
+        this.canvas = LayoutCanvas.from(this.pageSize.width(), this.pageSize.height(), margin);
         invalidate();
         return this;
     }
@@ -300,7 +300,7 @@ public final class DocumentSession implements AutoCloseable {
     public DocumentSession margin(DocumentInsets margin) {
         ensureOpen();
         this.margin = margin == null ? DocumentInsets.zero() : requireNonNegativePageMargin(margin);
-        this.canvas = LayoutCanvas.from(pageSize.width(), pageSize.height(), toEngineMargin(this.margin));
+        this.canvas = LayoutCanvas.from(pageSize.width(), pageSize.height(), this.margin);
         invalidate();
         return this;
     }
@@ -802,7 +802,7 @@ public final class DocumentSession implements AutoCloseable {
             int toIndexExclusive = rule.toPageExclusive() == Integer.MAX_VALUE
                     ? Integer.MAX_VALUE
                     : rule.toPageExclusive() - 1;
-            overrides.add(new PageMarginOverride(fromIndex, toIndexExclusive, toEngineMargin(rule.insets())));
+            overrides.add(PageMarginOverride.fromInsets(fromIndex, toIndexExclusive, rule.insets()));
         }
         return PageGeometry.of(canvas, overrides);
     }
@@ -1136,17 +1136,6 @@ public final class DocumentSession implements AutoCloseable {
             throw new IllegalStateException(
                     "Cannot render an empty document. Add at least one root before calling writePdf/toPdfBytes/buildPdf/toImages/toImage.");
         }
-    }
-
-    private com.demcha.compose.engine.components.style.Margin toEngineMargin(DocumentInsets insets) {
-        if (insets == null) {
-            return com.demcha.compose.engine.components.style.Margin.zero();
-        }
-        return new com.demcha.compose.engine.components.style.Margin(
-                insets.top(),
-                insets.right(),
-                insets.bottom(),
-                insets.left());
     }
 
     private void refreshMeasurementServices() {

--- a/src/main/java/com/demcha/compose/document/layout/LayoutCanvas.java
+++ b/src/main/java/com/demcha/compose/document/layout/LayoutCanvas.java
@@ -1,5 +1,6 @@
 package com.demcha.compose.document.layout;
 
+import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.engine.components.style.Margin;
 
 /**
@@ -29,6 +30,22 @@ public record LayoutCanvas(double width, double height, double innerWidth, doubl
                 Math.max(0.0, width - safeMargin.horizontal()),
                 Math.max(0.0, height - safeMargin.vertical()),
                 safeMargin);
+    }
+
+    /**
+     * Creates canvas geometry from backend-neutral page dimensions and canonical
+     * page insets, converting them to an engine margin at this layout boundary so
+     * the caller never has to. Equivalent to {@link #from(double, double, Margin)}
+     * with {@code LayoutInsets.toMargin(margin)}.
+     *
+     * @param width  physical page width
+     * @param height physical page height
+     * @param margin canonical page insets; null becomes zero margin
+     * @return normalized canvas geometry
+     * @since 2.0.0
+     */
+    public static LayoutCanvas from(double width, double height, DocumentInsets margin) {
+        return from(width, height, LayoutInsets.toMargin(margin));
     }
 }
 

--- a/src/main/java/com/demcha/compose/document/layout/LayoutInsets.java
+++ b/src/main/java/com/demcha/compose/document/layout/LayoutInsets.java
@@ -1,0 +1,30 @@
+package com.demcha.compose.document.layout;
+
+import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.engine.components.style.Margin;
+
+/**
+ * Converts canonical {@link DocumentInsets} into the engine's {@link Margin}
+ * value type at the layout boundary. Keeping this bridge here — rather than in
+ * the canonical {@code document.api} — lets the public session API feed page
+ * geometry into the compiler without ever referencing an engine type.
+ */
+final class LayoutInsets {
+
+    private LayoutInsets() {
+    }
+
+    /**
+     * Maps canonical page insets to an engine {@link Margin}; {@code null}
+     * insets become {@link Margin#zero()}.
+     *
+     * @param insets canonical page insets, or {@code null}
+     * @return the equivalent engine margin
+     */
+    static Margin toMargin(DocumentInsets insets) {
+        if (insets == null) {
+            return Margin.zero();
+        }
+        return new Margin(insets.top(), insets.right(), insets.bottom(), insets.left());
+    }
+}

--- a/src/main/java/com/demcha/compose/document/layout/PageMarginOverride.java
+++ b/src/main/java/com/demcha/compose/document/layout/PageMarginOverride.java
@@ -1,5 +1,6 @@
 package com.demcha.compose.document.layout;
 
+import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.engine.components.style.Margin;
 
 import java.util.Objects;
@@ -8,7 +9,9 @@ import java.util.Objects;
  * Engine-side per-page-range margin override: the margin to apply to a contiguous
  * run of pages, addressed by 0-based page index. The canonical
  * {@code PageMarginRule} (1-based, public API) is translated into this internal
- * form by {@code DocumentSession} before it reaches the compiler.
+ * form via {@link #fromInsets}, which converts the canonical insets to an engine
+ * margin at this layout boundary so {@code DocumentSession} never references an
+ * engine type.
  *
  * @param fromPageIndex        first page index the override covers (0-based, inclusive)
  * @param toPageIndexExclusive one past the last page index covered (exclusive)
@@ -31,6 +34,20 @@ public record PageMarginOverride(int fromPageIndex, int toPageIndexExclusive, Ma
                     "toPageIndexExclusive (" + toPageIndexExclusive + ") must be greater than fromPageIndex ("
                     + fromPageIndex + ")");
         }
+    }
+
+    /**
+     * Builds an override from canonical page insets, converting them to an engine
+     * {@link Margin} at this layout boundary.
+     *
+     * @param fromPageIndex        first page index the override covers (0-based, inclusive)
+     * @param toPageIndexExclusive one past the last page index covered (exclusive)
+     * @param insets               canonical page insets to apply across the covered pages
+     * @return the engine-side override
+     * @since 2.0.0
+     */
+    public static PageMarginOverride fromInsets(int fromPageIndex, int toPageIndexExclusive, DocumentInsets insets) {
+        return new PageMarginOverride(fromPageIndex, toPageIndexExclusive, LayoutInsets.toMargin(insets));
     }
 
     /**

--- a/src/main/java/com/demcha/compose/document/layout/PlacedFragment.java
+++ b/src/main/java/com/demcha/compose/document/layout/PlacedFragment.java
@@ -49,6 +49,29 @@ public record PlacedFragment(
                 placement.padding(),
                 fragment.payload());
     }
+
+    /**
+     * Places a synthetic fragment with no owner node — e.g. a page-background fill
+     * spliced in after compilation — at absolute page coordinates. The owner
+     * margin/padding (diagnostic only) are zero, letting a canonical caller build
+     * the fragment without referencing an engine style type.
+     *
+     * @param path          stable semantic path for the fragment
+     * @param fragmentIndex index within the owner's emitted fragments
+     * @param pageIndex     page that contains this fragment
+     * @param x             absolute page x coordinate
+     * @param y             absolute page y coordinate
+     * @param width         fragment width
+     * @param height        fragment height
+     * @param payload       backend-specific fragment payload
+     * @return placed fragment with zero owner insets
+     * @since 2.0.0
+     */
+    public static PlacedFragment withZeroInsets(String path, int fragmentIndex, int pageIndex,
+            double x, double y, double width, double height, Object payload) {
+        return new PlacedFragment(path, fragmentIndex, pageIndex, x, y, width, height,
+                Margin.zero(), Padding.zero(), payload);
+    }
 }
 
 

--- a/src/test/java/com/demcha/compose/architecture/ModuleBoundaryArchTest.java
+++ b/src/test/java/com/demcha/compose/architecture/ModuleBoundaryArchTest.java
@@ -58,18 +58,6 @@ class ModuleBoundaryArchTest {
             "com.demcha.compose.font.."
     };
 
-    /**
-     * The two session-orchestration classes that still convert canonical insets
-     * to engine value objects by fully-qualified reference
-     * ({@code DocumentSession.toEngineMargin} → {@code engine.components.style.Margin};
-     * {@code DocumentPageBackgrounds} → {@code Margin.zero()} / {@code Padding.zero()}).
-     * They are excluded by name — not by whole-package — so the other public
-     * {@code document.api} types stay guarded. Routing these conversions behind a
-     * public adapter (so the exclusion can be dropped) is tracked as a follow-up.
-     */
-    private static final String KNOWN_ENGINE_BRIDGE_CLASSES =
-            "com\\.demcha\\.compose\\.document\\.api\\.(DocumentSession|DocumentPageBackgrounds)(\\$.+)?";
-
     @Test
     void importedTheCoreProductionClasses() {
         assertThat(CORE_CLASSES.contain("com.demcha.compose.document.api.DocumentSession"))
@@ -85,7 +73,6 @@ class ModuleBoundaryArchTest {
     void canonicalSurfaceDoesNotDependOnTheEngine() {
         ArchRule rule = noClasses()
                 .that().resideInAnyPackage(CANONICAL_SURFACE_PACKAGES)
-                .and().haveNameNotMatching(KNOWN_ENGINE_BRIDGE_CLASSES)
                 .should().dependOnClassesThat().resideInAPackage("com.demcha.compose.engine..")
                 .because("the canonical public surface must reach the engine only through the "
                         + "document.layout bridge and the backend ServiceLoader seam, never by "


### PR DESCRIPTION
## Why

The ArchUnit guard added in #333 had to **exclude two classes** — `DocumentSession`
and `DocumentPageBackgrounds` — because they reached into the engine by
fully-qualified name to convert `DocumentInsets` → `engine.components.style.Margin` /
`Padding`. That was the last real engine leak in the canonical public API surface
(`document.api`), and the reason the boundary couldn't be fully enforced.

## What changed

The `DocumentInsets → engine.Margin` conversion moves into the **`document.layout`
bridge** — the sanctioned engine seam, which already imports both `engine.*` and
`document.style`:

- new package-private **`LayoutInsets.toMargin(DocumentInsets)`** (single-sources the
  conversion, null → `Margin.zero()`);
- **`LayoutCanvas.from(double, double, DocumentInsets)`** overload;
- **`PageMarginOverride.fromInsets(int, int, DocumentInsets)`** factory;
- **`PlacedFragment.withZeroInsets(...)`** factory (synthetic page-background fragments).

`DocumentSession` and `DocumentPageBackgrounds` now pass canonical insets and
reference **no engine type**. The private `DocumentSession.toEngineMargin` is deleted.
With the leak gone, `ModuleBoundaryArchTest` drops its `KNOWN_ENGINE_BRIDGE_CLASSES`
exclusion, so the **whole canonical surface — including `document.api` — is now
guarded** against `engine.*` dependencies.

## Verification

- **Pure refactor, byte-identical.** Full CI-slice `verify`: **BUILD SUCCESS** — the qa
  `LayoutSnapshotRegression` and `PdfVisualRegression` suites stayed green, so not a
  pixel moved. The conversion logic (null handling + `Margin(top,right,bottom,left)`
  order) and the `PlacedFragment` record fields are preserved exactly.
- `ModuleBoundaryArchTest` 3/3 green **with the exclusion removed** — `document.api` is
  genuinely engine-free (grep-confirmed: zero `com.demcha.compose.engine` references).
- Javadoc gate (`doclint=all`) green.
- japicmp-safe: the new factories are additive `public static` methods on already-public
  `document.layout` types; the deleted method was `private`.

## Notes

- The old `LayoutCanvas.from(double, double, Margin)` stays — still reached via the new
  overload's delegation and legitimate bridge API.
- Independently reviewed for byte-identity (conversion order, null paths, record fields,
  overload resolution) before opening.