### PR TITLE
build(release): parameterize cut-release for the 2.0 line + document the 2.0 cut

### DIFF
--- a/docs/contributing/release-process.md
+++ b/docs/contributing/release-process.md
@@ -17,6 +17,8 @@ Run this every time, in order. Stop on the first red gate and fix it before cont
 
 The shell setup and exact PowerShell commands live in the `graphcompose-release-engineer` skill (loaded via `Skill` tool). On Git Bash use `./mvnw` instead of `.\mvnw.cmd`; the gates are identical.
 
+> **Cutting the 2.0 line?** This checklist is written for the 1.9.x line on `develop` (the old single-jar layout, where `-pl .` is the engine). For a 2.0 cut from `2.0-dev`, substitute throughout: branch `develop` → `2.0-dev`; the full gate `clean verify -pl .` → the whole reactor **`./mvnw -B -ntp clean verify`** (the root pom is the aggregator now); engine-only commands `-pl .` → `-pl :graph-compose-core`; `aggregator/pom.xml` → the root `pom.xml`, with the engine version in `core/pom.xml`. The cut itself uses `cut-release.ps1 -Branch 2.0-dev` — see [§2.G](#2g-cutting-the-20-line-branch-flow).
+
 ### A. Branch + working tree
 
 - [ ] On `develop` branch (or in a `develop` worktree). Never tag from `main`.
@@ -186,6 +188,29 @@ aggregate. They all carry the **same** version.
   the whole train to the **GitHub Release pre-release surface only** — `publish.yml`
   skips Central for hyphenated tags (§2.B step 9). A beta is therefore installable from
   the GitHub pre-release (and from JitPack, which builds any tag), not from Central.
+
+### 2.G Cutting the 2.0 line (branch flow)
+
+The 2.0 train is cut from **`2.0-dev`**, not `develop`; `cut-release.ps1` takes the
+branch as a parameter. On the 2.0 layout the engine lives in `core/pom.xml` and the
+repository root `pom.xml` is the reactor aggregator — the script bumps both (plus the
+rest of the train) and its `Test-Path` guard skips `core/pom.xml` on the old 1.x layout,
+so the same script serves both lines.
+
+- **Release candidate:** `pwsh ./scripts/cut-release.ps1 -Version 2.0.0-rc.1 -Branch 2.0-dev`.
+  The hyphenated `-rc` tag ships to the GitHub pre-release surface only (Central skipped, §2.F).
+- **GA:** `pwsh ./scripts/cut-release.ps1 -Version 2.0.0 -Branch 2.0-dev`. The plain
+  `v2.0.0` tag fires `publish.yml`, which deploys the eight-module train to Maven Central in
+  dependency order — that sequence is version-agnostic and needs no per-release change.
+
+At **2.0 GA** the branches take their long-term roles, in this order:
+
+1. **Cut `1.x` from the current `main` tip first** (the final 1.9.x commit), *before* moving
+   main: `git branch 1.x main && git push origin 1.x`. It receives 1.9.x critical fixes only.
+2. **Fast-forward `main` to 2.0:** `git push origin 2.0-dev:main`. This is a clean
+   fast-forward because the pre-GA sync keeps `main`'s history an ancestor of `2.0-dev`.
+3. **Repoint ongoing work:** `develop` becomes the 2.x working branch; `2.0-dev` retires.
+   From then on `cut-release.ps1` runs with its default `-Branch develop` again.
 
 ---
 

--- a/scripts/cut-release.ps1
+++ b/scripts/cut-release.ps1
@@ -3,16 +3,16 @@
     Cuts a GraphCompose release: bumps pom versions, updates the
     showcase site links, regenerates the examples manifest, runs
     verify, commits, tags, pushes — then flips the showcase links
-    back to develop so ongoing dev work stays linkable.
+    back to the release branch so ongoing dev work stays linkable.
 
 .DESCRIPTION
     Modes:
 
-      Default          — full release cut. Requires clean develop in
-                         sync with origin. Performs all 10 steps end
-                         to end with prompts before each remote
-                         action (push develop, push tag, merge to
-                         main).
+      Default          — full release cut. Requires the release branch
+                         (-Branch, default develop) clean and in sync
+                         with origin. Performs all 10 steps end to end
+                         with prompts before each remote action (push
+                         the branch, push tag, merge to main).
 
       -DryRun          — print every step without executing it. Use
                          to preview what the release will do.
@@ -22,10 +22,10 @@
                          release locally before publishing.
 
       -PostReleaseOnly — skip the release work entirely. Just flips
-                         ShowcaseMetadata.GH_BASE back to /blob/develop,
+                         ShowcaseMetadata.GH_BASE back to /blob/<branch>,
                          re-runs ShowcaseSync, and commits +
                          pushes that change. Use after a release
-                         was cut and you want ongoing develop work
+                         was cut and you want ongoing branch work
                          to have linkable View Code buttons.
 
       -SkipVerify      — skip the mvnw verify gate. Only use when
@@ -48,29 +48,37 @@
     # preview what would happen
 
 .EXAMPLE
-    pwsh ./scripts/cut-release.ps1 -PostReleaseOnly
-    # post-release: flip showcase links back to develop
+    pwsh ./scripts/cut-release.ps1 -Version 2.0.0-rc.1 -Branch 2.0-dev -DryRun
+    # preview the 2.0 release-candidate cut from 2.0-dev
+
+.EXAMPLE
+    pwsh ./scripts/cut-release.ps1 -PostReleaseOnly -Branch 2.0-dev
+    # post-release: flip showcase links back to /blob/2.0-dev
 
 .NOTES
     Author: Artem Demchyshyn
     Pre-conditions:
-      - on develop branch
+      - on the release branch (-Branch, default develop)
       - working tree clean
-      - develop in sync with origin/develop
+      - the release branch in sync with its origin
       - tag v$Version doesn't already exist
 
-    Post-release reminder: after pushing the tag, merge develop into
-    main so GitHub Pages picks up the new docs, then run this script
-    with -PostReleaseOnly to flip the showcase links back to develop
-    for ongoing v1.x.y dev work.
+    Post-release reminder: after pushing the tag, merge the release
+    branch into main so GitHub Pages picks up the new docs, then run
+    this script with -PostReleaseOnly -Branch <branch> to flip the
+    showcase links back for ongoing dev work.
 #>
 
 [CmdletBinding(DefaultParameterSetName='Release')]
 param(
+    # The release branch to cut from / push to. Defaults to `develop` (the 1.9.x
+    # line); pass `-Branch 2.0-dev` to cut the 2.0 line. Common to both modes.
+    [string]$Branch = 'develop',
+
     [Parameter(Mandatory=$true, ParameterSetName='Release')]
     [string]$Version,
 
-    [Parameter(ParameterSetName='Release')]
+    # Common to both modes so -PostReleaseOnly can also be previewed.
     [switch]$DryRun,
 
     [Parameter(ParameterSetName='Release')]
@@ -396,15 +404,15 @@ function Render-ReadmeBanner {
 if ($PostReleaseOnly) {
     Push-Location $repoRoot
     try {
-        Step 1 "Switch ShowcaseMetadata GH_BASE back to /blob/develop"
-        $changed = Update-ShowcaseGhBase 'develop'
+        Step 1 "Switch ShowcaseMetadata GH_BASE back to /blob/$Branch"
+        $changed = Update-ShowcaseGhBase $Branch
 
         if ($changed -or $DryRun) {
-            Step 2 "Regenerate web/examples.json with develop links"
+            Step 2 "Regenerate web/examples.json with $Branch links"
             Run-ShowcaseSync
 
             Step 3 "Commit"
-            $msg = "post-release: flip showcase links back to /blob/develop"
+            $msg = "post-release: flip showcase links back to /blob/$Branch"
             if ($DryRun) {
                 Write-Host "    [DRY RUN] git commit -m `"$msg`"" -ForegroundColor Yellow
             } else {
@@ -412,20 +420,20 @@ if ($PostReleaseOnly) {
                 git commit -m $msg
             }
 
-            Step 4 "Push develop"
+            Step 4 "Push $Branch"
             if ($DryRun) {
-                Write-Host "    [DRY RUN] git push origin develop" -ForegroundColor Yellow
+                Write-Host "    [DRY RUN] git push origin $Branch" -ForegroundColor Yellow
             } else {
-                git push origin develop
+                git push origin $Branch
             }
         } else {
-            Note "GH_BASE already points to develop. Nothing to do."
+            Note "GH_BASE already points to $Branch. Nothing to do."
         }
     } finally {
         Pop-Location
     }
     Write-Host ""
-    Write-Host "Done. Ongoing develop work has linkable View Code buttons again." -ForegroundColor Green
+    Write-Host "Done. Ongoing $Branch work has linkable View Code buttons again." -ForegroundColor Green
     return
 }
 
@@ -441,17 +449,17 @@ try {
     # In -DryRun mode the script never mutates anything, so the branch /
     # working-tree / origin-sync gates are relaxed: a maintainer can preview
     # what a release cut would do from a feature branch (e.g. while iterating
-    # on the script itself) without having to switch to develop and back.
+    # on the script itself) without having to switch to the release branch and back.
     # Live cuts still fail these gates loudly.
-    $branch = (git rev-parse --abbrev-ref HEAD).Trim()
+    $currentBranch = (git rev-parse --abbrev-ref HEAD).Trim()
     if ($DryRun) {
-        Note "branch: $branch (gate relaxed for -DryRun)"
+        Note "branch: $currentBranch (gate relaxed for -DryRun)"
     } else {
-        # 1. On develop branch?
-        if ($branch -ne 'develop') {
-            throw "Not on develop branch (currently on $branch). Switch to develop first."
+        # 1. On the release branch (-Branch)?
+        if ($currentBranch -ne $Branch) {
+            throw "Not on $Branch branch (currently on $currentBranch). Switch to $Branch first."
         }
-        Note "branch: develop OK"
+        Note "branch: $Branch OK"
 
         # 2. Working tree clean?
         $status = git status --porcelain
@@ -461,13 +469,13 @@ try {
         Note "working tree: clean OK"
 
         # 3. In sync with origin?
-        git fetch origin develop --quiet
-        $local = (git rev-parse develop).Trim()
-        $remote = (git rev-parse origin/develop).Trim()
+        git fetch origin $Branch --quiet
+        $local = (git rev-parse $Branch).Trim()
+        $remote = (git rev-parse origin/$Branch).Trim()
         if ($local -ne $remote) {
-            throw "Local develop ($local) is not in sync with origin/develop ($remote). Pull/push first."
+            throw "Local $Branch ($local) is not in sync with origin/$Branch ($remote). Pull/push first."
         }
-        Note "in sync with origin/develop OK"
+        Note "in sync with origin/$Branch OK"
     }
 
     # 4. Tag doesn't already exist?
@@ -621,17 +629,17 @@ try {
 
     if ($SkipPush) {
         Step 8 "Skipped push (-SkipPush). Run manually:"
-        Write-Host "      git push origin develop" -ForegroundColor Cyan
+        Write-Host "      git push origin $Branch" -ForegroundColor Cyan
         Write-Host "      git push origin $tag" -ForegroundColor Cyan
     } else {
-        Step 8 "Push develop and tag"
+        Step 8 "Push $Branch and tag"
         if ($DryRun) {
-            Write-Host "    [DRY RUN] git push origin develop" -ForegroundColor Yellow
+            Write-Host "    [DRY RUN] git push origin $Branch" -ForegroundColor Yellow
             Write-Host "    [DRY RUN] git push origin $tag" -ForegroundColor Yellow
         } else {
-            git push origin develop
+            git push origin $Branch
             git push origin $tag
-            Note "pushed: develop + $tag"
+            Note "pushed: $Branch + $tag"
         }
     }
 
@@ -639,12 +647,12 @@ try {
     Write-Host "Release $tag committed locally." -ForegroundColor Green
     Write-Host ""
     Write-Host "Next steps (manual):" -ForegroundColor Cyan
-    Write-Host "  1. Merge develop into main on GitHub (PR or fast-forward)." -ForegroundColor Cyan
+    Write-Host "  1. Merge $Branch into main on GitHub (PR or fast-forward)." -ForegroundColor Cyan
     Write-Host "     This makes the deployed GitHub Pages site pick up $tag." -ForegroundColor Cyan
     Write-Host "  2. Create a GitHub Release for $tag with the CHANGELOG section as body." -ForegroundColor Cyan
-    Write-Host "  3. Verify JitPack: https://jitpack.io/com/github/DemchaAV/GraphCompose/$tag/build.log" -ForegroundColor Cyan
-    Write-Host "  4. Flip showcase links back to develop:" -ForegroundColor Cyan
-    Write-Host "       pwsh ./scripts/cut-release.ps1 -PostReleaseOnly" -ForegroundColor Cyan
+    Write-Host "  3. Verify the Maven Central publish (publish.yml) resolved: mvn dependency:get -DgroupId=io.github.demchaav -DartifactId=graph-compose -Dversion=$Version" -ForegroundColor Cyan
+    Write-Host "  4. Flip showcase links back to ${Branch}:" -ForegroundColor Cyan
+    Write-Host "       pwsh ./scripts/cut-release.ps1 -PostReleaseOnly -Branch $Branch" -ForegroundColor Cyan
 } finally {
     Pop-Location
 }


### PR DESCRIPTION
## Why

`cut-release.ps1` hard-coded `develop` for the pre-flight branch gate, the pushes, and the
`-PostReleaseOnly` showcase flip, so it could not cut the 2.0 line (which releases from `2.0-dev`).
`docs/contributing/release-process.md` described only the 1.9.x flow. This is the last tooling
prep before a 2.0.0-RC can be cut. (`release.yml`'s reactor gate already landed with the layout
move.)

## What

- **`cut-release.ps1 -Branch`** (default `develop`, common to both modes) threads through the
  pre-flight gate, the pushes, the `-PostReleaseOnly` GH_BASE flip, and the post-cut reminders, so
  the 2.0 line cuts with `-Branch 2.0-dev`. The pom-bump list already handles both layouts via the
  `Test-Path` guard (`core/pom.xml` is skipped on the old single-jar layout). The post-cut reminder
  now checks the Maven Central publish instead of the retired JitPack build log.
  - Renamed the pre-flight local `$branch` → `$currentBranch`: PowerShell variables are
    case-insensitive, so the old local was **clobbering the `-Branch` parameter** (the `-DryRun`
    caught it — Step 8 was pushing the current git branch, and the branch gate compared the variable
    to itself). 
  - Promoted `-DryRun` to a common parameter so `-PostReleaseOnly` can also be previewed (its
    `if ($DryRun)` branches were previously unreachable — a parameter-set conflict).
- **`release-process.md` §2.G** — the 2.0 cut branch flow: cut from `2.0-dev` via
  `cut-release.ps1 -Branch 2.0-dev`, `-rc` tags stay off Central, and the GA choreography cuts `1.x`
  from the current `main` tip **before** fast-forwarding `main` to 2.0 and repointing `develop`. Plus
  a note atop the pre-release checklist mapping the 1.9.x command forms to their 2.0 equivalents.

## Tests

- `pwsh cut-release.ps1 -Version 2.0.0-rc.1 -Branch 2.0-dev -DryRun` → previews the full 2.0 cut,
  bumps `core/pom.xml` + root `pom.xml` + the train, **pushes `2.0-dev`** (not the current branch),
  merge/flip reminders name `2.0-dev`. Pushes/writes nothing.
- `pwsh cut-release.ps1 -PostReleaseOnly -Branch 2.0-dev -DryRun` → flips GH_BASE to `/blob/2.0-dev`,
  pushes `2.0-dev`, exit 0.
- `pwsh cut-release.ps1 -Version 1.9.2 -DryRun` (default branch) → still `develop`: backward-compatible.
- PowerShell parse-check clean; doc guards (`CanonicalSurfaceGuardTest`, `DocumentationCoverageTest`,
  `PackageMapGuardTest`) green.

Build-script + docs only; no runtime change.
