### PR TITLE
docs(layout): add the @author tag to DocumentLayoutResolver

### DIFF
--- a/src/main/java/com/demcha/compose/document/layout/DocumentLayoutResolver.java
+++ b/src/main/java/com/demcha/compose/document/layout/DocumentLayoutResolver.java
@@ -25,6 +25,8 @@ import java.util.Objects;
  * derive from canonical/debug types (page geometry, page-reference resolution),
  * which the session pre-computes so this layout-package class depends only on
  * layout types.</p>
+ *
+ * @author Artem Demchyshyn
  */
 public final class DocumentLayoutResolver {
 


### PR DESCRIPTION
## Why
`DocumentLayoutResolver` (extracted in #341) follows the `RowSlots` / `TokenBreaking` engine-helper pattern, and both of those carry `@author Artem Demchyshyn` in their class Javadoc — the tag was missed on the resolver.

## What
- Add `@author Artem Demchyshyn` to the class Javadoc. Docs-only, no code change.
- (`@since` is intentionally not added — the package-private `@Internal` helpers in `document.layout`, including `RowSlots` / `TokenBreaking` / `LayoutInsets`, omit it; it is reserved for the public API surface.)