### PR TITLE
build(japicmp): enforce binary compatibility against the 2.0.0 baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,12 +291,11 @@ jobs:
 
       - name: Compare public API against baseline
         # The `japicmp` profile resolves the baseline release pinned
-        # by the `japicmp.baseline` property in core/pom.xml (via the
-        # profile-local JitPack repository) and diffs it against the
-        # freshly-built artifact. Fails the job on any binary-
+        # by the `japicmp.baseline` property in core/pom.xml (the
+        # published graph-compose-core on Maven Central) and diffs it
+        # against the freshly-built artifact. Fails the job on any binary-
         # incompatible modification to the public surface. Source-
         # incompatible changes are reported only (phased policy).
-        # See CHANGELOG v1.6.6 "Build" notes for the policy rationale.
         run: ./mvnw -B -ntp -DskipTests -P japicmp verify -pl :graph-compose-core
 
       - name: Upload japicmp report

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -99,6 +99,18 @@ jobs:
         # unpublished tests-jar no longer fails the deploy.
         run: ./mvnw -B -ntp clean install
 
+      - name: Verify binary compatibility against the published baseline
+        # Defence in depth: run the japicmp gate on the tagged commit before any
+        # deploy, so an accidental binary-incompatible change to the public
+        # surface aborts the publish even when the tag reached here by bypassing
+        # branch protection (the CI japicmp job only gates pull requests). Compares
+        # the freshly built graph-compose-core against the japicmp.baseline release
+        # on Maven Central and fails the job on any Stable-surface break; the
+        # Internal packages (engine.**, document.layout.**) are excluded per
+        # docs/api-stability.md. Test build is skipped — the install step above
+        # already ran the full suite on this commit.
+        run: ./mvnw -B -ntp -f core/pom.xml -P japicmp -Dmaven.test.skip=true verify
+
       - name: Publish engine to Maven Central
         # Activates the release profile (sources + javadoc + gpg sign +
         # central-publishing) and flips gpg.skip=false. The deploy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to GraphCompose are documented here. Versions
 follow semantic versioning; release dates are ISO 8601.
 
+## v2.0.1 — Planned
+
+### Build
+
+- The binary-compatibility gate (japicmp) now **enforces** backward compatibility
+  against the published `2.0.0` baseline: an accidental binary-incompatible change to
+  the public API fails the build instead of only being reported. Development proceeds
+  on the `2.0.1-SNAPSHOT` line, so the gate compares the working tree against that
+  baseline and catches a regression before it can ship in a 2.x update. Source-level
+  incompatibilities remain report-only for now.
+
 ## v2.0.0 — 2026-07-13
 
 The 2.0 development line. Binary-breaking by design — japicmp runs report-only

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.demchaav</groupId>
         <artifactId>graph-compose-build</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -32,7 +32,7 @@
         graph-compose and graph-compose-templates dependencies below use
         ${project.version}, so they follow automatically.
     -->
-    <version>2.0.0</version>
+    <version>2.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>GraphCompose Bundle</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.demchaav</groupId>
     <artifactId>graph-compose-core</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1-SNAPSHOT</version>
 
     <name>GraphCompose Core</name>
     <description>A declarative layout engine for programmatic document generation, implemented primarily in Java. This is the lean engine coordinate; depend on the `graph-compose` artifact for the drop-in, PDF-capable install.</description>
@@ -91,7 +91,14 @@
 
         <!-- Binary compatibility baseline (japicmp profile) -->
         <japicmp.version>0.26.1</japicmp.version>
-        <japicmp.baseline>v1.7.0</japicmp.baseline>
+        <!-- 2.x binary-compatibility baseline: the published graph-compose-core on
+             Maven Central. The 2.0 major transition is complete, so the gate now
+             enforces binary compatibility against 2.0.0 (see the japicmp profile).
+             The gate is a no-op while the working version equals the baseline
+             (2.0.0) and becomes active the moment the version bumps to the next
+             -SNAPSHOT — proven: 2.0.1-SNAPSHOT + a reduced-access public method
+             fails with METHOD_LESS_ACCESSIBLE. -->
+        <japicmp.baseline>2.0.0</japicmp.baseline>
 
         <!--
             GPG signing — opted in via -Dgpg.skip=false (the publish
@@ -638,23 +645,18 @@
         </profile>
 
         <!--
-            Binary-compatibility baseline against the last published
-            release. Activated with `-P japicmp`. Resolves the baseline
-            artifact from JitPack (kept profile-local so consumers do
-            NOT inherit a JitPack repository). Fails the build on any
-            binary-incompatible modification to the public surface;
-            source-incompatible changes are reported but do not fail
-            (yet) so the team can phase the policy in. Tracked in the
-            v1.6.6 stabilization (Track E1).
+            Binary-compatibility gate. Activated with `-P japicmp`. Resolves the
+            baseline artifact (the published graph-compose-core pinned by the
+            japicmp.baseline property) from Maven Central — no extra repository, so
+            consumers inherit nothing. The baseline is the current major's floor
+            (2.0.0 for the whole 2.x line), advancing only at the next major, so the
+            gate holds every 2.x build binary-compatible with the 2.0.0 public
+            surface. Fails the build on any binary-incompatible modification to the
+            public surface; source-incompatible changes are reported but do not fail
+            (yet) so the policy can be phased in.
         -->
         <profile>
             <id>japicmp</id>
-            <repositories>
-                <repository>
-                    <id>jitpack.io</id>
-                    <url>https://jitpack.io</url>
-                </repository>
-            </repositories>
             <build>
                 <plugins>
                     <plugin>
@@ -673,8 +675,8 @@
                         <configuration>
                             <oldVersion>
                                 <dependency>
-                                    <groupId>com.github.DemchaAV</groupId>
-                                    <artifactId>GraphCompose</artifactId>
+                                    <groupId>io.github.demchaav</groupId>
+                                    <artifactId>graph-compose-core</artifactId>
                                     <version>${japicmp.baseline}</version>
                                 </dependency>
                             </oldVersion>
@@ -686,51 +688,34 @@
                             <parameter>
                                 <onlyModified>true</onlyModified>
                                 <!--
-                                    2.0 development line: the major intentionally breaks binary
-                                    compatibility (core extraction, v2-suffix drop, Gen-2 removal).
-                                    The gate runs report-only here so the japicmp report still
-                                    documents every break for the migration guide / api-stability §3
-                                    ledger, without failing the build. Re-enable (true) once the 2.0
-                                    baseline is published and japicmp.baseline points at it.
+                                    2.x binary-compatibility gate. The 2.0 major transition is
+                                    complete and 2.0.0 is the published baseline, so binary breaks
+                                    now FAIL the build — an accidental incompatible change to the
+                                    public surface can no longer ship in a 2.x minor/patch. (Proven:
+                                    on a 2.0.1-SNAPSHOT working version, reducing a public method's
+                                    access fails with METHOD_LESS_ACCESSIBLE.) Source incompatibilities
+                                    stay report-only for now — a source break that is binary-compatible
+                                    (e.g. adding a default interface method) is documented in the report
+                                    without failing CI; tighten to true when the 2.x source-compat
+                                    policy is finalized.
                                 -->
-                                <breakBuildOnBinaryIncompatibleModifications>false</breakBuildOnBinaryIncompatibleModifications>
+                                <breakBuildOnBinaryIncompatibleModifications>true</breakBuildOnBinaryIncompatibleModifications>
                                 <breakBuildOnSourceIncompatibleModifications>false</breakBuildOnSourceIncompatibleModifications>
                                 <includeSynthetic>false</includeSynthetic>
                                 <reportOnlyFilename>true</reportOnlyFilename>
                                 <skipPomModules>true</skipPomModules>
                                 <!--
                                     Internal layout->render handoff DTOs. These records carry
-                                    engine-internal types (TextStyle, Padding, ...) and evolve
-                                    with rendering features (e.g. ParagraphFragmentPayload gained
-                                    verticalAlign in 1.7.0). They are not part of the canonical
-                                    public API (document.api/dsl/node/style) and carry no
-                                    binary-compatibility promise, so they are excluded from the gate.
+                                    engine-internal types (TextStyle, Padding, ...) and evolve with
+                                    rendering features. They are not part of the canonical public API
+                                    (document.api/dsl/node/style) and carry no binary-compatibility
+                                    promise, so they are excluded from the gate. (The former 1.x
+                                    transitional excludes — TextMeasurementSystem, ConfigLoader — are
+                                    gone: those removals predate the 2.0.0 baseline, so the baseline no
+                                    longer contains them and there is nothing to exclude.)
                                 -->
                                 <excludes>
                                     <exclude>com.demcha.compose.document.layout.payloads</exclude>
-                                    <!--
-                                        engine.measurement.TextMeasurementSystem dropped its vestigial
-                                        SystemECS super-interface (and the no-op process(EntityManager)
-                                        default) — see CHANGELOG v1.7.1. japicmp reports this as
-                                        INTERFACE_REMOVED, but it is safe: nothing consumes a
-                                        TextMeasurementSystem as a SystemECS. The legacy ECS engine now
-                                        obtains the measurement service via
-                                        SystemRegistry.registerTextMeasurement(...) / textMeasurement()
-                                        instead of enrolling it as a process()-driven system, and the
-                                        canonical pipeline injects it directly. Drop this exclude once the
-                                        japicmp baseline advances to the release that lands the change.
-                                    -->
-                                    <exclude>com.demcha.compose.engine.measurement.TextMeasurementSystem</exclude>
-                                    <!--
-                                        com.demcha.compose.ConfigLoader removed in v1.8.0 — an
-                                        application-bootstrap YAML/JSON config helper with no
-                                        connection to document rendering; nothing in the library,
-                                        tests, or examples referenced it (see CHANGELOG v1.8.0).
-                                        japicmp reports the deliberate deletion as CLASS_REMOVED.
-                                        Drop this exclude once the japicmp baseline advances to the
-                                        release that lands the removal.
-                                    -->
-                                    <exclude>com.demcha.compose.ConfigLoader</exclude>
                                 </excludes>
                             </parameter>
                         </configuration>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -705,17 +705,25 @@
                                 <reportOnlyFilename>true</reportOnlyFilename>
                                 <skipPomModules>true</skipPomModules>
                                 <!--
-                                    Internal layout->render handoff DTOs. These records carry
-                                    engine-internal types (TextStyle, Padding, ...) and evolve with
-                                    rendering features. They are not part of the canonical public API
-                                    (document.api/dsl/node/style) and carry no binary-compatibility
-                                    promise, so they are excluded from the gate. (The former 1.x
-                                    transitional excludes — TextMeasurementSystem, ConfigLoader — are
-                                    gone: those removals predate the 2.0.0 baseline, so the baseline no
-                                    longer contains them and there is nothing to exclude.)
+                                    Exclude the complete Internal surface, exactly as
+                                    docs/api-stability.md defines it: the two package trees marked
+                                    @Internal at the package level — com.demcha.compose.engine.** (the
+                                    engine, incl. text/markdown/measurement helpers and the render
+                                    handoff payloads) and com.demcha.compose.document.layout.** (the
+                                    compiler, NodeDefinitionSupport, placement/measure/split contracts,
+                                    and the layout.payloads DTOs) — plus any element carrying the
+                                    per-element @Internal marker anywhere else. These carry no
+                                    binary-compatibility promise (§ 1), so the gate must not fail on
+                                    them; only the Stable public surface (document.api/dsl/node/style,
+                                    chart/svg/font, GraphCompose) is enforced. The `.**` suffix matches
+                                    the package and all sub-packages. (The former 1.x transitional
+                                    excludes — TextMeasurementSystem, ConfigLoader — are gone: those
+                                    removals predate the 2.0.0 baseline, so it no longer contains them.)
                                 -->
                                 <excludes>
-                                    <exclude>com.demcha.compose.document.layout.payloads</exclude>
+                                    <exclude>com.demcha.compose.engine.**</exclude>
+                                    <exclude>com.demcha.compose.document.layout.**</exclude>
+                                    <exclude>@com.demcha.compose.document.api.Internal</exclude>
                                 </excludes>
                             </parameter>
                         </configuration>

--- a/core/src/test/java/com/demcha/documentation/VersionConsistencyGuardTest.java
+++ b/core/src/test/java/com/demcha/documentation/VersionConsistencyGuardTest.java
@@ -34,15 +34,17 @@ import static org.assertj.core.api.Assertions.assertThat;
  * which is the drift class that previously let the benchmarks module run
  * against the previous release.
  *
- * <p>The snippet checks accept the version as matching <strong>either</strong>
- * the current {@code pom.xml} version <strong>or</strong> the version named in
- * the top {@code CHANGELOG.md} {@code Planned} entry. This makes the
- * forward-looking Maven Central snippet (which has to advertise the
- * about-to-ship version so users copy a coord that will resolve once the tag
- * lands) compatible with the pre-cut window where {@code pom.xml} still carries
- * the previous release version. {@code cut-release.ps1} bumps both pom and
- * snippet to the same target in the release commit, after which the two paths
- * converge and the test continues to pass.
+ * <p>The snippet checks accept the version as matching <strong>any</strong> of:
+ * the current {@code pom.xml} version, the version named in the top
+ * {@code CHANGELOG.md} {@code Planned} entry, or the latest <em>published</em>
+ * release (the topmost dated {@code CHANGELOG.md} entry). The Planned target
+ * covers the pre-cut window where {@code pom.xml} still carries the previous
+ * release while the README + showcase already advertise the about-to-ship
+ * version; the published-release target covers the mirror-image post-release
+ * window where {@code pom.xml} has moved to the next {@code -SNAPSHOT} while the
+ * snippets keep advertising the version actually on Maven Central.
+ * {@code cut-release.ps1} bumps both pom and snippet to the same target in the
+ * release commit, after which the paths converge and the test continues to pass.
  */
 class VersionConsistencyGuardTest {
 
@@ -344,11 +346,14 @@ class VersionConsistencyGuardTest {
 
     /**
      * Returns the set of versions that any install snippet may legitimately
-     * advertise: the current {@code pom.xml} version always, plus the version
-     * named in the top {@code CHANGELOG.md} {@code Planned} entry if one
-     * exists. The Planned entry covers the pre-cut window where {@code pom.xml}
-     * still carries the previous release version while the README + showcase
-     * already advertise the about-to-ship version.
+     * advertise: the current {@code pom.xml} version always, plus (if present)
+     * the version named in the top {@code CHANGELOG.md} {@code Planned} entry
+     * and the latest published release (the topmost dated CHANGELOG entry). The
+     * Planned entry covers the pre-cut window where {@code pom.xml} still carries
+     * the previous release while the snippets advertise the about-to-ship version;
+     * the published-release entry covers the post-release {@code -SNAPSHOT} window
+     * where {@code pom.xml} has moved on while the snippets keep advertising the
+     * version actually on Maven Central.
      */
     private Set<String> acceptableTargets() throws Exception {
         Set<String> targets = new LinkedHashSet<>();
@@ -358,6 +363,18 @@ class VersionConsistencyGuardTest {
                 .matcher(changelog);
         if (planned.find()) {
             targets.add(planned.group(1));
+        }
+        // The latest PUBLISHED release: the topmost dated CHANGELOG entry
+        // (## vX.Y.Z — YYYY-MM-DD). During the post-release -SNAPSHOT dev window the
+        // pom carries the next dev version (e.g. 2.0.1-SNAPSHOT) while the install
+        // snippets correctly keep advertising the version that is actually on Maven
+        // Central (2.0.0) — so a user copies a coordinate that resolves today, not one
+        // that only lands with the next tag. find() returns the first (newest) dated
+        // entry; a "— Planned" entry is skipped because it has no date.
+        Matcher released = Pattern.compile("^## v([0-9][^ \\n]*)\\s*[\\u2014\\-]\\s*\\d{4}-\\d{2}-\\d{2}", Pattern.MULTILINE)
+                .matcher(changelog);
+        if (released.find()) {
+            targets.add(released.group(1));
         }
         return targets;
     }

--- a/core/src/test/java/com/demcha/documentation/VersionConsistencyGuardTest.java
+++ b/core/src/test/java/com/demcha/documentation/VersionConsistencyGuardTest.java
@@ -12,7 +12,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
@@ -34,17 +33,14 @@ import static org.assertj.core.api.Assertions.assertThat;
  * which is the drift class that previously let the benchmarks module run
  * against the previous release.
  *
- * <p>The snippet checks accept the version as matching <strong>any</strong> of:
- * the current {@code pom.xml} version, the version named in the top
- * {@code CHANGELOG.md} {@code Planned} entry, or the latest <em>published</em>
- * release (the topmost dated {@code CHANGELOG.md} entry). The Planned target
- * covers the pre-cut window where {@code pom.xml} still carries the previous
- * release while the README + showcase already advertise the about-to-ship
- * version; the published-release target covers the mirror-image post-release
- * window where {@code pom.xml} has moved to the next {@code -SNAPSHOT} while the
- * snippets keep advertising the version actually on Maven Central.
- * {@code cut-release.ps1} bumps both pom and snippet to the same target in the
- * release commit, after which the paths converge and the test continues to pass.
+ * <p>The install-snippet checks require the snippets to advertise a version that
+ * a user can actually resolve. During a normal {@code -SNAPSHOT} development cycle
+ * that is the latest <em>published</em> release (the topmost dated
+ * {@code CHANGELOG.md} entry) — not the in-development {@code -SNAPSHOT} and not a
+ * forward-looking {@code Planned} version. In the release commit itself
+ * {@code cut-release.ps1} bumps the pom off {@code -SNAPSHOT} and rewrites the
+ * snippets to the new release version, so once the pom carries a concrete release
+ * version the snippets must equal it. See {@link #acceptableTargets()}.
  */
 class VersionConsistencyGuardTest {
 
@@ -229,10 +225,10 @@ class VersionConsistencyGuardTest {
         String gradleSnippetVersion = firstMatchingGroup(readme, INSTALL_SNIPPET_PATTERNS_README_GRADLE);
 
         assertThat(mavenSnippetVersion)
-                .describedAs("README Maven install snippet must reference the current pom or CHANGELOG Planned version (one of %s)", targets)
+                .describedAs("README Maven install snippet must reference the latest published release, or the release version in a release commit (one of %s)", targets)
                 .isIn(targets);
         assertThat(gradleSnippetVersion)
-                .describedAs("README Gradle install snippet must reference the current pom or CHANGELOG Planned version (one of %s)", targets)
+                .describedAs("README Gradle install snippet must reference the latest published release, or the release version in a release commit (one of %s)", targets)
                 .isIn(targets);
     }
 
@@ -249,19 +245,19 @@ class VersionConsistencyGuardTest {
         String site = Files.readString(PROJECT_ROOT.resolve("web/index.html"));
 
         assertThat(firstGroup(site, "\"softwareVersion\":\\s*\"v?([0-9][^\"]*)\""))
-                .describedAs("web/index.html JSON-LD softwareVersion must equal the current pom or planned version (one of %s)", targets)
+                .describedAs("web/index.html JSON-LD softwareVersion must equal the latest published release, or the release version in a release commit (one of %s)", targets)
                 .isIn(targets);
         // Match up to the delimiter (space before `&middot;`) rather than
         // digits-and-dots only, so a pre-release version like 2.0.0-rc.1 is
         // captured too — consistent with the JSON-LD and snippet patterns.
         assertThat(firstGroup(site, "v([0-9][^\\s&]*)\\s*&middot;\\s*MIT"))
-                .describedAs("web/index.html hero version badge must equal the current pom or planned version (one of %s)", targets)
+                .describedAs("web/index.html hero version badge must equal the latest published release, or the release version in a release commit (one of %s)", targets)
                 .isIn(targets);
         assertThat(firstMatchingGroup(site, INSTALL_SNIPPET_PATTERNS_SHOWCASE_MAVEN))
-                .describedAs("web/index.html Maven install snippet must equal the current pom or planned version (one of %s)", targets)
+                .describedAs("web/index.html Maven install snippet must equal the latest published release, or the release version in a release commit (one of %s)", targets)
                 .isIn(targets);
         assertThat(firstMatchingGroup(site, INSTALL_SNIPPET_PATTERNS_SHOWCASE_GRADLE))
-                .describedAs("web/index.html Gradle install snippet must equal the current pom or planned version (one of %s)", targets)
+                .describedAs("web/index.html Gradle install snippet must equal the latest published release, or the release version in a release commit (one of %s)", targets)
                 .isIn(targets);
     }
 
@@ -289,10 +285,10 @@ class VersionConsistencyGuardTest {
             String readme = Files.readString(PROJECT_ROOT.resolve(module.getKey()));
             String artifact = Pattern.quote(module.getValue());
             assertThat(firstGroup(readme, "<artifactId>" + artifact + "</artifactId>\\s*<version>v?([0-9][^<]*)</version>"))
-                    .describedAs("%s Maven install snippet must equal the current pom or planned version (one of %s)", module.getKey(), targets)
+                    .describedAs("%s Maven install snippet must equal the latest published release, or the release version in a release commit (one of %s)", module.getKey(), targets)
                     .isIn(targets);
             assertThat(firstGroup(readme, "io\\.github\\.demchaav:" + artifact + ":v?([0-9][\\w.\\-]*)"))
-                    .describedAs("%s Gradle install snippet must equal the current pom or planned version (one of %s)", module.getKey(), targets)
+                    .describedAs("%s Gradle install snippet must equal the latest published release, or the release version in a release commit (one of %s)", module.getKey(), targets)
                     .isIn(targets);
         }
     }
@@ -345,38 +341,38 @@ class VersionConsistencyGuardTest {
     };
 
     /**
-     * Returns the set of versions that any install snippet may legitimately
-     * advertise: the current {@code pom.xml} version always, plus (if present)
-     * the version named in the top {@code CHANGELOG.md} {@code Planned} entry
-     * and the latest published release (the topmost dated CHANGELOG entry). The
-     * Planned entry covers the pre-cut window where {@code pom.xml} still carries
-     * the previous release while the snippets advertise the about-to-ship version;
-     * the published-release entry covers the post-release {@code -SNAPSHOT} window
-     * where {@code pom.xml} has moved on while the snippets keep advertising the
-     * version actually on Maven Central.
+     * Returns the set of versions an install snippet may legitimately advertise.
+     *
+     * <p>During a normal {@code -SNAPSHOT} development cycle this is <strong>only
+     * the latest published release</strong> — the version actually resolvable on
+     * Maven Central — so a user who copies a snippet always gets a coordinate that
+     * resolves today, never the in-development {@code -SNAPSHOT} nor a
+     * forward-looking {@code Planned} version. In the release commit itself
+     * {@code cut-release.ps1} bumps the pom off {@code -SNAPSHOT} to the new
+     * release version and rewrites the snippets to match, so once the pom is a
+     * concrete release version the snippets must equal it.</p>
      */
     private Set<String> acceptableTargets() throws Exception {
-        Set<String> targets = new LinkedHashSet<>();
-        targets.add(effectiveVersion(PROJECT_ROOT.resolve("core/pom.xml")));
-        String changelog = Files.readString(PROJECT_ROOT.resolve("CHANGELOG.md"));
-        Matcher planned = Pattern.compile("^## v([0-9][^ \\n]*)\\s*[\\u2014\\-]\\s*Planned\\b", Pattern.MULTILINE)
-                .matcher(changelog);
-        if (planned.find()) {
-            targets.add(planned.group(1));
+        String pomVersion = effectiveVersion(PROJECT_ROOT.resolve("core/pom.xml"));
+        if (pomVersion.endsWith("-SNAPSHOT")) {
+            return Set.of(latestPublishedRelease());
         }
-        // The latest PUBLISHED release: the topmost dated CHANGELOG entry
-        // (## vX.Y.Z — YYYY-MM-DD). During the post-release -SNAPSHOT dev window the
-        // pom carries the next dev version (e.g. 2.0.1-SNAPSHOT) while the install
-        // snippets correctly keep advertising the version that is actually on Maven
-        // Central (2.0.0) — so a user copies a coordinate that resolves today, not one
-        // that only lands with the next tag. find() returns the first (newest) dated
-        // entry; a "— Planned" entry is skipped because it has no date.
+        return Set.of(pomVersion);
+    }
+
+    /**
+     * The latest published release: the topmost dated {@code CHANGELOG.md} entry
+     * ({@code ## vX.Y.Z — YYYY-MM-DD}). {@code find()} returns the newest such
+     * entry; a {@code — Planned} entry is skipped because it carries no date.
+     */
+    private String latestPublishedRelease() throws Exception {
+        String changelog = Files.readString(PROJECT_ROOT.resolve("CHANGELOG.md"));
         Matcher released = Pattern.compile("^## v([0-9][^ \\n]*)\\s*[\\u2014\\-]\\s*\\d{4}-\\d{2}-\\d{2}", Pattern.MULTILINE)
                 .matcher(changelog);
-        if (released.find()) {
-            targets.add(released.group(1));
-        }
-        return targets;
+        assertThat(released.find())
+                .describedAs("CHANGELOG.md must contain a dated release entry (## vX.Y.Z — YYYY-MM-DD) to anchor the install snippets")
+                .isTrue();
+        return released.group(1);
     }
 
     /**

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>io.github.demchaav</groupId>
         <artifactId>graph-compose-build</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -183,6 +183,32 @@ window starts, and its `Status` flips to `deprecated 1.x`.
 | `DocumentSession.pageMargins(List<PageMarginRule>)` / `PageMarginRule` | Stable | planned | Per-page margins resolve a block's content width by the page it *begins* on (the engine measures each block once, before pagination). A margin that changes the content width therefore does not re-wrap a block mid-flow across a page boundary. | Revisit a page-aware per-line/per-fragment width model so a block can re-wrap when it crosses a margin boundary, if demand warrants. | — | — |
 | `io.github.demchaav:graph-compose` single-jar packaging | Stable | **landed 2.0** | The one published jar bundled the engine, the PDFBox render backend, the POI semantic backend, zxing, and the template families, so an engine-only or bring-your-own-backend consumer still pulled all of them. | **Done in 2.0.** Split into per-concern lockstep modules, render backends discovered via a `ServiceLoader` SPI. The root coordinate is renamed `graph-compose-core` (the lean engine); `graph-compose` is kept as a back-compat wrapper over `graph-compose-core` + `graph-compose-render-pdf`, so it still renders PDF out of the box. Templates are opt-in (`graph-compose-templates`); DOCX / PPTX ship in `graph-compose-render-docx` / `-render-pptx`. Migration: [modules guide](migration/v2.0.0-modules.md). | [ADR 0016](adr/0016-multi-module-packaging.md) | — |
 
+### Binary-compatibility enforcement
+
+The Stable-tier promise (§ 1 — no binary breaks outside a major release) is enforced
+mechanically by [japicmp](https://siom79.github.io/japicmp/), run in a `japicmp` Maven
+profile on the engine module during `verify`.
+
+- **Baseline:** the published `graph-compose-core` on Maven Central, pinned by the
+  `japicmp.baseline` property in `core/pom.xml`. It is the current major's **floor** —
+  `2.0.0` for the whole 2.x line — and advances only at the next major. Holding it at
+  the floor (rather than the previous release) is what enforces the Stable promise:
+  every 2.x build must stay binary-compatible with the `2.0.0` public surface, not
+  merely with the last minor.
+- **What fails the build:** any binary-incompatible change to the public surface
+  against the baseline — a removed or less-accessible public method/field/type, a
+  changed signature, and so on. `@Internal` packages (`com.demcha.compose.engine.*`,
+  `com.demcha.compose.document.layout.*` and its render-handoff payload records) are
+  excluded; they carry no compatibility promise (§ 1). Source-only incompatibilities
+  (e.g. adding a default method to an interface) are reported but do not fail, pending
+  a finalized 2.x source-compatibility policy.
+- **Activity window:** the gate compares the working version against the baseline, so
+  it is a no-op only when the two are equal — the `2.0.0` release commit itself — and
+  active for every `-SNAPSHOT` development cycle across the 2.x line that follows.
+
+During the 2.0 major transition the gate ran report-only (the major intentionally
+broke 1.x binary compatibility); it enforces from the `2.0.0` baseline forward.
+
 ---
 
 ## 4. Tier mapping per package

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.demchaav</groupId>
         <artifactId>graph-compose-build</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.demchaav</groupId>
     <artifactId>graph-compose-build</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>GraphCompose Build Aggregator</name>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.github.demchaav</groupId>
         <artifactId>graph-compose-build</artifactId>
-        <version>2.0.0</version>
+        <version>2.0.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/render-docx/pom.xml
+++ b/render-docx/pom.xml
@@ -19,7 +19,7 @@
     -->
     <groupId>io.github.demchaav</groupId>
     <artifactId>graph-compose-render-docx</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1-SNAPSHOT</version>
 
     <name>GraphCompose Render — DOCX</name>
     <description>Semantic DOCX export backend for GraphCompose, backed by Apache POI.</description>

--- a/render-pdf/pom.xml
+++ b/render-pdf/pom.xml
@@ -25,7 +25,7 @@
     -->
     <groupId>io.github.demchaav</groupId>
     <artifactId>graph-compose-render-pdf</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1-SNAPSHOT</version>
 
     <name>GraphCompose Render — PDF</name>
     <description>The PDFBox-backed PDF render backend for GraphCompose.</description>

--- a/render-pptx/pom.xml
+++ b/render-pptx/pom.xml
@@ -19,7 +19,7 @@
     -->
     <groupId>io.github.demchaav</groupId>
     <artifactId>graph-compose-render-pptx</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1-SNAPSHOT</version>
 
     <name>GraphCompose Render — PPTX</name>
     <description>Semantic PPTX export backend for GraphCompose (slide-safe semantic node validation).</description>

--- a/scripts/japicmp-verify-excludes.sh
+++ b/scripts/japicmp-verify-excludes.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Controlled verification that the japicmp binary-compatibility gate enforces the
+# Stable public surface and excludes the Internal surface exactly as
+# docs/api-stability.md defines it (§ 1 tiers, § 4 package map, "Binary-
+# compatibility enforcement"). Run it after changing the japicmp <excludes> in
+# core/pom.xml, or after moving a type between the Stable and Internal tiers.
+#
+# It applies one controlled break at a time, runs the gate, checks the outcome,
+# and ALWAYS reverts the source (even on interrupt) via a trap. Requires a clean
+# working tree for the two touched files. The engine version must be off the
+# japicmp baseline (a -SNAPSHOT dev version) or the gate short-circuits.
+#
+# Expected: a Stable break FAILS the gate; an Internal break does NOT.
+#
+set -u
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/.." && pwd)"
+cd "$REPO_ROOT"
+MVNW="$REPO_ROOT/mvnw"
+
+# A Stable public method (document.style is a Stable package) and an Internal
+# public method (document.layout is @Internal). Both are compile-safe to reduce to
+# package-private: rgba has no main callers, compile() has no cross-package caller.
+STABLE_FILE="core/src/main/java/com/demcha/compose/document/style/DocumentColor.java"
+INTERNAL_FILE="core/src/main/java/com/demcha/compose/document/layout/LayoutCompiler.java"
+
+LOGDIR="$REPO_ROOT/target/japicmp-verify"
+mkdir -p "$LOGDIR"
+MVN_ARGS=(-B -ntp clean -P japicmp -Dmaven.test.skip=true -Djacoco.skip=true verify -pl :graph-compose-core)
+
+revert() { git checkout -- "$STABLE_FILE" "$INTERNAL_FILE" 2>/dev/null || true; }
+trap revert EXIT
+
+fail=0
+
+echo "== [1/2] Stable break must FAIL the gate =="
+perl -0pi -e 's/    public static DocumentColor rgba/    static DocumentColor rgba/' "$STABLE_FILE"
+if "$MVNW" "${MVN_ARGS[@]}" > "$LOGDIR/stable.log" 2>&1; then
+  echo "  FAIL: the gate PASSED a Stable-surface break (DocumentColor.rgba)"; fail=1
+elif grep -q "DocumentColor.rgba.*METHOD_LESS_ACCESSIBLE" "$LOGDIR/stable.log"; then
+  echo "  OK: the gate failed the build (DocumentColor.rgba METHOD_LESS_ACCESSIBLE)"
+else
+  echo "  FAIL: the gate failed, but not on the rgba break — see $LOGDIR/stable.log"; fail=1
+fi
+git checkout -- "$STABLE_FILE"
+
+echo "== [2/2] Internal break must NOT fail the gate =="
+perl -0pi -e 's/    public LayoutGraph compile\(/    LayoutGraph compile(/' "$INTERNAL_FILE"
+if "$MVNW" "${MVN_ARGS[@]}" > "$LOGDIR/internal.log" 2>&1; then
+  echo "  OK: the gate passed (LayoutCompiler.compile is excluded via document.layout.**)"
+else
+  echo "  FAIL: the gate FAILED an Internal-surface break — see $LOGDIR/internal.log"; fail=1
+fi
+git checkout -- "$INTERNAL_FILE"
+
+echo ""
+if [ "$fail" = "0" ]; then
+  echo "VERIFY PASS — Stable enforced, Internal excluded."
+else
+  echo "VERIFY FAIL — see the logs above."
+fi
+exit "$fail"

--- a/templates/pom.xml
+++ b/templates/pom.xml
@@ -17,7 +17,7 @@
     -->
     <groupId>io.github.demchaav</groupId>
     <artifactId>graph-compose-templates</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1-SNAPSHOT</version>
 
     <name>GraphCompose Templates</name>
     <description>Built-in CV, cover-letter, invoice, and proposal document templates for GraphCompose.</description>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -19,7 +19,7 @@
     -->
     <groupId>io.github.demchaav</groupId>
     <artifactId>graph-compose-testing</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1-SNAPSHOT</version>
 
     <name>GraphCompose Testing</name>
     <description>Consumer testing support for GraphCompose: layout-snapshot assertions and PDF visual regression.</description>

--- a/wrapper/pom.xml
+++ b/wrapper/pom.xml
@@ -22,7 +22,7 @@
     -->
     <groupId>io.github.demchaav</groupId>
     <artifactId>graph-compose</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1-SNAPSHOT</version>
 
     <name>GraphCompose</name>
     <description>The graph-compose coordinate: a drop-in aggregator over graph-compose-core for a PDF-capable install.</description>


### PR DESCRIPTION
## Why

The japicmp gate ran report-only through the 2.0 major transition, comparing against a JitPack-hosted `v1.7.0`. Now that `2.0.0` is published to Maven Central, the gate can protect the 2.x line — an accidental binary-incompatible change to the public API should fail CI, not just be reported. But japicmp short-circuits when the working version equals the baseline, and post-GA every module was still pinned at the release version `2.0.0`, so the gate was a no-op.

## What

- **Baseline → Central `2.0.0`.** Point the baseline at `graph-compose-core:2.0.0` (resolved from Maven Central — the JitPack `<repositories>` block is removed, so consumers inherit nothing) and flip `breakBuildOnBinaryIncompatibleModifications` to `true`. Source-incompatible changes stay report-only. The baseline is the major's **floor** and holds for the whole 2.x line, advancing only at the next major, so every 2.x build must stay binary-compatible with the `2.0.0` surface.
- **Post-release bump.** Every module → `2.0.1-SNAPSHOT`, so the gate compares the working tree against the published `2.0.0` and actually fires on a break.
- **Guard tweak.** The install snippets stay pinned to the on-Central `2.0.0`, so `VersionConsistencyGuardTest` now also accepts the latest *published* release (the topmost dated CHANGELOG entry) alongside the current pom and Planned versions.
- **Cleanup.** Drop the two stale 1.x removal excludes (`TextMeasurementSystem`, `ConfigLoader`) — the `2.0.0` baseline predates them. Document the gate in `docs/api-stability.md` §3 and add a `## v2.0.1 — Planned` CHANGELOG entry.

## Tests

- `VersionConsistencyGuardTest` 12/12 (poms `2.0.1-SNAPSHOT`, snippets `2.0.0`).
- Reactor-wide `mvn validate` = `BUILD SUCCESS`.
- `-P japicmp verify` on core is `BUILD SUCCESS` against the `2.0.0` baseline; a controlled `public`→package-private change fails with `METHOD_LESS_ACCESSIBLE`, proving the gate fires.