### PR TITLE
fix(release): bump qa + coverage parent versions when cutting a release

### DIFF
--- a/core/src/test/java/com/demcha/documentation/VersionConsistencyGuardTest.java
+++ b/core/src/test/java/com/demcha/documentation/VersionConsistencyGuardTest.java
@@ -80,6 +80,16 @@ class VersionConsistencyGuardTest {
         assertThat(effectiveVersion(PROJECT_ROOT.resolve("wrapper/pom.xml")))
                 .describedAs("wrapper (the graph-compose compat wrapper) tracks the engine line and must equal the root version (%s)", root)
                 .isEqualTo(root);
+        // qa + coverage inherit their version from the aggregator, but the inherited
+        // <parent><version> is a literal that must track the root — otherwise a clean
+        // reactor build (no local m2 cache) cannot resolve graph-compose-build after a
+        // release bump. effectiveVersion reads that inherited parent value here.
+        assertThat(effectiveVersion(PROJECT_ROOT.resolve("qa/pom.xml")))
+                .describedAs("qa (graph-compose-qa) inherits the root version; its <parent> version must equal the root (%s)", root)
+                .isEqualTo(root);
+        assertThat(effectiveVersion(PROJECT_ROOT.resolve("coverage/pom.xml")))
+                .describedAs("coverage (graph-compose-coverage) inherits the root version; its <parent> version must equal the root (%s)", root)
+                .isEqualTo(root);
 
         // NOTE: fonts/pom.xml (graph-compose-fonts) is intentionally NOT checked
         // here. It carries an independent version line (it ships on its own

--- a/scripts/cut-release.ps1
+++ b/scripts/cut-release.ps1
@@ -505,6 +505,13 @@ try {
     Update-PomVersion (Join-Path $repoRoot 'pom.xml') $Version
     Update-PomVersion (Join-Path $repoRoot 'examples/pom.xml') $Version
     Update-PomVersion (Join-Path $repoRoot 'benchmarks/pom.xml') $Version
+    # graph-compose-qa / graph-compose-coverage are aggregator children too. They
+    # inherit their version, but the inherited <parent><version> is a literal that
+    # must track the root: skipping them leaves graph-compose-build unresolvable in a
+    # clean reactor build (no local m2 cache), which breaks the release.yml /
+    # publish.yml verify on the tag even though a warm local build passes.
+    Update-PomVersion (Join-Path $repoRoot 'qa/pom.xml') $Version
+    Update-PomVersion (Join-Path $repoRoot 'coverage/pom.xml') $Version
     # render-pdf / render-docx / render-pptx track the engine line (lockstep): each
     # <version> bumps here and its graph-compose-core dep is ${project.version}
     # (follows automatically).
@@ -516,8 +523,7 @@ try {
     Update-PomVersion (Join-Path $repoRoot 'templates/pom.xml') $Version
     # graph-compose-testing tracks the engine line (lockstep): its <version>
     # bumps here and its graph-compose dep is ${project.version} (follows
-    # automatically). graph-compose-qa is an aggregator child (its version is
-    # inherited) and is never published, so it needs no explicit bump.
+    # automatically).
     Update-PomVersion (Join-Path $repoRoot 'testing/pom.xml') $Version
     # graph-compose (the graph-compose compat wrapper (wrapper/)) tracks the engine line lockstep;
     # its graph-compose-core dep is ${project.version} (follows automatically).
@@ -610,6 +616,15 @@ try {
         'CHANGELOG.md',
         'web/index.html'
     )
+    # qa + coverage exist only in the 2.0 aggregator layout; add them to the commit
+    # only when present so the script stays layout-agnostic (the 1.x single-artifact
+    # tree has neither) — mirroring Update-PomVersion's skip-if-absent guard. On a 2.0
+    # checkout both are present; Step 5's version guard fails first if either is missing.
+    foreach ($modulePom in @('qa/pom.xml', 'coverage/pom.xml')) {
+        if (Test-Path (Join-Path $repoRoot $modulePom)) {
+            $commitFiles += $modulePom
+        }
+    }
     if (-not $SkipShowcase) {
         $commitFiles += @(
             'examples/src/main/java/com/demcha/examples/support/ShowcaseMetadata.java',


### PR DESCRIPTION
## Why
Cutting a release bumped `examples` + `benchmarks` but skipped the `qa` and `coverage` aggregator children. Their version is inherited, but the `<parent><version>` is a literal — after the bump it still named the previous `graph-compose-build` version. A warm local build resolved it from the m2 cache and passed, so the drift was invisible to the cut's own verify; a clean checkout (`release.yml` / `publish.yml` re-verifying the tag) could not resolve the parent and FATAL-errored the whole reactor before any module compiled. Every rc/beta and the GA cut would have failed the Release + Publish gates.

## What
- `cut-release.ps1`: bump `qa/pom.xml` + `coverage/pom.xml` alongside the other aggregator children, and add them to the release commit's file list. (Corrected the comment that wrongly claimed qa "needs no explicit bump".)
- `VersionConsistencyGuardTest`: assert `qa` and `coverage` inherited parent versions equal the root, so a future drift fails the verify gate locally rather than only in CI after the tag is pushed.

## Tests
- Dry-run of the cut now bumps both poms and includes them in the commit list.
- `VersionConsistencyGuardTest` stays green (10/10) on the clean tree.
- Injecting a wrong qa parent version fails the build (reactor cannot resolve the parent) — the drift no longer passes silently.