### PR TITLE
fix(publish): install to local m2 before the per-module Central deploys

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -88,12 +88,16 @@ jobs:
           gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
 
-      - name: Verify (full canonical suite green at tagged commit)
-        # Re-verify the tagged commit before publishing — defence in
-        # depth against a tag pushed from a broken branch by mistake.
-        # The publish step below would also fail at signing/upload,
-        # but failing here surfaces a clearer error.
-        run: ./mvnw -B -ntp clean verify
+      - name: Build, test and install to local m2 (verify + seed the deploys)
+        # Re-verify the tagged commit before publishing (defence in depth
+        # against a tag pushed from a broken branch). `install` — not `verify` —
+        # seeds the runner's local m2 with EVERY module artifact, including the
+        # core tests-jar that render-pdf depends on at test scope but the release
+        # profile never publishes. Each per-module `-P release deploy` below
+        # builds in isolation and resolves its inter-module deps (Maven resolves
+        # test-scope deps even with -DskipTests) from this local m2, so the
+        # unpublished tests-jar no longer fails the deploy.
+        run: ./mvnw -B -ntp clean install
 
       - name: Publish engine to Maven Central
         # Activates the release profile (sources + javadoc + gpg sign +
@@ -102,13 +106,9 @@ jobs:
         # which blocks until Sonatype's validator confirms validation.
         # The release profile also disables the tests-jar execution, so
         # only the main + sources + javadoc + pom artefacts are uploaded.
-        # -Dmaven.test.skip=true (not -DskipTests): each module deploys in
-        # isolation, so test-compilation would try to resolve test-scope deps
-        # that were never published — e.g. render-pdf depends on the core
-        # tests-jar, which the release profile deliberately does not deploy.
-        # Skipping test-compile avoids that (tests already ran in the verify
-        # step above).
-        run: ./mvnw -B -ntp -f core/pom.xml -P release -Dmaven.test.skip=true -Dgpg.skip=false deploy
+        # Inter-module deps (incl. the core tests-jar render-pdf needs) resolve
+        # from the local m2 seeded by the install step above.
+        run: ./mvnw -B -ntp -f core/pom.xml -P release -DskipTests -Dgpg.skip=false deploy
         env:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}
@@ -118,7 +118,7 @@ jobs:
         # The PDF render backend, lockstep-versioned with the engine (ships on the
         # same v* tag). graph-compose-core resolves from the local repo installed by
         # the engine deploy above; the wrapper below depends on this.
-        run: ./mvnw -B -ntp -f render-pdf/pom.xml -P release -Dmaven.test.skip=true -Dgpg.skip=false deploy
+        run: ./mvnw -B -ntp -f render-pdf/pom.xml -P release -DskipTests -Dgpg.skip=false deploy
         env:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}
@@ -128,7 +128,7 @@ jobs:
         # The empty jar that keeps the `graph-compose` coordinate a drop-in: it
         # depends on graph-compose-core + graph-compose-render-pdf, resolved from the
         # local repo installed by the deploys above. Ships on the same v* tag.
-        run: ./mvnw -B -ntp -f wrapper/pom.xml -P release -Dmaven.test.skip=true -Dgpg.skip=false deploy
+        run: ./mvnw -B -ntp -f wrapper/pom.xml -P release -DskipTests -Dgpg.skip=false deploy
         env:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}
@@ -138,7 +138,7 @@ jobs:
         # The semantic DOCX backend, lockstep-versioned with the engine (ships on
         # the same v* tag). graph-compose-core resolves from the local repo installed
         # by the engine deploy above.
-        run: ./mvnw -B -ntp -f render-docx/pom.xml -P release -Dmaven.test.skip=true -Dgpg.skip=false deploy
+        run: ./mvnw -B -ntp -f render-docx/pom.xml -P release -DskipTests -Dgpg.skip=false deploy
         env:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}
@@ -148,7 +148,7 @@ jobs:
         # The semantic PPTX backend, lockstep-versioned with the engine (ships on
         # the same v* tag). graph-compose-core resolves from the local repo installed
         # by the engine deploy above.
-        run: ./mvnw -B -ntp -f render-pptx/pom.xml -P release -Dmaven.test.skip=true -Dgpg.skip=false deploy
+        run: ./mvnw -B -ntp -f render-pptx/pom.xml -P release -DskipTests -Dgpg.skip=false deploy
         env:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}
@@ -158,7 +158,7 @@ jobs:
         # The built-in document templates, lockstep-versioned with the engine (ships
         # on the same v* tag). graph-compose-core resolves from the local repo
         # installed by the engine deploy above.
-        run: ./mvnw -B -ntp -f templates/pom.xml -P release -Dmaven.test.skip=true -Dgpg.skip=false deploy
+        run: ./mvnw -B -ntp -f templates/pom.xml -P release -DskipTests -Dgpg.skip=false deploy
         env:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}
@@ -168,7 +168,7 @@ jobs:
         # Consumer testing support (LayoutSnapshotAssertions / PdfVisualRegression),
         # lockstep-versioned with the engine (ships on the same v* tag). graph-compose
         # resolves from the local repo installed by the engine deploy above.
-        run: ./mvnw -B -ntp -f testing/pom.xml -P release -Dmaven.test.skip=true -Dgpg.skip=false deploy
+        run: ./mvnw -B -ntp -f testing/pom.xml -P release -DskipTests -Dgpg.skip=false deploy
         env:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}
@@ -182,7 +182,7 @@ jobs:
         # graph-compose wrapper), so the signed jar + pom are uploaded. The
         # train artifacts resolve from the preceding deploy steps; the
         # independently versioned fonts and emoji artifacts resolve from Maven Central.
-        run: ./mvnw -B -ntp -f bundle/pom.xml -P release -Dmaven.test.skip=true -Dgpg.skip=false deploy
+        run: ./mvnw -B -ntp -f bundle/pom.xml -P release -DskipTests -Dgpg.skip=false deploy
         env:
           CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
           CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}


### PR DESCRIPTION
## Why
The `v2.0.0` Central publish failed at `render-pdf` — and PR #388's `-Dmaven.test.skip=true` did **not** fix it. Maven resolves declared test-scope dependencies even when test *compilation/execution* is skipped, so render-pdf still couldn't find `graph-compose-core:jar:tests:2.0.0` (a test-scope dep the release profile deliberately never publishes). The pre-deploy step ran `clean verify`, which *builds* the core tests-jar but never *installs* it to the runner's m2; the isolated per-module `-P release deploy` steps then can't resolve it.

## What
- Pre-deploy step: `clean verify` → **`clean install`**, seeding the runner's local m2 with every module artifact (incl. the core tests-jar). Isolated deploys resolve inter-module deps locally; the release profile still uploads only main + sources + javadoc + pom.
- Revert the 8 deploy flags `-Dmaven.test.skip=true` → `-DskipTests` (undo the ineffective #388) and correct the comments.

## Tests
Proven locally on the v2.0.0 tree: cleared `~/.m2/.../2.0.0`, then (A) `render-pdf -P release package` **FAILS** on `core:jar:tests` (reproduces CI), (B) install core, (C) `render-pdf -P release package` **SUCCEEDS**. Recovery: drop the stray `core` deployment, merge this, `gh workflow run publish.yml --ref 2.0-dev -f tag=v2.0.0`.