### PR TITLE
ci: verify the whole reactor before tagging and publishing the 2.0 train

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,12 +149,15 @@ jobs:
 
       - name: Build and run tests
         # Reactor slice: the engine, the render-docx / render-pptx semantic backends,
-        # the extracted graph-compose-testing module, the graph-compose-qa
-        # cross-module suites (which need the testing module + the engine test-jar on
-        # the classpath and so cannot live in the engine's own test scope), and the
-        # graph-compose-coverage aggregator (report-only JaCoCo over core + qa exec).
-        # -am pulls the fonts / emoji upstreams; bundle / examples / benchmarks are excluded.
-        run: ./mvnw -B -ntp clean verify -pl :graph-compose-core,:graph-compose-render-pdf,:graph-compose-render-docx,:graph-compose-render-pptx,:graph-compose-templates,:graph-compose-testing,:graph-compose-qa,:graph-compose-coverage -am
+        # the graph-compose wrapper + graph-compose-bundle (the published empty-jar
+        # aggregates — covered here so a packaging break is caught on every push, not
+        # only via the examples job), the extracted graph-compose-testing module, the
+        # graph-compose-qa cross-module suites (which need the testing module + the
+        # engine test-jar on the classpath and so cannot live in the engine's own test
+        # scope), and the graph-compose-coverage aggregator (report-only JaCoCo over
+        # core + qa exec). -am pulls the fonts / emoji upstreams; only examples /
+        # benchmarks are excluded (their own CI jobs cover them).
+        run: ./mvnw -B -ntp clean verify -pl :graph-compose-core,:graph-compose-render-pdf,:graph-compose-render-docx,:graph-compose-render-pptx,:graph-compose-templates,:graph-compose-testing,:graph-compose,:graph-compose-bundle,:graph-compose-qa,:graph-compose-coverage -am
 
       - name: Generate Javadoc
         # Run only on the baseline JDK — Javadoc output is identical

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,7 +93,7 @@ jobs:
         # depth against a tag pushed from a broken branch by mistake.
         # The publish step below would also fail at signing/upload,
         # but failing here surfaces a clearer error.
-        run: ./mvnw -B -ntp clean verify -pl :graph-compose-core
+        run: ./mvnw -B -ntp clean verify
 
       - name: Publish engine to Maven Central
         # Activates the release profile (sources + javadoc + gpg sign +
@@ -170,10 +170,12 @@ jobs:
 
       - name: Publish bundle to Maven Central
         # The graph-compose-bundle convenience aggregate pins this engine
-        # version + a compatible graph-compose-fonts version. It tracks the
-        # engine line, so it ships on the same v* tag. pom-packaged → only a
-        # signed .pom is uploaded; engine + fonts resolve from the local repo
-        # (installed by the engine deploy above and the fonts step earlier).
+        # version + compatible graph-compose-fonts and graph-compose-emoji
+        # versions. It tracks the engine line, so it ships on the same v* tag.
+        # Packaged as an empty jar carrying only <dependencies> (like the
+        # graph-compose wrapper), so the signed jar + pom are uploaded. The
+        # train artifacts resolve from the preceding deploy steps; the
+        # independently versioned fonts and emoji artifacts resolve from Maven Central.
         run: ./mvnw -B -ntp -f bundle/pom.xml -P release -DskipTests -Dgpg.skip=false deploy
         env:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           cache: maven
 
       - name: Verify (gate the release on a green build)
-        run: ./mvnw -B -ntp clean verify -pl :graph-compose-core
+        run: ./mvnw -B -ntp clean verify
 
       - name: Extract CHANGELOG section for the tag
         id: notes

--- a/scripts/cut-release.ps1
+++ b/scripts/cut-release.ps1
@@ -565,11 +565,19 @@ try {
     }
 
     if (-not $SkipVerify) {
-        Step 5 "Run mvnw verify (sanity check)"
-        if ($DryRun) {
-            Write-Host "    [DRY RUN] $mvnw verify -pl :graph-compose-core" -ForegroundColor Yellow
+        Step 5 "Run mvnw clean verify (sanity check)"
+        # The whole train ships on the tag, so verify the whole reactor. The 2.0
+        # core/ layout builds every module from the root; the older 1.x layout
+        # scopes to the engine at the root (-pl .). Detect by core/pom.xml.
+        $verifyArgs = if (Test-Path (Join-Path $repoRoot 'core/pom.xml')) {
+            @('-B','-ntp','clean','verify')
         } else {
-            & $mvnw verify -pl :graph-compose-core 2>&1 | ForEach-Object {
+            @('-B','-ntp','clean','verify','-pl','.')
+        }
+        if ($DryRun) {
+            Write-Host "    [DRY RUN] $mvnw $($verifyArgs -join ' ')" -ForegroundColor Yellow
+        } else {
+            & $mvnw @verifyArgs 2>&1 | ForEach-Object {
                 if ($_ -match 'Tests run:|BUILD SUCCESS|BUILD FAILURE|ERROR') {
                     Write-Host "    $_" -ForegroundColor DarkGray
                 }
@@ -577,7 +585,7 @@ try {
             if ($LASTEXITCODE -ne 0) {
                 throw "mvnw verify failed."
             }
-            Note "mvnw verify: green"
+            Note "mvnw clean verify: green"
         }
     } else {
         Step 5 "Skipped mvnw verify (-SkipVerify)"


### PR DESCRIPTION
## Why

A 2.0 tag publishes the whole train — `graph-compose-core`, `graph-compose-render-pdf` /
`-render-docx` / `-render-pptx`, `graph-compose-templates`, `graph-compose-testing`, the
`graph-compose` wrapper, and `graph-compose-bundle` — but the pre-tag / pre-publish verify only
built `-pl :graph-compose-core`. A break in `bundle`, `render-docx`, etc. would pass the gate on a
green core and still cut the GitHub Release / start the Central upload. (This scope was
behaviour-preserving from the 1.x single-jar layout, where `-pl .` *was* the engine — it just never
widened for the multi-module 2.0 train.)

## What

- **`release.yml` + `publish.yml`** — the re-verify-at-tag step is now `./mvnw -B -ntp clean verify`
  (the whole reactor), so the GitHub Release and the Central publish only proceed when every shipped
  module is green.
- **`cut-release.ps1` Step 5** — full-reactor `clean verify`, layout-detected by `core/pom.xml` so the
  same script still scopes to `-pl .` when cutting the 1.x line.
- **`ci.yml`** — the reactor gate adds `:graph-compose` and `:graph-compose-bundle`, so the wrapper and
  bundle are covered on every push, not just indirectly (examples job / the manual #371 check).
- **`publish.yml`** — refreshed the stale comment calling the bundle "pom-packaged → only a signed
  .pom uploaded" (it is an empty jar since #371).

Build/CI only; no runtime or API change.

## Tests

- Bare `./mvnw -B -ntp clean verify` (all 14 modules incl examples/benchmarks) — green (exit 0, zero
  failing surefire reports), which is exactly the gate now wired into release/publish.
- `cut-release.ps1 -Version 2.0.0-rc.1 -Branch 2.0-dev -DryRun` → Step 5 previews
  `mvnw -B -ntp clean verify` (full reactor, no `-pl`); the 1.x default still scopes to `-pl .`.
  PowerShell parse-check clean.
- The CI reactor gate is a subset of the green full reactor, so adding wrapper+bundle stays green.
