### PR TITLE
docs: fix ModernInvoice.compose arity in the 2.0 migration guide

### DIFF
--- a/docs/migration/v2.0.0-modules.md
+++ b/docs/migration/v2.0.0-modules.md
@@ -51,7 +51,7 @@ The built-in presets (`com.demcha.compose.document.templates.**`) moved into the
 them. If your 1.x code called a preset through the single jar —
 
 ```java
-ModernInvoice.create(theme).compose(session);   // needs graph-compose-templates in 2.0
+ModernInvoice.create(theme).compose(session, spec);   // needs graph-compose-templates in 2.0
 ```
 
 — add the artifact (the package names are unchanged, so imports stay the same):


### PR DESCRIPTION
## Why
The templates-break example in the 2.0 migration guide called `ModernInvoice.create(theme).compose(session)`, but `DocumentTemplate.compose` is `(DocumentSession session, S spec)`. A reader copying the snippet to wire up templates during migration would not compile.

## What
Correct the call to the two-arg `compose(session, spec)` form that every real call site uses. Migration docs are exempt from the snippet-compile guard, so the arity was not caught mechanically.

## Tests
Matches `DocumentTemplate.compose(DocumentSession, S)` and the working two-arg form in the examples module; a consumer project depending on `graph-compose-templates:2.0.0-SNAPSHOT` renders a `ModernInvoice` with `compose(session, spec)`.