### PR TITLE
fix(pdf): rasterize embedded fonts correctly in toImages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,16 @@ follow semantic versioning; release dates are ISO 8601.
   with `UnsupportedNodeCapabilityException`; the live per-capability status
   lives in `docs/architecture/backend-capability-matrix.md`.
 
+### Fixed
+
+- `DocumentSession.toImages` / `toImage` rasterized documents that use binary
+  font families (any non-standard-14 file) with substitute glyphs — visually
+  garbled text with correct spacing. PDFBox writes embedded font subsets only
+  during `save()`, so rendering the unsaved in-memory document never saw the
+  real glyph programs. The PDF backend now saves to an in-memory buffer and
+  reloads before rasterizing; standard-14-only documents are unaffected apart
+  from the marginal serialization cost.
+
 ### Documentation
 
 - `docs/architecture/backend-capability-matrix.md` — a per-capability matrix

--- a/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/PdfFixedLayoutBackend.java
+++ b/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/PdfFixedLayoutBackend.java
@@ -27,6 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.awt.image.BufferedImage;
+import org.apache.pdfbox.Loader;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -325,10 +326,13 @@ public final class PdfFixedLayoutBackend implements FixedLayoutRenderer {
 
     /**
      * Renders the document to one rasterized image per page (or a single page
-     * when {@code pageIndex >= 0}). PDF-specific convenience that rasterizes the
-     * in-memory {@link PDDocument} directly via {@link PDFRenderer}, avoiding the
-     * serialize-to-bytes-then-reparse round-trip of {@link #render} +
-     * {@code Loader.loadPDF}.
+     * when {@code pageIndex >= 0}). The document is saved to an in-memory buffer
+     * and reloaded before rasterization: PDFBox writes embedded font subsets only
+     * during {@code save()}, so rendering the unsaved {@link PDDocument} draws
+     * documents that use binary font families (any non-standard-14 file) with
+     * fallback glyphs instead of the embedded program. Standard-14-only documents
+     * pay the extra serialization too — correctness over the marginal copy; the
+     * rasterization itself dominates the cost.
      *
      * @param graph       resolved layout graph
      * @param context     fixed-layout render configuration (output stream/file ignored)
@@ -347,7 +351,13 @@ public final class PdfFixedLayoutBackend implements FixedLayoutRenderer {
                                               int pageIndex) throws Exception {
         Objects.requireNonNull(graph, "graph");
         Objects.requireNonNull(context, "context");
-        try (PDDocument document = buildDocument(graph, context)) {
+        byte[] documentBytes;
+        try (PDDocument document = buildDocument(graph, context);
+             ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
+            document.save(buffer);
+            documentBytes = buffer.toByteArray();
+        }
+        try (PDDocument document = Loader.loadPDF(documentBytes)) {
             PDFRenderer renderer = new PDFRenderer(document);
             ImageType imageType = transparent ? ImageType.ARGB : ImageType.RGB;
             int pageCount = document.getNumberOfPages();

--- a/render-pdf/src/test/java/com/demcha/compose/document/backend/fixed/pdf/PdfRenderToImagesEmbeddedFontTest.java
+++ b/render-pdf/src/test/java/com/demcha/compose/document/backend/fixed/pdf/PdfRenderToImagesEmbeddedFontTest.java
@@ -1,0 +1,73 @@
+package com.demcha.compose.document.backend.fixed.pdf;
+
+import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.api.DocumentSession;
+import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.document.style.DocumentTextStyle;
+import com.demcha.compose.font.FontFamilyDefinition;
+import com.demcha.compose.font.FontName;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.rendering.ImageType;
+import org.apache.pdfbox.rendering.PDFRenderer;
+import org.junit.jupiter.api.Test;
+
+import java.awt.image.BufferedImage;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@code toImages} must rasterize embedded binary fonts with their real glyph
+ * programs. PDFBox writes a {@code PDType0Font} subset only during
+ * {@code save()}, so rendering the unsaved in-memory document falls back to
+ * substitute glyphs — visually garbled text with correct advances. The
+ * backend therefore saves and reloads before rasterizing; this test pins the
+ * contract by comparing {@code toImages} pixels against an independent
+ * save-reload-render of the same session.
+ */
+class PdfRenderToImagesEmbeddedFontTest {
+
+    private static final FontName FONT = FontName.of("RasterLato");
+    private static final FontFamilyDefinition FAMILY = FontFamilyDefinition.classpath(
+                    FONT, "fonts/google/lato/Lato-Regular.ttf")
+            .build();
+
+    @Test
+    void toImagesMatchesTheSaveReloadRenderOfTheSameSession() throws Exception {
+        try (DocumentSession session = GraphCompose.document()
+                .registerFontFamily(FAMILY)
+                .pageSize(400, 120)
+                .margin(DocumentInsets.of(20))
+                .create()) {
+            session.pageFlow().name("Raster")
+                    .addParagraph(p -> p.text("The quick brown fox jumps over the lazy dog")
+                            .textStyle(DocumentTextStyle.builder().fontName(FONT).size(14).build()))
+                    .build();
+
+            List<BufferedImage> images = session.toImages(144);
+            assertThat(images).hasSize(1);
+            BufferedImage viaToImages = images.get(0);
+
+            BufferedImage viaSaveReload;
+            try (PDDocument document = Loader.loadPDF(session.toPdfBytes())) {
+                viaSaveReload = new PDFRenderer(document)
+                        .renderImageWithDPI(0, 144, ImageType.RGB);
+            }
+
+            assertThat(viaToImages.getWidth()).isEqualTo(viaSaveReload.getWidth());
+            assertThat(viaToImages.getHeight()).isEqualTo(viaSaveReload.getHeight());
+            int mismatched = 0;
+            for (int y = 0; y < viaSaveReload.getHeight(); y++) {
+                for (int x = 0; x < viaSaveReload.getWidth(); x++) {
+                    if (viaToImages.getRGB(x, y) != viaSaveReload.getRGB(x, y)) {
+                        mismatched++;
+                    }
+                }
+            }
+            assertThat(mismatched)
+                    .as("toImages raster must match the save-reload raster pixel for pixel")
+                    .isZero();
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Any document that uses a binary font family — the bundled Google fonts or a custom TTF — rasterized through `DocumentSession.toImages` / `toImage` with substitute glyphs: visually garbled text with correct advances. The PDF bytes themselves were always correct (viewers and `Loader.loadPDF`-based rendering show perfect text); only the in-memory rasterization path was wrong. Standard-14-only documents were unaffected, which is why the visual regression suites never caught it.

Root cause: PDFBox writes a `PDType0Font` subset only during `save()`. `renderToImages` deliberately rasterized the freshly built, **unsaved** `PDDocument` to skip the serialize-reload round-trip — so `PDFRenderer` never saw the embedded glyph programs and fell back to substitute fonts, drawing the CID codes as garbage.

## Fix

`PdfFixedLayoutBackend.renderToImages` saves the built document to an in-memory buffer and reloads it before rasterization, so the renderer reads the embedded subsets exactly like an external viewer. The save-reload also runs for standard-14-only documents: the serialization cost is marginal next to rasterization itself, and one always-correct path beats a font-classifying branch. No API change.

## Verification

`./mvnw -B -ntp clean verify` (full 10-module reactor gate) → **BUILD SUCCESS**; existing visual pixel baselines unchanged.

New `PdfRenderToImagesEmbeddedFontTest` pins the contract: `toImages` output must be pixel-identical to an independent `toPdfBytes` → `Loader.loadPDF` → `PDFRenderer` render of the same Lato-based session. It fails with the pre-fix in-memory path.

**Lane:** canonical (document.backend.fixed.pdf) — render path only; layout and PDF bytes untouched.
