### PR TITLE
ci: run the full JDK matrix only for published-module and toolchain changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,9 @@ jobs:
   changes:
     # Path-based change detection for selective CI on pull requests. Emits the
     # reverse-dependency flags the heavy jobs gate on: `code` (any build input),
-    # `core` (the root graph-compose-core module — drives japicmp), and `perf`
-    # (modules the smoke benchmark exercises). Pushes/dispatch bypass these gates.
+    # `core` (the root graph-compose-core module — drives japicmp), `perf`
+    # (modules the smoke benchmark exercises), and `jvm` (published library modules
+    # + toolchain — drives the JDK matrix width). Pushes/dispatch bypass these gates.
     name: Detect changed paths
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
@@ -63,6 +64,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
       core: ${{ steps.filter.outputs.core }}
       perf: ${{ steps.filter.outputs.perf }}
+      jvm: ${{ steps.filter.outputs.jvm }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v7
@@ -90,6 +92,26 @@ jobs:
               - 'templates/**'
               - 'benchmarks/**'
               - 'pom.xml'
+            # Published library modules + build toolchain. A change here runs the
+            # full JDK matrix (it ships to users across JVMs); a PR touching only
+            # the non-published test/build infra (qa, coverage, examples,
+            # benchmarks, docs) runs the baseline JDK alone.
+            jvm:
+              - 'src/**'
+              - 'render-pdf/**'
+              - 'render-docx/**'
+              - 'render-pptx/**'
+              - 'templates/**'
+              - 'wrapper/**'
+              - 'testing/**'
+              - 'fonts/**'
+              - 'emoji/**'
+              - 'bundle/**'
+              - 'pom.xml'
+              - '.mvn/**'
+              - 'mvnw'
+              - 'mvnw.cmd'
+              - '.github/workflows/ci.yml'
 
   build-and-test:
     name: Build and run tests (JDK ${{ matrix.java }})
@@ -105,10 +127,12 @@ jobs:
       # still running.
       fail-fast: false
       matrix:
-        # 17 = baseline, 21 = previous baseline still supported,
-        # 25 = current LTS, validates the byte-buddy / Mockito 5.23
-        # bumps that #10 motivated.
-        java: ['17', '21', '25']
+        # 17 = baseline, 21 = previous baseline still supported, 25 = current LTS
+        # (validates the byte-buddy / Mockito 5.23 bumps that #10 motivated).
+        # Full three-JDK matrix on a push/dispatch or when a published library
+        # module / the toolchain changed (`jvm`); a PR that touches only the
+        # non-published test/build infra runs the baseline JDK alone.
+        java: ${{ fromJSON((github.event_name != 'pull_request' || needs.changes.outputs.jvm == 'true') && '["17","21","25"]' || '["17"]') }}
     env:
       JAVA_TOOL_OPTIONS: -Djava.awt.headless=true
 


### PR DESCRIPTION
## Why

`build-and-test` runs the JDK **17 / 21 / 25** matrix on every code PR — including a
PR that touches only the **non-published** test/build infra (`qa`, `coverage`,
`examples`, `benchmarks`), where a single JDK is enough. That's ~2 redundant reactor
builds per such PR. The matrix exists to validate what **ships** (the engine + the
render/wrapper/testing artifacts, and the byte-buddy / Mockito toolchain) across JVMs.

## What changed

A new `jvm` path filter in the `changes` job lists the **published library modules +
build toolchain**. The matrix width is gated on it:

```yaml
java: ${{ fromJSON((github.event_name != 'pull_request' || needs.changes.outputs.jvm == 'true')
        && '["17","21","25"]' || '["17"]') }}
```

- **Full matrix (17/21/25):** any push / dispatch, or a PR changing `src/**`,
  `render-pdf|docx|pptx/**`, `wrapper/**`, `templates/**`, `testing/**`,
  `fonts|emoji|bundle/**`, `pom.xml`, `.mvn/**`, `mvnw*`, or `ci.yml`.
- **Baseline JDK 17 only:** a PR touching only `qa/**`, `coverage/**`, `examples/**`,
  `benchmarks/**`, or docs.

The safety net is unchanged: **every integration-branch push and every release tag
runs the full matrix**, so no cross-JDK regression can reach a published artifact
without three-JDK validation.

## Verification

YAML validated (`yaml.safe_load`); the expression logic is symmetric and verified by
truth-table (push→full, jvm-change→full, infra-only PR→`["17"]`). **This PR touches
`ci.yml` (⇒ `jvm=true`), so its own CI run exercises the full-matrix branch** — which
also confirms GitHub accepts the `fromJSON` matrix expression. The baseline-only branch
is exercised by the next infra-only PR.

Docs-only PRs are unaffected (they already skip `build-and-test` via the `code` gate).