### PR TITLE
refactor(layout): extract the layer-stack placement geometry from LayoutCompiler

### DIFF
--- a/src/main/java/com/demcha/compose/document/layout/LayerStackGeometry.java
+++ b/src/main/java/com/demcha/compose/document/layout/LayerStackGeometry.java
@@ -1,0 +1,89 @@
+package com.demcha.compose.document.layout;
+
+import com.demcha.compose.document.node.LayerAlign;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Pure geometry for {@code LayerStackNode} placement, pulled out of
+ * {@link LayoutCompiler}: the stable z-index render order and the align-based
+ * offset of a layer within its stack. All inputs are passed in and the results
+ * depend only on them — no compiler pagination state is read — so the compiler
+ * calls these to position layers while owning the placement itself.
+ *
+ * @author Artem Demchyshyn
+ */
+final class LayerStackGeometry {
+
+    private LayerStackGeometry() {
+    }
+
+    /**
+     * Returns an iteration order over {@code zIndices} that is stable on
+     * ties. Layers with equal {@code zIndex} keep their source order, so
+     * the default of all-zero zIndices yields the identity permutation
+     * {@code [0, 1, ..., n-1]} and existing snapshots stay deterministic.
+     *
+     * @param zIndices per-layer render-order keys (in source order)
+     * @return source indices sorted by ascending {@code zIndex}, stable
+     * on ties
+     */
+    static int[] zOrder(List<Integer> zIndices) {
+        int n = zIndices.size();
+        if (n <= 1) {
+            return identityOrder(n);
+        }
+        // Common case: every layer uses the same zIndex (typically 0). A
+        // stable sort would preserve source order anyway, so skip the boxed
+        // array allocation and the full sort.
+        int firstZ = zIndices.get(0);
+        boolean allEqual = true;
+        for (int i = 1; i < n; i++) {
+            if (zIndices.get(i) != firstZ) {
+                allEqual = false;
+                break;
+            }
+        }
+        if (allEqual) {
+            return identityOrder(n);
+        }
+        Integer[] boxed = new Integer[n];
+        for (int i = 0; i < n; i++) {
+            boxed[i] = i;
+        }
+        // Comparator.comparingInt + java.util.Arrays.sort on boxed array is
+        // documented stable; primitive int[] sort is not.
+        Arrays.sort(boxed, Comparator.comparingInt(zIndices::get));
+        int[] order = new int[n];
+        for (int i = 0; i < n; i++) {
+            order[i] = boxed[i];
+        }
+        return order;
+    }
+
+    private static int[] identityOrder(int n) {
+        int[] order = new int[n];
+        for (int i = 0; i < n; i++) {
+            order[i] = i;
+        }
+        return order;
+    }
+
+    static double horizontalOffset(LayerAlign align, double innerWidth, double childOuterWidth) {
+        return switch (align) {
+            case TOP_LEFT, CENTER_LEFT, BOTTOM_LEFT -> 0.0;
+            case TOP_CENTER, CENTER, BOTTOM_CENTER -> Math.max(0.0, (innerWidth - childOuterWidth) / 2.0);
+            case TOP_RIGHT, CENTER_RIGHT, BOTTOM_RIGHT -> Math.max(0.0, innerWidth - childOuterWidth);
+        };
+    }
+
+    static double verticalOffset(LayerAlign align, double innerHeight, double childOuterHeight) {
+        return switch (align) {
+            case TOP_LEFT, TOP_CENTER, TOP_RIGHT -> 0.0;
+            case CENTER_LEFT, CENTER, CENTER_RIGHT -> Math.max(0.0, (innerHeight - childOuterHeight) / 2.0);
+            case BOTTOM_LEFT, BOTTOM_CENTER, BOTTOM_RIGHT -> Math.max(0.0, innerHeight - childOuterHeight);
+        };
+    }
+}

--- a/src/main/java/com/demcha/compose/document/layout/LayoutCompiler.java
+++ b/src/main/java/com/demcha/compose/document/layout/LayoutCompiler.java
@@ -58,77 +58,6 @@ public final class LayoutCompiler {
         this.registry = Objects.requireNonNull(registry, "registry");
     }
 
-    /**
-     * Returns an iteration order over {@code zIndices} that is stable on
-     * ties. Layers with equal {@code zIndex} keep their source order, so
-     * the default of all-zero zIndices yields the identity permutation
-     * {@code [0, 1, ..., n-1]} and existing snapshots stay deterministic.
-     *
-     * @param zIndices per-layer render-order keys (in source order)
-     * @return source indices sorted by ascending {@code zIndex}, stable
-     * on ties
-     */
-    private static int[] stableZIndexOrder(java.util.List<Integer> zIndices) {
-        int n = zIndices.size();
-        if (n <= 1) {
-            return identityOrder(n);
-        }
-        // Common case: every layer uses the same zIndex (typically 0). A
-        // stable sort would preserve source order anyway, so skip the boxed
-        // array allocation and the full sort.
-        int firstZ = zIndices.get(0);
-        boolean allEqual = true;
-        for (int i = 1; i < n; i++) {
-            if (zIndices.get(i) != firstZ) {
-                allEqual = false;
-                break;
-            }
-        }
-        if (allEqual) {
-            return identityOrder(n);
-        }
-        Integer[] boxed = new Integer[n];
-        for (int i = 0; i < n; i++) {
-            boxed[i] = i;
-        }
-        // Comparator.comparingInt + java.util.Arrays.sort on boxed array is
-        // documented stable; primitive int[] sort is not.
-        java.util.Arrays.sort(boxed, java.util.Comparator.comparingInt(zIndices::get));
-        int[] order = new int[n];
-        for (int i = 0; i < n; i++) {
-            order[i] = boxed[i];
-        }
-        return order;
-    }
-
-    private static int[] identityOrder(int n) {
-        int[] order = new int[n];
-        for (int i = 0; i < n; i++) {
-            order[i] = i;
-        }
-        return order;
-    }
-
-    private static double horizontalLayerOffset(com.demcha.compose.document.node.LayerAlign align,
-                                                double innerWidth,
-                                                double childOuterWidth) {
-        return switch (align) {
-            case TOP_LEFT, CENTER_LEFT, BOTTOM_LEFT -> 0.0;
-            case TOP_CENTER, CENTER, BOTTOM_CENTER -> Math.max(0.0, (innerWidth - childOuterWidth) / 2.0);
-            case TOP_RIGHT, CENTER_RIGHT, BOTTOM_RIGHT -> Math.max(0.0, innerWidth - childOuterWidth);
-        };
-    }
-
-    private static double verticalLayerOffset(com.demcha.compose.document.node.LayerAlign align,
-                                              double innerHeight,
-                                              double childOuterHeight) {
-        return switch (align) {
-            case TOP_LEFT, TOP_CENTER, TOP_RIGHT -> 0.0;
-            case CENTER_LEFT, CENTER, CENTER_RIGHT -> Math.max(0.0, (innerHeight - childOuterHeight) / 2.0);
-            case BOTTOM_LEFT, BOTTOM_CENTER, BOTTOM_RIGHT -> Math.max(0.0, innerHeight - childOuterHeight);
-        };
-    }
-
     private static double[] distributeRowSlotWidths(List<DocumentNode> children,
                                                     List<Double> weights,
                                                     double gap,
@@ -769,7 +698,7 @@ public final class LayoutCompiler {
         // earlier in the list → drawn first / behind. childIndex below
         // is the SOURCE index so semantic paths stay stable for tests
         // and snapshots; only the iteration order shifts.
-        int[] iterationOrder = stableZIndexOrder(stackLayout.zIndices());
+        int[] iterationOrder = LayerStackGeometry.zOrder(stackLayout.zIndices());
         PlacementContext layerHostCtx = new FixedSlotPlacementContext(
                 state.pageIndex, state.canvas, prepareContext, fragmentContext, nodes, fragments);
         for (int slot = 0; slot < iterationOrder.length; slot++) {
@@ -998,10 +927,10 @@ public final class LayoutCompiler {
         // offsetX > 0 nudges the layer right; offsetY > 0 nudges it down
         // (PDF y grows upward, so "down" subtracts from the top-Y).
         double alignedSlotX = innerStartX
-                              + horizontalLayerOffset(align, innerWidth, childOuterWidth)
+                              + LayerStackGeometry.horizontalOffset(align, innerWidth, childOuterWidth)
                               + layerOffsetX;
         double alignedSlotTopY = innerTopY
-                                 - verticalLayerOffset(align, innerHeight, childOuterHeight)
+                                 - LayerStackGeometry.verticalOffset(align, innerHeight, childOuterHeight)
                                  - layerOffsetY;
 
         // Layers always paint into a fixed page band — even when the
@@ -1285,7 +1214,7 @@ public final class LayoutCompiler {
                 // Same z-index iteration order as compileStackedLayer
                 // (root-level case). Source-order semantic paths are
                 // preserved — only render order shifts.
-                int[] iterationOrder = stableZIndexOrder(stackLayout.zIndices());
+                int[] iterationOrder = LayerStackGeometry.zOrder(stackLayout.zIndices());
                 for (int slot = 0; slot < iterationOrder.length; slot++) {
                     int i = iterationOrder[slot];
                     placeStackLayer(

--- a/src/test/java/com/demcha/compose/document/layout/LayerStackGeometryTest.java
+++ b/src/test/java/com/demcha/compose/document/layout/LayerStackGeometryTest.java
@@ -1,0 +1,81 @@
+package com.demcha.compose.document.layout;
+
+import com.demcha.compose.document.node.LayerAlign;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Engine-level contract for the {@code LayerStackNode} placement geometry
+ * extracted from {@link LayoutCompiler}. Whole-document stacking is guarded by
+ * the qa snapshot / visual-regression suites; these pin the z-order permutation
+ * and the align offsets in isolation.
+ */
+class LayerStackGeometryTest {
+
+    private static final double EPS = 1e-9;
+
+    @Test
+    void emptyAndSingletonYieldIdentityOrder() {
+        assertThat(LayerStackGeometry.zOrder(List.of())).isEmpty();
+        assertThat(LayerStackGeometry.zOrder(List.of(7))).containsExactly(0);
+    }
+
+    @Test
+    void allEqualZIndicesPreserveSourceOrder() {
+        assertThat(LayerStackGeometry.zOrder(List.of(0, 0, 0, 0))).containsExactly(0, 1, 2, 3);
+        assertThat(LayerStackGeometry.zOrder(List.of(5, 5, 5))).containsExactly(0, 1, 2);
+    }
+
+    @Test
+    void distinctZIndicesSortAscendingStableOnTies() {
+        // z per index: [2, 0, 1, 0] → ascending, ties keep source order → [1, 3, 2, 0].
+        assertThat(LayerStackGeometry.zOrder(List.of(2, 0, 1, 0))).containsExactly(1, 3, 2, 0);
+    }
+
+    @Test
+    void negativeZIndicesOrderBelowZero() {
+        assertThat(LayerStackGeometry.zOrder(List.of(0, -1, 3))).containsExactly(1, 0, 2);
+    }
+
+    @Test
+    void horizontalOffsetIsZeroForLeftAligns() {
+        for (LayerAlign a : List.of(LayerAlign.TOP_LEFT, LayerAlign.CENTER_LEFT, LayerAlign.BOTTOM_LEFT)) {
+            assertThat(LayerStackGeometry.horizontalOffset(a, 100, 40)).as("%s", a).isZero();
+        }
+    }
+
+    @Test
+    void horizontalOffsetHalvesSlackForCenterAndFillsForRight() {
+        assertThat(LayerStackGeometry.horizontalOffset(LayerAlign.CENTER, 100, 40)).isCloseTo(30, within(EPS));
+        assertThat(LayerStackGeometry.horizontalOffset(LayerAlign.TOP_RIGHT, 100, 40)).isCloseTo(60, within(EPS));
+    }
+
+    @Test
+    void horizontalOffsetClampsNonNegativeWhenChildWiderThanInner() {
+        assertThat(LayerStackGeometry.horizontalOffset(LayerAlign.CENTER, 40, 100)).isZero();
+        assertThat(LayerStackGeometry.horizontalOffset(LayerAlign.BOTTOM_RIGHT, 40, 100)).isZero();
+    }
+
+    @Test
+    void verticalOffsetIsZeroForTopAligns() {
+        for (LayerAlign a : List.of(LayerAlign.TOP_LEFT, LayerAlign.TOP_CENTER, LayerAlign.TOP_RIGHT)) {
+            assertThat(LayerStackGeometry.verticalOffset(a, 100, 40)).as("%s", a).isZero();
+        }
+    }
+
+    @Test
+    void verticalOffsetHalvesSlackForCenterAndFillsForBottom() {
+        assertThat(LayerStackGeometry.verticalOffset(LayerAlign.CENTER, 100, 40)).isCloseTo(30, within(EPS));
+        assertThat(LayerStackGeometry.verticalOffset(LayerAlign.BOTTOM_LEFT, 100, 40)).isCloseTo(60, within(EPS));
+    }
+
+    @Test
+    void verticalOffsetClampsNonNegativeWhenChildTallerThanInner() {
+        assertThat(LayerStackGeometry.verticalOffset(LayerAlign.CENTER, 40, 100)).isZero();
+        assertThat(LayerStackGeometry.verticalOffset(LayerAlign.BOTTOM_LEFT, 40, 100)).isZero();
+    }
+}


### PR DESCRIPTION
## Why
Continuing the `LayoutCompiler` decomposition. The `LayerStackNode` placement geometry — the stable z-index render order and the align-based offsets — is pure (reads no compiler pagination state), so it moves out into a focused, individually-tested helper, shrinking the hot-path class.

## What
- New package-private `LayerStackGeometry` (the `RowSlots` pattern — `final`, private ctor, pure static): `zOrder(zIndices)` (stable ascending render order, identity on all-equal), `horizontalOffset(align, innerWidth, childWidth)` and `verticalOffset(align, innerHeight, childHeight)` (align-based layer offset within the stack, clamped non-negative).
- `LayoutCompiler` keeps positioning the layers and only calls into the helper; call sites change by name only (identical arguments, signs and operand order preserved).
- No public API change (`document.layout` is `@Internal`); layout output is unchanged. Net −71 LOC in `LayoutCompiler`.

## Tests
- New `LayerStackGeometryTest` (10 cases): z-order (empty/singleton identity, source-order on equal z, ascending stable-on-ties, negative z) and both offsets (left/top zero, center half-slack, right/bottom full-slack, non-negative clamp on both axes).
- Core suite (395) and the qa byte-identity gate (642 — `LayoutCompilerInvariantsTest`, `ShapeContainerZIndexDemoTest`, `PdfVisualRegressionTest`, all `*VisualParityTest`, `LayoutSnapshotRegressionDemoTest`) green: renders are byte-identical.