### PR TITLE
test(engine): add a direct unit test for LayoutInsets.toMargin

### DIFF
--- a/src/test/java/com/demcha/compose/document/layout/LayoutInsetsTest.java
+++ b/src/test/java/com/demcha/compose/document/layout/LayoutInsetsTest.java
@@ -1,0 +1,31 @@
+package com.demcha.compose.document.layout;
+
+import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.engine.components.style.Margin;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the canonical-insets → engine-margin conversion that the document API
+ * relies on. Distinct edge values catch a field-order swap — the exact mistake a
+ * future refactor of this bridge could make while the higher-level snapshot suites
+ * (which mostly use symmetric margins) stay green.
+ */
+class LayoutInsetsTest {
+
+    @Test
+    void nullInsetsBecomeZeroMargin() {
+        assertThat(LayoutInsets.toMargin(null)).isEqualTo(Margin.zero());
+    }
+
+    @Test
+    void insetsMapToMarginPreservingEachEdge() {
+        Margin margin = LayoutInsets.toMargin(new DocumentInsets(1.0, 2.0, 3.0, 4.0));
+
+        assertThat(margin.top()).isEqualTo(1.0);
+        assertThat(margin.right()).isEqualTo(2.0);
+        assertThat(margin.bottom()).isEqualTo(3.0);
+        assertThat(margin.left()).isEqualTo(4.0);
+    }
+}


### PR DESCRIPTION
## Why

The `LayoutInsets.toMargin` bridge — the canonical `DocumentInsets` → engine `Margin`
conversion added with the `document.api` → layout-bridge refactor (#338) — is currently
covered **only transitively** by the snapshot / visual-regression suites. Those mostly
use symmetric margins, so a field-order swap in this conversion could slip through with
nothing going red. This pins the conversion directly.

(The test was written alongside #338 but landed on that branch just after its squash-merge,
so it didn't ride in — this brings it onto `2.0-dev` where the helper now lives.)

## What changed

New `LayoutInsetsTest` (package-private, in `document.layout` to reach the helper):
- `null` insets → `Margin.zero()`;
- each edge maps to the matching `Margin` field — distinct `1/2/3/4` values fail loudly on
  any top/right/bottom/left transposition.

Test-only.

## Verification

`./mvnw -pl . -Dtest=LayoutInsetsTest test` → **2 passed, BUILD SUCCESS** against the merged
`LayoutInsets`.