### PR TITLE
docs(adr): correct ADR 0016 to the shipped 2.0 module layout

### DIFF
--- a/docs/adr/0016-multi-module-packaging.md
+++ b/docs/adr/0016-multi-module-packaging.md
@@ -60,9 +60,10 @@ render backends discovered at runtime through a `ServiceLoader` SPI.
   (via the wrapper) + templates + the independently-versioned `graph-compose-fonts` and
   `graph-compose-emoji` companions. Office backends are not bundled.
 
-The engine sources stay at the repository root and only the **root coordinate** is
-renamed `graph-compose` → `graph-compose-core`; the new wrapper is a small module. The
-default coordinate `graph-compose` therefore continues to mean "PDF out of the box".
+The engine sources live in the `core/` module under the coordinate `graph-compose-core`;
+the repository root is the `graph-compose-build` aggregator pom that binds the modules
+into one lockstep reactor, and `graph-compose` is the small jar-wrapper. The default
+coordinate `graph-compose` therefore continues to mean "PDF out of the box".
 
 No JPMS: modules carry an `Automatic-Module-Name` only, so a split package across
 test-scope jars stays legal on the classpath.
@@ -82,6 +83,8 @@ test-scope jars stays legal on the classpath.
   `graph-compose-emoji` keep their own lines (they change rarely).
 - **A `MissingBackendException` is now the "why won't it render" signal** for a lean
   `graph-compose-core`, replacing the pre-split assumption that the backend is always present.
-- The legacy `Entity`-Component-System render pipeline moves into `graph-compose-render-pdf`
-  rather than being deleted; it is dead on the canonical path but still exercised by
-  test scaffolding, so its removal is deferred beyond 2.0.
+- The dormant `Entity`-Component-System engine internals — the `EntityManager` /
+  `SystemECS` runtime, the `Entity` component model, and the ECS render pipeline —
+  were removed in 2.0.0 rather than carried into a module. They were unreachable from
+  the live `DocumentSession` → layout compiler → fixed-layout backend path, so document
+  layout, PDF output, and the public `guideLines(...)` overlay are unchanged.


### PR DESCRIPTION
## Why

Two statements in [ADR 0016](../blob/develop/docs/adr/0016-multi-module-packaging.md) still described a superseded draft of the split rather than what actually shipped in 2.0.0, so a reader trusting the ADR would misunderstand the repository layout and believe dead code still lingers.

## What

- **Engine location.** The engine sources live in the `core/` module under the coordinate `graph-compose-core`; the repository root is the `graph-compose-build` aggregator pom binding the reactor. The ADR previously claimed the sources "stay at the repository root" — the root has no `src/main/java`.
- **ECS removal.** The dormant Entity-Component-System internals — the `EntityManager` / `SystemECS` runtime, the `Entity` component model, and the ECS render pipeline — were **removed** in 2.0.0, not "moved into `graph-compose-render-pdf`… removal deferred beyond 2.0." Zero files remain; the CHANGELOG v2.0.0 records the removal. They were unreachable from the live `DocumentSession` → layout compiler → fixed-layout backend path, so layout, PDF output, and `guideLines(...)` are unchanged.

The §3 api-stability packaging ledger row already reads "landed 2.0 / Done in 2.0"; no change needed there.

## Tests

Documentation guards green: `CanonicalSurfaceGuardTest`, `DocumentationCoverageTest`, `PackageMapGuardTest`, `VersionConsistencyGuardTest` (27 tests, 0 failures).