### PR TITLE
test: accept pre-release versions in the showcase version guard

### DIFF
--- a/core/src/test/java/com/demcha/documentation/VersionConsistencyGuardTest.java
+++ b/core/src/test/java/com/demcha/documentation/VersionConsistencyGuardTest.java
@@ -237,7 +237,10 @@ class VersionConsistencyGuardTest {
         assertThat(firstGroup(site, "\"softwareVersion\":\\s*\"v?([0-9][^\"]*)\""))
                 .describedAs("web/index.html JSON-LD softwareVersion must equal the current pom or planned version (one of %s)", targets)
                 .isIn(targets);
-        assertThat(firstGroup(site, "v([0-9][0-9.]*)\\s*&middot;\\s*MIT"))
+        // Match up to the delimiter (space before `&middot;`) rather than
+        // digits-and-dots only, so a pre-release version like 2.0.0-rc.1 is
+        // captured too — consistent with the JSON-LD and snippet patterns.
+        assertThat(firstGroup(site, "v([0-9][^\\s&]*)\\s*&middot;\\s*MIT"))
                 .describedAs("web/index.html hero version badge must equal the current pom or planned version (one of %s)", targets)
                 .isIn(targets);
         assertThat(firstMatchingGroup(site, INSTALL_SNIPPET_PATTERNS_SHOWCASE_MAVEN))


### PR DESCRIPTION
## Why
Cutting `v2.0.0-rc.1` fails the verify gate: `VersionConsistencyGuardTest.showcaseSiteVersionMatchesTheProjectVersion` matched the `web/index.html` hero badge with `v([0-9][0-9.]*)`, which stops at the first non-digit and so rejects a pre-release suffix. Every rc / beta / alpha cut would trip it — and since `release.yml` re-runs `clean verify` on the tag, the tagged workflow would fail too. A plain `vX.Y.Z` cut is unaffected.

## What
Match the badge version up to its delimiter — `v([0-9][^\s&]*)\s*&middot;\s*MIT` — the same tolerant shape the JSON-LD `softwareVersion` and the Maven/Gradle install-snippet patterns in this class already use. The other five version-scanning regexes already accept a suffix; this aligns the sixth.

## Tests
`VersionConsistencyGuardTest` stays green (10/10) on the current tree. The pattern now captures `2.0.0-rc.1`, `2.0.0`, and `1.9.1` from a `v… &middot; MIT` badge.