### PR TITLE
docs: freeze the 2.0 scope and link the RTL limitation to #140

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ For a Spring Boot `@RestController` streaming the PDF straight to the response, 
 
 ### Text &amp; internationalization
 
-- Text is laid out **left-to-right**. Bidirectional (RTL) reordering and complex-script shaping &mdash; Arabic contextual joining, Indic reordering &mdash; are **not** performed, so Arabic / Hebrew text renders in logical order without correct visual ordering.
+- Text is laid out **left-to-right**. Bidirectional (RTL) reordering and complex-script shaping &mdash; Arabic contextual joining, Indic reordering &mdash; are **not** performed, so Arabic / Hebrew text renders in logical order without correct visual ordering. Full RTL / bidi support is tracked in [#140](https://github.com/DemchaAV/GraphCompose/issues/140).
 - A glyph the active font does not cover renders as `?` (with a warning logged); load a font that covers the script you need.
 
 ### When to use GraphCompose

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,9 +6,15 @@ GraphCompose is solo-maintained. This roadmap is a direction, not a contract. Da
 
 In flight on `2.0-dev`, preparing the 2.0.0 GA. The 2.0 line is about **packaging and internal hygiene**, not new authoring API — binary-breaking by design, with `japicmp` report-only for the cycle.
 
+**Scope frozen (2026-07).** 2.0.0 ships exactly the set below; no further internal engineering is pulled in before GA — that work is the post-2.0 line (next section).
+
 - **Modular split** &mdash; the single jar is split into `graph-compose-core` plus `graph-compose-render-pdf` / `graph-compose-render-docx` / `graph-compose-render-pptx` / `graph-compose-templates` / `graph-compose-testing`, with render backends discovered through a `ServiceLoader` SPI. `graph-compose` stays a drop-in wrapper (core + render-pdf) so existing PDF callers upgrade unchanged. See the [2.0 modules migration guide](docs/migration/v2.0.0-modules.md) and [ADR 0016](docs/adr/0016-multi-module-packaging.md).
 - **Legacy removal** &mdash; the dead Entity-Component-System execution layer and the deprecated (`forRemoval`) public API are gone; the classic template presets are replaced by the layered `templates.*` stack on `BrandTheme`.
+- **Release &amp; publishing pipeline** &mdash; multi-module Maven Central publishing, the `core/`-layout reactor (`./mvnw clean verify` at the root builds everything), and the cut / tag / GA runbook.
+- **Compatibility tests** &mdash; the guard, snapshot, and visual-regression suites that prove the split left rendered output unchanged.
 - **Maintenance** &mdash; the **v1.9.x** line (current stable) receives critical fixes only.
+
+Further internal engineering — more layout-class decomposition, abstraction cleanup, streaming, optional performance work — is **deferred to post-2.0** and does not gate GA.
 
 Full detail in [CHANGELOG.md](CHANGELOG.md) under `v2.0.0 — Planned`.
 


### PR DESCRIPTION
## Why

The 2.0 line is scoped as "packaging + internal hygiene, no new authoring API", but the ROADMAP
didn't state the boundary explicitly — and post-2.0 internal refactoring (layout-class
decomposition, etc.) had started landing on `2.0-dev` before GA. An explicit freeze keeps the
release cycle closing instead of the internals improving indefinitely. Separately, the RTL
limitation was documented but not linked to where it's tracked.

## What

- **ROADMAP — freeze the 2.0 scope.** The "Now — 2.0 line" section now states 2.0.0 ships exactly
  the packaging + hygiene set (modular split, legacy removal, **release / publishing pipeline**,
  **compatibility tests**, 1.9.x maintenance — the last two were previously implicit) and that no
  further internal engineering is pulled in before GA. Further layout decomposition, abstraction
  cleanup, streaming, and optional perf work are explicitly deferred to the post-2.0 line (which
  already exists as the "Next — post-2.0 engineering" section — no restructure needed).
- **README — surface the RTL limitation.** The support matrix already states LTR-only / no bidi;
  link it to [#140](https://github.com/DemchaAV/GraphCompose/issues/140) so a reader sees where full
  RTL / bidi support is tracked.

Docs-only; no build or runtime change.

## Tests

`CanonicalSurfaceGuardTest`, `DocumentationCoverageTest`, `PackageMapGuardTest` green. The #140 link
resolves to the open RTL tracking issue.
