### PR TITLE
refactor(engine): give AtomicNodeTooLargeException its own message factory

### DIFF
--- a/src/main/java/com/demcha/compose/document/exceptions/AtomicNodeTooLargeException.java
+++ b/src/main/java/com/demcha/compose/document/exceptions/AtomicNodeTooLargeException.java
@@ -12,5 +12,25 @@ public final class AtomicNodeTooLargeException extends RuntimeException {
     public AtomicNodeTooLargeException(String message) {
         super(message);
     }
+
+    /**
+     * Creates an exception for a node whose required outer height exceeds a full
+     * page's capacity, with a diagnostic message that names the offending
+     * measurements but no user document content.
+     *
+     * @param path        the node's layout path
+     * @param outerHeight the node's required outer (margin-box) height
+     * @param pageHeight  the available full-page capacity
+     * @return the exception, ready to throw
+     * @since 2.0.0
+     */
+    public static AtomicNodeTooLargeException forNode(String path, double outerHeight, double pageHeight) {
+        return new AtomicNodeTooLargeException(
+                "Node '" + path + "' requires outer height " + outerHeight
+                + " but page capacity is " + pageHeight + ". "
+                + "Reduce the node height, split content into multiple atomic blocks, "
+                + "or increase the page size. Differences under 0.5 pt are tolerated as "
+                + "rounding noise (v1.6.2+).");
+    }
 }
 

--- a/src/main/java/com/demcha/compose/document/layout/LayoutCompiler.java
+++ b/src/main/java/com/demcha/compose/document/layout/LayoutCompiler.java
@@ -943,7 +943,7 @@ public final class LayoutCompiler {
                     state.newPage();
                     continue;
                 }
-                throw atomicTooLarge(path, pieceOuterHeight, fullPageOuterHeight);
+                throw AtomicNodeTooLargeException.forNode(path, pieceOuterHeight, fullPageOuterHeight);
             }
             if (tail != null && tail.equals(current)) {
                 throw new IllegalStateException("Split did not make progress for node '" + path
@@ -962,7 +962,7 @@ public final class LayoutCompiler {
                     state.newPage();
                     continue;
                 }
-                throw atomicTooLarge(path, headOuterHeight, fullPageOuterHeight);
+                throw AtomicNodeTooLargeException.forNode(path, headOuterHeight, fullPageOuterHeight);
             }
 
             state.touchPage();
@@ -1326,21 +1326,12 @@ public final class LayoutCompiler {
     private void admitAtomicBlock(double outerHeight, String path, CompilerState state) {
         double fullPageHeight = state.activeInnerHeight();
         if (outerHeight > fullPageHeight + CAPACITY_TOLERANCE) {
-            throw atomicTooLarge(path, outerHeight, fullPageHeight);
+            throw AtomicNodeTooLargeException.forNode(path, outerHeight, fullPageHeight);
         }
         if (outerHeight > state.remainingHeight() + EPS && state.usedHeight > EPS) {
             state.newPage();
         }
         state.touchPage();
-    }
-
-    private AtomicNodeTooLargeException atomicTooLarge(String path, double outerHeight, double pageHeight) {
-        return new AtomicNodeTooLargeException(
-                "Node '" + path + "' requires outer height " + outerHeight
-                + " but page capacity is " + pageHeight + ". "
-                + "Reduce the node height, split content into multiple atomic blocks, "
-                + "or increase the page size. Differences under 0.5 pt are tolerated as "
-                + "rounding noise (v1.6.2+).");
     }
 
     /**


### PR DESCRIPTION
## Why

The "node too large for a full page" diagnostic was assembled by a private
`LayoutCompiler.atomicTooLarge(path, outerHeight, pageHeight)` helper. The message
belongs with the exception that carries it, and keeping it on `LayoutCompiler` blocks any
collaborator extracted out of the compiler from throwing the same exception (it can't reach
a private helper) — the first step of continuing the `LayoutCompiler` breakdown.

## What

- Added a static `AtomicNodeTooLargeException.forNode(path, outerHeight, pageHeight)` factory
  that builds the diagnostic (measurements only, no user document content).
- The three throw sites in `LayoutCompiler` (`compileSplittableLeaf` ×2, `admitAtomicBlock`)
  now call `AtomicNodeTooLargeException.forNode(...)`; the private `atomicTooLarge` helper is
  removed.

## Tests

- `./mvnw -f aggregator/pom.xml verify -pl :graph-compose-qa -am` — full compile + javadoc
  gate + the qa visual/parity byte-identity suite (643): green. The exception type and message
  are unchanged, so the too-large regression tests (`PageCapacityToleranceDemoTest`,
  `PaginationEdgeCaseTest`) pass as before.

Byte-identical — same exception, same message string. The `forNode` factory is a new public
method on an already-public exception (an addition, not a break; japicmp is report-only for 2.0).
