### PR TITLE
fix(release): recompile examples before ShowcaseSync so View Code links track the tag

### DIFF
--- a/scripts/cut-release.ps1
+++ b/scripts/cut-release.ps1
@@ -318,7 +318,7 @@ function Run-ShowcaseSync {
         foreach ($modulePom in $exampleSnapshotSiblings) {
             Write-Host "    [DRY RUN] $mvnw -B -ntp -DskipTests install -f $modulePom" -ForegroundColor Yellow
         }
-        Write-Host "    [DRY RUN] $mvnw -f examples/pom.xml exec:java $execProp" -ForegroundColor Yellow
+        Write-Host "    [DRY RUN] $mvnw -B -ntp -f examples/pom.xml -DskipTests compile exec:java $execProp" -ForegroundColor Yellow
         return
     }
     Push-Location $repoRoot
@@ -352,7 +352,12 @@ function Run-ShowcaseSync {
                 throw "Install $modulePom failed (exit $LASTEXITCODE)"
             }
         }
-        & $mvnw -f examples/pom.xml exec:java $execProp 2>&1 | ForEach-Object {
+        # `compile` before exec:java is REQUIRED: Step 3 rewrote ShowcaseMetadata.GH_BASE
+        # to /blob/<tag>, and exec:java runs the COMPILED class. Without recompiling it here,
+        # ShowcaseSync would emit examples.json with the previous release's "View Code" links
+        # (the drift that shipped a 2.0 site still linking /blob/v1.9.0). Mirrors
+        # Render-ReadmeBanner, which recompiles for the same filtered-source reason.
+        & $mvnw -B -ntp -f examples/pom.xml -DskipTests compile exec:java $execProp 2>&1 | ForEach-Object {
             if ($_ -match 'Synced|Wrote manifest|BUILD SUCCESS|BUILD FAILURE|ERROR') {
                 Write-Host "    $_" -ForegroundColor DarkGray
             }


### PR DESCRIPTION
## Why
The GitHub Pages showcase renders each example's "View Code" button from `ShowcaseMetadata.GH_BASE`. The cut flips that constant to `/blob/<tag>` in Step 3, but `Run-ShowcaseSync` invoked `exec:java` **without recompiling** — so `ShowcaseSync` ran the previously-compiled `ShowcaseMetadata` and wrote `examples.json` with the *previous* release's links. The 2.0 site would ship with all 86 "View Code" links pointing at `/blob/v1.9.0` (1.x source), and 4 new 2.0 examples missing from the gallery. `Render-ReadmeBanner` already recompiles for the same reason; `Run-ShowcaseSync` was the asymmetric outlier.

## What
Add `-DskipTests compile` before `exec:java` in `Run-ShowcaseSync` (real call + dry-run echo), so the flipped `GH_BASE` is compiled in before the manifest is serialized.

## Tests
Reproduced the cut's showcase step on the 2.0 layout (install bumped siblings → **compile** → ShowcaseSync): `examples.json` flipped from 85×`/blob/v1.9.0` to **86×`/blob/v2.0.0`**, 86 preview PNGs regenerated, BUILD SUCCESS. Script parses clean; dry-run shows the recompile in Step 4.