### PR TITLE
refactor(layout): extract the document convergence loop into DocumentLayoutResolver

### DIFF
--- a/src/main/java/com/demcha/compose/document/api/DocumentSession.java
+++ b/src/main/java/com/demcha/compose/document/api/DocumentSession.java
@@ -64,13 +64,6 @@ import java.util.function.Consumer;
 public final class DocumentSession implements AutoCloseable {
     private static final Logger LIFECYCLE_LOG = LoggerFactory.getLogger("com.demcha.compose.document.lifecycle");
 
-    /**
-     * Cap on page-reference recompiles after the first resolve. A table of
-     * contents converges in one recompile; the cap bounds a pathological document
-     * whose numbers keep shifting pages, falling back to the last layout.
-     */
-    private static final int MAX_PAGE_REFERENCE_PASSES = 5;
-
     private final String sessionId = Integer.toHexString(System.identityHashCode(this));
     private final Path defaultOutputFile;
     private final NodeRegistry registry;
@@ -80,6 +73,7 @@ public final class DocumentSession implements AutoCloseable {
     private final DocumentChromeOptions chromeOptions = new DocumentChromeOptions();
     private final DocumentLayoutCache layoutCache = new DocumentLayoutCache();
     private final DocumentRenderingFacade renderingFacade = new DocumentRenderingFacade(new RenderingContextImpl());
+    private final DocumentLayoutResolver layoutResolver = new DocumentLayoutResolver(new LayoutResolverContext());
     private DocumentPageSize pageSize;
     private DocumentInsets margin;
     private LayoutCanvas canvas;
@@ -742,54 +736,14 @@ public final class DocumentSession implements AutoCloseable {
     }
 
     /**
-     * Compiles the semantic graph for one layout revision. A document that
-     * contains a {@link PageReferenceNode} is compiled in two passes — the first
-     * resolves every anchor's page, the next renders the references with the
-     * resolved numbers — then re-resolved to a fixed point: if rendering the
-     * numbers shifted any anchor's page (a reference whose own width re-wrapped a
-     * neighbour and pushed content across a boundary), it recompiles with the new
-     * numbers until the pages stop moving, capped at {@link #MAX_PAGE_REFERENCE_PASSES}
-     * recompiles. All passes run inside the cache compute, so the result is cached
-     * once per revision. Documents without a page reference compile once and are
-     * byte-identical to before.
+     * Compiles the semantic graph for this layout revision and splices in any
+     * session-wide page-background fills. The convergence fixed point lives in
+     * {@link DocumentLayoutResolver}; a document without a page reference or
+     * per-page margins compiles once and is byte-identical to before. All passes
+     * run inside the cache compute, so the result is cached once per revision.
      */
     private LayoutGraph computeLayout() {
-        PageGeometry geometry = buildPageGeometry();
-        boolean hasMargins = geometry != null;
-        boolean hasPageReference = containsPageReference(roots);
-
-        LayoutGraph graph = compilePass(Map.of(), geometry, Map.of());
-        if (!hasMargins && !hasPageReference) {
-            return DocumentPageBackgrounds.apply(graph, pageBackgrounds);
-        }
-        // Two coupled fixed points share one loop: page references resolve their
-        // numbers, and per-page margins resolve which page each top-level block
-        // begins on (its content width). A pass feeds back both; the layout is
-        // settled once neither changes. Capped so a document that never converges
-        // still returns its last (best) layout.
-        Map<String, Integer> resolved = hasPageReference ? resolvedPageNumbers(graph) : Map.of();
-        Map<String, Integer> startPages = hasMargins ? nodeStartPages(graph) : Map.of();
-        for (int pass = 0; pass < MAX_PAGE_REFERENCE_PASSES; pass++) {
-            graph = compilePass(resolved, geometry, startPages);
-            Map<String, Integer> renderedPages = hasPageReference ? resolvedPageNumbers(graph) : Map.of();
-            Map<String, Integer> renderedStarts = hasMargins ? nodeStartPages(graph) : Map.of();
-            if (renderedPages.equals(resolved) && renderedStarts.equals(startPages)) {
-                return DocumentPageBackgrounds.apply(graph, pageBackgrounds);
-            }
-            resolved = renderedPages;
-            startPages = renderedStarts;
-        }
-        LIFECYCLE_LOG.debug("document.layout.unconverged sessionId={} passes={}", sessionId, MAX_PAGE_REFERENCE_PASSES);
-        return DocumentPageBackgrounds.apply(graph, pageBackgrounds);
-    }
-
-    private LayoutGraph compilePass(Map<String, Integer> resolvedPages,
-                                    PageGeometry geometry,
-                                    Map<String, Integer> nodeStartPages) {
-        DocumentLayoutPassContext context = new DocumentLayoutPassContext(registry, canvas,
-                measurementResources.fontLibrary(), measurementResources.textMeasurementSystem(), markdown,
-                resolvedPages, geometry, nodeStartPages);
-        return compiler.compile(documentGraph(), context, context);
+        return DocumentPageBackgrounds.apply(layoutResolver.resolve(), pageBackgrounds);
     }
 
     private PageGeometry buildPageGeometry() {
@@ -805,14 +759,6 @@ public final class DocumentSession implements AutoCloseable {
             overrides.add(PageMarginOverride.fromInsets(fromIndex, toIndexExclusive, rule.insets()));
         }
         return PageGeometry.of(canvas, overrides);
-    }
-
-    private static Map<String, Integer> nodeStartPages(LayoutGraph graph) {
-        Map<String, Integer> starts = new HashMap<>();
-        for (PlacedNode node : graph.nodes()) {
-            starts.put(node.path(), node.startPage());
-        }
-        return starts;
     }
 
     private static boolean containsPageReference(List<DocumentNode> nodes) {
@@ -1269,6 +1215,58 @@ public final class DocumentSession implements AutoCloseable {
         @Override
         public FixedLayoutRenderer conveniencePdfBackend() {
             return chromeOptions.toConveniencePdfBackend(debug);
+        }
+    }
+
+    private final class LayoutResolverContext implements DocumentLayoutResolver.Context {
+        @Override
+        public NodeRegistry registry() {
+            return registry;
+        }
+
+        @Override
+        public LayoutCompiler compiler() {
+            return compiler;
+        }
+
+        @Override
+        public LayoutCanvas canvas() {
+            return canvas;
+        }
+
+        @Override
+        public MeasurementResources measurementResources() {
+            return measurementResources;
+        }
+
+        @Override
+        public boolean markdown() {
+            return markdown;
+        }
+
+        @Override
+        public DocumentGraph documentGraph() {
+            return DocumentSession.this.documentGraph();
+        }
+
+        @Override
+        public PageGeometry pageGeometry() {
+            return buildPageGeometry();
+        }
+
+        @Override
+        public boolean hasPageReference() {
+            return containsPageReference(roots);
+        }
+
+        @Override
+        public Map<String, Integer> resolvePageNumbers(LayoutGraph graph) {
+            return resolvedPageNumbers(graph);
+        }
+
+        @Override
+        public String sessionId() {
+            return sessionId;
         }
     }
 }

--- a/src/main/java/com/demcha/compose/document/layout/DocumentLayoutResolver.java
+++ b/src/main/java/com/demcha/compose/document/layout/DocumentLayoutResolver.java
@@ -1,0 +1,134 @@
+package com.demcha.compose.document.layout;
+
+import com.demcha.compose.document.backend.fixed.MeasurementResources;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Runs the canonical layout's coupled fixed point, pulled out of
+ * {@code DocumentSession} so the convergence algorithm is a focused, testable
+ * unit rather than a method buried in the session facade.
+ *
+ * <p>A document that contains a page reference or per-page margins is compiled in
+ * repeated passes: page references resolve their numbers, and per-page margins
+ * resolve which page each top-level block begins on. A pass feeds both back; the
+ * layout is settled once neither changes, capped at {@link #MAX_PASSES} recompiles
+ * so a document that never converges still returns its last (best) layout. A
+ * document with neither compiles exactly once and is byte-identical to before.</p>
+ *
+ * <p>Everything the loop needs is read through the small {@link Context} interface
+ * that {@code DocumentSession} implements internally — including the inputs that
+ * derive from canonical/debug types (page geometry, page-reference resolution),
+ * which the session pre-computes so this layout-package class depends only on
+ * layout types.</p>
+ */
+public final class DocumentLayoutResolver {
+
+    /**
+     * Cap on recompiles after the first resolve. A table of contents converges in
+     * one recompile; the cap bounds a pathological document whose numbers keep
+     * shifting pages, falling back to the last layout.
+     */
+    static final int MAX_PASSES = 5;
+
+    private static final Logger LIFECYCLE_LOG = LoggerFactory.getLogger("com.demcha.compose.document.lifecycle");
+
+    private final Context context;
+
+    public DocumentLayoutResolver(Context context) {
+        this.context = Objects.requireNonNull(context, "context");
+    }
+
+    /**
+     * Compiles the semantic graph for one layout revision to its fixed point.
+     * Returns the resolved layout graph <em>before</em> any page-background fills
+     * are spliced in — the session applies those around this result.
+     *
+     * @return the settled (or last, if uncapped) layout graph
+     */
+    public LayoutGraph resolve() {
+        PageGeometry geometry = context.pageGeometry();
+        boolean hasMargins = geometry != null;
+        boolean hasPageReference = context.hasPageReference();
+
+        LayoutGraph graph = compilePass(Map.of(), geometry, Map.of());
+        if (!hasMargins && !hasPageReference) {
+            return graph;
+        }
+        // Two coupled fixed points share one loop: page references resolve their
+        // numbers, and per-page margins resolve which page each top-level block
+        // begins on (its content width). A pass feeds back both; the layout is
+        // settled once neither changes.
+        Map<String, Integer> resolved = hasPageReference ? context.resolvePageNumbers(graph) : Map.of();
+        Map<String, Integer> startPages = hasMargins ? nodeStartPages(graph) : Map.of();
+        for (int pass = 0; pass < MAX_PASSES; pass++) {
+            graph = compilePass(resolved, geometry, startPages);
+            Map<String, Integer> renderedPages = hasPageReference ? context.resolvePageNumbers(graph) : Map.of();
+            Map<String, Integer> renderedStarts = hasMargins ? nodeStartPages(graph) : Map.of();
+            if (renderedPages.equals(resolved) && renderedStarts.equals(startPages)) {
+                return graph;
+            }
+            resolved = renderedPages;
+            startPages = renderedStarts;
+        }
+        LIFECYCLE_LOG.debug("document.layout.unconverged sessionId={} passes={}", context.sessionId(), MAX_PASSES);
+        return graph;
+    }
+
+    private LayoutGraph compilePass(Map<String, Integer> resolvedPages,
+                                    PageGeometry geometry,
+                                    Map<String, Integer> nodeStartPages) {
+        DocumentLayoutPassContext passContext = new DocumentLayoutPassContext(
+                context.registry(),
+                context.canvas(),
+                context.measurementResources().fontLibrary(),
+                context.measurementResources().textMeasurementSystem(),
+                context.markdown(),
+                resolvedPages, geometry, nodeStartPages);
+        return context.compiler().compile(context.documentGraph(), passContext, passContext);
+    }
+
+    private static Map<String, Integer> nodeStartPages(LayoutGraph graph) {
+        Map<String, Integer> starts = new HashMap<>();
+        for (PlacedNode node : graph.nodes()) {
+            starts.put(node.path(), node.startPage());
+        }
+        return starts;
+    }
+
+    /**
+     * The layout inputs the resolver reads, implemented by {@code DocumentSession}.
+     * The session pre-computes the values that derive from canonical / debug types
+     * ({@link #pageGeometry()}, {@link #hasPageReference()},
+     * {@link #resolvePageNumbers(LayoutGraph)}) so this class stays within the
+     * layout package.
+     */
+    public interface Context {
+        NodeRegistry registry();
+
+        LayoutCompiler compiler();
+
+        LayoutCanvas canvas();
+
+        MeasurementResources measurementResources();
+
+        boolean markdown();
+
+        DocumentGraph documentGraph();
+
+        /** Per-page margin overrides for this revision, or {@code null} if none. */
+        PageGeometry pageGeometry();
+
+        /** Whether the document contains a page reference (drives the fixed point). */
+        boolean hasPageReference();
+
+        /** Resolves each anchor's currently-rendered page number from a compiled graph. */
+        Map<String, Integer> resolvePageNumbers(LayoutGraph graph);
+
+        String sessionId();
+    }
+}

--- a/src/test/java/com/demcha/compose/document/layout/DocumentLayoutResolverTest.java
+++ b/src/test/java/com/demcha/compose/document/layout/DocumentLayoutResolverTest.java
@@ -1,0 +1,151 @@
+package com.demcha.compose.document.layout;
+
+import com.demcha.compose.document.backend.fixed.MeasurementResources;
+import com.demcha.compose.engine.components.style.Margin;
+import com.demcha.compose.engine.components.style.Padding;
+import com.demcha.compose.engine.measurement.TextMeasurementSystem;
+import com.demcha.compose.font.FontLibrary;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Locks the extracted convergence loop's control flow in isolation. The
+ * byte-identical layout output is guarded by the qa regression / parity suites;
+ * these assert the recompile count and returned graph directly, driving the
+ * resolver through a mocked {@link DocumentLayoutResolver.Context} and a mocked
+ * {@link LayoutCompiler} so no real layout is computed.
+ */
+class DocumentLayoutResolverTest {
+
+    private final LayoutCanvas canvas = mock(LayoutCanvas.class);
+    private final LayoutCompiler compiler = mock(LayoutCompiler.class);
+    private final DocumentLayoutResolver.Context context = mock(DocumentLayoutResolver.Context.class);
+
+    DocumentLayoutResolverTest() {
+        MeasurementResources measurementResources = mock(MeasurementResources.class);
+        when(measurementResources.fontLibrary()).thenReturn(mock(FontLibrary.class));
+        when(measurementResources.textMeasurementSystem()).thenReturn(mock(TextMeasurementSystem.class));
+        when(context.registry()).thenReturn(mock(NodeRegistry.class));
+        when(context.canvas()).thenReturn(canvas);
+        when(context.compiler()).thenReturn(compiler);
+        when(context.measurementResources()).thenReturn(measurementResources);
+        when(context.sessionId()).thenReturn("test-session");
+    }
+
+    private LayoutGraph graph() {
+        return new LayoutGraph(canvas, 1, List.of(), List.of());
+    }
+
+    private LayoutGraph graphWith(PlacedNode... nodes) {
+        return new LayoutGraph(canvas, 1, List.of(nodes), List.of());
+    }
+
+    private static PlacedNode placed(String path, int startPage) {
+        return new PlacedNode(path, path, "block", null, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, startPage, startPage, 0, 0, Margin.zero(), Padding.zero());
+    }
+
+    @Test
+    void nullContextIsRejected() {
+        assertThatNullPointerException()
+                .isThrownBy(() -> new DocumentLayoutResolver(null))
+                .withMessageContaining("context");
+    }
+
+    @Test
+    void plainDocumentCompilesExactlyOnce() {
+        LayoutGraph only = graph();
+        when(context.pageGeometry()).thenReturn(null);
+        when(context.hasPageReference()).thenReturn(false);
+        when(compiler.compile(any(), any(), any())).thenReturn(only);
+
+        LayoutGraph result = new DocumentLayoutResolver(context).resolve();
+
+        assertThat(result).isSameAs(only);
+        verify(compiler, times(1)).compile(any(), any(), any());
+        verify(context, never()).resolvePageNumbers(any());
+    }
+
+    @Test
+    void pageReferenceRecompilesUntilNumbersStabilize() {
+        LayoutGraph first = graph();
+        LayoutGraph settled = graph();
+        when(context.pageGeometry()).thenReturn(null);
+        when(context.hasPageReference()).thenReturn(true);
+        when(compiler.compile(any(), any(), any())).thenReturn(first, settled);
+        // Same resolved numbers on both reads → the layout settles after one recompile.
+        when(context.resolvePageNumbers(any())).thenReturn(Map.of("intro", 1));
+
+        LayoutGraph result = new DocumentLayoutResolver(context).resolve();
+
+        assertThat(result).isSameAs(settled);
+        verify(compiler, times(2)).compile(any(), any(), any());
+    }
+
+    @Test
+    void perPageMarginRecompilesUntilStartPagesStabilize() {
+        LayoutGraph first = graphWith(placed("body", 0));
+        LayoutGraph settled = graphWith(placed("body", 0));
+        when(context.pageGeometry()).thenReturn(mock(PageGeometry.class));
+        when(context.hasPageReference()).thenReturn(false);
+        when(compiler.compile(any(), any(), any())).thenReturn(first, settled);
+
+        LayoutGraph result = new DocumentLayoutResolver(context).resolve();
+
+        // Same node start-pages on both reads → the margin fixed point settles after
+        // one recompile, with no page-reference resolution involved.
+        assertThat(result).isSameAs(settled);
+        verify(compiler, times(2)).compile(any(), any(), any());
+        verify(context, never()).resolvePageNumbers(any());
+    }
+
+    @Test
+    void coupledResolveWaitsForBothPageNumbersAndStartPages() {
+        LayoutGraph pass0 = graphWith(placed("body", 0));
+        LayoutGraph pass1 = graphWith(placed("body", 1));
+        LayoutGraph pass2 = graphWith(placed("body", 1));
+        when(context.pageGeometry()).thenReturn(mock(PageGeometry.class));
+        when(context.hasPageReference()).thenReturn(true);
+        when(compiler.compile(any(), any(), any())).thenReturn(pass0, pass1, pass2);
+        // Page numbers are stable from the first read; only the start-pages keep
+        // moving, so the loop must NOT settle until the margin fixed point also does.
+        when(context.resolvePageNumbers(any())).thenReturn(Map.of("intro", 1));
+
+        LayoutGraph result = new DocumentLayoutResolver(context).resolve();
+
+        assertThat(result).isSameAs(pass2);
+        verify(compiler, times(3)).compile(any(), any(), any());
+    }
+
+    @Test
+    void nonConvergingDocumentIsCappedAndReturnsLastLayout() {
+        when(context.pageGeometry()).thenReturn(null);
+        when(context.hasPageReference()).thenReturn(true);
+        // A distinct graph per compile so we can assert the LAST one is returned.
+        LayoutGraph[] graphs = new LayoutGraph[1 + DocumentLayoutResolver.MAX_PASSES];
+        Arrays.setAll(graphs, i -> graph());
+        when(compiler.compile(any(), any(), any()))
+                .thenReturn(graphs[0], Arrays.copyOfRange(graphs, 1, graphs.length));
+        // Numbers never repeat → the loop never settles and runs to the cap.
+        AtomicInteger tick = new AtomicInteger();
+        when(context.resolvePageNumbers(any())).thenAnswer(inv -> Map.of("intro", tick.incrementAndGet()));
+
+        LayoutGraph result = new DocumentLayoutResolver(context).resolve();
+
+        assertThat(result).isSameAs(graphs[graphs.length - 1]);
+        verify(compiler, times(1 + DocumentLayoutResolver.MAX_PASSES)).compile(any(), any(), any());
+    }
+}


### PR DESCRIPTION
## Why
`DocumentSession.computeLayout` carried the coupled page-reference + per-page-margin fixed-point loop inline, mixing the convergence algorithm into the session facade and leaving it hard to test in isolation.

## What
- Move the fixed-point loop into a focused `DocumentLayoutResolver` in the `document.layout` bridge package.
- `DocumentSession` implements the resolver's small `Context` interface (registry / compiler / canvas / measurement / markdown / document graph, plus the pre-computed page geometry, page-reference flag and page-number resolution) and keeps splicing page-background fills around the resolved graph — so `document.api` stays engine-free.
- No public API change; layout output is unchanged.

## Tests
- New `DocumentLayoutResolverTest` (6 cases): single-pass fast path, page-reference convergence, the per-page-margin start-page fixed point, the two coupled together, the recompile cap, and the null-context guard.
- Core suite (375) and the qa byte-identity gate (642 — `PdfVisualRegressionTest`, `LayoutSnapshotRegressionDemoTest`, `PageMarginTest`, `PageIndexTest`, all `*VisualParityTest`) green: renders are byte-identical.
- `ModuleBoundaryArchTest` / `PublicApiNoEngineLeakTest` green: `document.api` remains engine-free.