### PR TITLE
docs(changelog): drop the premature v2.0.1 Planned entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,17 +3,6 @@
 All notable changes to GraphCompose are documented here. Versions
 follow semantic versioning; release dates are ISO 8601.
 
-## v2.0.1 — Planned
-
-### Build
-
-- The binary-compatibility gate (japicmp) now **enforces** backward compatibility
-  against the published `2.0.0` baseline: an accidental binary-incompatible change to
-  the public API fails the build instead of only being reported. Development proceeds
-  on the `2.0.1-SNAPSHOT` line, so the gate compares the working tree against that
-  baseline and catches a regression before it can ship in a 2.x update. Source-level
-  incompatibilities remain report-only for now.
-
 ## v2.0.0 — 2026-07-13
 
 The 2.0 development line. Binary-breaking by design — japicmp runs report-only


### PR DESCRIPTION
## Why

`develop` is on `2.0.1-SNAPSHOT`, but the `## v2.0.1 — Planned` CHANGELOG entry's only content was one internal `### Build` note about the japicmp binary-compatibility gate. That's repo-internal tooling — no user-facing change — and the policy is already documented in [`docs/api-stability.md`](docs/api-stability.md). Advertising a "v2.0.1 — Planned" release with nothing installable is misleading, and it contradicts the hardening plan's conclusion that no 2.0.1 release is warranted.

## What

Remove the `## v2.0.1 — Planned` entry. The CHANGELOG top is the dated `## v2.0.0 — 2026-07-13` again.

`develop` **stays on `2.0.1-SNAPSHOT`** — the japicmp gate short-circuits when the working version equals its `2.0.0` baseline, so the dev line must remain distinct from the release. A concrete version entry is added when a real user-facing change lands.

## Tests

`VersionConsistencyGuardTest` 12/12 — the guard anchors install snippets to the latest *dated* release (`2.0.0`) for a `-SNAPSHOT` working version, so the (undated) Planned entry was never used; removing it changes nothing. No pom or install-snippet touched.