### PR TITLE
feat(pptx): coordinate-exact fixed-layout PPTX backend — vector shapes slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ follow semantic versioning; release dates are ISO 8601.
   `MissingBackendException` naming the artifact to add.
 - `DocumentPageSize.SLIDE_16_9` (960 × 540 pt) and `DocumentPageSize.SLIDE_4_3`
   (720 × 540 pt) presets matching the PowerPoint slide defaults.
+- `graph-compose-render-pptx` gains a coordinate-exact fixed-layout backend:
+  `PptxFixedLayoutBackend` (with `PptxFixedLayoutBackendProvider`,
+  `format() == "pptx"`) consumes the same resolved `LayoutGraph` as the PDF
+  backend — one page becomes one identically-sized slide and fragments render
+  at identical coordinates. First capability slice: rectangle shapes (solid
+  fill, stroke, corner radii, per-side borders), ellipses, and lines, plus a
+  custom-handler seam (`PptxFragmentRenderHandler`,
+  `PptxFixedLayoutBackend.Builder#addHandler`). Unsupported payloads fail
+  with `UnsupportedNodeCapabilityException`; the live per-capability status
+  lives in `docs/architecture/backend-capability-matrix.md`.
 
 ### Documentation
 

--- a/docs/architecture/backend-capability-matrix.md
+++ b/docs/architecture/backend-capability-matrix.md
@@ -45,9 +45,9 @@ Payload records live in `core` under
 | Inline images (`ParagraphImageSpan`) | ✅ `PdfParagraphFragmentRenderHandler` | 🚧 | ❌ |
 | Inline vector shapes (`ParagraphShapeSpan`) | ✅ `PdfParagraphFragmentRenderHandler` | 🚧 | ❌ |
 | Inline SVG (`ParagraphSvgSpan`) | ✅ `PdfParagraphFragmentRenderHandler` + `PdfPathPainter` | 🚧 | ❌ |
-| Rectangle shape — fill, stroke, per-corner radii, side borders (`ShapeFragmentPayload`) | ✅ `PdfShapeFragmentRenderHandler` | 🚧 | ❌ |
-| Ellipse (`EllipseFragmentPayload`) | ✅ `PdfEllipseFragmentRenderHandler` | 🚧 | ❌ |
-| Line — dash pattern, line cap (`LineFragmentPayload`) | ✅ `PdfLineFragmentRenderHandler` | 🚧 | ❌ |
+| Rectangle shape — fill, stroke, per-corner radii, side borders (`ShapeFragmentPayload`) | ✅ `PdfShapeFragmentRenderHandler` | ⚠️ `PptxShapeFragmentRenderHandler` (distinct per-corner radii render with the top-left radius on all corners — single-adjust `roundRect` preset — until custom geometry lands; uniform radii and side borders exact) | ❌ |
+| Ellipse (`EllipseFragmentPayload`) | ✅ `PdfEllipseFragmentRenderHandler` | ✅ `PptxEllipseFragmentRenderHandler` | ❌ |
+| Line — dash pattern, line cap (`LineFragmentPayload`) | ✅ `PdfLineFragmentRenderHandler` | ⚠️ `PptxLineFragmentRenderHandler` (numeric dash arrays map to the generic dashed preset; solid lines and caps exact) | ❌ |
 | Polygon (`PolygonFragmentPayload`) | ✅ `PdfPolygonFragmentRenderHandler` | 🚧 | ❌ |
 | Free path — segments, dash, cap, join (`PathFragmentPayload`) | ✅ `PdfPathFragmentRenderHandler` + `PdfPathPainter` | 🚧 | ❌ |
 | Linear gradient fill (`DocumentPaint`) | ✅ `PdfShadingSupport` | 🚧 | ❌ |
@@ -88,11 +88,11 @@ honour an option ignores it (documented contract).
 
 | Capability | PDF (fixed) | PPTX (fixed) | DOCX (semantic) |
 |---|---|---|---|
-| Render to bytes / stream / file (`FixedLayoutRenderer`) | ✅ `PdfFixedLayoutBackend` | 🚧 `PptxFixedLayoutBackend` | ✅ `DocxSemanticBackend` (`SemanticBackend<byte[]>`) |
+| Render to bytes / stream / file (`FixedLayoutRenderer`) | ✅ `PdfFixedLayoutBackend` | ✅ `PptxFixedLayoutBackend` | ✅ `DocxSemanticBackend` (`SemanticBackend<byte[]>`) |
 | Render to images (`renderToImages`) | ✅ PDFBox `PDFRenderer` (in-memory, no round-trip) | 🚧 (decision pending: POI `XSLFSlide.draw` quality) | ❌ |
 | Multi-section documents (`renderSections`, per-section chrome, cross-section links) | ✅ `buildSectionsDocument` in `PdfFixedLayoutBackend` | 🚧 | ❌ |
 | Deterministic output (render twice → identical bytes) | ✅ `PdfDeterminismWriter` | 🚧 (pinned OPC timestamps + zip normalization) | ❌ |
-| ServiceLoader discovery (`FixedLayoutBackendProvider`) | ✅ `PdfFixedLayoutBackendProvider` (`format() == "pdf"`) | 🚧 (`format() == "pptx"`) | n/a (semantic SPI: `SemanticBackend`) |
+| ServiceLoader discovery (`FixedLayoutBackendProvider`) | ✅ `PdfFixedLayoutBackendProvider` (`format() == "pdf"`) | ✅ `PptxFixedLayoutBackendProvider` (`format() == "pptx"`) | n/a (semantic SPI: `SemanticBackend`) |
 | `DocumentSession` convenience methods | ✅ `buildPdf` / `writePdf` / `toPdfBytes` / `toImages` | 🚧 (`buildPptx` / `writePptx` / `toPptxBytes` planned) | via `session.export(new DocxSemanticBackend(...))` |
 
 ## Fidelity notes (PPTX)

--- a/render-pptx/pom.xml
+++ b/render-pptx/pom.xml
@@ -5,13 +5,13 @@
     <modelVersion>4.0.0</modelVersion>
 
     <!--
-        Semantic PPTX export backend, split out of graph-compose-render-docx in the
-        2.0 module line so a consumer that wants slide output does not also pull the
-        DOCX backend's Apache POI. Today PptxSemanticBackend is a skeleton that
-        validates slide-safe semantic nodes and returns an export manifest, so this
-        module needs nothing beyond the core — POI joins only when real .pptx
-        emission lands. SemanticBackend / SemanticExportContext / manifest — the SPI
-        — stay in the core `document.backend.semantic` package.
+        PPTX render backend. Two surfaces share this artifact: the fixed-layout
+        backend (document.backend.fixed.pptx, POI XSLF) consuming the resolved
+        LayoutGraph for geometry-identical slide output next to the PDF render,
+        and the semantic PptxSemanticBackend skeleton that validates slide-safe
+        semantic nodes and returns an export manifest. SemanticBackend /
+        SemanticExportContext / manifest — the SPI — stay in the core
+        `document.backend.semantic` package.
 
         Standalone pom (no aggregator parent, like fonts/render-docx); its version
         tracks the engine line in lockstep (bumped by cut-release.ps1), and the
@@ -57,6 +57,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
 
+        <poi.version>5.5.1</poi.version>
         <junit.bom.version>6.1.2</junit.bom.version>
         <assertj.version>3.27.7</assertj.version>
         <logback.version>1.5.38</logback.version>
@@ -79,6 +80,12 @@
             <groupId>io.github.demchaav</groupId>
             <artifactId>graph-compose-core</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <!-- The fixed-layout PPTX backend emits .pptx through POI XSLF. -->
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>${poi.version}</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/PptxCoordinates.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/PptxCoordinates.java
@@ -1,0 +1,68 @@
+package com.demcha.compose.document.backend.fixed.pptx;
+
+import com.demcha.compose.document.layout.PlacedFragment;
+
+import java.awt.geom.Rectangle2D;
+
+/**
+ * Single source of truth for mapping resolved layout coordinates into the
+ * PPTX drawing space.
+ *
+ * <p>{@link PlacedFragment} coordinates arrive in the engine's PDF-native page
+ * space: origin at the bottom-left of the page, y growing upwards, values in
+ * points, with {@code (x, y)} naming the fragment's bottom-left corner. PPTX
+ * anchors shapes from the top-left of the slide with y growing downwards, so
+ * every vertical coordinate flips against the canvas height. Anchors are
+ * expressed in points — POI converts to EMU (1 pt = 12 700 EMU) internally,
+ * so no precision is lost in this class.</p>
+ *
+ * <p>Public because custom {@link PptxFragmentRenderHandler} implementations
+ * need the same mapping; the canvas height comes from
+ * {@link PptxRenderEnvironment#canvasHeight()}.</p>
+ *
+ * @since 2.1.0
+ */
+public final class PptxCoordinates {
+
+    private PptxCoordinates() {
+    }
+
+    /**
+     * Converts a bottom-left-anchored y coordinate of a box into the slide's
+     * top-down space.
+     *
+     * @param canvasHeight page height in points
+     * @param y            box bottom edge in PDF-native space
+     * @param height       box height in points
+     * @return top edge of the box in slide space
+     */
+    public static double topY(double canvasHeight, double y, double height) {
+        return canvasHeight - y - height;
+    }
+
+    /**
+     * Flips a single point (not a box edge) into the slide's top-down space.
+     *
+     * @param canvasHeight page height in points
+     * @param y            point y in PDF-native space
+     * @return the same point's y in slide space
+     */
+    public static double flipPoint(double canvasHeight, double y) {
+        return canvasHeight - y;
+    }
+
+    /**
+     * Returns the fragment's box as a top-left-anchored shape anchor in points.
+     *
+     * @param canvasHeight page height in points
+     * @param fragment     placed fragment in PDF-native space
+     * @return anchor rectangle for {@code XSLFShape.setAnchor}
+     */
+    public static Rectangle2D.Double anchorOf(double canvasHeight, PlacedFragment fragment) {
+        return new Rectangle2D.Double(
+                fragment.x(),
+                topY(canvasHeight, fragment.y(), fragment.height()),
+                fragment.width(),
+                fragment.height());
+    }
+}

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/PptxFixedLayoutBackend.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/PptxFixedLayoutBackend.java
@@ -1,0 +1,271 @@
+package com.demcha.compose.document.backend.fixed.pptx;
+
+import com.demcha.compose.document.backend.fixed.FixedLayoutRenderContext;
+import com.demcha.compose.document.backend.fixed.FixedLayoutRenderer;
+import com.demcha.compose.document.backend.fixed.SectionUnit;
+import com.demcha.compose.document.backend.fixed.pptx.handlers.PptxEllipseFragmentRenderHandler;
+import com.demcha.compose.document.backend.fixed.pptx.handlers.PptxLineFragmentRenderHandler;
+import com.demcha.compose.document.backend.fixed.pptx.handlers.PptxShapeFragmentRenderHandler;
+import com.demcha.compose.document.exceptions.UnsupportedNodeCapabilityException;
+import com.demcha.compose.document.layout.LayoutGraph;
+import com.demcha.compose.document.layout.PlacedFragment;
+import com.demcha.compose.document.layout.payloads.PdfSemanticFragmentPayload;
+import org.apache.poi.xslf.usermodel.XMLSlideShow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Coordinate-exact PPTX render backend consuming a fully resolved
+ * {@link LayoutGraph} — the same graph the PDF backend paints, so both
+ * formats share identical geometry by construction.
+ *
+ * <p>One resolved page becomes one slide sized exactly like the page canvas;
+ * fragments render in graph order through a per-payload-type handler registry
+ * that mirrors the PDF backend's dispatch (exact class lookup, then an
+ * {@code instanceof} fallback for payload subclasses; an unknown payload
+ * throws {@link UnsupportedNodeCapabilityException}). Custom handlers replace
+ * built-in defaults per payload type via {@link Builder#addHandler}.</p>
+ *
+ * <p>The backend currently renders vector shape, line, and ellipse fragments;
+ * the remaining payload types arrive incrementally — see
+ * {@code docs/architecture/backend-capability-matrix.md} for the live
+ * per-capability status. Multi-section rendering and rasterization are not
+ * implemented yet and throw {@link UnsupportedOperationException}.</p>
+ *
+ * <p><b>Thread-safety:</b> immutable and reusable across renders; each render
+ * pass owns its own slide show and environment.</p>
+ *
+ * @since 2.1.0
+ */
+public final class PptxFixedLayoutBackend implements FixedLayoutRenderer {
+
+    private static final Logger RENDER_LOG = LoggerFactory.getLogger("com.demcha.compose.engine.render");
+
+    private final Map<Class<?>, PptxFragmentRenderHandler<?>> handlers;
+
+    /**
+     * Creates a backend with the default handler set.
+     */
+    public PptxFixedLayoutBackend() {
+        this(builder());
+    }
+
+    private PptxFixedLayoutBackend(Builder builder) {
+        Map<Class<?>, PptxFragmentRenderHandler<?>> merged = new LinkedHashMap<>();
+        for (PptxFragmentRenderHandler<?> handler : defaultHandlers()) {
+            merged.put(handler.payloadType(), handler);
+        }
+        for (PptxFragmentRenderHandler<?> handler : builder.customHandlers) {
+            merged.put(handler.payloadType(), handler);
+        }
+        this.handlers = Map.copyOf(merged);
+    }
+
+    /**
+     * Returns a builder for a backend with custom handlers.
+     *
+     * @return new builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private static List<PptxFragmentRenderHandler<?>> defaultHandlers() {
+        return List.of(
+                new PptxShapeFragmentRenderHandler(),
+                new PptxLineFragmentRenderHandler(),
+                new PptxEllipseFragmentRenderHandler());
+    }
+
+    @Override
+    public String name() {
+        return "pptx-fixed-layout";
+    }
+
+    @Override
+    public byte[] render(LayoutGraph graph, FixedLayoutRenderContext context) throws Exception {
+        Objects.requireNonNull(graph, "graph");
+        Objects.requireNonNull(context, "context");
+
+        long startNanos = System.nanoTime();
+        try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            renderToOutput(graph, output);
+            byte[] bytes = output.toByteArray();
+            if (context.outputFile() != null) {
+                Files.write(context.outputFile(), bytes);
+            }
+            RENDER_LOG.debug(
+                    "render.pptx.fixed.end pages={} fragments={} byteCount={} durationMs={}",
+                    graph.totalPages(),
+                    graph.fragments().size(),
+                    bytes.length,
+                    TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos));
+            return bytes;
+        } catch (Exception ex) {
+            RENDER_LOG.error(
+                    "render.pptx.fixed.failed pages={} fragments={} errorType={}",
+                    graph.totalPages(),
+                    graph.fragments().size(),
+                    ex.getClass().getSimpleName(),
+                    ex);
+            throw ex;
+        }
+    }
+
+    @Override
+    public void write(LayoutGraph graph, FixedLayoutRenderContext context) throws Exception {
+        Objects.requireNonNull(graph, "graph");
+        Objects.requireNonNull(context, "context");
+        OutputStream output = Objects.requireNonNull(context.outputStream(), "context.outputStream");
+
+        if (context.outputFile() == null) {
+            renderToOutput(graph, output);
+            return;
+        }
+        try (ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
+            renderToOutput(graph, buffer);
+            byte[] bytes = buffer.toByteArray();
+            Files.write(context.outputFile(), bytes);
+            output.write(bytes);
+        }
+    }
+
+    /**
+     * Rasterization is not implemented for the PPTX backend yet; render the
+     * same session through the PDF backend when images are needed.
+     */
+    @Override
+    public List<BufferedImage> renderToImages(LayoutGraph graph,
+                                              FixedLayoutRenderContext context,
+                                              int dpi,
+                                              boolean transparent,
+                                              int pageIndex) {
+        throw new UnsupportedOperationException(
+                "The PPTX backend does not rasterize yet — render through the PDF backend for images.");
+    }
+
+    /**
+     * Multi-section concatenation is not implemented for the PPTX backend yet.
+     */
+    @Override
+    public byte[] renderSections(List<SectionUnit> sections) {
+        throw new UnsupportedOperationException(
+                "The PPTX backend does not render multi-section documents yet.");
+    }
+
+    /**
+     * Multi-section concatenation is not implemented for the PPTX backend yet.
+     */
+    @Override
+    public void writeSections(List<SectionUnit> sections, OutputStream output) {
+        throw new UnsupportedOperationException(
+                "The PPTX backend does not render multi-section documents yet.");
+    }
+
+    private void renderToOutput(LayoutGraph graph, OutputStream output) throws Exception {
+        try (XMLSlideShow show = new XMLSlideShow()) {
+            PptxRenderSession session = new PptxRenderSession(
+                    show, graph.canvas().width(), graph.canvas().height(), graph.totalPages());
+            PptxRenderEnvironment environment =
+                    new PptxRenderEnvironment(show, session, 0, graph.canvas().height());
+            for (PlacedFragment fragment : graph.fragments()) {
+                renderFragment(fragment, environment);
+            }
+            show.write(output);
+        }
+    }
+
+    private void renderFragment(PlacedFragment fragment, PptxRenderEnvironment environment) throws Exception {
+        Object payload = fragment.payload();
+        PptxFragmentRenderHandler<Object> handler = handlerFor(payload);
+        handler.render(fragment, payload, environment);
+        finishRenderedFragment(fragment, payload, environment);
+    }
+
+    /**
+     * Generic post-render bookkeeping shared by every semantic payload:
+     * fragment-rectangle links and bookmark records are collected here so no
+     * individual handler has to remember navigation concerns.
+     */
+    private void finishRenderedFragment(PlacedFragment fragment,
+                                        Object payload,
+                                        PptxRenderEnvironment environment) {
+        if (payload instanceof PdfSemanticFragmentPayload semanticPayload) {
+            if (semanticPayload.linkTarget() != null) {
+                environment.recordFragmentLink(fragment, semanticPayload.linkTarget());
+            }
+            if (semanticPayload.bookmarkOptions() != null) {
+                environment.registerBookmark(fragment, semanticPayload.bookmarkOptions());
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private PptxFragmentRenderHandler<Object> handlerFor(Object payload) {
+        if (payload == null) {
+            throw new UnsupportedNodeCapabilityException(
+                    "The PPTX fixed-layout backend cannot render a fragment without a payload.");
+        }
+        PptxFragmentRenderHandler<?> handler = handlers.get(payload.getClass());
+        if (handler == null) {
+            for (Map.Entry<Class<?>, PptxFragmentRenderHandler<?>> entry : handlers.entrySet()) {
+                if (entry.getKey().isInstance(payload)) {
+                    handler = entry.getValue();
+                    break;
+                }
+            }
+        }
+        if (handler == null) {
+            throw new UnsupportedNodeCapabilityException(
+                    "The PPTX fixed-layout backend has no render handler for payload type "
+                    + payload.getClass().getName()
+                    + " yet — see docs/architecture/backend-capability-matrix.md for supported capabilities.");
+        }
+        return (PptxFragmentRenderHandler<Object>) handler;
+    }
+
+    /**
+     * Builder assembling a backend with custom fragment handlers.
+     *
+     * @since 2.1.0
+     */
+    public static final class Builder {
+
+        private final List<PptxFragmentRenderHandler<?>> customHandlers = new ArrayList<>();
+
+        private Builder() {
+        }
+
+        /**
+         * Registers a custom fragment handler. A handler reporting the same
+         * payload type as a built-in default replaces that default.
+         *
+         * @param handler handler to register
+         * @return this builder
+         */
+        public Builder addHandler(PptxFragmentRenderHandler<?> handler) {
+            customHandlers.add(Objects.requireNonNull(handler, "handler"));
+            return this;
+        }
+
+        /**
+         * Builds the configured backend.
+         *
+         * @return immutable backend instance
+         */
+        public PptxFixedLayoutBackend build() {
+            return new PptxFixedLayoutBackend(this);
+        }
+    }
+}

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/PptxFixedLayoutBackendProvider.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/PptxFixedLayoutBackendProvider.java
@@ -1,0 +1,38 @@
+package com.demcha.compose.document.backend.fixed.pptx;
+
+import com.demcha.compose.document.backend.fixed.FixedLayoutBackendProvider;
+import com.demcha.compose.document.backend.fixed.FixedLayoutRenderer;
+import com.demcha.compose.document.output.DocumentDebugOptions;
+import com.demcha.compose.document.output.DocumentOutputOptions;
+
+/**
+ * POI-backed {@link FixedLayoutBackendProvider} for the {@code "pptx"} format,
+ * registered through {@code META-INF/services} so the document API can resolve
+ * the PPTX backend by format without importing it.
+ *
+ * <p>Document chrome (metadata, watermark, headers/footers) is not translated
+ * yet: options a backend cannot honour are ignored per the
+ * {@link DocumentOutputOptions} contract, and the chrome translation arrives
+ * together with the corresponding PPTX capabilities — see
+ * {@code docs/architecture/backend-capability-matrix.md}.</p>
+ *
+ * @since 2.1.0
+ */
+public final class PptxFixedLayoutBackendProvider implements FixedLayoutBackendProvider {
+
+    /**
+     * Creates the provider. Invoked reflectively by {@link java.util.ServiceLoader}.
+     */
+    public PptxFixedLayoutBackendProvider() {
+    }
+
+    @Override
+    public String format() {
+        return "pptx";
+    }
+
+    @Override
+    public FixedLayoutRenderer create(DocumentOutputOptions chrome, DocumentDebugOptions debug) {
+        return new PptxFixedLayoutBackend();
+    }
+}

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/PptxFragmentRenderHandler.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/PptxFragmentRenderHandler.java
@@ -1,0 +1,41 @@
+package com.demcha.compose.document.backend.fixed.pptx;
+
+import com.demcha.compose.document.layout.PlacedFragment;
+
+/**
+ * Public extension point for painting one PPTX fragment payload type.
+ *
+ * <p>Each handler owns exactly one payload type and materializes it as shapes
+ * on the slide supplied by the surrounding {@link PptxRenderEnvironment}. The
+ * contract mirrors the PDF backend's handler seam: handlers are small,
+ * stateless, and reused across slides and documents — per-render mutable state
+ * belongs in {@link PptxRenderEnvironment}, never in handler fields.</p>
+ *
+ * <p><b>Adding a custom handler.</b> Register through
+ * {@link PptxFixedLayoutBackend.Builder#addHandler(PptxFragmentRenderHandler)}.
+ * A custom handler reporting the same {@link #payloadType()} as a built-in
+ * default replaces that default for the backend instance.</p>
+ *
+ * @param <T> payload type supported by the handler
+ * @since 2.1.0
+ */
+public interface PptxFragmentRenderHandler<T> {
+
+    /**
+     * Returns the payload class accepted by this handler.
+     *
+     * @return concrete payload type supported by the handler
+     */
+    Class<T> payloadType();
+
+    /**
+     * Renders one resolved fragment.
+     *
+     * @param fragment    resolved fragment placement (PDF-native page space —
+     *                    convert through the environment's canvas height)
+     * @param payload     fragment payload data already validated by the layout layer
+     * @param environment shared PPTX render environment for the current document pass
+     * @throws Exception if the drawing operation fails
+     */
+    void render(PlacedFragment fragment, T payload, PptxRenderEnvironment environment) throws Exception;
+}

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/PptxRenderEnvironment.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/PptxRenderEnvironment.java
@@ -1,0 +1,160 @@
+package com.demcha.compose.document.backend.fixed.pptx;
+
+import com.demcha.compose.document.layout.PlacedFragment;
+import com.demcha.compose.document.node.DocumentBookmarkOptions;
+import com.demcha.compose.document.node.DocumentLinkTarget;
+import org.apache.poi.xslf.usermodel.XMLSlideShow;
+import org.apache.poi.xslf.usermodel.XSLFSlide;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.awt.geom.Rectangle2D;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Shared per-render-pass state for the fixed-layout PPTX backend.
+ *
+ * <p>The environment owns the slide surfaces for one document render pass plus
+ * the navigation bookkeeping that resolves after all fragments have been
+ * painted: bookmark records, anchor destinations, and fragment-level link
+ * rectangles. Handlers draw through {@link #slide(int)} and never create
+ * slides themselves.</p>
+ *
+ * <p>Navigation records are collected in slide top-down space (rectangles are
+ * top-left anchored, in points). Their emission — slide-jump hyperlinks and
+ * the bookmark-to-slide-name mapping — lands together with the navigation
+ * support; the records are collected from the first release so no handler
+ * needs retrofitting.</p>
+ *
+ * <p><b>Thread-safety:</b> mutable and confined to one render pass.</p>
+ *
+ * @since 2.1.0
+ */
+public final class PptxRenderEnvironment {
+
+    private static final Logger LOG = LoggerFactory.getLogger("com.demcha.compose.engine.render");
+
+    private final XMLSlideShow show;
+    private final PptxRenderSession session;
+    private final int pageIndexOffset;
+    private final double canvasHeight;
+    private final List<BookmarkRecord> bookmarkRecords = new ArrayList<>();
+    private final Map<String, AnchorDestination> anchorDestinations = new LinkedHashMap<>();
+    private final List<FragmentLink> fragmentLinks = new ArrayList<>();
+
+    PptxRenderEnvironment(XMLSlideShow show,
+                          PptxRenderSession session,
+                          int pageIndexOffset,
+                          double canvasHeight) {
+        this.show = show;
+        this.session = session;
+        this.pageIndexOffset = pageIndexOffset;
+        this.canvasHeight = canvasHeight;
+    }
+
+    /**
+     * Returns the live slide show for the current render pass.
+     *
+     * @return mutable POI slide show owned by the backend
+     */
+    public XMLSlideShow slideShow() {
+        return show;
+    }
+
+    /**
+     * Returns the drawing surface for one resolved page.
+     *
+     * @param pageIndex zero-based page index
+     * @return the slide backing that page
+     */
+    public XSLFSlide slide(int pageIndex) {
+        return session.slide(pageIndex);
+    }
+
+    /**
+     * Returns the page height in points — the constant every vertical
+     * coordinate flips against when moving from the engine's bottom-left page
+     * space into the slide's top-down space.
+     *
+     * @return canvas height in points
+     */
+    public double canvasHeight() {
+        return canvasHeight;
+    }
+
+    void registerBookmark(PlacedFragment fragment, DocumentBookmarkOptions bookmarkOptions) {
+        bookmarkRecords.add(new BookmarkRecord(
+                bookmarkOptions.title(),
+                bookmarkOptions.level(),
+                fragment.pageIndex() + pageIndexOffset));
+    }
+
+    /**
+     * Records the resolved slide and top-left corner of a named anchor declared
+     * by an {@code AnchorMarkerPayload} fragment. A duplicate name keeps the
+     * last registration (and logs a warning), matching the engine contract.
+     *
+     * @param fragment placed anchor marker fragment
+     * @param anchor   non-blank anchor name
+     */
+    public void registerAnchor(PlacedFragment fragment, String anchor) {
+        if (anchor == null || anchor.isBlank()) {
+            return;
+        }
+        AnchorDestination destination = new AnchorDestination(
+                fragment.pageIndex() + pageIndexOffset,
+                fragment.x(),
+                PptxCoordinates.topY(canvasHeight, fragment.y(), fragment.height()));
+        AnchorDestination previous = anchorDestinations.put(anchor, destination);
+        if (previous != null) {
+            LOG.warn("render.pptx.anchor.duplicate name={} — last registration wins", anchor);
+        }
+    }
+
+    void recordFragmentLink(PlacedFragment fragment, DocumentLinkTarget target) {
+        fragmentLinks.add(new FragmentLink(
+                fragment.pageIndex() + pageIndexOffset,
+                PptxCoordinates.anchorOf(canvasHeight, fragment),
+                target));
+    }
+
+    List<BookmarkRecord> bookmarkRecords() {
+        return List.copyOf(bookmarkRecords);
+    }
+
+    Map<String, AnchorDestination> anchorDestinations() {
+        return Map.copyOf(anchorDestinations);
+    }
+
+    List<FragmentLink> fragmentLinks() {
+        return List.copyOf(fragmentLinks);
+    }
+
+    record BookmarkRecord(String title, int level, int pageIndex) {
+    }
+
+    /**
+     * Resolved slide and top-left corner of a named anchor destination, in
+     * slide top-down space.
+     *
+     * @param pageIndex zero-based slide index the anchor resolved to
+     * @param left      left edge in points
+     * @param top       top edge in points
+     */
+    record AnchorDestination(int pageIndex, double left, double top) {
+    }
+
+    /**
+     * A fragment-level clickable rectangle awaiting link emission, in slide
+     * top-down space.
+     *
+     * @param pageIndex zero-based slide index the rectangle lives on
+     * @param rectangle clickable rectangle in points
+     * @param target    resolved link target
+     */
+    record FragmentLink(int pageIndex, Rectangle2D.Double rectangle, DocumentLinkTarget target) {
+    }
+}

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/PptxRenderSession.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/PptxRenderSession.java
@@ -1,0 +1,52 @@
+package com.demcha.compose.document.backend.fixed.pptx;
+
+import org.apache.poi.util.Units;
+import org.apache.poi.xslf.usermodel.XMLSlideShow;
+import org.apache.poi.xslf.usermodel.XSLFSlide;
+import org.openxmlformats.schemas.presentationml.x2006.main.CTSlideSize;
+
+import java.awt.Dimension;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Page-scoped PPTX render session: one {@link XSLFSlide} per resolved page,
+ * created up front so handlers can draw on any page in fragment order.
+ *
+ * <p>The slide size is stamped twice: once through POI's integer-point
+ * {@code setPageSize} (which creates the size element), then overwritten with
+ * exact EMU values so fractional page sizes (A4 is 595.27563 pt wide) keep
+ * sub-point precision instead of rounding to whole points. Note the OOXML
+ * schema floor for a slide dimension is 914400 EMU (72 pt) — page sizes below
+ * that are not representable as slides.</p>
+ *
+ * <p><b>Thread-safety:</b> mutable and not thread-safe.</p>
+ */
+final class PptxRenderSession {
+
+    private final List<XSLFSlide> slides;
+
+    PptxRenderSession(XMLSlideShow show, double width, double height, int totalPages) {
+        show.setPageSize(new Dimension(
+                (int) Math.round(width),
+                (int) Math.round(height)));
+        CTSlideSize slideSize = show.getCTPresentation().getSldSz();
+        slideSize.setCx(Units.toEMU(width));
+        slideSize.setCy(Units.toEMU(height));
+
+        int pageCount = Math.max(totalPages, 1);
+        List<XSLFSlide> created = new ArrayList<>(pageCount);
+        for (int pageIndex = 0; pageIndex < pageCount; pageIndex++) {
+            created.add(show.createSlide());
+        }
+        this.slides = List.copyOf(created);
+    }
+
+    XSLFSlide slide(int pageIndex) {
+        if (pageIndex < 0 || pageIndex >= slides.size()) {
+            throw new IllegalArgumentException(
+                    "Page index " + pageIndex + " is outside the render session.");
+        }
+        return slides.get(pageIndex);
+    }
+}

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxCapabilityNotes.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxCapabilityNotes.java
@@ -1,0 +1,46 @@
+package com.demcha.compose.document.backend.fixed.pptx.handlers;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * One-time capability warnings for PPTX features that render with a documented
+ * deviation, so a large document logs each deviation once instead of once per
+ * fragment — the same convention the DOCX semantic backend uses for its
+ * clip/transform fallbacks.
+ */
+final class PptxCapabilityNotes {
+
+    private static final Logger LOG = LoggerFactory.getLogger("com.demcha.compose.engine.render");
+    private static final Set<String> WARNED = ConcurrentHashMap.newKeySet();
+
+    private PptxCapabilityNotes() {
+    }
+
+    static void numericDashApproximated() {
+        warnOnce("dash",
+                "numeric dash patterns map to the generic dashed preset — DrawingML dashes are "
+                + "percent-of-line-width presets, not point arrays");
+    }
+
+    static void perCornerRadiiApproximated() {
+        warnOnce("corner-radii",
+                "distinct per-corner radii render with the top-left radius on all four corners — "
+                + "the PPTX roundRect preset carries a single adjust value");
+    }
+
+    static void gradientApproximated() {
+        warnOnce("gradient",
+                "gradient fills render as the gradient's primary color until DrawingML gradient "
+                + "support lands");
+    }
+
+    private static void warnOnce(String key, String message) {
+        if (WARNED.add(key)) {
+            LOG.warn("render.pptx.capability {}", message);
+        }
+    }
+}

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxEllipseFragmentRenderHandler.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxEllipseFragmentRenderHandler.java
@@ -1,0 +1,48 @@
+package com.demcha.compose.document.backend.fixed.pptx.handlers;
+
+import com.demcha.compose.document.backend.fixed.pptx.PptxCoordinates;
+import com.demcha.compose.document.backend.fixed.pptx.PptxFragmentRenderHandler;
+import com.demcha.compose.document.backend.fixed.pptx.PptxRenderEnvironment;
+import com.demcha.compose.document.layout.PlacedFragment;
+import com.demcha.compose.document.layout.payloads.EllipseFragmentPayload;
+import org.apache.poi.sl.usermodel.ShapeType;
+import org.apache.poi.xslf.usermodel.XSLFAutoShape;
+
+/**
+ * Renders fixed ellipse and circle fragments as the native {@code ellipse}
+ * preset inscribed in the fragment box — the same geometry the PDF handler
+ * builds from four Bézier arcs.
+ *
+ * @since 2.1.0
+ */
+public final class PptxEllipseFragmentRenderHandler
+        implements PptxFragmentRenderHandler<EllipseFragmentPayload> {
+
+    /**
+     * Creates the ellipse fragment renderer.
+     */
+    public PptxEllipseFragmentRenderHandler() {
+    }
+
+    @Override
+    public Class<EllipseFragmentPayload> payloadType() {
+        return EllipseFragmentPayload.class;
+    }
+
+    @Override
+    public void render(PlacedFragment fragment,
+                       EllipseFragmentPayload payload,
+                       PptxRenderEnvironment environment) {
+        if (fragment.width() <= 0 || fragment.height() <= 0) {
+            return;
+        }
+        if (payload.fillColor() == null && !PptxShapeStyle.drawable(payload.stroke())) {
+            return;
+        }
+        XSLFAutoShape shape = environment.slide(fragment.pageIndex()).createAutoShape();
+        shape.setShapeType(ShapeType.ELLIPSE);
+        shape.setAnchor(PptxCoordinates.anchorOf(environment.canvasHeight(), fragment));
+        PptxShapeStyle.applyFill(shape, payload.fillColor());
+        PptxShapeStyle.applyStroke(shape, payload.stroke());
+    }
+}

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxLineFragmentRenderHandler.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxLineFragmentRenderHandler.java
@@ -1,0 +1,69 @@
+package com.demcha.compose.document.backend.fixed.pptx.handlers;
+
+import com.demcha.compose.document.backend.fixed.pptx.PptxCoordinates;
+import com.demcha.compose.document.backend.fixed.pptx.PptxFragmentRenderHandler;
+import com.demcha.compose.document.backend.fixed.pptx.PptxRenderEnvironment;
+import com.demcha.compose.document.layout.PlacedFragment;
+import com.demcha.compose.document.layout.payloads.LineFragmentPayload;
+import com.demcha.compose.engine.components.content.shape.Stroke;
+import org.apache.poi.sl.usermodel.ShapeType;
+import org.apache.poi.xslf.usermodel.XSLFConnectorShape;
+
+import java.awt.geom.Rectangle2D;
+
+/**
+ * Renders fixed line fragments as native line connector shapes.
+ *
+ * <p>The payload carries start/end offsets inside the fragment box in the
+ * engine's y-up space; both endpoints flip into slide space and the connector
+ * anchors on their bounding box. The {@code line} preset draws from the
+ * anchor's top-left to bottom-right, so an ascending segment sets the
+ * vertical flip instead of relying on coordinate order.</p>
+ *
+ * @since 2.1.0
+ */
+public final class PptxLineFragmentRenderHandler
+        implements PptxFragmentRenderHandler<LineFragmentPayload> {
+
+    /**
+     * Creates the line fragment renderer.
+     */
+    public PptxLineFragmentRenderHandler() {
+    }
+
+    @Override
+    public Class<LineFragmentPayload> payloadType() {
+        return LineFragmentPayload.class;
+    }
+
+    @Override
+    public void render(PlacedFragment fragment,
+                       LineFragmentPayload payload,
+                       PptxRenderEnvironment environment) {
+        Stroke stroke = payload.stroke();
+        if (!PptxShapeStyle.drawable(stroke)) {
+            return;
+        }
+
+        double canvasHeight = environment.canvasHeight();
+        double x1 = fragment.x() + payload.startX();
+        double y1 = PptxCoordinates.flipPoint(canvasHeight, fragment.y() + payload.startY());
+        double x2 = fragment.x() + payload.endX();
+        double y2 = PptxCoordinates.flipPoint(canvasHeight, fragment.y() + payload.endY());
+
+        XSLFConnectorShape line = environment.slide(fragment.pageIndex()).createConnector();
+        line.setShapeType(ShapeType.LINE);
+        line.setAnchor(new Rectangle2D.Double(
+                Math.min(x1, x2),
+                Math.min(y1, y2),
+                Math.abs(x2 - x1),
+                Math.abs(y2 - y1)));
+        // The preset always draws top-left → bottom-right inside the anchor;
+        // flip vertically when the segment ascends left-to-right.
+        line.setFlipVertical((x2 - x1) * (y2 - y1) < 0);
+        line.setLineColor(stroke.strokeColor().color());
+        line.setLineWidth(stroke.width());
+        PptxShapeStyle.applyLineCap(line, payload.lineCap());
+        PptxShapeStyle.applyDashPattern(line, payload.dashPattern());
+    }
+}

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxShapeFragmentRenderHandler.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxShapeFragmentRenderHandler.java
@@ -1,0 +1,154 @@
+package com.demcha.compose.document.backend.fixed.pptx.handlers;
+
+import com.demcha.compose.document.backend.fixed.pptx.PptxCoordinates;
+import com.demcha.compose.document.backend.fixed.pptx.PptxFragmentRenderHandler;
+import com.demcha.compose.document.backend.fixed.pptx.PptxRenderEnvironment;
+import com.demcha.compose.document.layout.PlacedFragment;
+import com.demcha.compose.document.layout.payloads.ShapeFragmentPayload;
+import com.demcha.compose.document.style.DocumentCornerRadius;
+import com.demcha.compose.engine.components.content.shape.Stroke;
+import org.apache.poi.sl.usermodel.ShapeType;
+import org.apache.poi.xslf.usermodel.XSLFAutoShape;
+import org.apache.poi.xslf.usermodel.XSLFConnectorShape;
+import org.apache.poi.xslf.usermodel.XSLFSlide;
+import org.openxmlformats.schemas.drawingml.x2006.main.CTGeomGuide;
+import org.openxmlformats.schemas.drawingml.x2006.main.CTGeomGuideList;
+import org.openxmlformats.schemas.drawingml.x2006.main.CTPresetGeometry2D;
+import org.openxmlformats.schemas.presentationml.x2006.main.CTShape;
+
+import java.awt.geom.Rectangle2D;
+
+/**
+ * Renders fixed rectangle-like shape fragments as native PPTX shapes.
+ *
+ * <p>Sharp and uniformly-rounded rectangles use the {@code rect} /
+ * {@code roundRect} presets (the roundRect adjust value expresses the radius
+ * as a fraction of the smaller side, matching the PDF handler's clamp to half
+ * the smaller side). Distinct per-corner radii cannot be expressed by the
+ * single-adjust preset and render with the top-left radius on all corners
+ * until the custom-geometry path support lands. Per-side borders draw as four
+ * separate line shapes, exactly like the PDF handler draws four separate
+ * strokes. Gradient fills are not implemented yet and fall back to the
+ * gradient's primary color via {@link ShapeFragmentPayload}'s documented
+ * fallback.</p>
+ *
+ * @since 2.1.0
+ */
+public final class PptxShapeFragmentRenderHandler
+        implements PptxFragmentRenderHandler<ShapeFragmentPayload> {
+
+    /**
+     * Creates the shape fragment renderer.
+     */
+    public PptxShapeFragmentRenderHandler() {
+    }
+
+    @Override
+    public Class<ShapeFragmentPayload> payloadType() {
+        return ShapeFragmentPayload.class;
+    }
+
+    @Override
+    public void render(PlacedFragment fragment,
+                       ShapeFragmentPayload payload,
+                       PptxRenderEnvironment environment) {
+        if (fragment.width() <= 0 || fragment.height() <= 0) {
+            return;
+        }
+
+        boolean hasFill = payload.fillColor() != null || payload.fillPaint() != null;
+        boolean hasStroke = PptxShapeStyle.drawable(payload.stroke());
+        boolean hasSideBorders = payload.sideBorders() != null && payload.sideBorders().hasAny();
+        if (!hasFill && !hasStroke && !hasSideBorders) {
+            return;
+        }
+
+        XSLFSlide slide = environment.slide(fragment.pageIndex());
+        Rectangle2D.Double anchor = PptxCoordinates.anchorOf(environment.canvasHeight(), fragment);
+
+        if (hasFill || (hasStroke && !hasSideBorders)) {
+            XSLFAutoShape shape = slide.createAutoShape();
+            double radius = uniformRadius(payload.cornerRadius(), anchor.width, anchor.height);
+            if (radius > 0) {
+                shape.setShapeType(ShapeType.ROUND_RECT);
+                applyRoundRectAdjust(shape, radius, Math.min(anchor.width, anchor.height));
+            } else {
+                shape.setShapeType(ShapeType.RECT);
+            }
+            shape.setAnchor(anchor);
+            // Solid paints are pre-normalised to fillColor; a non-null fillPaint is
+            // always a gradient, drawn as its primary color until gradient fills land.
+            if (payload.fillPaint() != null) {
+                PptxCapabilityNotes.gradientApproximated();
+            }
+            java.awt.Color fill = payload.fillColor() != null
+                    ? payload.fillColor()
+                    : (payload.fillPaint() != null ? payload.fillPaint().primaryColor().color() : null);
+            PptxShapeStyle.applyFill(shape, fill);
+            PptxShapeStyle.applyStroke(shape, hasSideBorders ? null : payload.stroke());
+        }
+
+        if (hasSideBorders) {
+            double top = anchor.y;
+            double bottom = anchor.y + anchor.height;
+            double left = anchor.x;
+            double right = anchor.x + anchor.width;
+            drawSideBorder(slide, payload.sideBorders().top(), left, top, right, top);
+            drawSideBorder(slide, payload.sideBorders().right(), right, top, right, bottom);
+            drawSideBorder(slide, payload.sideBorders().bottom(), left, bottom, right, bottom);
+            drawSideBorder(slide, payload.sideBorders().left(), left, top, left, bottom);
+        }
+    }
+
+    private static double uniformRadius(DocumentCornerRadius radii, double width, double height) {
+        double maxRadius = Math.min(width, height) / 2.0;
+        double topLeft = clamp(radii.topLeft(), maxRadius);
+        double topRight = clamp(radii.topRight(), maxRadius);
+        double bottomRight = clamp(radii.bottomRight(), maxRadius);
+        double bottomLeft = clamp(radii.bottomLeft(), maxRadius);
+        boolean uniform = topLeft == topRight && topRight == bottomRight && bottomRight == bottomLeft;
+        if (!uniform) {
+            PptxCapabilityNotes.perCornerRadiiApproximated();
+        }
+        return topLeft;
+    }
+
+    private static double clamp(double raw, double maxAllowed) {
+        if (raw <= 0.0 || Double.isNaN(raw)) {
+            return 0.0;
+        }
+        return Math.min(raw, maxAllowed);
+    }
+
+    /**
+     * Stamps the roundRect {@code adj} guide: the radius as a fraction of the
+     * smaller side, in DrawingML's 1/100000 units, capped at the preset's
+     * half-side maximum of 50000.
+     */
+    private static void applyRoundRectAdjust(XSLFAutoShape shape, double radius, double smallerSide) {
+        long adj = Math.round(radius / smallerSide * 100000.0);
+        adj = Math.max(0, Math.min(adj, 50000));
+        CTPresetGeometry2D geometry = ((CTShape) shape.getXmlObject()).getSpPr().getPrstGeom();
+        CTGeomGuideList adjustValues = geometry.isSetAvLst() ? geometry.getAvLst() : geometry.addNewAvLst();
+        CTGeomGuide guide = adjustValues.addNewGd();
+        guide.setName("adj");
+        guide.setFmla("val " + adj);
+    }
+
+    private static void drawSideBorder(XSLFSlide slide,
+                                       Stroke side,
+                                       double x1, double y1, double x2, double y2) {
+        if (!PptxShapeStyle.drawable(side)) {
+            return;
+        }
+        XSLFConnectorShape line = slide.createConnector();
+        line.setShapeType(ShapeType.LINE);
+        line.setAnchor(new Rectangle2D.Double(
+                Math.min(x1, x2),
+                Math.min(y1, y2),
+                Math.abs(x2 - x1),
+                Math.abs(y2 - y1)));
+        line.setLineColor(side.strokeColor().color());
+        line.setLineWidth(side.width());
+    }
+}

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxShapeStyle.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxShapeStyle.java
@@ -1,0 +1,74 @@
+package com.demcha.compose.document.backend.fixed.pptx.handlers;
+
+import com.demcha.compose.document.style.DocumentDashPattern;
+import com.demcha.compose.document.style.DocumentLineCap;
+import com.demcha.compose.engine.components.content.shape.Stroke;
+import org.apache.poi.sl.usermodel.StrokeStyle.LineCap;
+import org.apache.poi.sl.usermodel.StrokeStyle.LineDash;
+import org.apache.poi.xslf.usermodel.XSLFSimpleShape;
+
+import java.awt.Color;
+
+/**
+ * Shared fill/stroke application for the PPTX fragment handlers, mirroring the
+ * role {@code PdfShapeGeometry} plays for the PDF handlers: one place mapping
+ * the engine's style values onto POI shape properties.
+ */
+final class PptxShapeStyle {
+
+    private PptxShapeStyle() {
+    }
+
+    /**
+     * Applies a solid fill; {@code null} writes an explicit {@code noFill}
+     * (POI's default fill would otherwise paint theme blue).
+     */
+    static void applyFill(XSLFSimpleShape shape, Color fillColor) {
+        shape.setFillColor(fillColor);
+    }
+
+    /**
+     * Applies a uniform stroke, or removes the outline when the stroke carries
+     * no drawable color/width.
+     */
+    static void applyStroke(XSLFSimpleShape shape, Stroke stroke) {
+        if (!drawable(stroke)) {
+            shape.setLineColor(null);
+            return;
+        }
+        shape.setLineColor(stroke.strokeColor().color());
+        shape.setLineWidth(stroke.width());
+    }
+
+    static boolean drawable(Stroke stroke) {
+        return stroke != null
+                && stroke.strokeColor() != null
+                && stroke.strokeColor().color() != null
+                && stroke.width() > 0;
+    }
+
+    static void applyLineCap(XSLFSimpleShape shape, DocumentLineCap cap) {
+        if (cap == null) {
+            return;
+        }
+        shape.setLineCap(switch (cap) {
+            case BUTT -> LineCap.FLAT;
+            case ROUND -> LineCap.ROUND;
+            case SQUARE -> LineCap.SQUARE;
+        });
+    }
+
+    /**
+     * Applies a dash pattern. DrawingML dashes are percent-of-line-width
+     * presets rather than point arrays, so a non-solid pattern maps to the
+     * generic dashed preset for now; the exact numeric mapping belongs to the
+     * custom-geometry work that also brings free paths.
+     */
+    static void applyDashPattern(XSLFSimpleShape shape, DocumentDashPattern pattern) {
+        if (pattern == null || pattern.isSolid()) {
+            return;
+        }
+        PptxCapabilityNotes.numericDashApproximated();
+        shape.setLineDash(LineDash.DASH);
+    }
+}

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/package-info.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/package-info.java
@@ -1,0 +1,9 @@
+/**
+ * Fragment render handlers for the fixed-layout PPTX backend: one small,
+ * stateless handler per payload type, dispatched by
+ * {@link com.demcha.compose.document.backend.fixed.pptx.PptxFixedLayoutBackend}
+ * in graph order — the PPTX twin of the PDF backend's handler package.
+ *
+ * @since 2.1.0
+ */
+package com.demcha.compose.document.backend.fixed.pptx.handlers;

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/package-info.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/package-info.java
@@ -1,0 +1,11 @@
+/**
+ * Coordinate-exact PPTX render backend consuming the resolved
+ * {@link com.demcha.compose.document.layout.LayoutGraph} — the fixed-layout
+ * twin of the PDF backend, sharing identical geometry by construction. The
+ * only place Apache POI slide-show lifecycle is allowed in the backend
+ * package tree; drawing itself lives in the
+ * {@code document.backend.fixed.pptx.handlers} package.
+ *
+ * @since 2.1.0
+ */
+package com.demcha.compose.document.backend.fixed.pptx;

--- a/render-pptx/src/main/resources/META-INF/services/com.demcha.compose.document.backend.fixed.FixedLayoutBackendProvider
+++ b/render-pptx/src/main/resources/META-INF/services/com.demcha.compose.document.backend.fixed.FixedLayoutBackendProvider
@@ -1,0 +1,1 @@
+com.demcha.compose.document.backend.fixed.pptx.PptxFixedLayoutBackendProvider

--- a/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/GraphCapturingBackend.java
+++ b/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/GraphCapturingBackend.java
@@ -1,0 +1,23 @@
+package com.demcha.compose.document.backend.fixed.pptx;
+
+import com.demcha.compose.document.backend.fixed.FixedLayoutBackend;
+import com.demcha.compose.document.backend.fixed.FixedLayoutRenderContext;
+import com.demcha.compose.document.layout.LayoutGraph;
+
+/**
+ * Test backend that returns the resolved {@link LayoutGraph} instead of
+ * rendering it — the geometry tests compare the PPTX output against exactly
+ * the graph the backend consumed, with no snapshot indirection.
+ */
+final class GraphCapturingBackend implements FixedLayoutBackend<LayoutGraph> {
+
+    @Override
+    public String name() {
+        return "graph-capture";
+    }
+
+    @Override
+    public LayoutGraph render(LayoutGraph graph, FixedLayoutRenderContext context) {
+        return graph;
+    }
+}

--- a/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxCoordinatesTest.java
+++ b/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxCoordinatesTest.java
@@ -1,0 +1,34 @@
+package com.demcha.compose.document.backend.fixed.pptx;
+
+import com.demcha.compose.document.layout.PlacedFragment;
+import org.junit.jupiter.api.Test;
+
+import java.awt.geom.Rectangle2D;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The y-flip contract: fragments arrive bottom-left-anchored with y growing
+ * up; anchors leave top-left-anchored with y growing down.
+ */
+class PptxCoordinatesTest {
+
+    @Test
+    void flipsABottomLeftBoxIntoTopDownSlideSpace() {
+        // A 100×50 box whose bottom edge sits 120pt above the page bottom on
+        // a 300pt-tall page has its top edge 130pt below the slide top.
+        assertThat(PptxCoordinates.topY(300, 120, 50)).isEqualTo(130.0);
+        assertThat(PptxCoordinates.flipPoint(300, 120)).isEqualTo(180.0);
+    }
+
+    @Test
+    void anchorPreservesXAndSizeAndFlipsY() {
+        PlacedFragment fragment = new PlacedFragment(
+                "root/shape", 0, 0, 40, 120, 100, 50, null, null, null);
+        Rectangle2D.Double anchor = PptxCoordinates.anchorOf(300, fragment);
+        assertThat(anchor.x).isEqualTo(40.0);
+        assertThat(anchor.y).isEqualTo(130.0);
+        assertThat(anchor.width).isEqualTo(100.0);
+        assertThat(anchor.height).isEqualTo(50.0);
+    }
+}

--- a/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxFixedLayoutBackendTest.java
+++ b/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxFixedLayoutBackendTest.java
@@ -1,0 +1,159 @@
+package com.demcha.compose.document.backend.fixed.pptx;
+
+import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.api.DocumentSession;
+import com.demcha.compose.document.dsl.DocumentDsl;
+import com.demcha.compose.document.dsl.EllipseBuilder;
+import com.demcha.compose.document.dsl.LineBuilder;
+import com.demcha.compose.document.exceptions.UnsupportedNodeCapabilityException;
+import com.demcha.compose.document.layout.LayoutGraph;
+import com.demcha.compose.document.backend.fixed.FixedLayoutRenderContext;
+import com.demcha.compose.document.node.PageBreakNode;
+import com.demcha.compose.document.style.DocumentColor;
+import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.document.style.DocumentLineCap;
+import com.demcha.compose.document.style.DocumentStroke;
+import org.apache.poi.sl.usermodel.StrokeStyle;
+import org.apache.poi.xslf.usermodel.XMLSlideShow;
+import org.apache.poi.xslf.usermodel.XSLFAutoShape;
+import org.apache.poi.xslf.usermodel.XSLFConnectorShape;
+import org.junit.jupiter.api.Test;
+import org.openxmlformats.schemas.presentationml.x2006.main.CTShape;
+
+import java.awt.Color;
+import java.io.ByteArrayInputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * End-to-end geometry identity for the first vector payload slice: the same
+ * resolved {@link LayoutGraph} renders to a .pptx whose shape anchors sit
+ * exactly on the fragment boxes, across a page break, with fills, strokes,
+ * corner radii, and line orientation surviving a POI round-trip.
+ */
+class PptxFixedLayoutBackendTest {
+
+    private static DocumentSession composeVectorDocument() {
+        DocumentSession session = GraphCompose.document()
+                .pageSize(400, 300)
+                .margin(DocumentInsets.of(20))
+                .create();
+        DocumentDsl dsl = session.dsl();
+        session.add(dsl.shape().name("Card").size(160, 60)
+                .fillColor(DocumentColor.ROYAL_BLUE)
+                .stroke(DocumentStroke.of(DocumentColor.BLACK, 2))
+                .cornerRadius(8)
+                .build());
+        session.add(dsl.shape().name("Plain").size(120, 40)
+                .fillColor(DocumentColor.ORANGE)
+                .build());
+        session.add(new EllipseBuilder().name("Dot").circle(30)
+                .fillColor(DocumentColor.DARK_GRAY)
+                .build());
+        session.add(new LineBuilder().name("Rule").horizontal(200)
+                .color(DocumentColor.GRAY)
+                .thickness(2)
+                .build());
+        session.add(new PageBreakNode("Break", DocumentInsets.zero()));
+        session.add(dsl.shape().name("SecondPage").size(80, 80)
+                .stroke(DocumentStroke.of(DocumentColor.DARK_GRAY, 1.5))
+                .build());
+        return session;
+    }
+
+    @Test
+    void rendersVectorFragmentsAtTheExactGraphCoordinates() throws Exception {
+        try (DocumentSession session = composeVectorDocument()) {
+            LayoutGraph graph = session.render(new GraphCapturingBackend());
+            byte[] pptx = session.render(new PptxFixedLayoutBackend());
+
+            assertThat(graph.totalPages()).isEqualTo(2);
+            PptxGeometryAssertions.assertGeometryMatches(graph, pptx);
+        }
+    }
+
+    @Test
+    void fillAndStrokeSurviveThePoiRoundTrip() throws Exception {
+        try (DocumentSession session = composeVectorDocument()) {
+            byte[] pptx = session.render(new PptxFixedLayoutBackend());
+            try (XMLSlideShow show = new XMLSlideShow(new ByteArrayInputStream(pptx))) {
+                XSLFAutoShape card = (XSLFAutoShape) show.getSlides().get(0).getShapes().get(0);
+                assertThat(card.getFillColor())
+                        .isEqualTo(DocumentColor.ROYAL_BLUE.color());
+                assertThat(card.getLineColor()).isEqualTo(Color.BLACK);
+                assertThat(card.getLineWidth()).isEqualTo(2.0);
+
+                XSLFAutoShape outlineOnly = (XSLFAutoShape) show.getSlides().get(1).getShapes().get(0);
+                assertThat(outlineOnly.getFillColor()).isNull();
+                assertThat(outlineOnly.getLineWidth()).isEqualTo(1.5);
+
+                // Card is 160×60 with radius 8: the roundRect adjust value is the
+                // radius as a fraction of the smaller side — 8/60 in 1/100000 units.
+                CTShape cardXml = (CTShape) card.getXmlObject();
+                assertThat(cardXml.getSpPr().getPrstGeom().getAvLst().getGdArray(0).getFmla())
+                        .isEqualTo("val 13333");
+            }
+        }
+    }
+
+    @Test
+    void diagonalLinesCarryOppositeVerticalFlips() throws Exception {
+        try (DocumentSession session = GraphCompose.document()
+                .pageSize(300, 300)
+                .margin(DocumentInsets.of(20))
+                .create()) {
+            session.add(new LineBuilder().name("Descending").diagonal(120, 60)
+                    .color(DocumentColor.BLACK).thickness(2)
+                    .build());
+            session.add(new LineBuilder().name("Ascending").size(120, 60).from(0, 60).to(120, 0)
+                    .color(DocumentColor.BLACK).thickness(2)
+                    .dashed(4, 2).lineCap(DocumentLineCap.ROUND)
+                    .build());
+            byte[] pptx = session.render(new PptxFixedLayoutBackend());
+            try (XMLSlideShow show = new XMLSlideShow(new ByteArrayInputStream(pptx))) {
+                XSLFConnectorShape first = (XSLFConnectorShape) show.getSlides().get(0).getShapes().get(0);
+                XSLFConnectorShape second = (XSLFConnectorShape) show.getSlides().get(0).getShapes().get(1);
+                assertThat(first.getFlipVertical())
+                        .as("opposite slopes must carry opposite flips")
+                        .isNotEqualTo(second.getFlipVertical());
+                assertThat(second.getLineDash()).isEqualTo(StrokeStyle.LineDash.DASH);
+                assertThat(second.getLineCap()).isEqualTo(StrokeStyle.LineCap.ROUND);
+            }
+        }
+    }
+
+    @Test
+    void writeStreamsAValidDocumentAndLeavesTheStreamOpen() throws Exception {
+        try (DocumentSession session = composeVectorDocument()) {
+            LayoutGraph graph = session.render(new GraphCapturingBackend());
+            class ProbeStream extends java.io.ByteArrayOutputStream {
+                boolean closed;
+
+                @Override
+                public void close() {
+                    closed = true;
+                }
+            }
+            ProbeStream output = new ProbeStream();
+            new PptxFixedLayoutBackend().write(graph,
+                    new FixedLayoutRenderContext(graph.canvas(), java.util.List.of(), null, output));
+            assertThat(output.closed).as("caller-owned stream must stay open").isFalse();
+            try (XMLSlideShow show = new XMLSlideShow(new ByteArrayInputStream(output.toByteArray()))) {
+                assertThat(show.getSlides()).hasSize(2);
+            }
+        }
+    }
+
+    @Test
+    void unsupportedPayloadFailsWithACapabilityError() {
+        try (DocumentSession session = GraphCompose.document()
+                .pageSize(300, 200)
+                .create()) {
+            session.pageFlow(page -> page.module("m", module -> module.paragraph("text")));
+            assertThatThrownBy(() -> session.render(new PptxFixedLayoutBackend()))
+                    .isInstanceOf(UnsupportedNodeCapabilityException.class)
+                    .hasMessageContaining("ParagraphFragmentPayload");
+        }
+    }
+}

--- a/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxGeometryAssertions.java
+++ b/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxGeometryAssertions.java
@@ -1,0 +1,119 @@
+package com.demcha.compose.document.backend.fixed.pptx;
+
+import com.demcha.compose.document.layout.LayoutGraph;
+import com.demcha.compose.document.layout.PlacedFragment;
+import com.demcha.compose.document.layout.payloads.EllipseFragmentPayload;
+import com.demcha.compose.document.layout.payloads.LineFragmentPayload;
+import com.demcha.compose.document.layout.payloads.ShapeFragmentPayload;
+import org.apache.poi.util.Units;
+import org.apache.poi.xslf.usermodel.XMLSlideShow;
+import org.apache.poi.xslf.usermodel.XSLFShape;
+import org.apache.poi.xslf.usermodel.XSLFSlide;
+
+import java.awt.geom.Rectangle2D;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Geometry-identity assertions for the fixed-layout PPTX backend: reopens the
+ * emitted bytes with POI and checks every shape anchor against the resolved
+ * {@link LayoutGraph} the backend consumed. Expected anchors are re-derived
+ * here from payload semantics (independently of the handlers), so a handler
+ * mapping bug cannot cancel itself out in the comparison.
+ */
+final class PptxGeometryAssertions {
+
+    /** Anchor tolerance in points — well under half a point. */
+    static final double EPSILON_PT = 0.5;
+
+    private PptxGeometryAssertions() {
+    }
+
+    static void assertGeometryMatches(LayoutGraph graph, byte[] pptxBytes) throws IOException {
+        try (XMLSlideShow show = new XMLSlideShow(new ByteArrayInputStream(pptxBytes))) {
+            assertThat(show.getSlides()).hasSize(Math.max(graph.totalPages(), 1));
+
+            long expectedCx = Units.toEMU(graph.canvas().width());
+            long expectedCy = Units.toEMU(graph.canvas().height());
+            assertThat(show.getCTPresentation().getSldSz().getCx()).isEqualTo((int) expectedCx);
+            assertThat(show.getCTPresentation().getSldSz().getCy()).isEqualTo((int) expectedCy);
+
+            Map<Integer, List<Rectangle2D.Double>> expectedByPage = expectedAnchors(graph);
+            assertThat(expectedByPage)
+                    .as("the graph must contain drawable fragments — an empty expectation set proves nothing")
+                    .isNotEmpty();
+            for (int pageIndex = 0; pageIndex < show.getSlides().size(); pageIndex++) {
+                List<Rectangle2D.Double> expected =
+                        expectedByPage.getOrDefault(pageIndex, List.of());
+                XSLFSlide slide = show.getSlides().get(pageIndex);
+                List<XSLFShape> shapes = slide.getShapes();
+                assertThat(shapes)
+                        .as("slide %d shape count", pageIndex)
+                        .hasSize(expected.size());
+                for (int i = 0; i < expected.size(); i++) {
+                    Rectangle2D actual = shapes.get(i).getAnchor();
+                    Rectangle2D.Double want = expected.get(i);
+                    assertThat(actual.getX()).as("slide %d shape %d x", pageIndex, i)
+                            .isCloseTo(want.x, org.assertj.core.data.Offset.offset(EPSILON_PT));
+                    assertThat(actual.getY()).as("slide %d shape %d y", pageIndex, i)
+                            .isCloseTo(want.y, org.assertj.core.data.Offset.offset(EPSILON_PT));
+                    assertThat(actual.getWidth()).as("slide %d shape %d width", pageIndex, i)
+                            .isCloseTo(want.width, org.assertj.core.data.Offset.offset(EPSILON_PT));
+                    assertThat(actual.getHeight()).as("slide %d shape %d height", pageIndex, i)
+                            .isCloseTo(want.height, org.assertj.core.data.Offset.offset(EPSILON_PT));
+                }
+            }
+        }
+    }
+
+    /**
+     * Re-derives the expected shape anchors per page, in fragment order:
+     * shape/ellipse anchors are the fragment box flipped into top-down space;
+     * a line's anchor is the bounding box of its two flipped endpoints.
+     */
+    private static Map<Integer, List<Rectangle2D.Double>> expectedAnchors(LayoutGraph graph) {
+        double canvasHeight = graph.canvas().height();
+        Map<Integer, List<Rectangle2D.Double>> byPage = new TreeMap<>();
+        for (PlacedFragment fragment : graph.fragments()) {
+            Object payload = fragment.payload();
+            Rectangle2D.Double anchor = null;
+            if (payload instanceof ShapeFragmentPayload || payload instanceof EllipseFragmentPayload) {
+                anchor = boxAnchor(canvasHeight, fragment);
+            } else if (payload instanceof LineFragmentPayload line) {
+                anchor = lineAnchor(canvasHeight, fragment, line);
+            }
+            if (anchor != null) {
+                byPage.computeIfAbsent(fragment.pageIndex(), ignored -> new ArrayList<>()).add(anchor);
+            }
+        }
+        return byPage;
+    }
+
+    private static Rectangle2D.Double boxAnchor(double canvasHeight, PlacedFragment fragment) {
+        return new Rectangle2D.Double(
+                fragment.x(),
+                canvasHeight - fragment.y() - fragment.height(),
+                fragment.width(),
+                fragment.height());
+    }
+
+    private static Rectangle2D.Double lineAnchor(double canvasHeight,
+                                                 PlacedFragment fragment,
+                                                 LineFragmentPayload line) {
+        double x1 = fragment.x() + line.startX();
+        double y1 = canvasHeight - (fragment.y() + line.startY());
+        double x2 = fragment.x() + line.endX();
+        double y2 = canvasHeight - (fragment.y() + line.endY());
+        return new Rectangle2D.Double(
+                Math.min(x1, x2),
+                Math.min(y1, y2),
+                Math.abs(x2 - x1),
+                Math.abs(y2 - y1));
+    }
+}

--- a/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxParityDemoTest.java
+++ b/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxParityDemoTest.java
@@ -1,0 +1,120 @@
+package com.demcha.compose.document.backend.fixed.pptx;
+
+import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.api.DocumentSession;
+import com.demcha.compose.document.dsl.DocumentDsl;
+import com.demcha.compose.document.dsl.EllipseBuilder;
+import com.demcha.compose.document.dsl.LineBuilder;
+import com.demcha.compose.document.style.DocumentColor;
+import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.document.style.DocumentStroke;
+import org.apache.poi.xslf.usermodel.XMLSlideShow;
+import org.apache.poi.xslf.usermodel.XSLFSlide;
+import org.junit.jupiter.api.Test;
+
+import javax.imageio.ImageIO;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Produces the reviewable side-by-side parity artifacts for the vector
+ * capabilities: the same session rendered to {@code demo.pdf} and
+ * {@code demo.pptx} under {@code target/visual-tests/pptx-parity/}, plus a
+ * PNG per page from each format at matching scale. The PDF raster is exact;
+ * the PPTX raster uses POI's Graphics2D drawing (a preview, not PowerPoint's
+ * renderer) — good for geometry inspection, approximate for text shaping.
+ */
+class PptxParityDemoTest {
+
+    private static final double SCALE = 2.0;
+
+    @Test
+    void writesTheVectorParityDemoPair() throws Exception {
+        Path outputDirectory = Path.of("target", "visual-tests", "pptx-parity", "vector-shapes");
+        Files.createDirectories(outputDirectory);
+
+        try (DocumentSession session = composeDemo()) {
+            byte[] pdf = session.toPdfBytes();
+            Files.write(outputDirectory.resolve("demo.pdf"), pdf);
+
+            byte[] pptx = session.render(new PptxFixedLayoutBackend());
+            Files.write(outputDirectory.resolve("demo.pptx"), pptx);
+
+            List<BufferedImage> pdfPages = session.toImages((int) Math.round(72 * SCALE));
+            for (int i = 0; i < pdfPages.size(); i++) {
+                ImageIO.write(pdfPages.get(i), "png",
+                        outputDirectory.resolve("demo-page-" + (i + 1) + ".pdf.png").toFile());
+            }
+
+            try (XMLSlideShow show = new XMLSlideShow(new ByteArrayInputStream(pptx))) {
+                List<XSLFSlide> slides = show.getSlides();
+                assertThat(slides).hasSameSizeAs(pdfPages);
+                for (int i = 0; i < slides.size(); i++) {
+                    BufferedImage image = rasterize(slides.get(i),
+                            show.getPageSize().width, show.getPageSize().height);
+                    ImageIO.write(image, "png",
+                            outputDirectory.resolve("demo-page-" + (i + 1) + ".pptx.png").toFile());
+                }
+            }
+        }
+    }
+
+    private static DocumentSession composeDemo() {
+        DocumentSession session = GraphCompose.document()
+                .pageSize(400, 300)
+                .margin(DocumentInsets.of(20))
+                .create();
+        DocumentDsl dsl = session.dsl();
+        session.add(dsl.shape().name("HeroCard").size(200, 70)
+                .fillColor(DocumentColor.ROYAL_BLUE)
+                .stroke(DocumentStroke.of(DocumentColor.BLACK, 2))
+                .cornerRadius(10)
+                .build());
+        session.add(dsl.shape().name("AccentBar").size(320, 14)
+                .fillColor(DocumentColor.ORANGE)
+                .build());
+        session.add(new EllipseBuilder().name("Badge").circle(44)
+                .fillColor(DocumentColor.DARK_GRAY)
+                .stroke(DocumentStroke.of(DocumentColor.BLACK, 1))
+                .build());
+        session.add(new LineBuilder().name("Rule").horizontal(320)
+                .color(DocumentColor.GRAY)
+                .thickness(3)
+                .build());
+        session.add(new LineBuilder().name("Descending").diagonal(140, 50)
+                .color(DocumentColor.BLACK)
+                .thickness(2)
+                .build());
+        session.add(new LineBuilder().name("Ascending").size(140, 50).from(0, 50).to(140, 0)
+                .color(DocumentColor.ROYAL_BLUE)
+                .thickness(2)
+                .build());
+        return session;
+    }
+
+    private static BufferedImage rasterize(XSLFSlide slide, int widthPt, int heightPt) {
+        BufferedImage image = new BufferedImage(
+                (int) Math.round(widthPt * SCALE),
+                (int) Math.round(heightPt * SCALE),
+                BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = image.createGraphics();
+        try {
+            graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            graphics.setColor(Color.WHITE);
+            graphics.fillRect(0, 0, image.getWidth(), image.getHeight());
+            graphics.scale(SCALE, SCALE);
+            slide.draw(graphics);
+        } finally {
+            graphics.dispose();
+        }
+        return image;
+    }
+}

--- a/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxProviderResolutionTest.java
+++ b/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxProviderResolutionTest.java
@@ -1,0 +1,38 @@
+package com.demcha.compose.document.backend.fixed.pptx;
+
+import com.demcha.compose.document.backend.fixed.BackendProviders;
+import com.demcha.compose.document.backend.fixed.FixedLayoutBackendProvider;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * ServiceLoader wiring for the PPTX provider, exercised on the first real
+ * two-backend classpath (render-pdf sits in this module's test scope): the
+ * PPTX backend resolves by format while the no-arg default keeps preferring
+ * PDF — the coexistence contract the format-keyed lookup exists for.
+ */
+class PptxProviderResolutionTest {
+
+    @Test
+    void resolvesThePptxProviderByFormat() {
+        FixedLayoutBackendProvider provider = BackendProviders.fixedLayout("pptx");
+        assertThat(provider).isInstanceOf(PptxFixedLayoutBackendProvider.class);
+        assertThat(provider.format()).isEqualTo("pptx");
+        assertThat(BackendProviders.fixedLayout("PPTX")).isSameAs(provider);
+    }
+
+    @Test
+    void theDefaultProviderStaysPdfWithBothBackendsPresent() {
+        assertThat(BackendProviders.fixedLayout().format()).isEqualTo("pdf");
+    }
+
+    @Test
+    void theProviderCreatesAWorkingRenderer() {
+        assertThat(BackendProviders.fixedLayout("pptx")
+                .create(com.demcha.compose.document.output.DocumentOutputOptions.EMPTY,
+                        com.demcha.compose.document.output.DocumentDebugOptions.none())
+                .name())
+                .isEqualTo("pptx-fixed-layout");
+    }
+}

--- a/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxShapeSideBordersTest.java
+++ b/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxShapeSideBordersTest.java
@@ -1,0 +1,56 @@
+package com.demcha.compose.document.backend.fixed.pptx;
+
+import com.demcha.compose.document.backend.fixed.pptx.handlers.PptxShapeFragmentRenderHandler;
+import com.demcha.compose.document.layout.PlacedFragment;
+import com.demcha.compose.document.layout.payloads.ShapeFragmentPayload;
+import com.demcha.compose.document.layout.payloads.SideBorders;
+import com.demcha.compose.document.style.DocumentCornerRadius;
+import com.demcha.compose.engine.components.content.shape.Stroke;
+import org.apache.poi.xslf.usermodel.XMLSlideShow;
+import org.apache.poi.xslf.usermodel.XSLFShape;
+import org.junit.jupiter.api.Test;
+
+import java.awt.Color;
+import java.awt.geom.Rectangle2D;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Per-side borders draw as separate edge lines at the exact flipped edge
+ * coordinates, with no rectangle shape when the payload carries neither fill
+ * nor uniform stroke — the PPTX twin of the PDF handler's side-border pass.
+ */
+class PptxShapeSideBordersTest {
+
+    @Test
+    void topAndBottomBordersDrawAsEdgeLinesWithoutARectangle() throws Exception {
+        try (XMLSlideShow show = new XMLSlideShow()) {
+            PptxRenderSession session = new PptxRenderSession(show, 300, 200, 1);
+            PptxRenderEnvironment environment = new PptxRenderEnvironment(show, session, 0, 200);
+
+            ShapeFragmentPayload payload = new ShapeFragmentPayload(
+                    null, null, DocumentCornerRadius.ZERO, null, null,
+                    new SideBorders(new Stroke(Color.BLACK, 1), null, new Stroke(Color.BLACK, 2), null));
+            // 120×40 box whose bottom edge sits 100pt above the page bottom on a
+            // 200pt page: slide-space top edge = 60, bottom edge = 100.
+            PlacedFragment fragment = new PlacedFragment(
+                    "root/box", 0, 0, 50, 100, 120, 40, null, null, payload);
+
+            new PptxShapeFragmentRenderHandler().render(fragment, payload, environment);
+
+            List<XSLFShape> shapes = show.getSlides().get(0).getShapes();
+            assertThat(shapes).hasSize(2);
+
+            Rectangle2D top = shapes.get(0).getAnchor();
+            assertThat(top.getY()).isEqualTo(60.0);
+            assertThat(top.getX()).isEqualTo(50.0);
+            assertThat(top.getWidth()).isEqualTo(120.0);
+            assertThat(top.getHeight()).isEqualTo(0.0);
+
+            Rectangle2D bottom = shapes.get(1).getAnchor();
+            assertThat(bottom.getY()).isEqualTo(100.0);
+            assertThat(bottom.getWidth()).isEqualTo(120.0);
+        }
+    }
+}


### PR DESCRIPTION
## Why

GraphCompose has exactly one coordinate-exact render backend — PDF. Slide output exists only as the `PptxSemanticBackend` manifest skeleton, which re-validates semantic nodes and writes no file. Since the layout compiler resolves all geometry in core before any backend runs, a PPTX backend that consumes the same `LayoutGraph` gets renders geometrically identical to the PDF page-for-page — without touching the compiler, pagination, or the PDF path.

## What changed

- New package `document.backend.fixed.pptx` in `graph-compose-render-pptx` (which gains `poi-ooxml` 5.5.1, same version as render-docx): `PptxFixedLayoutBackend implements FixedLayoutRenderer` renders one slide per resolved page, stamped with the exact EMU page size (POI's `setPageSize` rounds to whole points; the `CTSlideSize` overwrite keeps A4's fractional width exact).
- `PptxCoordinates` owns the single y-flip from the engine's bottom-left y-up page space into the slide's top-down space (`topY = canvasHeight − y − height`); anchors stay in points and POI converts to EMU, so no precision is lost in our code. It is public because custom handlers need the same mapping.
- Dispatch mirrors the PDF backend: a per-payload-type handler registry (`PptxFragmentRenderHandler`, exact-class lookup + `instanceof` fallback, custom handlers replace defaults via `Builder.addHandler`); unknown payloads throw `UnsupportedNodeCapabilityException` pointing at the capability matrix.
- First capability slice — vector shapes: rectangles (solid fill, stroke, uniform corner radii via the `roundRect` adjust value, per-side borders as separate edge lines, exactly like the PDF handler's four strokes), ellipses (native preset), lines (connector shapes; opposite slopes carry opposite vertical flips since the `line` preset always draws top-left → bottom-right).
- Documented deviations warn once per JVM (`PptxCapabilityNotes`, the DOCX capability-warning convention): distinct per-corner radii render with the top-left radius (single-adjust preset), numeric dash arrays map to the dashed preset (DrawingML dashes are percent-of-line-width presets), gradient fills draw their primary color until DrawingML gradients land.
- `finishRenderedFragment` collects fragment-level link targets and bookmark records generically after every fragment (the PDF backend's pattern), so navigation emission lands later without retrofitting handlers; `PptxRenderEnvironment` documents that the records are collected but not yet emitted.
- `PptxFixedLayoutBackendProvider` (`format() == "pptx"`) registers via `META-INF/services` — the first real two-provider classpath; the no-arg `BackendProviders.fixedLayout()` default stays PDF. `renderToImages` and multi-section rendering throw `UnsupportedOperationException` with pointers.
- Capability matrix cells flip from planned to supported/degraded with the implementing classes named; CHANGELOG `v2.1.0` entry extended.

## Verification

`./mvnw -B -ntp clean verify` (full 10-module reactor gate) → **BUILD SUCCESS**; render-pptx suite grows 1 → **13** tests, all green.

- `PptxFixedLayoutBackendTest` — geometry identity: the same session renders through a graph-capturing backend and the PPTX backend; every reopened `XSLFShape.getAnchor()` matches anchors **re-derived independently from payload semantics** (`PptxGeometryAssertions`, tolerance 0.5 pt), across a page break, plus the roundRect adjust value (`val 13333` for radius 8 on a 60 pt side), opposite vertical flips for opposite line slopes, dash/cap round-trip, and the unsupported-payload diagnostic.
- `PptxShapeSideBordersTest` — side borders draw as edge lines at the exact flipped coordinates, with no rectangle shape when the payload has neither fill nor uniform stroke.
- `PptxProviderResolutionTest` — `fixedLayout("pptx")` resolves case-insensitively while the default stays PDF on the two-backend classpath.
- `PptxParityDemoTest` — writes the reviewable pair `demo.pdf` / `demo.pptx` + per-page PNGs from both formats under `render-pptx/target/visual-tests/pptx-parity/vector-shapes/`; the rasters match visually including diagonal slopes (PPTX raster via POI's `Graphics2D` draw — a preview, not PowerPoint's renderer).
- `PptxCoordinatesTest` — the y-flip contract in isolation.

## Notes

- Text, tables, images, clip/transform markers, chrome, navigation emission, multi-section, and determinism are intentionally out of scope for this slice and arrive incrementally; `docs/architecture/backend-capability-matrix.md` is the live status.
- Geometry identity is guaranteed at the shape-frame level by construction (same `LayoutGraph`, same metrics seam). Glyph-level fidelity in PowerPoint is a later concern — no text renders yet.

**Lane:** canonical (document.backend.fixed.pptx) — new backend surface; engine and PDF path untouched.

Follow-up to #404 (format-keyed backend selection, already merged).
