### PR TITLE
feat(core): select fixed-layout render backends by format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes to GraphCompose are documented here. Versions
 follow semantic versioning; release dates are ISO 8601.
 
+## v2.1.0 — in progress
+
+### Public API
+
+- `BackendProviders.fixedLayout(String format)` selects a fixed-layout render
+  backend by its `FixedLayoutBackendProvider.format()` key (case-insensitive),
+  so several fixed-layout backends can coexist on one classpath. The no-arg
+  `BackendProviders.fixedLayout()` default is now deterministic regardless of
+  classpath order: the `"pdf"` provider wins when present, otherwise the
+  provider with the lexicographically smallest format. The PDF convenience
+  paths (`toPdfBytes`, `buildPdf`, multi-section rendering) resolve the PDF
+  backend explicitly by format. A missing format fails with a
+  `MissingBackendException` naming the artifact to add.
+- `DocumentPageSize.SLIDE_16_9` (960 × 540 pt) and `DocumentPageSize.SLIDE_4_3`
+  (720 × 540 pt) presets matching the PowerPoint slide defaults.
+
+### Documentation
+
+- `docs/architecture/backend-capability-matrix.md` — a per-capability matrix
+  of what each render backend supports and which class implements it,
+  maintained as part of every capability-changing PR.
+
+### Tests
+
+- `BackendProvidersTest` (qa) pins format-keyed resolution and the
+  deterministic PDF default; `MissingBackendContractTest` (core, backend-free
+  classpath) pins the missing-format diagnostics; `DocumentPageSizeTest` pins
+  the slide presets.
+
 ## v2.0.0 — 2026-07-13
 
 The 2.0 development line. Binary-breaking by design — japicmp runs report-only

--- a/core/src/main/java/com/demcha/compose/document/api/DocumentChromeOptions.java
+++ b/core/src/main/java/com/demcha/compose/document/api/DocumentChromeOptions.java
@@ -106,6 +106,6 @@ final class DocumentChromeOptions {
      * @return a configured renderer
      */
     FixedLayoutRenderer toConveniencePdfBackend(DocumentDebugOptions debug) {
-        return BackendProviders.fixedLayout().create(snapshot(), debug);
+        return BackendProviders.fixedLayout("pdf").create(snapshot(), debug);
     }
 }

--- a/core/src/main/java/com/demcha/compose/document/api/DocumentPageSize.java
+++ b/core/src/main/java/com/demcha/compose/document/api/DocumentPageSize.java
@@ -27,6 +27,22 @@ public record DocumentPageSize(double width, double height) {
     public static final DocumentPageSize LEGAL = new DocumentPageSize(612.0, 1008.0);
 
     /**
+     * Widescreen 16:9 slide size in points (13.333 × 7.5 in), matching the
+     * PowerPoint widescreen default.
+     *
+     * @since 2.1.0
+     */
+    public static final DocumentPageSize SLIDE_16_9 = new DocumentPageSize(960.0, 540.0);
+
+    /**
+     * Classic 4:3 slide size in points (10 × 7.5 in), matching the classic
+     * PowerPoint slide default.
+     *
+     * @since 2.1.0
+     */
+    public static final DocumentPageSize SLIDE_4_3 = new DocumentPageSize(720.0, 540.0);
+
+    /**
      * Creates a page size from point dimensions.
      *
      * @param width  page width in points

--- a/core/src/main/java/com/demcha/compose/document/api/MultiSectionDocument.java
+++ b/core/src/main/java/com/demcha/compose/document/api/MultiSectionDocument.java
@@ -48,7 +48,7 @@ public final class MultiSectionDocument implements AutoCloseable {
     private final Path defaultOutputFile;
     private final List<DocumentSession> sections;
     private final FixedLayoutRenderer backend =
-            BackendProviders.fixedLayout().create(DocumentOutputOptions.EMPTY, DocumentDebugOptions.none());
+            BackendProviders.fixedLayout("pdf").create(DocumentOutputOptions.EMPTY, DocumentDebugOptions.none());
     private boolean closed;
 
     MultiSectionDocument(Path defaultOutputFile, List<DocumentSession> sections) {

--- a/core/src/main/java/com/demcha/compose/document/backend/fixed/BackendProviders.java
+++ b/core/src/main/java/com/demcha/compose/document/backend/fixed/BackendProviders.java
@@ -2,7 +2,14 @@ package com.demcha.compose.document.backend.fixed;
 
 import com.demcha.compose.document.exceptions.MissingBackendException;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 import java.util.ServiceLoader;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
 
 /**
@@ -16,9 +23,18 @@ import java.util.function.Supplier;
  * {@code render(FixedLayoutBackend)} / {@code export(SemanticBackend)} paths do
  * not go through here — they use a caller-supplied backend.</p>
  *
+ * <p>Several fixed-layout backends may coexist on one classpath. The
+ * {@link #fixedLayout(String)} overload selects one by its
+ * {@link FixedLayoutBackendProvider#format() format}. The no-argument
+ * {@link #fixedLayout()} default stays deterministic regardless of classpath
+ * order: it prefers the {@code "pdf"} provider and falls back to the
+ * lexicographically smallest format when no PDF backend is present.</p>
+ *
  * @since 2.0.0
  */
 public final class BackendProviders {
+
+    private static final String DEFAULT_FIXED_LAYOUT_FORMAT = "pdf";
 
     private static final String MISSING_BACKEND_MESSAGE =
             "No fixed-layout render backend on the classpath: add the "
@@ -28,24 +44,59 @@ public final class BackendProviders {
 
     private static volatile FontMetricsProvider fontMetrics;
     private static volatile FixedLayoutBackendProvider fixedLayout;
+    private static final Map<String, FixedLayoutBackendProvider> fixedLayoutByFormat =
+            new ConcurrentHashMap<>();
 
     private BackendProviders() {
     }
 
     /**
-     * Returns the registered fixed-layout backend provider, resolving and caching
+     * Returns the default fixed-layout backend provider, resolving and caching
      * it on first use.
      *
-     * @return the fixed-layout backend provider
+     * <p>When several providers are registered the choice is deterministic:
+     * the {@code "pdf"} provider wins if present, otherwise the provider with
+     * the lexicographically smallest {@link FixedLayoutBackendProvider#format()
+     * format}.</p>
+     *
+     * @return the default fixed-layout backend provider
      * @throws MissingBackendException if no provider is registered on the classpath
      */
     public static FixedLayoutBackendProvider fixedLayout() {
         FixedLayoutBackendProvider provider = fixedLayout;
         if (provider == null) {
-            provider = load(FixedLayoutBackendProvider.class);
+            provider = defaultFixedLayout();
             fixedLayout = provider;
         }
         return provider;
+    }
+
+    /**
+     * Returns the fixed-layout backend provider registered for one output
+     * format, resolving and caching it on first use.
+     *
+     * <p>Matching against {@link FixedLayoutBackendProvider#format()} is
+     * case-insensitive. When several providers declare the same format the
+     * first one enumerated by {@link ServiceLoader} wins.</p>
+     *
+     * @param format output format identifier such as {@code "pdf"} or {@code "pptx"}
+     * @return the provider rendering that format
+     * @throws MissingBackendException if no provider for the format is registered
+     *                                 on the classpath
+     * @since 2.1.0
+     */
+    public static FixedLayoutBackendProvider fixedLayout(String format) {
+        Objects.requireNonNull(format, "format");
+        String key = format.toLowerCase(Locale.ROOT);
+        FixedLayoutBackendProvider cached = fixedLayoutByFormat.get(key);
+        if (cached != null) {
+            return cached;
+        }
+        FixedLayoutBackendProvider resolved = fixedLayoutProviders().stream()
+                .filter(provider -> key.equals(normalizedFormat(provider)))
+                .findFirst()
+                .orElseThrow(() -> new MissingBackendException(missingFormatMessage(key)));
+        return cacheByFormat(key, resolved);
     }
 
     /**
@@ -62,6 +113,58 @@ public final class BackendProviders {
             fontMetrics = provider;
         }
         return provider;
+    }
+
+    private static FixedLayoutBackendProvider defaultFixedLayout() {
+        FixedLayoutBackendProvider chosen = fixedLayoutProviders().stream()
+                .min(Comparator
+                        .comparing((FixedLayoutBackendProvider provider) ->
+                                !DEFAULT_FIXED_LAYOUT_FORMAT.equals(normalizedFormat(provider)))
+                        .thenComparing(BackendProviders::normalizedFormat))
+                .orElseThrow(missingBackend());
+        return cacheByFormat(normalizedFormat(chosen), chosen);
+    }
+
+    /**
+     * Canonicalizes provider instances per format so the default lookup and the
+     * format-keyed lookup always hand out the same instance for one format.
+     */
+    private static FixedLayoutBackendProvider cacheByFormat(
+            String key, FixedLayoutBackendProvider resolved) {
+        FixedLayoutBackendProvider prior = fixedLayoutByFormat.putIfAbsent(key, resolved);
+        return prior != null ? prior : resolved;
+    }
+
+    private static List<FixedLayoutBackendProvider> fixedLayoutProviders() {
+        List<FixedLayoutBackendProvider> providers = new ArrayList<>();
+        ServiceLoader.load(FixedLayoutBackendProvider.class,
+                FixedLayoutBackendProvider.class.getClassLoader()).forEach(provider -> {
+            // A provider without a format cannot be selected or win the default;
+            // registering one is a contract violation, so it is skipped entirely.
+            if (!normalizedFormat(provider).isEmpty()) {
+                providers.add(provider);
+            }
+        });
+        return providers;
+    }
+
+    private static String normalizedFormat(FixedLayoutBackendProvider provider) {
+        String format = provider.format();
+        return format == null ? "" : format.toLowerCase(Locale.ROOT);
+    }
+
+    private static String missingFormatMessage(String format) {
+        return switch (format) {
+            case "pdf" -> "No fixed-layout render backend for format \"pdf\" on the "
+                    + "classpath: add the io.github.demchaav:graph-compose-render-pdf "
+                    + "artifact (or the io.github.demchaav:graph-compose-bundle aggregate).";
+            case "pptx" -> "No fixed-layout render backend for format \"pptx\" on the "
+                    + "classpath: add the io.github.demchaav:graph-compose-render-pptx "
+                    + "artifact.";
+            default -> "No fixed-layout render backend for format \"" + format
+                    + "\" on the classpath: add an artifact that registers a "
+                    + "FixedLayoutBackendProvider for that format.";
+        };
     }
 
     private static <T> T load(Class<T> service) {

--- a/core/src/main/java/com/demcha/compose/document/backend/fixed/FixedLayoutBackendProvider.java
+++ b/core/src/main/java/com/demcha/compose/document/backend/fixed/FixedLayoutBackendProvider.java
@@ -10,7 +10,9 @@ import com.demcha.compose.document.output.DocumentOutputOptions;
  * <p>Implementations are discovered through {@link java.util.ServiceLoader};
  * each render backend artifact registers one (for example the PDF backend in
  * {@code io.github.demchaav:graph-compose-render-pdf}). The core resolves a
- * provider lazily via {@link BackendProviders#fixedLayout()} and fails with a
+ * provider lazily via {@link BackendProviders#fixedLayout()} (deterministic
+ * default) or {@link BackendProviders#fixedLayout(String)} (selection by
+ * {@link #format()}) and fails with a
  * {@link com.demcha.compose.document.exceptions.MissingBackendException} naming
  * the artifact to add when none is registered.</p>
  *
@@ -19,8 +21,9 @@ import com.demcha.compose.document.output.DocumentOutputOptions;
 public interface FixedLayoutBackendProvider {
 
     /**
-     * Returns the output format this provider renders, used for diagnostics and
-     * manifests.
+     * Returns the output format this provider renders. This is the selection
+     * key consulted by {@link BackendProviders#fixedLayout(String)} (matched
+     * case-insensitively) and is also used for diagnostics and manifests.
      *
      * @return a stable format identifier such as {@code "pdf"}
      */

--- a/core/src/test/java/com/demcha/compose/document/api/DocumentPageSizeTest.java
+++ b/core/src/test/java/com/demcha/compose/document/api/DocumentPageSizeTest.java
@@ -1,0 +1,40 @@
+package com.demcha.compose.document.api;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Pins the slide preset page sizes and their orientation behaviour. The slide
+ * presets must match the PowerPoint defaults exactly (13.333 × 7.5 in and
+ * 10 × 7.5 in at 72 pt/in) so a slide-sized document maps 1:1 onto a
+ * presentation canvas.
+ */
+class DocumentPageSizeTest {
+
+    @Test
+    void slidePresetsMatchThePowerPointDefaults() {
+        assertThat(DocumentPageSize.SLIDE_16_9.width()).isEqualTo(960.0);
+        assertThat(DocumentPageSize.SLIDE_16_9.height()).isEqualTo(540.0);
+        assertThat(DocumentPageSize.SLIDE_16_9.width() / DocumentPageSize.SLIDE_16_9.height())
+                .isEqualTo(16.0 / 9.0);
+
+        assertThat(DocumentPageSize.SLIDE_4_3.width()).isEqualTo(720.0);
+        assertThat(DocumentPageSize.SLIDE_4_3.height()).isEqualTo(540.0);
+        assertThat(DocumentPageSize.SLIDE_4_3.width() / DocumentPageSize.SLIDE_4_3.height())
+                .isEqualTo(4.0 / 3.0);
+    }
+
+    @Test
+    void slidePresetsAreAlreadyLandscape() {
+        assertThat(DocumentPageSize.SLIDE_16_9.landscape()).isSameAs(DocumentPageSize.SLIDE_16_9);
+        assertThat(DocumentPageSize.SLIDE_4_3.landscape()).isSameAs(DocumentPageSize.SLIDE_4_3);
+    }
+
+    @Test
+    void portraitFlipsASlidePreset() {
+        DocumentPageSize portrait = DocumentPageSize.SLIDE_16_9.portrait();
+        assertThat(portrait.width()).isEqualTo(540.0);
+        assertThat(portrait.height()).isEqualTo(960.0);
+    }
+}

--- a/core/src/test/java/com/demcha/compose/document/api/MissingBackendContractTest.java
+++ b/core/src/test/java/com/demcha/compose/document/api/MissingBackendContractTest.java
@@ -1,6 +1,7 @@
 package com.demcha.compose.document.api;
 
 import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.backend.fixed.BackendProviders;
 import com.demcha.compose.document.exceptions.MissingBackendException;
 import org.junit.jupiter.api.Test;
 
@@ -30,5 +31,21 @@ class MissingBackendContractTest {
         })
                 .isInstanceOf(MissingBackendException.class)
                 .hasMessageContaining("graph-compose-render-pdf");
+    }
+
+    @Test
+    void missingKnownFormatNamesTheArtifactToAdd() {
+        assertThatThrownBy(() -> BackendProviders.fixedLayout("pptx"))
+                .isInstanceOf(MissingBackendException.class)
+                .hasMessageContaining("\"pptx\"")
+                .hasMessageContaining("io.github.demchaav:graph-compose-render-pptx");
+    }
+
+    @Test
+    void missingUnknownFormatFailsWithTheFormatInTheMessage() {
+        assertThatThrownBy(() -> BackendProviders.fixedLayout("xps"))
+                .isInstanceOf(MissingBackendException.class)
+                .hasMessageContaining("\"xps\"")
+                .hasMessageContaining("FixedLayoutBackendProvider");
     }
 }

--- a/core/src/test/java/com/demcha/compose/document/backend/fixed/AlphaFakeFixedLayoutBackendProvider.java
+++ b/core/src/test/java/com/demcha/compose/document/backend/fixed/AlphaFakeFixedLayoutBackendProvider.java
@@ -1,0 +1,22 @@
+package com.demcha.compose.document.backend.fixed;
+
+import com.demcha.compose.document.output.DocumentDebugOptions;
+import com.demcha.compose.document.output.DocumentOutputOptions;
+
+/**
+ * ServiceLoader fake with format {@code "aaa"}. Selection tests need several
+ * registered providers on the backend-free core test classpath; rendering is
+ * never exercised.
+ */
+public final class AlphaFakeFixedLayoutBackendProvider implements FixedLayoutBackendProvider {
+
+    @Override
+    public String format() {
+        return "aaa";
+    }
+
+    @Override
+    public FixedLayoutRenderer create(DocumentOutputOptions chrome, DocumentDebugOptions debug) {
+        throw new UnsupportedOperationException("selection-test fake; never renders");
+    }
+}

--- a/core/src/test/java/com/demcha/compose/document/backend/fixed/BackendProvidersSelectionTest.java
+++ b/core/src/test/java/com/demcha/compose/document/backend/fixed/BackendProvidersSelectionTest.java
@@ -1,0 +1,42 @@
+package com.demcha.compose.document.backend.fixed;
+
+import com.demcha.compose.document.exceptions.MissingBackendException;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Selection semantics of {@link BackendProviders} on a classpath with several
+ * fixed-layout providers but no PDF backend (two test fakes, formats
+ * {@code "aaa"} and {@code "zzz"}, registered in the reverse of lexicographic
+ * order so classpath enumeration order cannot masquerade as the contract):
+ * the no-arg default falls back to the lexicographically smallest format,
+ * format lookup is case-insensitive and hands out one canonical instance per
+ * format, and a missing format still fails with the artifact-naming
+ * diagnostic.
+ */
+class BackendProvidersSelectionTest {
+
+    @Test
+    void defaultFallsBackToTheLexicographicallySmallestFormatWithoutPdf() {
+        assertThat(BackendProviders.fixedLayout().format()).isEqualTo("aaa");
+        assertThat(BackendProviders.fixedLayout())
+                .isSameAs(BackendProviders.fixedLayout("aaa"));
+    }
+
+    @Test
+    void formatLookupIsCaseInsensitiveAndInstanceCanonical() {
+        assertThat(BackendProviders.fixedLayout("ZZZ"))
+                .isSameAs(BackendProviders.fixedLayout("zzz"));
+        assertThat(BackendProviders.fixedLayout("zzz").format()).isEqualTo("zzz");
+    }
+
+    @Test
+    void pdfStaysMissingDespiteOtherRegisteredProviders() {
+        assertThatThrownBy(() -> BackendProviders.fixedLayout("pdf"))
+                .isInstanceOf(MissingBackendException.class)
+                .hasMessageContaining("graph-compose-render-pdf")
+                .hasMessageContaining("graph-compose-bundle");
+    }
+}

--- a/core/src/test/java/com/demcha/compose/document/backend/fixed/ZuluFakeFixedLayoutBackendProvider.java
+++ b/core/src/test/java/com/demcha/compose/document/backend/fixed/ZuluFakeFixedLayoutBackendProvider.java
@@ -1,0 +1,22 @@
+package com.demcha.compose.document.backend.fixed;
+
+import com.demcha.compose.document.output.DocumentDebugOptions;
+import com.demcha.compose.document.output.DocumentOutputOptions;
+
+/**
+ * ServiceLoader fake with format {@code "zzz"}. Selection tests need several
+ * registered providers on the backend-free core test classpath; rendering is
+ * never exercised.
+ */
+public final class ZuluFakeFixedLayoutBackendProvider implements FixedLayoutBackendProvider {
+
+    @Override
+    public String format() {
+        return "zzz";
+    }
+
+    @Override
+    public FixedLayoutRenderer create(DocumentOutputOptions chrome, DocumentDebugOptions debug) {
+        throw new UnsupportedOperationException("selection-test fake; never renders");
+    }
+}

--- a/core/src/test/resources/META-INF/services/com.demcha.compose.document.backend.fixed.FixedLayoutBackendProvider
+++ b/core/src/test/resources/META-INF/services/com.demcha.compose.document.backend.fixed.FixedLayoutBackendProvider
@@ -1,0 +1,2 @@
+com.demcha.compose.document.backend.fixed.ZuluFakeFixedLayoutBackendProvider
+com.demcha.compose.document.backend.fixed.AlphaFakeFixedLayoutBackendProvider

--- a/docs/architecture/backend-capability-matrix.md
+++ b/docs/architecture/backend-capability-matrix.md
@@ -1,0 +1,108 @@
+# Backend capability matrix
+
+One row per engine capability, one column per render backend, and — for
+every supported cell — the class that implements it. This file is the
+source of truth for "which backend can do what, and where is that code".
+
+Maintenance rule: any PR that adds, degrades, or removes a backend
+capability updates this file in the same change. A capability without a
+row here does not exist; a ✅ cell without a class name is a doc bug.
+
+Legend:
+
+- ✅ supported — cell names the implementing class
+- ⚠️ degraded — supported with a documented deviation (see the note)
+- 🚧 in development — implementation in progress, not usable yet
+- ❌ not supported — no implementation, no current plan
+- n/a — concept does not apply to this backend's output model
+
+Backends:
+
+- **PDF (fixed-layout)** — `graph-compose-render-pdf`,
+  `com.demcha.compose.document.backend.fixed.pdf`. Consumes the resolved
+  `LayoutGraph`; the reference implementation.
+- **PPTX (fixed-layout)** — `graph-compose-render-pptx`,
+  `com.demcha.compose.document.backend.fixed.pptx` (in development).
+  Consumes the same resolved `LayoutGraph`; geometry-identical to PDF by
+  construction, since layout is compiled in core before any backend runs.
+- **DOCX (semantic)** — `graph-compose-render-docx`,
+  `DocxSemanticBackend`. Walks the semantic node tree, deliberately
+  ignores fixed-layout geometry; Word owns the flow. Geometry rows are
+  n/a for it by design.
+
+The PPTX *semantic* skeleton (`PptxSemanticBackend`, slide-safe node
+validation + manifest, writes no file) is out of scope for this matrix.
+
+## Fragment payloads (fixed-layout drawing surface)
+
+Payload records live in `core` under
+`com.demcha.compose.document.layout.payloads`.
+
+| Capability (payload) | PDF (fixed) | PPTX (fixed) | DOCX (semantic) |
+|---|---|---|---|
+| Paragraph — pre-wrapped lines, runs, alignment (`ParagraphFragmentPayload`) | ✅ `PdfParagraphFragmentRenderHandler` | 🚧 | ✅ semantic paragraphs (`DocxSemanticBackend`) |
+| Inline code/badge chips (`InlineBackground` on text spans) | ✅ `PdfParagraphFragmentRenderHandler` | 🚧 | ❌ |
+| Inline images (`ParagraphImageSpan`) | ✅ `PdfParagraphFragmentRenderHandler` | 🚧 | ❌ |
+| Inline vector shapes (`ParagraphShapeSpan`) | ✅ `PdfParagraphFragmentRenderHandler` | 🚧 | ❌ |
+| Inline SVG (`ParagraphSvgSpan`) | ✅ `PdfParagraphFragmentRenderHandler` + `PdfPathPainter` | 🚧 | ❌ |
+| Rectangle shape — fill, stroke, per-corner radii, side borders (`ShapeFragmentPayload`) | ✅ `PdfShapeFragmentRenderHandler` | 🚧 | ❌ |
+| Ellipse (`EllipseFragmentPayload`) | ✅ `PdfEllipseFragmentRenderHandler` | 🚧 | ❌ |
+| Line — dash pattern, line cap (`LineFragmentPayload`) | ✅ `PdfLineFragmentRenderHandler` | 🚧 | ❌ |
+| Polygon (`PolygonFragmentPayload`) | ✅ `PdfPolygonFragmentRenderHandler` | 🚧 | ❌ |
+| Free path — segments, dash, cap, join (`PathFragmentPayload`) | ✅ `PdfPathFragmentRenderHandler` + `PdfPathPainter` | 🚧 | ❌ |
+| Linear gradient fill (`DocumentPaint`) | ✅ `PdfShadingSupport` | 🚧 | ❌ |
+| Radial gradient fill (`DocumentPaint`) | ✅ `PdfShadingSupport` | 🚧 (approximation expected — DrawingML cannot express radius-to-farthest-corner exactly) | ❌ |
+| Gradient strokes | ✅ `PdfPathPainter` (pattern stroking colour) | 🚧 | ❌ |
+| Image — STRETCH / CONTAIN / COVER fit (`ImageFragmentPayload`) | ✅ `PdfImageFragmentRenderHandler` | 🚧 | ✅ semantic images (`DocxSemanticBackend`) |
+| Barcode / QR (`BarcodeFragmentPayload`) | ✅ `PdfBarcodeFragmentRenderHandler` (ZXing raster) | 🚧 | ❌ |
+| Table rows — resolved cells, row/col spans, two-pass fill/border paint (`TableRowFragmentPayload`) | ✅ `PdfTableRowFragmentRenderHandler` + row grouping in `PdfFixedLayoutBackend` | 🚧 | ✅ semantic tables (`DocxSemanticBackend`) |
+| Clip region open/close (`ShapeClipBegin/EndPayload`) | ✅ `PdfShapeClipBegin/EndRenderHandler` (CLIP_BOUNDS + CLIP_PATH) | 🚧 (rect crops for pictures; other content degrades with a one-time warning — PPTX has no graphics-state clipping) | ⚠️ inline fallback + one-time capability warning |
+| Transform open/close — rotate/scale about fragment centre (`TransformBegin/EndPayload`) | ✅ `PdfTransformBegin/EndRenderHandler` | 🚧 (group shape with `xfrm`) | ⚠️ inline fallback + one-time capability warning |
+| Anchor markers (`AnchorMarkerPayload`) | ✅ `PdfAnchorMarkerRenderHandler` + `PdfInternalLinkWriter` | 🚧 | ❌ |
+| Bookmark markers (`BookmarkMarkerPayload`) | ✅ `PdfBookmarkMarkerRenderHandler` + `PdfBookmarkOutlineWriter` | 🚧 (PPTX has no document outline; mapped to slide names where 1:1) | ❌ |
+| Alpha / opacity | ✅ `PdfAlphaSupport` (`PDExtendedGraphicsState`) | 🚧 (native fill alpha) | ❌ |
+
+## Navigation and interactivity
+
+| Capability | PDF (fixed) | PPTX (fixed) | DOCX (semantic) |
+|---|---|---|---|
+| External hyperlinks (fragment- and run-level) | ✅ `PdfLinkAnnotationWriter` + link rects in `PdfFixedLayoutBackend` | 🚧 (`XSLFHyperlink`) | ❌ |
+| Internal links (anchor jump, forward references) | ✅ `PdfInternalLinkWriter` (two-pass) | 🚧 (slide-jump hyperlinks) | ❌ |
+| Document outline / bookmarks tree | ✅ `PdfBookmarkOutlineWriter` | 🚧 (no PPTX outline concept — slide names where 1:1, otherwise dropped with a note) | ❌ |
+
+## Document chrome and output options
+
+Neutral options come from `DocumentOutputOptions`; a backend that cannot
+honour an option ignores it (documented contract).
+
+| Capability | PDF (fixed) | PPTX (fixed) | DOCX (semantic) |
+|---|---|---|---|
+| Metadata (title, author, …) | ✅ `PdfDocumentPostProcessor` | 🚧 (OPC core properties) | ✅ (`DocxSemanticBackend` via `SemanticExportContext`) |
+| Watermark (front/back layers) | ✅ `PdfWatermarkRenderer` | 🚧 (per-slide shape, send-to-back/front) | ❌ |
+| Repeating headers / footers | ✅ `PdfHeaderFooterRenderer` | 🚧 (positioned per-slide text boxes) | ❌ |
+| Protection / encryption | ✅ `PdfDocumentPostProcessor` | ❌ (ignored — no OOXML encryption support planned) | ❌ |
+| Viewer preferences | ✅ `applyViewerPreferences` in `PdfFixedLayoutBackend` | ❌ (ignored — PDF-viewer concept) | n/a |
+| Debug guide lines / node labels | ✅ `PdfGuideLinesRenderer`, `PdfNodeLabelRenderer` | 🚧 | n/a |
+
+## Output surface and lifecycle
+
+| Capability | PDF (fixed) | PPTX (fixed) | DOCX (semantic) |
+|---|---|---|---|
+| Render to bytes / stream / file (`FixedLayoutRenderer`) | ✅ `PdfFixedLayoutBackend` | 🚧 `PptxFixedLayoutBackend` | ✅ `DocxSemanticBackend` (`SemanticBackend<byte[]>`) |
+| Render to images (`renderToImages`) | ✅ PDFBox `PDFRenderer` (in-memory, no round-trip) | 🚧 (decision pending: POI `XSLFSlide.draw` quality) | ❌ |
+| Multi-section documents (`renderSections`, per-section chrome, cross-section links) | ✅ `buildSectionsDocument` in `PdfFixedLayoutBackend` | 🚧 | ❌ |
+| Deterministic output (render twice → identical bytes) | ✅ `PdfDeterminismWriter` | 🚧 (pinned OPC timestamps + zip normalization) | ❌ |
+| ServiceLoader discovery (`FixedLayoutBackendProvider`) | ✅ `PdfFixedLayoutBackendProvider` (`format() == "pdf"`) | 🚧 (`format() == "pptx"`) | n/a (semantic SPI: `SemanticBackend`) |
+| `DocumentSession` convenience methods | ✅ `buildPdf` / `writePdf` / `toPdfBytes` / `toImages` | 🚧 (`buildPptx` / `writePptx` / `toPptxBytes` planned) | via `session.export(new DocxSemanticBackend(...))` |
+
+## Fidelity notes (PPTX)
+
+Geometry identity with PDF is guaranteed by construction at the
+shape-frame level: both backends consume the same resolved `LayoutGraph`,
+and text is emitted as one absolutely-positioned, wrap-disabled text box
+per already-wrapped line, so PowerPoint can never reflow content. What
+PPTX cannot guarantee is glyph-level rasterization: PowerPoint draws text
+with the fonts installed on the viewing machine. Standard-14 font names are mapped to
+metric-compatible system fonts (Helvetica → Arial, Times → Times New
+Roman, Courier → Courier New); binary font families keep their real
+family names and should be installed on the viewer for exact glyphs.

--- a/qa/src/test/java/com/demcha/compose/document/backend/fixed/AlphaFakeFixedLayoutBackendProvider.java
+++ b/qa/src/test/java/com/demcha/compose/document/backend/fixed/AlphaFakeFixedLayoutBackendProvider.java
@@ -1,0 +1,24 @@
+package com.demcha.compose.document.backend.fixed;
+
+import com.demcha.compose.document.output.DocumentDebugOptions;
+import com.demcha.compose.document.output.DocumentOutputOptions;
+
+/**
+ * ServiceLoader fake with format {@code "aaa"}. It coexists with the real PDF
+ * provider on the qa classpath so the default-selection test proves the
+ * no-arg {@link BackendProviders#fixedLayout()} prefers PDF over both
+ * classpath enumeration order and lexicographic order; rendering is never
+ * exercised.
+ */
+public final class AlphaFakeFixedLayoutBackendProvider implements FixedLayoutBackendProvider {
+
+    @Override
+    public String format() {
+        return "aaa";
+    }
+
+    @Override
+    public FixedLayoutRenderer create(DocumentOutputOptions chrome, DocumentDebugOptions debug) {
+        throw new UnsupportedOperationException("selection-test fake; never renders");
+    }
+}

--- a/qa/src/test/java/com/demcha/compose/document/backend/fixed/BackendProvidersTest.java
+++ b/qa/src/test/java/com/demcha/compose/document/backend/fixed/BackendProvidersTest.java
@@ -32,4 +32,26 @@ class BackendProvidersTest {
         assertThat(provider).isInstanceOf(PdfFixedLayoutBackendProvider.class);
         assertThat(provider.format()).isEqualTo("pdf");
     }
+
+    @Test
+    void resolvesTheFixedLayoutBackendProviderByFormatCaseInsensitively() {
+        assertThat(BackendProviders.fixedLayout("pdf"))
+                .isInstanceOf(PdfFixedLayoutBackendProvider.class);
+        assertThat(BackendProviders.fixedLayout("PDF"))
+                .isSameAs(BackendProviders.fixedLayout("pdf"));
+    }
+
+    /**
+     * The qa test classpath registers a fake {@code "aaa"} provider next to the
+     * real PDF one, so this only passes if the default genuinely prefers PDF —
+     * both classpath enumeration order and lexicographic order would pick the
+     * fake.
+     */
+    @Test
+    void theDefaultFixedLayoutProviderIsThePdfProvider() {
+        assertThat(BackendProviders.fixedLayout())
+                .isSameAs(BackendProviders.fixedLayout("pdf"));
+        assertThat(BackendProviders.fixedLayout("aaa"))
+                .isInstanceOf(AlphaFakeFixedLayoutBackendProvider.class);
+    }
 }

--- a/qa/src/test/resources/META-INF/services/com.demcha.compose.document.backend.fixed.FixedLayoutBackendProvider
+++ b/qa/src/test/resources/META-INF/services/com.demcha.compose.document.backend.fixed.FixedLayoutBackendProvider
@@ -1,0 +1,1 @@
+com.demcha.compose.document.backend.fixed.AlphaFakeFixedLayoutBackendProvider


### PR DESCRIPTION
## Why

Only one fixed-layout backend exists today (PDF), and `BackendProviders` resolves it with `ServiceLoader.findFirst()` — whichever provider the classpath enumerates first wins, and `FixedLayoutBackendProvider.format()` is never consulted for selection. The moment a second fixed-layout backend artifact appears on a consumer classpath (a coordinate-exact PPTX backend is in development in `graph-compose-render-pptx`), `toPdfBytes()` could silently hand the document to a non-PDF renderer depending on jar order.

## What changed

- `BackendProviders.fixedLayout(String format)` (new, `@since 2.1.0`) resolves a provider by its `format()` key, case-insensitively, and canonicalizes one instance per format, so the default and by-format lookups hand out the same object. A missing format throws `MissingBackendException` naming the artifact to add (`graph-compose-render-pdf` incl. the bundle alternative, `graph-compose-render-pptx`, or a generic `FixedLayoutBackendProvider` pointer for unknown formats).
- The no-arg `fixedLayout()` default is now deterministic regardless of classpath order: `"pdf"` wins when present, otherwise the lexicographically smallest format. Providers returning a null/blank `format()` are skipped — they can neither be selected by key nor win the default.
- The PDF convenience paths resolve PDF explicitly: `DocumentChromeOptions.toConveniencePdfBackend(...)` and `MultiSectionDocument`'s default backend call `fixedLayout("pdf")`, so `toPdfBytes()` / `buildPdf()` mean PDF by contract, not by classpath luck.
- `FixedLayoutBackendProvider.format()` javadoc is promoted from "diagnostics and manifests" to the selection key contract.
- `DocumentPageSize.SLIDE_16_9` (960 × 540 pt) and `SLIDE_4_3` (720 × 540 pt) presets matching the PowerPoint slide defaults, for slide-shaped documents.
- New `docs/architecture/backend-capability-matrix.md`: a capability × backend support table where every supported cell names the implementing class; maintained by any PR that changes a backend capability.

## Verification

`./mvnw -B -ntp clean verify` (full 10-module reactor gate) → **BUILD SUCCESS**; `./mvnw -B -ntp javadoc:javadoc -pl :graph-compose-core` green; qa suite **645** tests green.

New tests:

- `BackendProvidersSelectionTest` (core — the core test classpath is backend-free, so it registers two fakes with formats `"zzz"` + `"aaa"` in reverse-lexicographic ServiceLoader order): pins the lexicographic fallback, per-format instance canonicalization, and the missing-`"pdf"` diagnostic.
- `MissingBackendContractTest` gains the missing-format cases: `"pptx"` names `graph-compose-render-pptx`; an unknown format points at `FixedLayoutBackendProvider`. These live in core rather than qa so they stay valid if qa later gains a render-pptx dependency.
- `BackendProvidersTest` (qa) registers a fake `"aaa"` provider next to the real PDF one — the PDF-first default assertion only passes if the preference is real, since both classpath order and lexicographic order would pick the fake.
- `DocumentPageSizeTest` pins the slide presets (exact PowerPoint defaults, already-landscape invariant).

## Notes

- The new API carries `@since 2.1.0` and the CHANGELOG entry is headed `v2.1.0 — in progress`: the additions are public API, so the next release from `develop` should be a minor; the pom currently says `2.0.1-SNAPSHOT` and the version flip belongs to the release flow.
- When several providers declare the same format, the first one enumerated wins — same-format shadowing is not an error, matching ServiceLoader conventions.

**Lane:** canonical (document.backend.fixed) — additive core seam; PDF behaviour on a PDF-only classpath is unchanged.
