### PR TITLE
refactor(layout): extract the composite decoration band builder from LayoutCompiler

### DIFF
--- a/src/main/java/com/demcha/compose/document/layout/CompositeDecoration.java
+++ b/src/main/java/com/demcha/compose/document/layout/CompositeDecoration.java
@@ -1,0 +1,174 @@
+package com.demcha.compose.document.layout;
+
+import com.demcha.compose.document.node.DocumentNode;
+import com.demcha.compose.document.style.DocumentBleed;
+import com.demcha.compose.document.style.DocumentEdge;
+import com.demcha.compose.engine.components.style.Margin;
+import com.demcha.compose.engine.components.style.Padding;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Builds a composite node's per-page decoration bands — the fill / border band
+ * drawn behind its children ({@link #fill}) and the overlay band drawn in front
+ * ({@link #overlay}). A node that spans several pages is segmented so each
+ * page's band clamps to that page's own content area (or, on a bled edge, the
+ * physical page edge), and empty segments are dropped.
+ *
+ * <p>Pure geometry: every input is passed in and each call returns a fresh
+ * fragment list. The caller ({@link LayoutCompiler}) owns where each list is
+ * spliced — fills before the children, overlays appended after — because that
+ * draw order is the load-bearing behaviour, not part of building the band.
+ *
+ * @author Artem Demchyshyn
+ */
+final class CompositeDecoration {
+
+    private static final double EPS = 1e-6;
+
+    private CompositeDecoration() {
+    }
+
+    static List<PlacedFragment> fill(PreparedNode<DocumentNode> prepared,
+                                     NodeDefinition<DocumentNode> definition,
+                                     String path,
+                                     String parentPath,
+                                     int childIndex,
+                                     int depth,
+                                     double placementX,
+                                     double startPageTopY,
+                                     double endPageBottomY,
+                                     double placementWidth,
+                                     int startPage,
+                                     int endPage,
+                                     Margin margin,
+                                     Padding padding,
+                                     LayoutCanvas canvas,
+                                     DocumentBleed bleed,
+                                     FragmentContext fragmentContext) {
+        List<PlacedFragment> placed = new ArrayList<>();
+        // The intermediate-page band edges follow each page's own margin, so a fill
+        // spanning a per-page-margin boundary clamps to the right content area on
+        // every page. With no per-page margins every page resolves to the canvas
+        // margin and the bounds are identical for all pages, as before.
+        PageGeometry geometry = fragmentContext.pageGeometry();
+        for (int pageIndex = startPage; pageIndex <= endPage; pageIndex++) {
+            // On bled edges the clamp bound is the physical page edge rather than the
+            // content-area edge, so the fill reaches past the top/bottom margin.
+            double pageTopY = bleed.bleeds(DocumentEdge.TOP)
+                    ? canvas.height()
+                    : canvas.height() - pageMarginTop(canvas, geometry, pageIndex);
+            double pageBottomY = bleed.bleeds(DocumentEdge.BOTTOM)
+                    ? 0.0
+                    : pageMarginBottom(canvas, geometry, pageIndex);
+            double segmentTopY = pageIndex == startPage ? startPageTopY : pageTopY;
+            double segmentBottomY = pageIndex == endPage ? endPageBottomY : pageBottomY;
+            segmentTopY = Math.min(segmentTopY, pageTopY);
+            segmentBottomY = Math.max(pageBottomY, Math.min(segmentBottomY, segmentTopY));
+            double segmentHeight = segmentTopY - segmentBottomY;
+            if (segmentHeight <= EPS) {
+                continue;
+            }
+
+            FragmentPlacement placement = new FragmentPlacement(
+                    path,
+                    parentPath,
+                    childIndex,
+                    depth,
+                    pageIndex,
+                    placementX,
+                    segmentBottomY,
+                    placementWidth,
+                    segmentHeight,
+                    startPage,
+                    endPage,
+                    margin,
+                    padding);
+            placed.addAll(toPlacedFragments(definition.emitFragments(prepared, fragmentContext, placement), placement));
+        }
+
+        return placed;
+    }
+
+    static List<PlacedFragment> overlay(PreparedNode<DocumentNode> prepared,
+                                        NodeDefinition<DocumentNode> definition,
+                                        String path,
+                                        String parentPath,
+                                        int childIndex,
+                                        int depth,
+                                        double placementX,
+                                        double startPageTopY,
+                                        double endPageBottomY,
+                                        double placementWidth,
+                                        int startPage,
+                                        int endPage,
+                                        Margin margin,
+                                        Padding padding,
+                                        LayoutCanvas canvas,
+                                        FragmentContext fragmentContext) {
+        List<PlacedFragment> placed = new ArrayList<>();
+        PageGeometry geometry = fragmentContext.pageGeometry();
+        for (int pageIndex = startPage; pageIndex <= endPage; pageIndex++) {
+            double pageTopY = canvas.height() - pageMarginTop(canvas, geometry, pageIndex);
+            double pageBottomY = pageMarginBottom(canvas, geometry, pageIndex);
+            double segmentTopY = pageIndex == startPage ? startPageTopY : pageTopY;
+            double segmentBottomY = pageIndex == endPage ? endPageBottomY : pageBottomY;
+            segmentTopY = Math.min(segmentTopY, pageTopY);
+            segmentBottomY = Math.max(pageBottomY, Math.min(segmentBottomY, segmentTopY));
+            double segmentHeight = segmentTopY - segmentBottomY;
+            if (segmentHeight <= EPS) {
+                continue;
+            }
+
+            FragmentPlacement placement = new FragmentPlacement(
+                    path,
+                    parentPath,
+                    childIndex,
+                    depth,
+                    pageIndex,
+                    placementX,
+                    segmentBottomY,
+                    placementWidth,
+                    segmentHeight,
+                    startPage,
+                    endPage,
+                    margin,
+                    padding);
+            placed.addAll(toPlacedFragments(definition.emitOverlayFragments(prepared, fragmentContext, placement), placement));
+        }
+
+        return placed;
+    }
+
+    /**
+     * Normalizes emitted fragments to a placement, re-indexing {@code fragmentIndex}
+     * from zero per placement. Shared by the decoration bands and by the compiler's
+     * non-decoration fragment sites.
+     */
+    static List<PlacedFragment> toPlacedFragments(List<LayoutFragment> emitted,
+                                                  FragmentPlacement placement) {
+        List<PlacedFragment> placed = new ArrayList<>(emitted.size());
+        int fragmentIndex = 0;
+        for (LayoutFragment fragment : emitted) {
+            LayoutFragment normalized = new LayoutFragment(
+                    placement.path(),
+                    fragmentIndex++,
+                    fragment.localX(),
+                    fragment.localY(),
+                    fragment.width(),
+                    fragment.height(),
+                    fragment.payload());
+            placed.add(PlacedFragment.from(normalized, placement));
+        }
+        return placed;
+    }
+
+    private static double pageMarginTop(LayoutCanvas canvas, PageGeometry geometry, int pageIndex) {
+        return geometry == null ? canvas.margin().top() : geometry.marginForPage(pageIndex).top();
+    }
+
+    private static double pageMarginBottom(LayoutCanvas canvas, PageGeometry geometry, int pageIndex) {
+        return geometry == null ? canvas.margin().bottom() : geometry.marginForPage(pageIndex).bottom();
+    }
+}

--- a/src/main/java/com/demcha/compose/document/layout/LayoutCompiler.java
+++ b/src/main/java/com/demcha/compose/document/layout/LayoutCompiler.java
@@ -451,7 +451,7 @@ public final class LayoutCompiler {
                 decorBottomY = 0.0;
             }
         }
-        List<PlacedFragment> decorationFragments = compositeDecorationFragments(
+        List<PlacedFragment> decorationFragments = CompositeDecoration.fill(
                 prepared,
                 definition,
                 path,
@@ -674,7 +674,7 @@ public final class LayoutCompiler {
 
         int endPage = state.pageIndex;
         double endPageBottomY = placementTopY - naturalMeasure.height() + margin.bottom();
-        List<PlacedFragment> decorationFragments = compositeDecorationFragments(
+        List<PlacedFragment> decorationFragments = CompositeDecoration.fill(
                 prepared,
                 definition,
                 path,
@@ -791,7 +791,7 @@ public final class LayoutCompiler {
 
         int endPage = state.pageIndex;
         double endPageBottomY = placementTopY - naturalMeasure.height() + margin.bottom();
-        List<PlacedFragment> decorationFragments = compositeDecorationFragments(
+        List<PlacedFragment> decorationFragments = CompositeDecoration.fill(
                 prepared,
                 definition,
                 path,
@@ -816,7 +816,7 @@ public final class LayoutCompiler {
         // Overlay fragments arrive AFTER children — they are the
         // "after the body" half of paired begin/end markers (e.g. the
         // graphics-state restore of a ShapeContainerNode clip path).
-        List<PlacedFragment> overlayFragments = compositeOverlayFragments(
+        List<PlacedFragment> overlayFragments = CompositeDecoration.overlay(
                 prepared,
                 definition,
                 path,
@@ -1303,7 +1303,7 @@ public final class LayoutCompiler {
                             ctx);
                 }
 
-                List<PlacedFragment> stackDecorations = compositeDecorationFragments(
+                List<PlacedFragment> stackDecorations = CompositeDecoration.fill(
                         prepared,
                         definition,
                         path,
@@ -1325,7 +1325,7 @@ public final class LayoutCompiler {
                     fragments.addAll(decorationInsertIndex, stackDecorations);
                 }
 
-                List<PlacedFragment> stackOverlays = compositeOverlayFragments(
+                List<PlacedFragment> stackOverlays = CompositeDecoration.overlay(
                         prepared,
                         definition,
                         path,
@@ -1398,7 +1398,7 @@ public final class LayoutCompiler {
             }
 
             double endPageBottomY = placementY + margin.bottom();
-            List<PlacedFragment> decorationFragments = compositeDecorationFragments(
+            List<PlacedFragment> decorationFragments = CompositeDecoration.fill(
                     prepared,
                     definition,
                     path,
@@ -1449,125 +1449,6 @@ public final class LayoutCompiler {
         return measure.height() + margin.vertical();
     }
 
-    private List<PlacedFragment> compositeDecorationFragments(PreparedNode<DocumentNode> prepared,
-                                                              NodeDefinition<DocumentNode> definition,
-                                                              String path,
-                                                              String parentPath,
-                                                              int childIndex,
-                                                              int depth,
-                                                              double placementX,
-                                                              double startPageTopY,
-                                                              double endPageBottomY,
-                                                              double placementWidth,
-                                                              int startPage,
-                                                              int endPage,
-                                                              Margin margin,
-                                                              Padding padding,
-                                                              LayoutCanvas canvas,
-                                                              DocumentBleed bleed,
-                                                              FragmentContext fragmentContext) {
-        List<PlacedFragment> placed = new ArrayList<>();
-        // The intermediate-page band edges follow each page's own margin, so a fill
-        // spanning a per-page-margin boundary clamps to the right content area on
-        // every page. With no per-page margins every page resolves to the canvas
-        // margin and the bounds are identical for all pages, as before.
-        PageGeometry geometry = fragmentContext.pageGeometry();
-        for (int pageIndex = startPage; pageIndex <= endPage; pageIndex++) {
-            // On bled edges the clamp bound is the physical page edge rather than the
-            // content-area edge, so the fill reaches past the top/bottom margin.
-            double pageTopY = bleed.bleeds(DocumentEdge.TOP)
-                    ? canvas.height()
-                    : canvas.height() - pageMarginTop(canvas, geometry, pageIndex);
-            double pageBottomY = bleed.bleeds(DocumentEdge.BOTTOM)
-                    ? 0.0
-                    : pageMarginBottom(canvas, geometry, pageIndex);
-            double segmentTopY = pageIndex == startPage ? startPageTopY : pageTopY;
-            double segmentBottomY = pageIndex == endPage ? endPageBottomY : pageBottomY;
-            segmentTopY = Math.min(segmentTopY, pageTopY);
-            segmentBottomY = Math.max(pageBottomY, Math.min(segmentBottomY, segmentTopY));
-            double segmentHeight = segmentTopY - segmentBottomY;
-            if (segmentHeight <= EPS) {
-                continue;
-            }
-
-            FragmentPlacement placement = new FragmentPlacement(
-                    path,
-                    parentPath,
-                    childIndex,
-                    depth,
-                    pageIndex,
-                    placementX,
-                    segmentBottomY,
-                    placementWidth,
-                    segmentHeight,
-                    startPage,
-                    endPage,
-                    margin,
-                    padding);
-            placed.addAll(toPlacedFragments(definition.emitFragments(prepared, fragmentContext, placement), placement));
-        }
-
-        return placed;
-    }
-
-    private static double pageMarginTop(LayoutCanvas canvas, PageGeometry geometry, int pageIndex) {
-        return geometry == null ? canvas.margin().top() : geometry.marginForPage(pageIndex).top();
-    }
-
-    private static double pageMarginBottom(LayoutCanvas canvas, PageGeometry geometry, int pageIndex) {
-        return geometry == null ? canvas.margin().bottom() : geometry.marginForPage(pageIndex).bottom();
-    }
-
-    private List<PlacedFragment> compositeOverlayFragments(PreparedNode<DocumentNode> prepared,
-                                                           NodeDefinition<DocumentNode> definition,
-                                                           String path,
-                                                           String parentPath,
-                                                           int childIndex,
-                                                           int depth,
-                                                           double placementX,
-                                                           double startPageTopY,
-                                                           double endPageBottomY,
-                                                           double placementWidth,
-                                                           int startPage,
-                                                           int endPage,
-                                                           Margin margin,
-                                                           Padding padding,
-                                                           LayoutCanvas canvas,
-                                                           FragmentContext fragmentContext) {
-        List<PlacedFragment> placed = new ArrayList<>();
-        PageGeometry geometry = fragmentContext.pageGeometry();
-        for (int pageIndex = startPage; pageIndex <= endPage; pageIndex++) {
-            double pageTopY = canvas.height() - pageMarginTop(canvas, geometry, pageIndex);
-            double pageBottomY = pageMarginBottom(canvas, geometry, pageIndex);
-            double segmentTopY = pageIndex == startPage ? startPageTopY : pageTopY;
-            double segmentBottomY = pageIndex == endPage ? endPageBottomY : pageBottomY;
-            segmentTopY = Math.min(segmentTopY, pageTopY);
-            segmentBottomY = Math.max(pageBottomY, Math.min(segmentBottomY, segmentTopY));
-            double segmentHeight = segmentTopY - segmentBottomY;
-            if (segmentHeight <= EPS) {
-                continue;
-            }
-
-            FragmentPlacement placement = new FragmentPlacement(
-                    path,
-                    parentPath,
-                    childIndex,
-                    depth,
-                    pageIndex,
-                    placementX,
-                    segmentBottomY,
-                    placementWidth,
-                    segmentHeight,
-                    startPage,
-                    endPage,
-                    margin,
-                    padding);
-            placed.addAll(toPlacedFragments(definition.emitOverlayFragments(prepared, fragmentContext, placement), placement));
-        }
-
-        return placed;
-    }
-
     private PreparedNode<DocumentNode> prepareForRegionWidth(PrepareContext prepareContext,
                                                              DocumentNode node,
                                                              double regionWidth) {
@@ -1582,25 +1463,7 @@ public final class LayoutCompiler {
     private void addPlacedFragments(List<LayoutFragment> emitted,
                                     FragmentPlacement placement,
                                     List<PlacedFragment> fragments) {
-        fragments.addAll(toPlacedFragments(emitted, placement));
-    }
-
-    private List<PlacedFragment> toPlacedFragments(List<LayoutFragment> emitted,
-                                                   FragmentPlacement placement) {
-        List<PlacedFragment> placed = new ArrayList<>(emitted.size());
-        int fragmentIndex = 0;
-        for (LayoutFragment fragment : emitted) {
-            LayoutFragment normalized = new LayoutFragment(
-                    placement.path(),
-                    fragmentIndex++,
-                    fragment.localX(),
-                    fragment.localY(),
-                    fragment.width(),
-                    fragment.height(),
-                    fragment.payload());
-            placed.add(PlacedFragment.from(normalized, placement));
-        }
-        return placed;
+        fragments.addAll(CompositeDecoration.toPlacedFragments(emitted, placement));
     }
 
     private void advanceSpace(double amount, CompilerState state) {

--- a/src/test/java/com/demcha/compose/document/layout/CompositeDecorationTest.java
+++ b/src/test/java/com/demcha/compose/document/layout/CompositeDecorationTest.java
@@ -1,0 +1,177 @@
+package com.demcha.compose.document.layout;
+
+import com.demcha.compose.document.node.DocumentNode;
+import com.demcha.compose.document.style.DocumentBleed;
+import com.demcha.compose.document.style.DocumentEdge;
+import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.engine.components.style.Margin;
+import com.demcha.compose.engine.components.style.Padding;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Engine-level contract for the composite decoration / overlay band builder
+ * extracted from {@link LayoutCompiler}. Whole-document geometry is guarded
+ * end-to-end by the qa parity / snapshot suites (DocumentBleedTest,
+ * PageMarginTest, PageIndexTest, …); these pin the per-page segmentation math in
+ * isolation, driving a stub {@link NodeDefinition} that emits one band-sized
+ * fragment so the resulting placement reflects each page's segment directly.
+ */
+class CompositeDecorationTest {
+
+    private static final double EPS = 1e-9;
+
+    // 200×100 canvas, 10pt margins → content band spans y=10 (bottom) to y=90 (top).
+    private final LayoutCanvas canvas = LayoutCanvas.from(200, 100, Margin.of(10));
+
+    @SuppressWarnings("unchecked")
+    private final NodeDefinition<DocumentNode> definition = mock(NodeDefinition.class);
+    private final FragmentContext ctx = mock(FragmentContext.class);
+
+    CompositeDecorationTest() {
+        // Emit a single fragment sized to the placement band, so each returned
+        // PlacedFragment carries that page-segment's y (bottom) and height.
+        when(definition.emitFragments(any(), any(), any())).thenAnswer(inv -> bandFragment(inv.getArgument(2)));
+        when(definition.emitOverlayFragments(any(), any(), any())).thenAnswer(inv -> bandFragment(inv.getArgument(2)));
+    }
+
+    private static List<LayoutFragment> bandFragment(FragmentPlacement p) {
+        return List.of(new LayoutFragment(p.path(), 0, 0.0, 0.0, p.width(), p.height(), "band"));
+    }
+
+    private List<PlacedFragment> fill(int startPage, int endPage, double startTopY, double endBottomY,
+                                      DocumentBleed bleed, PageGeometry geometry) {
+        when(ctx.pageGeometry()).thenReturn(geometry);
+        return CompositeDecoration.fill(null, definition, "deco", null, 0, 0, 10, startTopY, endBottomY,
+                180, startPage, endPage, Margin.zero(), Padding.zero(), canvas, bleed, ctx);
+    }
+
+    private List<PlacedFragment> overlay(int startPage, int endPage, double startTopY, double endBottomY,
+                                         PageGeometry geometry) {
+        when(ctx.pageGeometry()).thenReturn(geometry);
+        return CompositeDecoration.overlay(null, definition, "deco", null, 0, 0, 10, startTopY, endBottomY,
+                180, startPage, endPage, Margin.zero(), Padding.zero(), canvas, ctx);
+    }
+
+    @Test
+    void singlePageBandKeepsItsRequestedTopAndBottom() {
+        List<PlacedFragment> placed = fill(0, 0, 80, 30, DocumentBleed.none(), null);
+
+        assertThat(placed).singleElement().satisfies(f -> {
+            assertThat(f.pageIndex()).isZero();
+            assertThat(f.x()).isEqualTo(10);
+            assertThat(f.width()).isEqualTo(180);
+            assertThat(f.y()).isCloseTo(30, within(EPS));      // segment bottom
+            assertThat(f.height()).isCloseTo(50, within(EPS)); // 80 - 30
+        });
+    }
+
+    @Test
+    void multiPageBandClampsIntermediatePagesToTheContentBand() {
+        List<PlacedFragment> placed = fill(0, 2, 80, 40, DocumentBleed.none(), null);
+
+        assertThat(placed).hasSize(3);
+        // Page 0: top follows the requested start (80), bottom drops to the margin (10).
+        assertThat(placed.get(0).pageIndex()).isZero();
+        assertThat(placed.get(0).y()).isCloseTo(10, within(EPS));
+        assertThat(placed.get(0).height()).isCloseTo(70, within(EPS));
+        // Page 1 (intermediate): full content band 10..90.
+        assertThat(placed.get(1).pageIndex()).isEqualTo(1);
+        assertThat(placed.get(1).y()).isCloseTo(10, within(EPS));
+        assertThat(placed.get(1).height()).isCloseTo(80, within(EPS));
+        // Page 2: top at the margin (90), bottom at the requested end (40).
+        assertThat(placed.get(2).pageIndex()).isEqualTo(2);
+        assertThat(placed.get(2).y()).isCloseTo(40, within(EPS));
+        assertThat(placed.get(2).height()).isCloseTo(50, within(EPS));
+    }
+
+    @Test
+    void intermediatePageClampsToThatPagesOwnMargin() {
+        // Page 1 gets a 20pt margin override; pages 0 and 2 keep the 10pt canvas margin.
+        PageGeometry geometry = PageGeometry.of(canvas,
+                List.of(PageMarginOverride.fromInsets(1, 2, DocumentInsets.of(20))));
+
+        List<PlacedFragment> placed = fill(0, 2, 95, 5, DocumentBleed.none(), geometry);
+
+        assertThat(placed).hasSize(3);
+        // Page 1 uses its OWN margin (20): band 20..80, not the canvas 10..90.
+        assertThat(placed.get(1).y()).isCloseTo(20, within(EPS));
+        assertThat(placed.get(1).height()).isCloseTo(60, within(EPS));
+    }
+
+    @Test
+    void bledIntermediatePageReachesThePhysicalPageEdges() {
+        List<PlacedFragment> placed = fill(0, 2, 95, 5, DocumentBleed.all(), null);
+
+        // The intermediate page spans the full physical height (0..100), not the
+        // content band (10..90) — the bleed pushes the clamp to the page edges.
+        assertThat(placed.get(1).y()).isCloseTo(0, within(EPS));
+        assertThat(placed.get(1).height()).isCloseTo(100, within(EPS));
+    }
+
+    @Test
+    void collapsedSegmentIsSkipped() {
+        // Requested top == bottom → zero-height segment, nothing emitted.
+        List<PlacedFragment> placed = fill(0, 0, 50, 50, DocumentBleed.none(), null);
+
+        assertThat(placed).isEmpty();
+        verify(definition, never()).emitFragments(any(), any(), any());
+    }
+
+    @Test
+    void overlayBuildsTheBandFromTheOverlayEmitHook() {
+        when(ctx.pageGeometry()).thenReturn(null);
+
+        List<PlacedFragment> placed = CompositeDecoration.overlay(null, definition, "deco", null, 0, 0, 10,
+                80, 30, 180, 0, 0, Margin.zero(), Padding.zero(), canvas, ctx);
+
+        assertThat(placed).singleElement().satisfies(f -> {
+            assertThat(f.y()).isCloseTo(30, within(EPS));
+            assertThat(f.height()).isCloseTo(50, within(EPS));
+        });
+        verify(definition).emitOverlayFragments(any(), any(), any());
+        verify(definition, never()).emitFragments(any(), any(), any());
+    }
+
+    @Test
+    void overlaySegmentsMultiplePagesClampingIntermediatePagesToTheContentBand() {
+        List<PlacedFragment> placed = overlay(0, 2, 80, 40, null);
+
+        assertThat(placed).hasSize(3);
+        assertThat(placed.get(0).y()).isCloseTo(10, within(EPS));
+        assertThat(placed.get(0).height()).isCloseTo(70, within(EPS));
+        // Intermediate page fills the whole content band, same as fill() minus bleed.
+        assertThat(placed.get(1).y()).isCloseTo(10, within(EPS));
+        assertThat(placed.get(1).height()).isCloseTo(80, within(EPS));
+        assertThat(placed.get(2).y()).isCloseTo(40, within(EPS));
+        assertThat(placed.get(2).height()).isCloseTo(50, within(EPS));
+    }
+
+    @Test
+    void toPlacedFragmentsReindexesFragmentIndexPerPlacement() {
+        FragmentPlacement placement = new FragmentPlacement("owner", null, 0, 0, 3,
+                10, 20, 180, 40, 0, 0, Margin.zero(), Padding.zero());
+        List<LayoutFragment> emitted = List.of(
+                new LayoutFragment("stale-a", 99, 0, 0, 5, 5, "a"),
+                new LayoutFragment("stale-b", 42, 0, 0, 5, 5, "b"));
+
+        List<PlacedFragment> placed = CompositeDecoration.toPlacedFragments(emitted, placement);
+
+        assertThat(placed).hasSize(2);
+        assertThat(placed.get(0).fragmentIndex()).isZero();
+        assertThat(placed.get(1).fragmentIndex()).isEqualTo(1);
+        assertThat(placed).allSatisfy(f -> {
+            assertThat(f.path()).isEqualTo("owner");
+            assertThat(f.pageIndex()).isEqualTo(3);
+        });
+    }
+}


### PR DESCRIPTION
## Why
`LayoutCompiler` is one of the two largest files in `document.layout` and mixes several concerns. The per-page decoration / overlay band construction is a self-contained, near-pure seam — it reads no compiler pagination state — so it can move out into a focused, individually-tested helper, shrinking the hot-path class.

## What
- New package-private `CompositeDecoration` (the `RowSlots` pattern — `final`, private ctor, pure static): `fill(...)` builds the fill/border band drawn behind a composite's children, `overlay(...)` the band drawn in front; both segment a node spanning several pages so each page's band clamps to that page's content area, or the physical page edge on a bled edge. The shared `toPlacedFragments` moves with them.
- `LayoutCompiler` keeps the load-bearing splice order — fills spliced before children, overlays appended after; the helper only builds the fragment lists. Call sites change by name only (flat parameter lists preserved).
- No public API change (`document.layout` is `@Internal`); layout output is unchanged. Net −137 LOC in `LayoutCompiler`.

## Tests
- New `CompositeDecorationTest` (8 cases): single- and multi-page segmentation, the per-page-margin clamp (geometry ≠ null), bleed reaching the physical page edge, the empty-segment skip, the overlay emit hook, multi-page overlay, and per-placement fragment re-indexing.
- Core suite (384) and the qa byte-identity gate (642 — `PdfVisualRegressionTest`, `DocumentBleedTest`, `PageMarginTest`, `PageIndexTest`, all `*VisualParityTest`, `LayoutSnapshotRegressionDemoTest`) green: renders are byte-identical.