### PR TITLE
build(coverage): gate aggregate coverage against a non-regression ratchet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,9 +154,11 @@ jobs:
         # only via the examples job), the extracted graph-compose-testing module, the
         # graph-compose-qa cross-module suites (which need the testing module + the
         # engine test-jar on the classpath and so cannot live in the engine's own test
-        # scope), and the graph-compose-coverage aggregator (report-only JaCoCo over
-        # core + qa exec). -am pulls the fonts / emoji upstreams; only examples /
-        # benchmarks are excluded (their own CI jobs cover them).
+        # scope), and the graph-compose-coverage aggregator (JaCoCo over core +
+        # render-pdf + templates, counting the qa exec, now with a NON-REGRESSION
+        # RATCHET — this step fails if aggregate INSTRUCTION or BRANCH coverage drops
+        # below the floor in coverage/pom.xml). -am pulls the fonts / emoji upstreams;
+        # only examples / benchmarks are excluded (their own CI jobs cover them).
         run: ./mvnw -B -ntp clean verify -pl :graph-compose-core,:graph-compose-render-pdf,:graph-compose-render-docx,:graph-compose-render-pptx,:graph-compose-templates,:graph-compose-testing,:graph-compose,:graph-compose-bundle,:graph-compose-qa,:graph-compose-coverage -am
 
       - name: Generate Javadoc
@@ -168,14 +170,15 @@ jobs:
         run: ./mvnw -B -ntp javadoc:javadoc -pl :graph-compose-core
 
       - name: Upload aggregate coverage report
-        # Report-only: the cross-module JaCoCo report (core coverage counting the
-        # qa suites) is published as an artifact for inspection; no threshold gate.
-        # One JDK is enough — coverage is identical across JVMs.
+        # The cross-module JaCoCo report (core + render-pdf + templates coverage,
+        # counting the qa suites) is published as an artifact for inspection. The
+        # non-regression gate itself is enforced by the `verify` step above; this just
+        # captures the numbers. One JDK is enough — coverage is identical across JVMs.
         if: matrix.java == '17'
         uses: actions/upload-artifact@v7
         with:
-          # Core-scope aggregate (engine coverage counting the qa suites);
-          # render-pdf / templates are a follow-up, so the name is explicit.
+          # Cross-module aggregate (core + render-pdf + templates, counting the qa
+          # suites). The artifact name is kept for continuity with earlier runs.
           name: coverage-core-aggregate-${{ github.run_id }}
           path: coverage/target/site/jacoco-aggregate/**
           if-no-files-found: error

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -13,10 +13,13 @@
         traverse test-scope dependencies, hence this dedicated module that
         compile-depends on the measured modules).
 
-        Report-only: no coverage threshold is enforced yet. The aggregate HTML/XML
-        lands in target/site/jacoco-aggregate/. Sits at the reactor tail (listed
-        last in the aggregator) so every measured module's exec exists first, and
-        never publishes (maven.deploy.skip=true, inherited from the parent).
+        Enforced: a non-regression ratchet on the aggregate (the jacoco check-aggregate
+        execution below fails the build if INSTRUCTION or BRANCH coverage drops below
+        the floor). The aggregate HTML/XML also lands in target/site/jacoco-aggregate/.
+        Sits at the reactor tail (listed last in the aggregator) so every measured
+        module's exec exists first, and never publishes (maven.deploy.skip=true,
+        inherited from the parent). The check runs in CI's build-and-test job (which
+        runs `verify` on this module), which feeds the required CI Gate.
 
         Scope: the engine (graph-compose-core), the PDF backend
         (graph-compose-render-pdf), and the built-in templates
@@ -64,8 +67,54 @@
         </dependency>
     </dependencies>
 
+    <properties>
+        <!--
+            Non-regression ratchet on the AGGREGATE report (core + render-pdf +
+            templates, counting the qa cross-module exec). Measured stable baseline on
+            the v2.0.0 line: INSTRUCTION 87.86 % (0.87857), BRANCH 68.31 % (0.68310) —
+            verified identical on Windows and CI Linux (branch byte-identical; instruction
+            differs by 5 of ~102k). The floors sit ~0.36 pp (instruction) and ~0.31 pp
+            (branch) below the baseline — rounding/variance headroom only, not vanity.
+            Ratchet UP as coverage improves; never lower to make a red build pass —
+            fix the tests.
+        -->
+        <coverage.min.instruction>0.875</coverage.min.instruction>
+        <coverage.min.branch>0.68</coverage.min.branch>
+        <maven.dependency.plugin.version>3.8.1</maven.dependency.plugin.version>
+    </properties>
+
     <build>
         <plugins>
+            <!--
+                JaCoCo has no native aggregate-check goal, so reproduce the aggregate
+                inputs for a BUNDLE check: (1) unpack the measured modules' main classes
+                into this module's output dir, (2) merge their four jacoco.exec into one
+                aggregate.exec, (3) run jacoco:check against that class set + merged exec.
+                Same classes + same execs as report-aggregate above, so the enforced
+                numbers match the published aggregate report.
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>${maven.dependency.plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>unpack-measured-classes</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <!-- qa has no main classes (test-only); it contributes exec, not classes. -->
+                            <includeArtifactIds>graph-compose-core,graph-compose-render-pdf,graph-compose-templates</includeArtifactIds>
+                            <includes>**/*.class</includes>
+                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                            <overWriteReleases>true</overWriteReleases>
+                            <overWriteSnapshots>true</overWriteSnapshots>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
@@ -77,6 +126,55 @@
                         <goals>
                             <goal>report-aggregate</goal>
                         </goals>
+                    </execution>
+                    <execution>
+                        <id>merge-exec</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>merge</goal>
+                        </goals>
+                        <configuration>
+                            <fileSets>
+                                <fileSet>
+                                    <directory>${project.basedir}/..</directory>
+                                    <includes>
+                                        <include>core/target/jacoco.exec</include>
+                                        <include>render-pdf/target/jacoco.exec</include>
+                                        <include>templates/target/jacoco.exec</include>
+                                        <include>qa/target/jacoco.exec</include>
+                                    </includes>
+                                </fileSet>
+                            </fileSets>
+                            <destFile>${project.build.directory}/aggregate.exec</destFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>check-aggregate</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <dataFile>${project.build.directory}/aggregate.exec</dataFile>
+                            <haltOnFailure>true</haltOnFailure>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>INSTRUCTION</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>${coverage.min.instruction}</minimum>
+                                        </limit>
+                                        <limit>
+                                            <counter>BRANCH</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>${coverage.min.branch}</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
## Why

The `graph-compose-coverage` module builds a cross-module JaCoCo aggregate report (core + render-pdf + templates, counting the `graph-compose-qa` cross-module exec) but enforces no threshold, so aggregate coverage could silently decline release-over-release.

## What

- Measured the current aggregate baseline: **INSTRUCTION 0.87857 (89515/101887 ≈ 87.86 %), BRANCH 0.68310 (5529/8094 ≈ 68.31 %)** — verified identical on Windows and CI Linux (branch byte-identical; instruction differs by 5 of ~102k).
- Added a non-regression ratchet in `coverage/pom.xml` with floors `coverage.min.instruction=0.875` and `coverage.min.branch=0.68` — ~0.36 pp / ~0.31 pp below the baseline, only rounding/variance headroom.
- JaCoCo has no native aggregate-check goal, so the check reproduces the aggregate inputs: `maven-dependency-plugin` unpacks the measured modules' classes → `jacoco:merge` combines the four execs → `jacoco:check` on the combined BUNDLE (INSTRUCTION + BRANCH covered-ratio, `haltOnFailure`). Same classes and execs as the existing `report-aggregate`, so the enforced numbers match the published report.
- Refreshed the now-stale "report-only" comments in `coverage/pom.xml` and `.github/workflows/ci.yml`.

Enforcement is automatic: the check runs in the existing `build-and-test` `verify` step, which feeds the required `CI Gate` — a coverage regression fails the PR with no new CI job.

## Tests

- Full `clean verify -pl :graph-compose-core,:graph-compose-render-pdf,:graph-compose-templates,:graph-compose-qa,:graph-compose-coverage -am` → the aggregate check analyzes 671 classes, reports "All coverage checks have been met.", BUILD SUCCESS.
- Gate proven to fire: `jacoco:check@check-aggregate -Dcoverage.min.instruction=0.90` → BUILD FAILURE ("instructions covered ratio is 0.87, but expected minimum is 0.90"). The override was a temporary `-D`; nothing committed to revert.