### PR TITLE
docs(modules): copy-paste install snippets in every module README

### DIFF
--- a/bundle/README.md
+++ b/bundle/README.md
@@ -2,7 +2,7 @@
 
 `io.github.demchaav:graph-compose-bundle`
 
-The batteries-included aggregate (pom-packaged). One dependency pulls the default PDF stack
+The batteries-included aggregate. One dependency pulls the default PDF stack
 (the `graph-compose` wrapper = core + render-pdf), the built-in templates
 (`graph-compose-templates`), the bundled Google fonts (`graph-compose-fonts`), and the
 colour-emoji set (`graph-compose-emoji`) at compatible versions.
@@ -13,11 +13,25 @@ Depend on it when you want everything wired up in one coordinate — the closest
 pre-split single jar. The office backends (`graph-compose-render-docx` /
 `graph-compose-render-pptx`) stay opt-in and are **not** bundled.
 
-Because it is `pom`-packaged, a dependency on it needs `<type>pom</type>`.
+Packaged as an empty `jar` carrying only `<dependencies>` (like the `graph-compose` wrapper),
+so a plain `<dependency>` works — no `<type>pom</type>` needed.
 
 ## Install
 
-The engine/templates track the GraphCompose train version (lockstep); `graph-compose-fonts`
-and `graph-compose-emoji` are pinned to compatible independent versions. Copy-paste snippet
-and the full "which artifact?" table: [root README → Installation](../README.md#installation).
+Tracks the GraphCompose train version (lockstep); the fonts and emoji it carries are pinned
+to compatible independent versions:
+
+```xml
+<dependency>
+    <groupId>io.github.demchaav</groupId>
+    <artifactId>graph-compose-bundle</artifactId>
+    <version>2.0.0</version>
+</dependency>
+```
+
+```kotlin
+dependencies { implementation("io.github.demchaav:graph-compose-bundle:2.0.0") }
+```
+
+The full "which artifact?" table: [root README → Installation](../README.md#installation).
 Upgrading from 1.x: [modules migration guide](../docs/migration/v2.0.0-modules.md).

--- a/core/README.md
+++ b/core/README.md
@@ -1,0 +1,50 @@
+# GraphCompose Core
+
+`io.github.demchaav:graph-compose-core`
+
+The lean document engine: the canonical authoring surface (`com.demcha.compose.document.*` —
+DSL, semantic nodes, themes, layout snapshots) and the deterministic two-pass layout behind
+it, with **no PDFBox, POI, or template code** on its dependency tree.
+
+## When to depend on it
+
+- You want the smallest engine and will **bring your own render backend** — add
+  `graph-compose-render-pdf`, or implement the `FixedLayoutBackendProvider` SPI.
+- You are building a library on top of GraphCompose and don't want to impose a backend
+  on your consumers.
+
+Most applications should depend on `graph-compose` (core + the PDF backend, the 1.x
+drop-in) or `graph-compose-bundle` (batteries included) instead.
+
+## Usage
+
+Author against the canonical surface; a render backend on the classpath is discovered
+through `ServiceLoader` at render time:
+
+```java
+try (var doc = GraphCompose.document(out).create()) {
+    doc.pageFlow().addParagraph("Hello").build();
+} // with graph-compose-render-pdf present, buildPdf() / toPdfBytes() / toImages() work
+```
+
+A core-only classpath asked to render throws `MissingBackendException`, whose message
+names the artifact to add.
+
+## Install
+
+Same version as the rest of the GraphCompose train (lockstep):
+
+```xml
+<dependency>
+    <groupId>io.github.demchaav</groupId>
+    <artifactId>graph-compose-core</artifactId>
+    <version>2.0.0</version>
+</dependency>
+```
+
+```kotlin
+dependencies { implementation("io.github.demchaav:graph-compose-core:2.0.0") }
+```
+
+The full "which artifact?" table: [root README → Installation](../README.md#installation).
+Upgrading from 1.x: [modules migration guide](../docs/migration/v2.0.0-modules.md).

--- a/core/src/test/java/com/demcha/documentation/VersionConsistencyGuardTest.java
+++ b/core/src/test/java/com/demcha/documentation/VersionConsistencyGuardTest.java
@@ -11,7 +11,9 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -259,6 +261,57 @@ class VersionConsistencyGuardTest {
         assertThat(firstMatchingGroup(site, INSTALL_SNIPPET_PATTERNS_SHOWCASE_GRADLE))
                 .describedAs("web/index.html Gradle install snippet must equal the current pom or planned version (one of %s)", targets)
                 .isIn(targets);
+    }
+
+    /**
+     * Every train module's README carries a copy-paste install snippet (Maven +
+     * Gradle) for its own artifact. {@code cut-release.ps1} bumps them in the
+     * release commit; this fails the verify gate if any snippet lags the pom —
+     * the drift class where a browsed module README advertises the previous
+     * release's coordinate.
+     */
+    @Test
+    void moduleReadmeInstallSnippetsMatchTheProjectVersion() throws Exception {
+        Set<String> targets = acceptableTargets();
+        Map<String, String> trainReadmes = new LinkedHashMap<>();
+        trainReadmes.put("core/README.md", "graph-compose-core");
+        trainReadmes.put("render-pdf/README.md", "graph-compose-render-pdf");
+        trainReadmes.put("render-docx/README.md", "graph-compose-render-docx");
+        trainReadmes.put("render-pptx/README.md", "graph-compose-render-pptx");
+        trainReadmes.put("templates/README.md", "graph-compose-templates");
+        trainReadmes.put("testing/README.md", "graph-compose-testing");
+        trainReadmes.put("wrapper/README.md", "graph-compose");
+        trainReadmes.put("bundle/README.md", "graph-compose-bundle");
+
+        for (Map.Entry<String, String> module : trainReadmes.entrySet()) {
+            String readme = Files.readString(PROJECT_ROOT.resolve(module.getKey()));
+            String artifact = Pattern.quote(module.getValue());
+            assertThat(firstGroup(readme, "<artifactId>" + artifact + "</artifactId>\\s*<version>v?([0-9][^<]*)</version>"))
+                    .describedAs("%s Maven install snippet must equal the current pom or planned version (one of %s)", module.getKey(), targets)
+                    .isIn(targets);
+            assertThat(firstGroup(readme, "io\\.github\\.demchaav:" + artifact + ":v?([0-9][\\w.\\-]*)"))
+                    .describedAs("%s Gradle install snippet must equal the current pom or planned version (one of %s)", module.getKey(), targets)
+                    .isIn(targets);
+        }
+    }
+
+    /**
+     * fonts/emoji carry independent version lines, so their README snippets are
+     * checked against their own pom versions — never the engine train's.
+     */
+    @Test
+    void companionReadmeInstallSnippetsMatchTheirPomVersions() throws Exception {
+        for (String module : new String[] {"fonts", "emoji"}) {
+            String own = effectiveVersion(PROJECT_ROOT.resolve(module + "/pom.xml"));
+            String readme = Files.readString(PROJECT_ROOT.resolve(module + "/README.md"));
+            String artifact = Pattern.quote("graph-compose-" + module);
+            assertThat(firstGroup(readme, "<artifactId>" + artifact + "</artifactId>\\s*<version>v?([0-9][^<]*)</version>"))
+                    .describedAs("%s/README.md Maven install snippet must equal the module's own pom version (%s)", module, own)
+                    .isEqualTo(own);
+            assertThat(firstGroup(readme, "io\\.github\\.demchaav:" + artifact + ":v?([0-9][\\w.\\-]*)"))
+                    .describedAs("%s/README.md Gradle install snippet must equal the module's own pom version (%s)", module, own)
+                    .isEqualTo(own);
+        }
     }
 
     // ── Install-snippet patterns ────────────────────────────────────

--- a/emoji/README.md
+++ b/emoji/README.md
@@ -23,5 +23,18 @@ engine reads it from the classpath.
 
 ## Install
 
-Independent version line (`emoji-v*`), pinned to a version compatible with your engine train.
-See [root README → Installation](../README.md#installation) for the pinned coordinate.
+Independent version line (`emoji-v*`) — pinned, not the engine version:
+
+```xml
+<dependency>
+    <groupId>io.github.demchaav</groupId>
+    <artifactId>graph-compose-emoji</artifactId>
+    <version>1.0.0</version>
+</dependency>
+```
+
+```kotlin
+dependencies { implementation("io.github.demchaav:graph-compose-emoji:1.0.0") }
+```
+
+The full "which artifact?" table: [root README → Installation](../README.md#installation).

--- a/fonts/README.md
+++ b/fonts/README.md
@@ -19,6 +19,19 @@ catalog when it is on the classpath. `graph-compose-bundle` includes it.
 
 ## Install
 
-Independent version line (`fonts-v*`), pinned to a version compatible with your engine train.
-See [root README → Installation](../README.md#installation) for the pinned coordinate and the
-[v1.8.0 fonts migration note](../docs/migration/v1.8.0-fonts.md).
+Independent version line (`fonts-v*`) — pinned, not the engine version:
+
+```xml
+<dependency>
+    <groupId>io.github.demchaav</groupId>
+    <artifactId>graph-compose-fonts</artifactId>
+    <version>1.0.0</version>
+</dependency>
+```
+
+```kotlin
+dependencies { implementation("io.github.demchaav:graph-compose-fonts:1.0.0") }
+```
+
+The full "which artifact?" table: [root README → Installation](../README.md#installation);
+background in the [v1.8.0 fonts migration note](../docs/migration/v1.8.0-fonts.md).

--- a/render-docx/README.md
+++ b/render-docx/README.md
@@ -24,6 +24,19 @@ PDF backend.
 
 ## Install
 
-Same version as the rest of the GraphCompose train (lockstep). Copy-paste snippet and the
-full "which artifact?" table: [root README → Installation](../README.md#installation).
+Same version as the rest of the GraphCompose train (lockstep):
+
+```xml
+<dependency>
+    <groupId>io.github.demchaav</groupId>
+    <artifactId>graph-compose-render-docx</artifactId>
+    <version>2.0.0</version>
+</dependency>
+```
+
+```kotlin
+dependencies { implementation("io.github.demchaav:graph-compose-render-docx:2.0.0") }
+```
+
+The full "which artifact?" table: [root README → Installation](../README.md#installation).
 Upgrading from 1.x: [modules migration guide](../docs/migration/v2.0.0-modules.md).

--- a/render-pdf/README.md
+++ b/render-pdf/README.md
@@ -32,6 +32,19 @@ handlers, options).
 
 ## Install
 
-Same version as the rest of the GraphCompose train (lockstep). Copy-paste snippet and the
-full "which artifact?" table: [root README → Installation](../README.md#installation).
+Same version as the rest of the GraphCompose train (lockstep):
+
+```xml
+<dependency>
+    <groupId>io.github.demchaav</groupId>
+    <artifactId>graph-compose-render-pdf</artifactId>
+    <version>2.0.0</version>
+</dependency>
+```
+
+```kotlin
+dependencies { implementation("io.github.demchaav:graph-compose-render-pdf:2.0.0") }
+```
+
+The full "which artifact?" table: [root README → Installation](../README.md#installation).
 Upgrading from 1.x: [modules migration guide](../docs/migration/v2.0.0-modules.md).

--- a/render-pptx/README.md
+++ b/render-pptx/README.md
@@ -19,6 +19,19 @@ of `graph-compose`, `graph-compose-core`, or `graph-compose-bundle`.
 
 ## Install
 
-Same version as the rest of the GraphCompose train (lockstep). Copy-paste snippet and the
-full "which artifact?" table: [root README → Installation](../README.md#installation).
+Same version as the rest of the GraphCompose train (lockstep):
+
+```xml
+<dependency>
+    <groupId>io.github.demchaav</groupId>
+    <artifactId>graph-compose-render-pptx</artifactId>
+    <version>2.0.0</version>
+</dependency>
+```
+
+```kotlin
+dependencies { implementation("io.github.demchaav:graph-compose-render-pptx:2.0.0") }
+```
+
+The full "which artifact?" table: [root README → Installation](../README.md#installation).
 Upgrading from 1.x: [modules migration guide](../docs/migration/v2.0.0-modules.md).

--- a/scripts/cut-release.ps1
+++ b/scripts/cut-release.ps1
@@ -237,6 +237,48 @@ function Update-ReadmeInstallVersion($readmePath, $newVersion) {
     }
 }
 
+function Update-ModuleReadmeInstallVersion($readmePath, $newVersion) {
+    # Per-module READMEs carry copy-paste install snippets for THEIR OWN train
+    # artifact (Maven + Gradle). Bump every occurrence — unlike the root README
+    # there is no legacy-format fallback, and each file only ever references its
+    # own coordinate, so a blanket replace within the file is safe. Called for
+    # the train modules only; fonts/emoji READMEs pin their own independent
+    # versions and must never be touched by an engine cut.
+    if (-not (Test-Path $readmePath)) {
+        Note "skip (no file): $readmePath"
+        return
+    }
+    $content = Get-Content $readmePath -Raw
+    $changed = $false
+
+    $mavenRegex = [regex]'(?<=<artifactId>graph-compose[\w\-]*</artifactId>\s*<version>)v?[\w\.\-]+(?=</version>)'
+    $afterMaven = $mavenRegex.Replace($content, $newVersion)
+    if ($content -ne $afterMaven) {
+        $content = $afterMaven
+        $changed = $true
+        Note "bumped module README Maven snippet: $readmePath -> $newVersion"
+    }
+
+    $gradleRegex = [regex]'(?<=io\.github\.demchaav:graph-compose[\w\-]*:)v?[\w\.\-]+(?=")'
+    $afterGradle = $gradleRegex.Replace($content, $newVersion)
+    if ($content -ne $afterGradle) {
+        $content = $afterGradle
+        $changed = $true
+        Note "bumped module README Gradle snippet: $readmePath -> $newVersion"
+    }
+
+    if (-not $changed) {
+        Note "no change: $readmePath (version already $newVersion?)"
+        return
+    }
+
+    if ($DryRun) {
+        Write-Host "    [DRY RUN] Bump $readmePath install snippets -> $newVersion" -ForegroundColor Yellow
+    } else {
+        [System.IO.File]::WriteAllText($readmePath, $content)
+    }
+}
+
 function Update-IndexHtmlVersion($indexHtmlPath, $newVersion) {
     if (-not (Test-Path $indexHtmlPath)) {
         Note "skip (no file): $indexHtmlPath"
@@ -539,6 +581,14 @@ try {
     # the bump regex does not touch the $-prefixed property reference).
     Update-PomVersion (Join-Path $repoRoot 'bundle/pom.xml') $Version
     Update-ReadmeInstallVersion (Join-Path $repoRoot 'README.md') $Version
+    # Per-module README install snippets (train modules only — fonts/emoji pin
+    # their own independent versions). VersionConsistencyGuardTest fails the
+    # Step-5 verify if any of these lag the pom version.
+    foreach ($moduleReadme in @('core/README.md', 'render-pdf/README.md', 'render-docx/README.md',
+            'render-pptx/README.md', 'templates/README.md', 'testing/README.md',
+            'wrapper/README.md', 'bundle/README.md')) {
+        Update-ModuleReadmeInstallVersion (Join-Path $repoRoot $moduleReadme) $Version
+    }
     Update-IndexHtmlVersion (Join-Path $repoRoot 'web/index.html') $Version
     # The Next.js site/ and the docs->site/public mirror were retired when the static
     # showcase moved to web/ (deployed directly via .github/workflows/deploy-web.yml).
@@ -628,6 +678,14 @@ try {
     foreach ($modulePom in @('qa/pom.xml', 'coverage/pom.xml')) {
         if (Test-Path (Join-Path $repoRoot $modulePom)) {
             $commitFiles += $modulePom
+        }
+    }
+    # Per-module READMEs carry version-bumped install snippets (2.0 layout only).
+    foreach ($moduleReadme in @('core/README.md', 'render-pdf/README.md', 'render-docx/README.md',
+            'render-pptx/README.md', 'templates/README.md', 'testing/README.md',
+            'wrapper/README.md', 'bundle/README.md')) {
+        if (Test-Path (Join-Path $repoRoot $moduleReadme)) {
+            $commitFiles += $moduleReadme
         }
     }
     if (-not $SkipShowcase) {

--- a/templates/README.md
+++ b/templates/README.md
@@ -29,6 +29,19 @@ See the [layered-template guides](../docs/templates/v2-layered/README.md).
 
 ## Install
 
-Same version as the rest of the GraphCompose train (lockstep). Copy-paste snippet and the
-full "which artifact?" table: [root README → Installation](../README.md#installation).
+Same version as the rest of the GraphCompose train (lockstep):
+
+```xml
+<dependency>
+    <groupId>io.github.demchaav</groupId>
+    <artifactId>graph-compose-templates</artifactId>
+    <version>2.0.0</version>
+</dependency>
+```
+
+```kotlin
+dependencies { implementation("io.github.demchaav:graph-compose-templates:2.0.0") }
+```
+
+The full "which artifact?" table: [root README → Installation](../README.md#installation).
 Upgrading from 1.x: [modules migration guide](../docs/migration/v2.0.0-modules.md).

--- a/testing/README.md
+++ b/testing/README.md
@@ -26,6 +26,20 @@ Update baselines deliberately with the documented system properties
 
 ## Install
 
-Same version as the rest of the GraphCompose train (lockstep). Copy-paste snippet and the
-full "which artifact?" table: [root README → Installation](../README.md#installation).
+Same version as the rest of the GraphCompose train (lockstep):
+
+```xml
+<dependency>
+    <groupId>io.github.demchaav</groupId>
+    <artifactId>graph-compose-testing</artifactId>
+    <version>2.0.0</version>
+    <scope>test</scope>
+</dependency>
+```
+
+```kotlin
+dependencies { testImplementation("io.github.demchaav:graph-compose-testing:2.0.0") }
+```
+
+The full "which artifact?" table: [root README → Installation](../README.md#installation).
 Upgrading from 1.x: [modules migration guide](../docs/migration/v2.0.0-modules.md).

--- a/wrapper/README.md
+++ b/wrapper/README.md
@@ -18,6 +18,19 @@ Packaging stays `jar` (never `pom`) so existing `<dependency>` declarations need
 
 ## Install
 
-Same version as the rest of the GraphCompose train (lockstep). Copy-paste snippet and the
-full "which artifact?" table: [root README → Installation](../README.md#installation).
+Same version as the rest of the GraphCompose train (lockstep):
+
+```xml
+<dependency>
+    <groupId>io.github.demchaav</groupId>
+    <artifactId>graph-compose</artifactId>
+    <version>2.0.0</version>
+</dependency>
+```
+
+```kotlin
+dependencies { implementation("io.github.demchaav:graph-compose:2.0.0") }
+```
+
+The full "which artifact?" table: [root README → Installation](../README.md#installation).
 Upgrading from 1.x: [modules migration guide](../docs/migration/v2.0.0-modules.md).


### PR DESCRIPTION
## Why
A developer browsing a module directory on GitHub (`render-pdf/`, `templates/`, …) found an `## Install` section that only linked back to the root README — no coordinate to copy. `core/`, the flagship lean-engine module, had no README at all. And `bundle/README.md` still claimed the artifact is pom-packaged and needs `<type>pom</type>` — stale since the packaging fix made it an empty jar.

## What
- Every published module README now carries a copy-paste **Maven + Gradle** snippet for its own artifact: train modules at the shared train version (`2.0.0`), `testing` at test scope, `fonts`/`emoji` at their own pinned `1.0.0` lines. The root-README table + migration-guide links stay.
- **New `core/README.md`** in the sibling shape: lean-engine story, `MissingBackendException` note, install snippet.
- **bundle/README** corrected: empty jar, plain `<dependency>`, no `<type>pom</type>`.
- **Anti-drift wiring** — `cut-release.ps1` bumps the 8 train READMEs in the release commit (new `Update-ModuleReadmeInstallVersion`, all-occurrence, train list only so an engine cut never touches fonts/emoji) and stages them; `VersionConsistencyGuardTest` gains `moduleReadmeInstallSnippetsMatchTheProjectVersion` + `companionReadmeInstallSnippetsMatchTheirPomVersions`.

## Tests
- `VersionConsistencyGuardTest` 12/12 green on the tree.
- Drift proof: setting a train snippet to `9.9.9` fails the guard naming the file; restored.
- `cut-release -DryRun -Version 2.0.1` shows all 8 train READMEs bumping and joining the release `git add`; script parses clean.
- All 12 staged files are LF in the index (`git ls-files --eol` = `i/lf`).