### PR TITLE
feat(layout): opt-in loud failure when a document layout never converges

### DIFF
--- a/docs/roadmaps/post-2.0-engineering.md
+++ b/docs/roadmaps/post-2.0-engineering.md
@@ -59,11 +59,12 @@ engine refactor, sequenced after the module line stabilises. **Status: Deferred.
 
 ### Fail loudly on non-converged layout
 
-Some layout passes iterate toward a fixed point. Today a pass that does not
-converge silently uses its last iteration. A `FAIL_ON_UNCONVERGED` policy flag
-would let a build opt into failing loudly instead, surfacing the rare
-non-converging document in tests rather than shipping a subtly-wrong render.
-**Status: Planned.**
+Some layout passes iterate toward a fixed point. By default a pass that does not
+converge silently uses its last iteration. Setting the
+`graphcompose.failOnUnconvergedLayout` system property makes the resolver throw
+instead, surfacing the rare non-converging document in a test or build run rather
+than shipping a subtly-wrong render. Off by default, so production output is
+unchanged. **Status: Done.**
 
 ## Scale & memory
 

--- a/src/main/java/com/demcha/compose/document/layout/DocumentLayoutResolver.java
+++ b/src/main/java/com/demcha/compose/document/layout/DocumentLayoutResolver.java
@@ -37,6 +37,16 @@ public final class DocumentLayoutResolver {
      */
     static final int MAX_PASSES = 5;
 
+    /**
+     * Opt-in build / test diagnostic. When the system property
+     * {@code graphcompose.failOnUnconvergedLayout} is set, a document whose layout
+     * does not settle within {@link #MAX_PASSES} passes throws instead of silently
+     * returning its last iteration — surfacing the rare non-converging document in a
+     * test run rather than shipping a subtly-wrong render. Off by default, so the
+     * production path and its output are unchanged.
+     */
+    static final String FAIL_ON_UNCONVERGED_PROPERTY = "graphcompose.failOnUnconvergedLayout";
+
     private static final Logger LIFECYCLE_LOG = LoggerFactory.getLogger("com.demcha.compose.document.lifecycle");
 
     private final Context context;
@@ -48,9 +58,13 @@ public final class DocumentLayoutResolver {
     /**
      * Compiles the semantic graph for one layout revision to its fixed point.
      * Returns the resolved layout graph <em>before</em> any page-background fills
-     * are spliced in — the session applies those around this result.
+     * are spliced in — the session applies those around this result. A document
+     * that does not settle within {@link #MAX_PASSES} passes returns its last
+     * iteration, unless {@link #FAIL_ON_UNCONVERGED_PROPERTY} is set.
      *
      * @return the settled (or last, if uncapped) layout graph
+     * @throws IllegalStateException if the layout never converges and
+     *                               {@link #FAIL_ON_UNCONVERGED_PROPERTY} is set
      */
     public LayoutGraph resolve() {
         PageGeometry geometry = context.pageGeometry();
@@ -76,6 +90,12 @@ public final class DocumentLayoutResolver {
             }
             resolved = renderedPages;
             startPages = renderedStarts;
+        }
+        if (Boolean.getBoolean(FAIL_ON_UNCONVERGED_PROPERTY)) {
+            throw new IllegalStateException(
+                    "Document layout did not converge within " + MAX_PASSES + " passes (sessionId="
+                            + context.sessionId() + "); the coupled page-reference / per-page-margin"
+                            + " fixed point did not settle.");
         }
         LIFECYCLE_LOG.debug("document.layout.unconverged sessionId={} passes={}", context.sessionId(), MAX_PASSES);
         return graph;

--- a/src/test/java/com/demcha/compose/document/layout/DocumentLayoutResolverTest.java
+++ b/src/test/java/com/demcha/compose/document/layout/DocumentLayoutResolverTest.java
@@ -14,6 +14,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -147,5 +148,31 @@ class DocumentLayoutResolverTest {
 
         assertThat(result).isSameAs(graphs[graphs.length - 1]);
         verify(compiler, times(1 + DocumentLayoutResolver.MAX_PASSES)).compile(any(), any(), any());
+    }
+
+    @Test
+    void nonConvergingDocumentThrowsWhenFailOnUnconvergedPropertyIsSet() {
+        when(context.pageGeometry()).thenReturn(null);
+        when(context.hasPageReference()).thenReturn(true);
+        when(compiler.compile(any(), any(), any())).thenReturn(graph());
+        // Numbers never repeat → the loop runs to the cap without settling.
+        AtomicInteger tick = new AtomicInteger();
+        when(context.resolvePageNumbers(any())).thenAnswer(inv -> Map.of("intro", tick.incrementAndGet()));
+
+        String property = DocumentLayoutResolver.FAIL_ON_UNCONVERGED_PROPERTY;
+        String previous = System.getProperty(property);
+        System.setProperty(property, "true");
+        try {
+            assertThatThrownBy(() -> new DocumentLayoutResolver(context).resolve())
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("did not converge")
+                    .hasMessageContaining("test-session");
+        } finally {
+            if (previous == null) {
+                System.clearProperty(property);
+            } else {
+                System.setProperty(property, previous);
+            }
+        }
     }
 }


### PR DESCRIPTION
## Why
A document with a coupled page-reference / per-page-margin fixed point that never settles is compiled up to a recompile cap and then **silently uses its last iteration** — a rare but subtly-wrong render with no signal. The post-2.0 roadmap asked for a way to surface this loudly in tests/builds instead.

## What
- `DocumentLayoutResolver`: when the `graphcompose.failOnUnconvergedLayout` system property is set, the non-converged branch throws an `IllegalStateException` (naming the pass count and session) instead of returning the last iteration.
- **Off by default** — the production path (and its byte output) is unchanged; the check sits only on the already-rare unconverged branch, so no hot-path cost.
- Internal build/test diagnostic, in the spirit of `graphcompose.updateSnapshots`; no public API added (`document.layout` is `@Internal`).
- Roadmap item flipped to Done.

## Tests
- New `DocumentLayoutResolverTest.nonConvergingDocumentThrowsWhenFailOnUnconvergedPropertyIsSet` (sets the property, asserts the throw, restores it in `finally`). The existing `nonConvergingDocumentIsCappedAndReturnsLastLayout` stays green — confirming the **default** still returns the last layout.
- Core suite (401) and the qa suite (642, property unset) green: default behaviour and renders are unchanged.