### PR TITLE
refactor(engine): thread SplittableLeafCompiler through CompileContext

### DIFF
--- a/src/main/java/com/demcha/compose/document/layout/LayoutCompiler.java
+++ b/src/main/java/com/demcha/compose/document/layout/LayoutCompiler.java
@@ -171,7 +171,7 @@ public final class LayoutCompiler {
 
         if (definition.paginationPolicy(node) == PaginationPolicy.SPLITTABLE) {
             SplittableLeafCompiler.compile(prepared, definition, path, semanticName, parentPath, childIndex, depth, regionX,
-                    availableWidth, state, prepareContext, fragmentContext, nodes, fragments);
+                    availableWidth, new CompileContext(state, prepareContext, fragmentContext, nodes, fragments));
             return;
         }
 

--- a/src/main/java/com/demcha/compose/document/layout/SplittableLeafCompiler.java
+++ b/src/main/java/com/demcha/compose/document/layout/SplittableLeafCompiler.java
@@ -44,11 +44,7 @@ final class SplittableLeafCompiler {
      * @param depth           the leaf's tree depth
      * @param regionX         the content region's left edge
      * @param availableWidth  the content width available to the leaf
-     * @param state           the compiler cursor (mutated as pages advance)
-     * @param prepareContext  the node preparation context (drives re-measurement of tails)
-     * @param fragmentContext the fragment emission context
-     * @param nodes           accumulator for placed nodes (appended to)
-     * @param fragments       accumulator for placed fragments (appended to)
+     * @param ctx             the cursor + emission context (mutated as pages advance)
      * @throws AtomicNodeTooLargeException if a piece cannot fit on an empty page
      */
     static void compile(PreparedNode<DocumentNode> prepared,
@@ -60,11 +56,13 @@ final class SplittableLeafCompiler {
                         int depth,
                         double regionX,
                         double availableWidth,
-                        CompilerState state,
-                        PrepareContext prepareContext,
-                        FragmentContext fragmentContext,
-                        List<PlacedNode> nodes,
-                        List<PlacedFragment> fragments) {
+                        CompileContext ctx) {
+        CompilerState state = ctx.state();
+        PrepareContext prepareContext = ctx.prepareContext();
+        FragmentContext fragmentContext = ctx.fragmentContext();
+        List<PlacedNode> nodes = ctx.nodes();
+        List<PlacedFragment> fragments = ctx.fragments();
+
         Margin originalMargin = toMargin(prepared.node().margin());
         Padding originalPadding = toPadding(prepared.node().padding());
 

--- a/src/test/java/com/demcha/compose/document/layout/SplittableLeafCompilerTest.java
+++ b/src/test/java/com/demcha/compose/document/layout/SplittableLeafCompilerTest.java
@@ -44,7 +44,7 @@ class SplittableLeafCompilerTest {
 
     private void compile(PreparedNode<DocumentNode> prepared) {
         SplittableLeafCompiler.compile(prepared, definition, "leaf", "leaf", null, 0, 1,
-                10, 180, state, prepareContext, fragmentContext, nodes, fragments);
+                10, 180, new CompileContext(state, prepareContext, fragmentContext, nodes, fragments));
     }
 
     @Test


### PR DESCRIPTION
## Why

[#361](https://github.com/DemchaAV/GraphCompose/pull/361) introduced `CompileContext` (bundling the five always-threaded
`state` / `prepareContext` / `fragmentContext` / `nodes` / `fragments` params) and used it in
`StackedLayerCompiler`, but `SplittableLeafCompiler` (from [#360](https://github.com/DemchaAV/GraphCompose/pull/360)) still took them
flat. This gives the two extracted compile collaborators one consistent shape.

## What

- `SplittableLeafCompiler.compile(...)` now takes a `CompileContext` instead of the five
  separate params (**14 → 10 args**), unpacking them into the same local names at the top so
  the pagination-loop body is untouched.
- Updated the dispatch in `LayoutCompiler` and the `compile(...)` helper in
  `SplittableLeafCompilerTest` to build the `CompileContext`.

## Tests

- `./mvnw -f aggregator/pom.xml verify -pl :graph-compose-qa -am` — full compile + javadoc gate
  + the qa visual/parity byte-identity suite (643): green.
- `SplittableLeafCompilerTest`: 3 tests, 0 failures (unchanged behaviour, new call shape).

Byte-identical — the change is parameter repackaging only; the split loop is unmodified.
