### PR TITLE
ci: serialize the fonts and emoji Maven Central publish workflows

### DIFF
--- a/.github/workflows/publish-emoji.yml
+++ b/.github/workflows/publish-emoji.yml
@@ -26,6 +26,14 @@ on:
 permissions:
   contents: read
 
+# Serialize this artifact's Central publishes so an overlapping tag push and a
+# workflow_dispatch re-publish of the same coordinates cannot double-deploy, and
+# never cancel a publish mid-deploy. Mirrors publish.yml; kept on its own group
+# so the independent engine / fonts / emoji tag lines don't block one another.
+concurrency:
+  group: publish-emoji-maven-central
+  cancel-in-progress: false
+
 jobs:
   publish-emoji:
     name: Publish ${{ github.ref_name }} to Maven Central

--- a/.github/workflows/publish-fonts.yml
+++ b/.github/workflows/publish-fonts.yml
@@ -26,6 +26,14 @@ on:
 permissions:
   contents: read
 
+# Serialize this artifact's Central publishes so an overlapping tag push and a
+# workflow_dispatch re-publish of the same coordinates cannot double-deploy, and
+# never cancel a publish mid-deploy. Mirrors publish.yml; kept on its own group
+# so the independent engine / fonts / emoji tag lines don't block one another.
+concurrency:
+  group: publish-fonts-maven-central
+  cancel-in-progress: false
+
 jobs:
   publish-fonts:
     name: Publish ${{ github.ref_name }} to Maven Central


### PR DESCRIPTION
## Why
`publish.yml` (engine) got a concurrency guard in #331, but the sibling `publish-fonts.yml` and `publish-emoji.yml` were left ungated — an overlapping `*-v*` tag push and a `workflow_dispatch` re-publish of the same coordinates could double-deploy to Maven Central.

## What
- Add a `concurrency` group to both publish workflows, mirroring `publish.yml`.
- `cancel-in-progress: false` — a publish is never cancelled mid-deploy.
- Each artifact keeps its own group (`publish-fonts-maven-central` / `publish-emoji-maven-central`) so the independent engine / fonts / emoji tag lines don't block one another.

## Tests
- CI-only, no runtime code. Both files parse cleanly (`yaml.safe_load`).
- Closes the follow-up noted on #331 (same guards for publish-fonts / publish-emoji).