### PR TITLE
feat(pptx): text fidelity — paragraphs, chips, inline graphics, font embedding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,20 @@ follow semantic versioning; release dates are ISO 8601.
   `PptxFixedLayoutBackend.Builder#addHandler`). Unsupported payloads fail
   with `UnsupportedNodeCapabilityException`; the live per-capability status
   lives in `docs/architecture/backend-capability-matrix.md`.
+- The fixed PPTX backend renders pre-wrapped paragraph lines as absolute,
+  wrap-disabled, no-autofit text frames with PDF-identical glyph sanitization,
+  standard-14 font-family mapping and rich run styles. External hyperlinks use
+  transparent measured-span hotspots so PowerPoint cannot replace the resolved
+  text colour and decoration with its hyperlink theme.
+  Inline chips, raster images, vector shapes and SVG paths retain their measured
+  baseline boxes. Simple SVG layers stay native; arbitrary clips, exact stroke
+  styles and off-viewBox art use a transparent PNG fallback. SVG gradients use
+  their primary colour. Document-local fonts preserve their registered
+  viewer-facing family name and embed into the deck as EOT-wrapped programs
+  when their license bits allow; restricted or unreadable fonts degrade to a
+  plain family-name reference with a one-time warning, and the run baseline
+  compensates the PDF-vs-viewer ascent difference so text sits on the
+  measured baseline either way.
 
 ### Fixed
 
@@ -51,6 +65,10 @@ follow semantic versioning; release dates are ISO 8601.
   deterministic PDF default; `MissingBackendContractTest` (core, backend-free
   classpath) pins the missing-format diagnostics; `DocumentPageSizeTest` pins
   the slide presets.
+- PPTX text tests re-read line, absolute-span and inline-graphic anchors through
+  POI; cover real wrapping, mixed font sizes, vertical seating, custom fonts,
+  rich styles, links, chips, SVG fallback and exact inline radii; and lock the
+  shared text-fidelity demo with a backend-neutral layout snapshot.
 
 ## v2.0.0 — 2026-07-13
 

--- a/docs/architecture/backend-capability-matrix.md
+++ b/docs/architecture/backend-capability-matrix.md
@@ -40,11 +40,11 @@ Payload records live in `core` under
 
 | Capability (payload) | PDF (fixed) | PPTX (fixed) | DOCX (semantic) |
 |---|---|---|---|
-| Paragraph — pre-wrapped lines, runs, alignment (`ParagraphFragmentPayload`) | ✅ `PdfParagraphFragmentRenderHandler` | 🚧 | ✅ semantic paragraphs (`DocxSemanticBackend`) |
-| Inline code/badge chips (`InlineBackground` on text spans) | ✅ `PdfParagraphFragmentRenderHandler` | 🚧 | ❌ |
-| Inline images (`ParagraphImageSpan`) | ✅ `PdfParagraphFragmentRenderHandler` | 🚧 | ❌ |
-| Inline vector shapes (`ParagraphShapeSpan`) | ✅ `PdfParagraphFragmentRenderHandler` | 🚧 | ❌ |
-| Inline SVG (`ParagraphSvgSpan`) | ✅ `PdfParagraphFragmentRenderHandler` + `PdfPathPainter` | 🚧 | ❌ |
+| Paragraph — pre-wrapped lines, runs, alignment (`ParagraphFragmentPayload`) | ✅ `PdfParagraphFragmentRenderHandler` | ✅ `PptxParagraphFragmentRenderHandler` (one absolute, wrap-disabled frame per measured line) | ✅ semantic paragraphs (`DocxSemanticBackend`) |
+| Inline code/badge chips (`InlineBackground` on text spans) | ✅ `PdfParagraphFragmentRenderHandler` | ✅ `PptxParagraphFragmentRenderHandler` | ❌ |
+| Inline images (`ParagraphImageSpan`) | ✅ `PdfParagraphFragmentRenderHandler` | ✅ `PptxParagraphFragmentRenderHandler` | ❌ |
+| Inline vector shapes (`ParagraphShapeSpan`) | ✅ `PdfParagraphFragmentRenderHandler` | ⚠️ `PptxParagraphFragmentRenderHandler` + `PptxInlineGeometry` (distinct per-corner radii render with the top-left radius — single-adjust preset) | ❌ |
+| Inline SVG (`ParagraphSvgSpan`) | ✅ `PdfParagraphFragmentRenderHandler` + `PdfPathPainter` | ⚠️ `PptxParagraphFragmentRenderHandler` + `PptxInlineGeometry` + `PptxInlineSvgRasterizer` (simple layers stay native; arbitrary clips, exact dash/cap/join styles, and off-viewBox art use a transparent PNG fallback; gradient paints use their primary colour) | ❌ |
 | Rectangle shape — fill, stroke, per-corner radii, side borders (`ShapeFragmentPayload`) | ✅ `PdfShapeFragmentRenderHandler` | ⚠️ `PptxShapeFragmentRenderHandler` (distinct per-corner radii render with the top-left radius on all corners — single-adjust `roundRect` preset — until custom geometry lands; uniform radii and side borders exact) | ❌ |
 | Ellipse (`EllipseFragmentPayload`) | ✅ `PdfEllipseFragmentRenderHandler` | ✅ `PptxEllipseFragmentRenderHandler` | ❌ |
 | Line — dash pattern, line cap (`LineFragmentPayload`) | ✅ `PdfLineFragmentRenderHandler` | ⚠️ `PptxLineFragmentRenderHandler` (numeric dash arrays map to the generic dashed preset; solid lines and caps exact) | ❌ |
@@ -66,7 +66,7 @@ Payload records live in `core` under
 
 | Capability | PDF (fixed) | PPTX (fixed) | DOCX (semantic) |
 |---|---|---|---|
-| External hyperlinks (fragment- and run-level) | ✅ `PdfLinkAnnotationWriter` + link rects in `PdfFixedLayoutBackend` | 🚧 (`XSLFHyperlink`) | ❌ |
+| External hyperlinks (fragment- and run-level) | ✅ `PdfLinkAnnotationWriter` + link rects in `PdfFixedLayoutBackend` | ⚠️ `PptxParagraphFragmentRenderHandler` (transparent measured-span shape hotspots preserve resolved text styling; fragment rectangles arrive with navigation support) | ❌ |
 | Internal links (anchor jump, forward references) | ✅ `PdfInternalLinkWriter` (two-pass) | 🚧 (slide-jump hyperlinks) | ❌ |
 | Document outline / bookmarks tree | ✅ `PdfBookmarkOutlineWriter` | 🚧 (no PPTX outline concept — slide names where 1:1, otherwise dropped with a note) | ❌ |
 
@@ -104,5 +104,5 @@ per already-wrapped line, so PowerPoint can never reflow content. What
 PPTX cannot guarantee is glyph-level rasterization: PowerPoint draws text
 with the fonts installed on the viewing machine. Standard-14 font names are mapped to
 metric-compatible system fonts (Helvetica → Arial, Times → Times New
-Roman, Courier → Courier New); binary font families keep their real
-family names and should be installed on the viewer for exact glyphs.
+Roman, Courier → Courier New); document-local fonts use their registered
+viewer-facing `wordFamily` and should be installed on the viewer for exact glyphs.

--- a/render-pptx/pom.xml
+++ b/render-pptx/pom.xml
@@ -22,7 +22,7 @@
     <version>2.0.1-SNAPSHOT</version>
 
     <name>GraphCompose Render — PPTX</name>
-    <description>Semantic PPTX export backend for GraphCompose (slide-safe semantic node validation).</description>
+    <description>PPTX render backends for GraphCompose: the coordinate-exact fixed-layout backend (POI XSLF) and the slide-safe semantic export skeleton.</description>
     <url>https://github.com/DemchaAV/GraphCompose</url>
 
     <licenses>
@@ -58,6 +58,9 @@
         <maven.compiler.release>17</maven.compiler.release>
 
         <poi.version>5.5.1</poi.version>
+        <!-- Keep in lockstep with render-pdf/pom.xml: a drift would mix fontbox
+             and pdfbox versions at runtime (the direct fontbox wins mediation). -->
+        <pdfbox.version>3.0.8</pdfbox.version>
         <junit.bom.version>6.1.2</junit.bom.version>
         <assertj.version>3.27.7</assertj.version>
         <logback.version>1.5.38</logback.version>
@@ -87,16 +90,25 @@
             <artifactId>poi-ooxml</artifactId>
             <version>${poi.version}</version>
         </dependency>
+        <!-- FontBox reads the OpenType metadata required by the EOT wrapper
+             used for native PowerPoint font embedding. -->
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>fontbox</artifactId>
+            <version>${pdfbox.version}</version>
+        </dependency>
 
-        <!-- Test dependencies -->
-        <!-- The export test builds a DocumentSession, which lays out through the
-             font-metrics seam now provided by graph-compose-render-pdf. -->
+        <!-- The fixed PPTX backend deliberately reuses the PDF measurement font
+             library so glyph sanitization stays byte-for-byte aligned with the
+             widths that produced the LayoutGraph. A backend-neutral metrics
+             artifact is a separate future extraction. -->
         <dependency>
             <groupId>io.github.demchaav</groupId>
             <artifactId>graph-compose-render-pdf</artifactId>
             <version>${project.version}</version>
-            <scope>test</scope>
         </dependency>
+
+        <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
@@ -107,6 +119,12 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>${assertj.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.github.demchaav</groupId>
+            <artifactId>graph-compose-testing</artifactId>
+            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/PptxEmbeddedFont.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/PptxEmbeddedFont.java
@@ -1,0 +1,184 @@
+package com.demcha.compose.document.backend.fixed.pptx;
+
+import org.apache.fontbox.ttf.FontHeaders;
+import org.apache.fontbox.ttf.OS2WindowsMetricsTable;
+import org.apache.fontbox.ttf.OTFParser;
+import org.apache.pdfbox.io.RandomAccessReadBuffer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+
+/** Builds the uncompressed EOT container required by PowerPoint font parts. */
+final class PptxEmbeddedFont {
+
+    private static final int EOT_VERSION_2_1 = 0x00020001;
+    private static final int EOT_MAGIC = 0x504C;
+    private static final int EOT_FIXED_HEADER_SIZE = 100;
+    private static final int DEFAULT_CHARSET = 1;
+    private static final int ITALIC_SELECTION_BIT = 0x0001;
+    private static final int MAC_STYLE_ITALIC_BIT = 0x0002;
+    private static final int RESTRICTED_LICENSE_EMBEDDING = 0x0002;
+    private static final int BITMAP_EMBEDDING_ONLY = 0x0200;
+
+    private PptxEmbeddedFont() {
+    }
+
+    static byte[] wrap(InputStream input) throws IOException {
+        byte[] fontData = input.readAllBytes();
+        Metadata metadata = metadata(fontData);
+        validateEmbeddingRights(metadata.fsType());
+
+        byte[] family = utf16(metadata.familyName());
+        byte[] style = utf16(metadata.styleName());
+        byte[] version = utf16(metadata.versionName());
+        byte[] full = utf16(metadata.fullName());
+        int eotSize = Math.addExact(
+                Math.addExact(EOT_FIXED_HEADER_SIZE, fontData.length),
+                Math.addExact(Math.addExact(family.length, style.length),
+                        Math.addExact(version.length, full.length)));
+
+        ByteBuffer eot = ByteBuffer.allocate(eotSize).order(ByteOrder.LITTLE_ENDIAN);
+        eot.putInt(eotSize);
+        eot.putInt(fontData.length);
+        eot.putInt(EOT_VERSION_2_1);
+        eot.putInt(0); // raw, uncompressed OpenType data
+        eot.put(metadata.panose());
+        eot.put((byte) DEFAULT_CHARSET);
+        eot.put((byte) (metadata.italic() ? 1 : 0));
+        eot.putInt(metadata.weight());
+        eot.putShort((short) metadata.fsType());
+        eot.putShort((short) EOT_MAGIC);
+        eot.putInt((int) metadata.unicodeRange1());
+        eot.putInt((int) metadata.unicodeRange2());
+        eot.putInt((int) metadata.unicodeRange3());
+        eot.putInt((int) metadata.unicodeRange4());
+        eot.putInt((int) metadata.codePageRange1());
+        eot.putInt((int) metadata.codePageRange2());
+        eot.putInt((int) metadata.checkSumAdjustment());
+        eot.putInt(0);
+        eot.putInt(0);
+        eot.putInt(0);
+        eot.putInt(0);
+        eot.putShort((short) 0); // padding before the family name
+        putName(eot, family);
+        putName(eot, style);
+        putName(eot, version);
+        putName(eot, full);
+        eot.putShort((short) 0); // empty root string (EOT 0x00020001)
+        eot.put(fontData);
+        return eot.array();
+    }
+
+    private static Metadata metadata(byte[] fontData) throws IOException {
+        try (RandomAccessReadBuffer input = new RandomAccessReadBuffer(fontData)) {
+            FontHeaders headers = new OTFParser().parseTableHeaders(input);
+            if (headers.getError() != null) {
+                throw new IOException("Unable to read OpenType headers: " + headers.getError());
+            }
+            OS2WindowsMetricsTable os2 = headers.getOS2Windows();
+
+            byte[] panose = os2 == null || os2.getPanose() == null
+                    ? new byte[10]
+                    : normalizedPanose(os2.getPanose());
+            int fsSelection = os2 == null ? 0 : os2.getFsSelection();
+            int macStyle = headers.getHeaderMacStyle() == null ? 0 : headers.getHeaderMacStyle();
+            boolean italic = (fsSelection & ITALIC_SELECTION_BIT) != 0
+                    || (macStyle & MAC_STYLE_ITALIC_BIT) != 0;
+            String family = valueOr(headers.getFontFamily(), headers.getName());
+            String style = valueOr(headers.getFontSubFamily(), "Regular");
+            return new Metadata(
+                    panose,
+                    italic,
+                    os2 == null ? 400 : os2.getWeightClass(),
+                    os2 == null ? 0 : Short.toUnsignedInt(os2.getFsType()),
+                    os2 == null ? 0 : os2.getUnicodeRange1(),
+                    os2 == null ? 0 : os2.getUnicodeRange2(),
+                    os2 == null ? 0 : os2.getUnicodeRange3(),
+                    os2 == null ? 0 : os2.getUnicodeRange4(),
+                    os2 == null ? 0 : os2.getCodePageRange1(),
+                    os2 == null ? 0 : os2.getCodePageRange2(),
+                    checkSumAdjustment(fontData),
+                    family,
+                    style,
+                    "",
+                    family + " " + style);
+        }
+    }
+
+    private static long checkSumAdjustment(byte[] fontData) throws IOException {
+        if (fontData.length < 12) {
+            throw new IOException("OpenType font data is shorter than its table directory");
+        }
+        ByteBuffer sfnt = ByteBuffer.wrap(fontData).order(ByteOrder.BIG_ENDIAN);
+        int tableCount = Short.toUnsignedInt(sfnt.getShort(4));
+        long directoryEnd = 12L + tableCount * 16L;
+        if (directoryEnd > fontData.length) {
+            throw new IOException("OpenType table directory exceeds the font data");
+        }
+        for (int index = 0; index < tableCount; index++) {
+            int record = 12 + index * 16;
+            if (sfnt.getInt(record) != 0x68656164) { // 'head'
+                continue;
+            }
+            long offset = Integer.toUnsignedLong(sfnt.getInt(record + 8));
+            if (offset + 12 > fontData.length) {
+                throw new IOException("OpenType head table exceeds the font data");
+            }
+            return Integer.toUnsignedLong(sfnt.getInt((int) offset + 8));
+        }
+        return 0;
+    }
+
+    private static byte[] normalizedPanose(byte[] panose) {
+        byte[] normalized = new byte[10];
+        System.arraycopy(panose, 0, normalized, 0, Math.min(panose.length, normalized.length));
+        return normalized;
+    }
+
+    private static byte[] utf16(String value) throws IOException {
+        byte[] encoded = value.getBytes(StandardCharsets.UTF_16LE);
+        if (encoded.length > 0xFFFF) {
+            throw new IOException("PPTX embedded-font metadata exceeds the EOT name limit");
+        }
+        return encoded;
+    }
+
+    private static void putName(ByteBuffer target, byte[] encoded) {
+        target.putShort((short) encoded.length);
+        target.put(encoded);
+        target.putShort((short) 0);
+    }
+
+    private static String valueOr(String value, String fallback) {
+        return value == null || value.isBlank() ? fallback : value;
+    }
+
+    private static void validateEmbeddingRights(int fsType) throws IOException {
+        if ((fsType & RESTRICTED_LICENSE_EMBEDDING) != 0) {
+            throw new IOException("Font license flags prohibit embedding in PPTX");
+        }
+        if ((fsType & BITMAP_EMBEDDING_ONLY) != 0) {
+            throw new IOException("Font license flags permit bitmap embedding only");
+        }
+    }
+
+    private record Metadata(byte[] panose,
+                            boolean italic,
+                            int weight,
+                            int fsType,
+                            long unicodeRange1,
+                            long unicodeRange2,
+                            long unicodeRange3,
+                            long unicodeRange4,
+                            long codePageRange1,
+                            long codePageRange2,
+                            long checkSumAdjustment,
+                            String familyName,
+                            String styleName,
+                            String versionName,
+                            String fullName) {
+    }
+}

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/PptxFixedLayoutBackend.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/PptxFixedLayoutBackend.java
@@ -5,7 +5,9 @@ import com.demcha.compose.document.backend.fixed.FixedLayoutRenderer;
 import com.demcha.compose.document.backend.fixed.SectionUnit;
 import com.demcha.compose.document.backend.fixed.pptx.handlers.PptxEllipseFragmentRenderHandler;
 import com.demcha.compose.document.backend.fixed.pptx.handlers.PptxLineFragmentRenderHandler;
+import com.demcha.compose.document.backend.fixed.pptx.handlers.PptxParagraphFragmentRenderHandler;
 import com.demcha.compose.document.backend.fixed.pptx.handlers.PptxShapeFragmentRenderHandler;
+import com.demcha.compose.document.backend.fixed.pdf.PdfMeasurementResources;
 import com.demcha.compose.document.exceptions.UnsupportedNodeCapabilityException;
 import com.demcha.compose.document.layout.LayoutGraph;
 import com.demcha.compose.document.layout.PlacedFragment;
@@ -37,10 +39,11 @@ import java.util.concurrent.TimeUnit;
  * throws {@link UnsupportedNodeCapabilityException}). Custom handlers replace
  * built-in defaults per payload type via {@link Builder#addHandler}.</p>
  *
- * <p>The backend currently renders vector shape, line, and ellipse fragments;
+ * <p>The backend currently renders paragraphs (including rich runs, chips and
+ * inline graphics) plus vector shape, line, and ellipse fragments;
  * the remaining payload types arrive incrementally — see
  * {@code docs/architecture/backend-capability-matrix.md} for the live
- * per-capability status. Multi-section rendering and rasterization are not
+ * per-capability status. Multi-section rendering and render-to-images are not
  * implemented yet and throw {@link UnsupportedOperationException}.</p>
  *
  * <p><b>Thread-safety:</b> immutable and reusable across renders; each render
@@ -85,7 +88,8 @@ public final class PptxFixedLayoutBackend implements FixedLayoutRenderer {
         return List.of(
                 new PptxShapeFragmentRenderHandler(),
                 new PptxLineFragmentRenderHandler(),
-                new PptxEllipseFragmentRenderHandler());
+                new PptxEllipseFragmentRenderHandler(),
+                new PptxParagraphFragmentRenderHandler());
     }
 
     @Override
@@ -100,7 +104,7 @@ public final class PptxFixedLayoutBackend implements FixedLayoutRenderer {
 
         long startNanos = System.nanoTime();
         try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
-            renderToOutput(graph, output);
+            renderToOutput(graph, context, output);
             byte[] bytes = output.toByteArray();
             if (context.outputFile() != null) {
                 Files.write(context.outputFile(), bytes);
@@ -130,11 +134,11 @@ public final class PptxFixedLayoutBackend implements FixedLayoutRenderer {
         OutputStream output = Objects.requireNonNull(context.outputStream(), "context.outputStream");
 
         if (context.outputFile() == null) {
-            renderToOutput(graph, output);
+            renderToOutput(graph, context, output);
             return;
         }
         try (ByteArrayOutputStream buffer = new ByteArrayOutputStream()) {
-            renderToOutput(graph, buffer);
+            renderToOutput(graph, context, buffer);
             byte[] bytes = buffer.toByteArray();
             Files.write(context.outputFile(), bytes);
             output.write(bytes);
@@ -142,8 +146,8 @@ public final class PptxFixedLayoutBackend implements FixedLayoutRenderer {
     }
 
     /**
-     * Rasterization is not implemented for the PPTX backend yet; render the
-     * same session through the PDF backend when images are needed.
+     * Render-to-images is not implemented for the PPTX backend yet; render
+     * the same session through the PDF backend when page images are needed.
      */
     @Override
     public List<BufferedImage> renderToImages(LayoutGraph graph,
@@ -152,7 +156,8 @@ public final class PptxFixedLayoutBackend implements FixedLayoutRenderer {
                                               boolean transparent,
                                               int pageIndex) {
         throw new UnsupportedOperationException(
-                "The PPTX backend does not rasterize yet — render through the PDF backend for images.");
+                "The PPTX backend does not render pages to images yet — "
+                        + "render through the PDF backend for page images.");
     }
 
     /**
@@ -173,12 +178,17 @@ public final class PptxFixedLayoutBackend implements FixedLayoutRenderer {
                 "The PPTX backend does not render multi-section documents yet.");
     }
 
-    private void renderToOutput(LayoutGraph graph, OutputStream output) throws Exception {
-        try (XMLSlideShow show = new XMLSlideShow()) {
+    private void renderToOutput(LayoutGraph graph,
+                                FixedLayoutRenderContext context,
+                                OutputStream output) throws Exception {
+        try (XMLSlideShow show = new XMLSlideShow();
+             PdfMeasurementResources measurement =
+                     PdfMeasurementResources.open(context.customFontFamilies())) {
             PptxRenderSession session = new PptxRenderSession(
                     show, graph.canvas().width(), graph.canvas().height(), graph.totalPages());
             PptxRenderEnvironment environment =
-                    new PptxRenderEnvironment(show, session, 0, graph.canvas().height());
+                    new PptxRenderEnvironment(show, session, 0, graph.canvas().height(),
+                            measurement.fontLibrary(), context.customFontFamilies());
             for (PlacedFragment fragment : graph.fragments()) {
                 renderFragment(fragment, environment);
             }

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/PptxRenderEnvironment.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/PptxRenderEnvironment.java
@@ -19,9 +19,6 @@ import org.apache.poi.xslf.usermodel.XSLFSlide;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.awt.Font;
-import java.awt.FontFormatException;
-import java.awt.font.FontRenderContext;
 import java.awt.geom.Rectangle2D;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -56,9 +53,6 @@ import java.util.Set;
 public final class PptxRenderEnvironment {
 
     private static final Logger LOG = LoggerFactory.getLogger("com.demcha.compose.engine.render");
-    private static final FontRenderContext FONT_RENDER_CONTEXT =
-            new FontRenderContext(null, true, true);
-    private static final float FONT_METRICS_SIZE = 1000.0f;
 
     private final XMLSlideShow show;
     private final PptxRenderSession session;
@@ -66,7 +60,7 @@ public final class PptxRenderEnvironment {
     private final double canvasHeight;
     private final FontLibrary fonts;
     private final Map<FontName, String> customFontFamilies;
-    private final Map<FontName, ViewerFontMetrics> viewerFontMetrics;
+    private final Map<FontName, PptxViewerMetrics.ViewerFontMetrics> viewerFontMetrics;
     private final Map<String, XSLFPictureData> pictureDataCache = new LinkedHashMap<>();
     private final List<BookmarkRecord> bookmarkRecords = new ArrayList<>();
     private final Map<String, AnchorDestination> anchorDestinations = new LinkedHashMap<>();
@@ -84,12 +78,12 @@ public final class PptxRenderEnvironment {
         this.canvasHeight = canvasHeight;
         this.fonts = fonts;
         Map<FontName, String> familyNames = new LinkedHashMap<>();
-        Map<FontName, ViewerFontMetrics> metrics = new LinkedHashMap<>();
+        Map<FontName, PptxViewerMetrics.ViewerFontMetrics> metrics = new LinkedHashMap<>();
         for (FontFamilyDefinition family : customFontFamilies) {
             familyNames.put(family.name(), family.wordFamily());
             family.fontSourceSet().ifPresent(sources -> {
                 if (embedFontFamily(show, family, sources)) {
-                    metrics.put(family.name(), viewerMetrics(family, sources));
+                    metrics.put(family.name(), PptxViewerMetrics.load(family, sources));
                 }
             });
         }
@@ -166,31 +160,39 @@ public final class PptxRenderEnvironment {
     }
 
     /**
-     * Returns the DrawingML baseline shift needed to place the viewer font on
-     * the PDF-measured baseline. PowerPoint seats a run using the viewer font's
-     * hhea ascent, while the layout graph carries the PDF descriptor ascent;
-     * the percentage difference is written to the run's baseline property.
+     * Returns the ascent, in points, that the viewer's font engine uses to seat
+     * this run's first baseline below a top-anchored frame. PowerPoint positions
+     * text by frame, not by baseline: the first baseline lands at
+     * {@code frameTop + viewerAscent}, so frames anchor at
+     * {@code baseline − viewerAscent}. Embedded fonts report their real font
+     * program ascent per facet; standard-14 replacements use the known Arial /
+     * Times New Roman / Courier New ratios; anything else assumes the PDF
+     * descriptor ascent.
      *
-     * @param style resolved text style
-     * @return positive percentage that moves the run upward
+     * <p>Deliberately never written to the run's DrawingML {@code baseline}
+     * property: PowerPoint treats any non-zero baseline as super/subscript and
+     * shrinks the glyphs.</p>
+     *
+     * @param style          resolved text style
+     * @param fallbackAscent ascent to assume when the style cannot be resolved
+     * @return viewer ascent in points
      */
     @Internal
-    public double baselineOffset(TextStyle style) {
+    public double viewerAscent(TextStyle style, double fallbackAscent) {
         if (style == null || style.size() <= 0) {
-            return 0;
+            return fallbackAscent;
         }
         PdfFont font = fonts.getFont(style.fontName(), PdfFont.class).orElse(null);
         if (font == null) {
-            return 0;
+            return fallbackAscent;
         }
         double pdfAscentRatio = font.verticalMetrics(style).ascent() / style.size();
-        ViewerFontMetrics customMetrics = viewerFontMetrics.get(style.fontName());
+        PptxViewerMetrics.ViewerFontMetrics customMetrics = viewerFontMetrics.get(style.fontName());
         double viewerAscentRatio = customMetrics == null
                 ? PptxFontMapping.viewerAscentRatio(style.fontName(), pdfAscentRatio)
                 : customMetrics.ascent(PptxFontMapping.isBold(style),
                         PptxFontMapping.isItalic(style));
-        return Math.max(-100.0, Math.min(100.0,
-                (viewerAscentRatio - pdfAscentRatio) * 100.0));
+        return viewerAscentRatio * style.size();
     }
 
     /**
@@ -245,42 +247,6 @@ public final class PptxRenderEnvironment {
         return true;
     }
 
-    private static ViewerFontMetrics viewerMetrics(
-            FontFamilyDefinition family,
-            FontFamilyDefinition.FontSourceSet sources) {
-        return new ViewerFontMetrics(
-                viewerAscent(family, sources.regular()),
-                viewerAscent(family, sources.bold()),
-                viewerAscent(family, sources.italic()),
-                viewerAscent(family, sources.boldItalic()));
-    }
-
-    private static double viewerAscent(FontFamilyDefinition family,
-                                       FontFamilyDefinition.FontBinarySource source) {
-        try (InputStream stream = source.openStream()) {
-            Font font = Font.createFont(Font.TRUETYPE_FONT, stream).deriveFont(FONT_METRICS_SIZE);
-            return font.getLineMetrics("Hg", FONT_RENDER_CONTEXT).getAscent() / FONT_METRICS_SIZE;
-        } catch (IOException | FontFormatException exception) {
-            throw new IllegalStateException(
-                    "Unable to read PPTX font metrics for " + family.name().name()
-                            + " from " + source.description(), exception);
-        }
-    }
-
-    private record ViewerFontMetrics(double regularAscent,
-                                     double boldAscent,
-                                     double italicAscent,
-                                     double boldItalicAscent) {
-        double ascent(boolean bold, boolean italic) {
-            if (bold && italic) {
-                return boldItalicAscent;
-            }
-            if (bold) {
-                return boldAscent;
-            }
-            return italic ? italicAscent : regularAscent;
-        }
-    }
 
     void registerBookmark(PlacedFragment fragment, DocumentBookmarkOptions bookmarkOptions) {
         bookmarkRecords.add(new BookmarkRecord(

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/PptxRenderEnvironment.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/PptxRenderEnvironment.java
@@ -1,18 +1,38 @@
 package com.demcha.compose.document.backend.fixed.pptx;
 
+import com.demcha.compose.document.api.Internal;
 import com.demcha.compose.document.layout.PlacedFragment;
 import com.demcha.compose.document.node.DocumentBookmarkOptions;
 import com.demcha.compose.document.node.DocumentLinkTarget;
+import com.demcha.compose.document.backend.fixed.pptx.handlers.PptxFontMapping;
+import com.demcha.compose.engine.components.content.ImageData;
+import com.demcha.compose.engine.components.content.text.TextStyle;
+import com.demcha.compose.engine.render.pdf.PdfFont;
+import com.demcha.compose.font.FontFamilyDefinition;
+import com.demcha.compose.font.FontLibrary;
+import com.demcha.compose.font.FontName;
+import org.apache.poi.sl.usermodel.PictureData;
 import org.apache.poi.xslf.usermodel.XMLSlideShow;
+import org.apache.poi.xslf.usermodel.XSLFFontInfo;
+import org.apache.poi.xslf.usermodel.XSLFPictureData;
 import org.apache.poi.xslf.usermodel.XSLFSlide;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.awt.Font;
+import java.awt.FontFormatException;
+import java.awt.font.FontRenderContext;
 import java.awt.geom.Rectangle2D;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Shared per-render-pass state for the fixed-layout PPTX backend.
@@ -36,11 +56,18 @@ import java.util.Map;
 public final class PptxRenderEnvironment {
 
     private static final Logger LOG = LoggerFactory.getLogger("com.demcha.compose.engine.render");
+    private static final FontRenderContext FONT_RENDER_CONTEXT =
+            new FontRenderContext(null, true, true);
+    private static final float FONT_METRICS_SIZE = 1000.0f;
 
     private final XMLSlideShow show;
     private final PptxRenderSession session;
     private final int pageIndexOffset;
     private final double canvasHeight;
+    private final FontLibrary fonts;
+    private final Map<FontName, String> customFontFamilies;
+    private final Map<FontName, ViewerFontMetrics> viewerFontMetrics;
+    private final Map<String, XSLFPictureData> pictureDataCache = new LinkedHashMap<>();
     private final List<BookmarkRecord> bookmarkRecords = new ArrayList<>();
     private final Map<String, AnchorDestination> anchorDestinations = new LinkedHashMap<>();
     private final List<FragmentLink> fragmentLinks = new ArrayList<>();
@@ -48,11 +75,36 @@ public final class PptxRenderEnvironment {
     PptxRenderEnvironment(XMLSlideShow show,
                           PptxRenderSession session,
                           int pageIndexOffset,
-                          double canvasHeight) {
+                          double canvasHeight,
+                          FontLibrary fonts,
+                          Collection<FontFamilyDefinition> customFontFamilies) {
         this.show = show;
         this.session = session;
         this.pageIndexOffset = pageIndexOffset;
         this.canvasHeight = canvasHeight;
+        this.fonts = fonts;
+        Map<FontName, String> familyNames = new LinkedHashMap<>();
+        Map<FontName, ViewerFontMetrics> metrics = new LinkedHashMap<>();
+        for (FontFamilyDefinition family : customFontFamilies) {
+            familyNames.put(family.name(), family.wordFamily());
+            family.fontSourceSet().ifPresent(sources -> {
+                if (embedFontFamily(show, family, sources)) {
+                    metrics.put(family.name(), viewerMetrics(family, sources));
+                }
+            });
+        }
+        if (!metrics.isEmpty()) {
+            show.getCTPresentation().setSaveSubsetFonts(false);
+        }
+        this.customFontFamilies = Map.copyOf(familyNames);
+        this.viewerFontMetrics = Map.copyOf(metrics);
+    }
+
+    PptxRenderEnvironment(XMLSlideShow show,
+                          PptxRenderSession session,
+                          int pageIndexOffset,
+                          double canvasHeight) {
+        this(show, session, pageIndexOffset, canvasHeight, new FontLibrary(), List.of());
     }
 
     /**
@@ -83,6 +135,151 @@ public final class PptxRenderEnvironment {
      */
     public double canvasHeight() {
         return canvasHeight;
+    }
+
+    /**
+     * Returns the same PDF-backed measurement font library that produced the
+     * paragraph geometry, so emitted text can use identical glyph sanitization.
+     *
+     * @return resolved render-pass fonts
+     */
+    public FontLibrary fonts() {
+        return fonts;
+    }
+
+    /**
+     * Resolves the viewer-facing family registered for a document-local font,
+     * falling back to the standard PPTX mapping for bundled/standard names.
+     *
+     * @param fontName logical document font name
+     * @return viewer-facing PPTX family name
+     */
+    @Internal
+    public String fontFamily(FontName fontName) {
+        if (fontName != null) {
+            String customFamily = customFontFamilies.get(fontName);
+            if (customFamily != null) {
+                return customFamily;
+            }
+        }
+        return PptxFontMapping.familyFor(fontName);
+    }
+
+    /**
+     * Returns the DrawingML baseline shift needed to place the viewer font on
+     * the PDF-measured baseline. PowerPoint seats a run using the viewer font's
+     * hhea ascent, while the layout graph carries the PDF descriptor ascent;
+     * the percentage difference is written to the run's baseline property.
+     *
+     * @param style resolved text style
+     * @return positive percentage that moves the run upward
+     */
+    @Internal
+    public double baselineOffset(TextStyle style) {
+        if (style == null || style.size() <= 0) {
+            return 0;
+        }
+        PdfFont font = fonts.getFont(style.fontName(), PdfFont.class).orElse(null);
+        if (font == null) {
+            return 0;
+        }
+        double pdfAscentRatio = font.verticalMetrics(style).ascent() / style.size();
+        ViewerFontMetrics customMetrics = viewerFontMetrics.get(style.fontName());
+        double viewerAscentRatio = customMetrics == null
+                ? PptxFontMapping.viewerAscentRatio(style.fontName(), pdfAscentRatio)
+                : customMetrics.ascent(PptxFontMapping.isBold(style),
+                        PptxFontMapping.isItalic(style));
+        return Math.max(-100.0, Math.min(100.0,
+                (viewerAscentRatio - pdfAscentRatio) * 100.0));
+    }
+
+    /**
+     * Resolves picture data once per distinct image fingerprint.
+     *
+     * @param imageData engine image payload
+     * @return PPTX picture data owned by the current slide show
+     */
+    public XSLFPictureData resolvePicture(ImageData imageData) {
+        return pictureDataCache.computeIfAbsent(imageData.getFingerprint(), ignored ->
+                show.addPicture(imageData.getBytes(), pictureType(imageData)));
+    }
+
+    private static PictureData.PictureType pictureType(ImageData imageData) {
+        String format = imageData.getMetadata() == null ? "" : imageData.getMetadata().format();
+        return switch (format == null ? "" : format.toLowerCase(java.util.Locale.ROOT)) {
+            case "jpg", "jpeg" -> PictureData.PictureType.JPEG;
+            case "gif" -> PictureData.PictureType.GIF;
+            case "bmp" -> PictureData.PictureType.BMP;
+            case "tif", "tiff" -> PictureData.PictureType.TIFF;
+            default -> PictureData.PictureType.PNG;
+        };
+    }
+
+    /**
+     * Embeds every distinct facet of one font family, returning whether the
+     * family made it into the presentation. Embedding is best-effort: a font
+     * whose license bits forbid embedding (or whose bytes cannot be read)
+     * degrades to a plain family-name reference — page geometry is unaffected,
+     * viewers simply substitute glyphs — instead of failing a render that the
+     * PDF backend would complete.
+     */
+    private static boolean embedFontFamily(XMLSlideShow show,
+                                           FontFamilyDefinition family,
+                                           FontFamilyDefinition.FontSourceSet sources) {
+        XSLFFontInfo embedded = new XSLFFontInfo(show, family.wordFamily());
+        Set<String> embeddedSources = new LinkedHashSet<>();
+        for (FontFamilyDefinition.FontBinarySource source : List.of(
+                sources.regular(), sources.bold(), sources.italic(), sources.boldItalic())) {
+            if (!embeddedSources.add(source.description())) {
+                continue;
+            }
+            try (InputStream stream = source.openStream()) {
+                byte[] eot = PptxEmbeddedFont.wrap(stream);
+                embedded.addFacet(new ByteArrayInputStream(eot));
+            } catch (IOException exception) {
+                LOG.warn("render.pptx.font.embed.skipped family={} source={} reason={}",
+                        family.name().name(), source.description(), exception.getMessage());
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static ViewerFontMetrics viewerMetrics(
+            FontFamilyDefinition family,
+            FontFamilyDefinition.FontSourceSet sources) {
+        return new ViewerFontMetrics(
+                viewerAscent(family, sources.regular()),
+                viewerAscent(family, sources.bold()),
+                viewerAscent(family, sources.italic()),
+                viewerAscent(family, sources.boldItalic()));
+    }
+
+    private static double viewerAscent(FontFamilyDefinition family,
+                                       FontFamilyDefinition.FontBinarySource source) {
+        try (InputStream stream = source.openStream()) {
+            Font font = Font.createFont(Font.TRUETYPE_FONT, stream).deriveFont(FONT_METRICS_SIZE);
+            return font.getLineMetrics("Hg", FONT_RENDER_CONTEXT).getAscent() / FONT_METRICS_SIZE;
+        } catch (IOException | FontFormatException exception) {
+            throw new IllegalStateException(
+                    "Unable to read PPTX font metrics for " + family.name().name()
+                            + " from " + source.description(), exception);
+        }
+    }
+
+    private record ViewerFontMetrics(double regularAscent,
+                                     double boldAscent,
+                                     double italicAscent,
+                                     double boldItalicAscent) {
+        double ascent(boolean bold, boolean italic) {
+            if (bold && italic) {
+                return boldItalicAscent;
+            }
+            if (bold) {
+                return boldAscent;
+            }
+            return italic ? italicAscent : regularAscent;
+        }
     }
 
     void registerBookmark(PlacedFragment fragment, DocumentBookmarkOptions bookmarkOptions) {

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/PptxViewerMetrics.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/PptxViewerMetrics.java
@@ -1,0 +1,65 @@
+package com.demcha.compose.document.backend.fixed.pptx;
+
+import com.demcha.compose.font.FontFamilyDefinition;
+
+import java.awt.Font;
+import java.awt.FontFormatException;
+import java.awt.font.FontRenderContext;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Reads the ascent the viewer's font engine will use for an embedded family,
+ * per facet, from the actual font program. PowerPoint anchors a top-aligned
+ * text frame's first baseline at {@code frameTop + viewerAscent}, so the
+ * backend needs the viewer's ascent — not the PDF descriptor's — to seat
+ * frames such that baselines land on the engine-measured coordinates.
+ */
+final class PptxViewerMetrics {
+
+    private static final FontRenderContext FONT_RENDER_CONTEXT =
+            new FontRenderContext(null, true, true);
+    private static final float FONT_METRICS_SIZE = 1000.0f;
+
+    private PptxViewerMetrics() {
+    }
+
+    record ViewerFontMetrics(double regularAscent,
+                             double boldAscent,
+                             double italicAscent,
+                             double boldItalicAscent) {
+        double ascent(boolean bold, boolean italic) {
+            if (bold && italic) {
+                return boldItalicAscent;
+            }
+            if (bold) {
+                return boldAscent;
+            }
+            if (italic) {
+                return italicAscent;
+            }
+            return regularAscent;
+        }
+    }
+
+    static ViewerFontMetrics load(FontFamilyDefinition family,
+                                  FontFamilyDefinition.FontSourceSet sources) {
+        return new ViewerFontMetrics(
+                ascentRatio(family, sources.regular()),
+                ascentRatio(family, sources.bold()),
+                ascentRatio(family, sources.italic()),
+                ascentRatio(family, sources.boldItalic()));
+    }
+
+    private static double ascentRatio(FontFamilyDefinition family,
+                                      FontFamilyDefinition.FontBinarySource source) {
+        try (InputStream stream = source.openStream()) {
+            Font font = Font.createFont(Font.TRUETYPE_FONT, stream).deriveFont(FONT_METRICS_SIZE);
+            return font.getLineMetrics("Hg", FONT_RENDER_CONTEXT).getAscent() / FONT_METRICS_SIZE;
+        } catch (IOException | FontFormatException exception) {
+            throw new IllegalStateException(
+                    "Unable to read PPTX font metrics for " + family.name().name()
+                            + " from " + source.description(), exception);
+        }
+    }
+}

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxCapabilityNotes.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxCapabilityNotes.java
@@ -38,6 +38,12 @@ final class PptxCapabilityNotes {
                 + "support lands");
     }
 
+    static void inlineSvgRasterized() {
+        warnOnce("inline-svg-raster",
+                "inline SVG layers that require exact clipping or stroke styles render through "
+                + "a transparent PNG fallback; simple layers remain native DrawingML paths");
+    }
+
     private static void warnOnce(String key, String message) {
         if (WARNED.add(key)) {
             LOG.warn("render.pptx.capability {}", message);

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxFontMapping.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxFontMapping.java
@@ -1,0 +1,118 @@
+package com.demcha.compose.document.backend.fixed.pptx.handlers;
+
+import com.demcha.compose.document.api.Internal;
+import com.demcha.compose.engine.components.content.text.TextDecoration;
+import com.demcha.compose.engine.components.content.text.TextStyle;
+import com.demcha.compose.font.FontName;
+
+import java.util.Locale;
+
+/**
+ * Maps the engine's {@link FontName} identifiers onto PPTX font families and
+ * style flags.
+ *
+ * <p>PPTX references fonts by family name and lets the viewer resolve them,
+ * so the standard-14 PostScript families map to their metric-compatible
+ * system fonts (Helvetica → Arial, Times → Times New Roman, Courier →
+ * Courier New) — page geometry is safe either way because every line is
+ * pre-wrapped and placed by the engine, but metric-compatible glyphs keep
+ * intra-line rendering close. Binary families keep their real family name
+ * with the style suffix stripped ({@code Roboto-Bold} → {@code Roboto});
+ * the bold/italic axis travels as run flags, combining the name's own style
+ * suffix with the span's {@link TextDecoration}.</p>
+ *
+ * @since 2.1.0
+ */
+@Internal
+public final class PptxFontMapping {
+
+    private static final double ARIAL_ASCENT_RATIO = 1854.0 / 2048.0;
+    private static final double TIMES_NEW_ROMAN_ASCENT_RATIO = 1825.0 / 2048.0;
+    private static final double COURIER_NEW_ASCENT_RATIO = 1705.0 / 2048.0;
+
+    private PptxFontMapping() {
+    }
+
+    /**
+     * Maps one logical engine font identifier to a viewer-facing PPTX family.
+     *
+     * @param fontName logical font identifier, or {@code null} for Helvetica
+     * @return PPTX family name
+     */
+    public static String familyFor(FontName fontName) {
+        String name = (fontName == null ? FontName.HELVETICA : fontName).name();
+        String lower = name.toLowerCase(Locale.ROOT);
+        if (lower.startsWith("helvetica")) {
+            return "Arial";
+        }
+        if (lower.startsWith("times")) {
+            return "Times New Roman";
+        }
+        if (lower.startsWith("courier")) {
+            return "Courier New";
+        }
+        return stripStyleSuffix(name);
+    }
+
+    /**
+     * Returns the viewer ascent ratio for a standard-14 replacement font.
+     *
+     * @param fontName logical document font
+     * @param fallback ratio to return for a non-standard family
+     * @return viewer-font ascent divided by em size
+     */
+    public static double viewerAscentRatio(FontName fontName, double fallback) {
+        String name = (fontName == null ? FontName.HELVETICA : fontName).name();
+        String lower = name.toLowerCase(Locale.ROOT);
+        if (lower.startsWith("helvetica")) {
+            return ARIAL_ASCENT_RATIO;
+        }
+        if (lower.startsWith("times")) {
+            return TIMES_NEW_ROMAN_ASCENT_RATIO;
+        }
+        if (lower.startsWith("courier")) {
+            return COURIER_NEW_ASCENT_RATIO;
+        }
+        return fallback;
+    }
+
+    /** Returns whether the run selects a bold face. */
+    public static boolean isBold(TextStyle style) {
+        TextDecoration decoration = style.decoration();
+        if (decoration == TextDecoration.BOLD || decoration == TextDecoration.BOLD_ITALIC) {
+            return true;
+        }
+        return style.fontName() != null
+                && style.fontName().name().toLowerCase(Locale.ROOT).contains("bold");
+    }
+
+    /** Returns whether the run selects an italic face. */
+    public static boolean isItalic(TextStyle style) {
+        TextDecoration decoration = style.decoration();
+        if (decoration == TextDecoration.ITALIC || decoration == TextDecoration.BOLD_ITALIC) {
+            return true;
+        }
+        String name = style.fontName() == null ? "" : style.fontName().name().toLowerCase(Locale.ROOT);
+        return name.contains("italic") || name.contains("oblique");
+    }
+
+    static boolean isUnderline(TextStyle style) {
+        return style.decoration() == TextDecoration.UNDERLINE;
+    }
+
+    static boolean isStrikethrough(TextStyle style) {
+        return style.decoration() == TextDecoration.STRIKETHROUGH;
+    }
+
+    private static String stripStyleSuffix(String name) {
+        String lower = name.toLowerCase(Locale.ROOT);
+        for (String suffix : new String[]{
+                "-bolditalic", "-boldoblique", "-bold", "-italic", "-oblique", "-regular"
+        }) {
+            if (lower.endsWith(suffix)) {
+                return name.substring(0, name.length() - suffix.length());
+            }
+        }
+        return name;
+    }
+}

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxInlineGeometry.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxInlineGeometry.java
@@ -1,0 +1,109 @@
+package com.demcha.compose.document.backend.fixed.pptx.handlers;
+
+import com.demcha.compose.document.style.DocumentPathSegment;
+import com.demcha.compose.document.style.ShapeOutline;
+import com.demcha.compose.document.style.ShapePoint;
+import com.demcha.compose.engine.components.content.shape.Stroke;
+import org.apache.poi.sl.usermodel.ShapeType;
+import org.apache.poi.xslf.usermodel.XSLFAutoShape;
+import org.apache.poi.xslf.usermodel.XSLFFreeformShape;
+import org.apache.poi.xslf.usermodel.XSLFSlide;
+
+import java.awt.Color;
+import java.awt.geom.Path2D;
+import java.awt.geom.Rectangle2D;
+import java.util.List;
+
+/** Shared native-DrawingML geometry used by inline shape and SVG spans. */
+final class PptxInlineGeometry {
+
+    private PptxInlineGeometry() {
+    }
+
+    static void drawOutline(XSLFSlide slide,
+                            ShapeOutline outline,
+                            Rectangle2D box,
+                            Color fill,
+                            Stroke stroke) {
+        if (outline instanceof ShapeOutline.Rectangle) {
+            drawPreset(slide, ShapeType.RECT, box, fill, stroke);
+        } else if (outline instanceof ShapeOutline.RoundedRectangle rounded) {
+            XSLFAutoShape shape = drawPreset(slide, ShapeType.ROUND_RECT, box, fill, stroke);
+            PptxShapeStyle.applyRoundRectAdjust(shape, rounded.cornerRadius(),
+                    box.getWidth(), box.getHeight());
+        } else if (outline instanceof ShapeOutline.RoundedRectanglePerCorner rounded) {
+            PptxCapabilityNotes.perCornerRadiiApproximated();
+            XSLFAutoShape shape = drawPreset(slide, ShapeType.ROUND_RECT, box, fill, stroke);
+            PptxShapeStyle.applyRoundRectAdjust(shape, rounded.corners().topLeft(),
+                    box.getWidth(), box.getHeight());
+        } else if (outline instanceof ShapeOutline.Ellipse) {
+            drawPreset(slide, ShapeType.ELLIPSE, box, fill, stroke);
+        } else if (outline instanceof ShapeOutline.Polygon polygon) {
+            drawPath(slide, polygonPath(polygon.points(), box), fill, stroke);
+        } else if (outline instanceof ShapeOutline.Path path) {
+            drawPath(slide, path(path.segments(), box), fill, stroke);
+        }
+    }
+
+    static XSLFFreeformShape drawPath(XSLFSlide slide, Path2D path, Color fill, Stroke stroke) {
+        XSLFFreeformShape shape = slide.createFreeform();
+        shape.setPath(path);
+        PptxShapeStyle.applyFill(shape, fill);
+        PptxShapeStyle.applyStroke(shape, stroke);
+        return shape;
+    }
+
+    static Path2D path(List<DocumentPathSegment> segments, Rectangle2D box) {
+        Path2D.Double path = new Path2D.Double(Path2D.WIND_NON_ZERO);
+        for (DocumentPathSegment segment : segments) {
+            if (segment instanceof DocumentPathSegment.MoveTo move) {
+                path.moveTo(x(box, move.x()), y(box, move.y()));
+            } else if (segment instanceof DocumentPathSegment.LineTo line) {
+                path.lineTo(x(box, line.x()), y(box, line.y()));
+            } else if (segment instanceof DocumentPathSegment.CubicTo curve) {
+                path.curveTo(
+                        x(box, curve.control1X()), y(box, curve.control1Y()),
+                        x(box, curve.control2X()), y(box, curve.control2Y()),
+                        x(box, curve.x()), y(box, curve.y()));
+            } else if (segment instanceof DocumentPathSegment.Close) {
+                path.closePath();
+            }
+        }
+        return path;
+    }
+
+    private static Path2D polygonPath(List<ShapePoint> points, Rectangle2D box) {
+        Path2D.Double path = new Path2D.Double(Path2D.WIND_NON_ZERO);
+        for (int i = 0; i < points.size(); i++) {
+            ShapePoint point = points.get(i);
+            if (i == 0) {
+                path.moveTo(x(box, point.x()), y(box, point.y()));
+            } else {
+                path.lineTo(x(box, point.x()), y(box, point.y()));
+            }
+        }
+        path.closePath();
+        return path;
+    }
+
+    private static XSLFAutoShape drawPreset(XSLFSlide slide,
+                                            ShapeType type,
+                                            Rectangle2D box,
+                                            Color fill,
+                                            Stroke stroke) {
+        XSLFAutoShape shape = slide.createAutoShape();
+        shape.setShapeType(type);
+        shape.setAnchor(box);
+        PptxShapeStyle.applyFill(shape, fill);
+        PptxShapeStyle.applyStroke(shape, stroke);
+        return shape;
+    }
+
+    private static double x(Rectangle2D box, double normalized) {
+        return box.getX() + normalized * box.getWidth();
+    }
+
+    private static double y(Rectangle2D box, double normalized) {
+        return box.getY() + (1.0 - normalized) * box.getHeight();
+    }
+}

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxInlineSvgRasterizer.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxInlineSvgRasterizer.java
@@ -1,0 +1,151 @@
+package com.demcha.compose.document.backend.fixed.pptx.handlers;
+
+import com.demcha.compose.document.layout.payloads.ParagraphSvgSpan;
+import com.demcha.compose.document.layout.payloads.ResolvedSvgLayer;
+import com.demcha.compose.document.style.DocumentLineCap;
+import com.demcha.compose.document.style.DocumentLineJoin;
+import com.demcha.compose.engine.components.content.ImageData;
+import com.demcha.compose.engine.components.content.shape.Stroke;
+
+import javax.imageio.ImageIO;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.geom.Path2D;
+import java.awt.geom.Rectangle2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+/**
+ * Transparent raster fallback for inline SVG details DrawingML cannot express
+ * faithfully: arbitrary clip paths, exact point dashes, line joins, and art
+ * that relies on the SVG viewBox clipping off-canvas geometry.
+ */
+final class PptxInlineSvgRasterizer {
+
+    private static final double PIXELS_PER_POINT = 4.0;
+    private static final int MAX_DIMENSION = 2048;
+    private static final double BOUNDS_EPSILON = 0.0001;
+
+    private PptxInlineSvgRasterizer() {
+    }
+
+    static boolean requiresRaster(ParagraphSvgSpan span) {
+        if (span.width() <= 0 || span.height() <= 0) {
+            return false;
+        }
+        Rectangle2D viewBox = new Rectangle2D.Double(0, 0, span.width(), span.height());
+        for (ResolvedSvgLayer layer : span.layers()) {
+            if (layer.clip() != null && !layer.clip().isEmpty()) {
+                return true;
+            }
+            if (!layer.dashPattern().isSolid()
+                    || layer.lineCap() != DocumentLineCap.BUTT
+                    || layer.lineJoin() != DocumentLineJoin.MITER) {
+                return true;
+            }
+            Path2D path = PptxInlineGeometry.path(layer.segments(), viewBox);
+            Rectangle2D bounds = path.getBounds2D();
+            double strokePad = PptxShapeStyle.drawable(layer.stroke())
+                    ? layer.stroke().width() / 2.0 : 0.0;
+            if (bounds.getMinX() - strokePad < -BOUNDS_EPSILON
+                    || bounds.getMinY() - strokePad < -BOUNDS_EPSILON
+                    || bounds.getMaxX() + strokePad > span.width() + BOUNDS_EPSILON
+                    || bounds.getMaxY() + strokePad > span.height() + BOUNDS_EPSILON) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static ImageData rasterize(ParagraphSvgSpan span) {
+        if (span.width() <= 0 || span.height() <= 0) {
+            throw new IllegalArgumentException("inline SVG dimensions must be positive");
+        }
+        double scale = Math.min(PIXELS_PER_POINT,
+                MAX_DIMENSION / Math.max(span.width(), span.height()));
+        int pixelWidth = Math.max(1, (int) Math.ceil(span.width() * scale));
+        int pixelHeight = Math.max(1, (int) Math.ceil(span.height() * scale));
+        BufferedImage image = new BufferedImage(pixelWidth, pixelHeight, BufferedImage.TYPE_INT_ARGB);
+        Graphics2D graphics = image.createGraphics();
+        try {
+            graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            graphics.setRenderingHint(RenderingHints.KEY_STROKE_CONTROL, RenderingHints.VALUE_STROKE_PURE);
+            graphics.scale(pixelWidth / span.width(), pixelHeight / span.height());
+            Rectangle2D viewBox = new Rectangle2D.Double(0, 0, span.width(), span.height());
+            graphics.clip(viewBox);
+            for (ResolvedSvgLayer layer : span.layers()) {
+                paintLayer(graphics, layer, viewBox);
+            }
+        } finally {
+            graphics.dispose();
+        }
+
+        try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            ImageIO.write(image, "png", output);
+            return ImageData.create(output.toByteArray());
+        } catch (IOException exception) {
+            throw new IllegalStateException("Unable to encode inline SVG fallback", exception);
+        }
+    }
+
+    private static void paintLayer(Graphics2D target,
+                                   ResolvedSvgLayer layer,
+                                   Rectangle2D viewBox) {
+        Graphics2D graphics = (Graphics2D) target.create();
+        try {
+            if (layer.clip() != null && !layer.clip().isEmpty()) {
+                graphics.clip(PptxInlineGeometry.path(layer.clip(), viewBox));
+            }
+            Path2D path = PptxInlineGeometry.path(layer.segments(), viewBox);
+            Color fill = layer.fillPaint() == null
+                    ? layer.fillColor() : layer.fillPaint().primaryColor().color();
+            if (fill != null) {
+                graphics.setColor(fill);
+                graphics.fill(path);
+            }
+
+            Stroke stroke = resolvedStroke(layer);
+            if (PptxShapeStyle.drawable(stroke)) {
+                graphics.setColor(stroke.strokeColor().color());
+                graphics.setStroke(awtStroke(stroke.width(), layer));
+                graphics.draw(path);
+            }
+        } finally {
+            graphics.dispose();
+        }
+    }
+
+    private static Stroke resolvedStroke(ResolvedSvgLayer layer) {
+        if (layer.stroke() == null || layer.strokePaint() == null) {
+            return layer.stroke();
+        }
+        return new Stroke(layer.strokePaint().primaryColor().color(), layer.stroke().width());
+    }
+
+    static BasicStroke awtStroke(double width, ResolvedSvgLayer layer) {
+        int cap = switch (layer.lineCap()) {
+            case BUTT -> BasicStroke.CAP_BUTT;
+            case ROUND -> BasicStroke.CAP_ROUND;
+            case SQUARE -> BasicStroke.CAP_SQUARE;
+        };
+        int join = switch (layer.lineJoin()) {
+            case MITER -> BasicStroke.JOIN_MITER;
+            case ROUND -> BasicStroke.JOIN_ROUND;
+            case BEVEL -> BasicStroke.JOIN_BEVEL;
+        };
+        float[] dash = layer.dashPattern().isSolid() ? null
+                : toFloatArray(layer.dashPattern().segments());
+        return new BasicStroke((float) width, cap, join, 10.0f, dash, 0.0f);
+    }
+
+    private static float[] toFloatArray(java.util.List<Double> values) {
+        float[] result = new float[values.size()];
+        for (int i = 0; i < values.size(); i++) {
+            result[i] = values.get(i).floatValue();
+        }
+        return result;
+    }
+}

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxParagraphFragmentRenderHandler.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxParagraphFragmentRenderHandler.java
@@ -86,7 +86,8 @@ public final class PptxParagraphFragmentRenderHandler
                 !(span instanceof ParagraphTextSpan textSpan) || textSpan.background() != null);
         XSLFTextParagraph paragraph = null;
         if (!usesAbsoluteSpans) {
-            double top = environment.canvasHeight() - baselineY - line.textAscent();
+            double top = environment.canvasHeight() - baselineY
+                    - sharedBoxViewerAscent(line, environment);
             XSLFTextBox lineBox = newTextBox(slide,
                     new Rectangle2D.Double(lineX, top,
                             Math.max(FRAME_EPSILON, line.width() + FRAME_EPSILON),
@@ -129,6 +130,23 @@ public final class PptxParagraphFragmentRenderHandler
         // line box — the same per-line emission the PDF backend uses.
         renderExternalLinkOverlay(slide, payload.linkTarget(), lineX, line.width(),
                 lineTop, line, environment);
+    }
+
+    /**
+     * Returns the viewer ascent that will seat the shared frame's first
+     * baseline: PowerPoint uses the tallest run, so the frame top compensates
+     * with the largest viewer ascent among the line's plain runs.
+     */
+    private static double sharedBoxViewerAscent(ParagraphLine line,
+                                                PptxRenderEnvironment environment) {
+        double ascent = 0;
+        for (ParagraphSpan span : line.spans()) {
+            if (span instanceof ParagraphTextSpan textSpan && textSpan.background() == null) {
+                ascent = Math.max(ascent,
+                        environment.viewerAscent(textSpan.textStyle(), line.textAscent()));
+            }
+        }
+        return ascent > 0 ? ascent : line.textAscent();
     }
 
     /**
@@ -197,7 +215,6 @@ public final class PptxParagraphFragmentRenderHandler
         run.setFontFamily(environment.fontFamily(style.fontName()));
         run.setFontSize(style.size());
         run.setFontColor(style.color() == null ? Color.BLACK : style.color());
-        run.setBaselineOffset(environment.baselineOffset(style));
         run.setBold(PptxFontMapping.isBold(style));
         run.setItalic(PptxFontMapping.isItalic(style));
         run.setUnderlined(PptxFontMapping.isUnderline(style));
@@ -213,7 +230,8 @@ public final class PptxParagraphFragmentRenderHandler
                                        double canvasHeight,
                                        PptxRenderEnvironment environment) {
         PdfFont.VerticalMetrics metrics = verticalMetrics(fonts, span);
-        double top = canvasHeight - baselineY - metrics.ascent();
+        double top = canvasHeight - baselineY
+                - environment.viewerAscent(span.textStyle(), metrics.ascent());
         XSLFTextBox textBox = newTextBox(slide, new Rectangle2D.Double(
                 cursorX, top, Math.max(FRAME_EPSILON, span.width() + FRAME_EPSILON),
                 Math.max(FRAME_EPSILON, metrics.lineHeight())));
@@ -252,7 +270,8 @@ public final class PptxParagraphFragmentRenderHandler
         chip.setLineColor(null);
 
         PdfFont.VerticalMetrics metrics = verticalMetrics(fonts, span);
-        double textTop = canvasHeight - baselineY - metrics.ascent();
+        double textTop = canvasHeight - baselineY
+                - environment.viewerAscent(span.textStyle(), metrics.ascent());
         double textWidth = Math.max(FRAME_EPSILON, span.width() - padding.horizontal());
         XSLFTextBox textBox = newTextBox(slide, new Rectangle2D.Double(
                 cursorX + padding.left(), textTop, textWidth,

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxParagraphFragmentRenderHandler.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxParagraphFragmentRenderHandler.java
@@ -16,6 +16,8 @@ import org.apache.poi.sl.usermodel.ShapeType;
 import org.apache.poi.sl.usermodel.TextShape.TextAutofit;
 import org.apache.poi.sl.usermodel.VerticalAlignment;
 import org.apache.poi.xslf.usermodel.*;
+import org.openxmlformats.schemas.drawingml.x2006.main.CTRegularTextRun;
+import org.openxmlformats.schemas.drawingml.x2006.main.CTTextCharacterProperties;
 import org.openxmlformats.schemas.presentationml.x2006.main.CTShape;
 
 import java.awt.Color;
@@ -219,6 +221,21 @@ public final class PptxParagraphFragmentRenderHandler
         run.setItalic(PptxFontMapping.isItalic(style));
         run.setUnderlined(PptxFontMapping.isUnderline(style));
         run.setStrikethrough(PptxFontMapping.isStrikethrough(style));
+        disableKerning(run);
+    }
+
+    /**
+     * PowerPoint auto-kerns text above ~12pt, but the engine measures and the
+     * PDF backend draws plain unkerned advances — kerned glyphs would drift off
+     * the measured grid and change the visual rhythm of large text. An explicit
+     * {@code kern="0"} keeps the viewer on the measured advances.
+     */
+    private static void disableKerning(XSLFTextRun run) {
+        if (run.getXmlObject() instanceof CTRegularTextRun ctRun) {
+            CTTextCharacterProperties properties =
+                    ctRun.isSetRPr() ? ctRun.getRPr() : ctRun.addNewRPr();
+            properties.setKern(0);
+        }
     }
 
     private static void renderTextSpan(XSLFSlide slide,

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxParagraphFragmentRenderHandler.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxParagraphFragmentRenderHandler.java
@@ -1,0 +1,423 @@
+package com.demcha.compose.document.backend.fixed.pptx.handlers;
+
+import com.demcha.compose.document.backend.fixed.pptx.PptxFragmentRenderHandler;
+import com.demcha.compose.document.backend.fixed.pptx.PptxRenderEnvironment;
+import com.demcha.compose.document.layout.PlacedFragment;
+import com.demcha.compose.document.layout.payloads.*;
+import com.demcha.compose.document.node.ExternalLinkTarget;
+import com.demcha.compose.document.node.InlineImageAlignment;
+import com.demcha.compose.document.node.TextVerticalAlign;
+import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.document.style.InlineBackground;
+import com.demcha.compose.engine.components.content.text.TextStyle;
+import com.demcha.compose.engine.render.pdf.PdfFont;
+import com.demcha.compose.font.FontLibrary;
+import org.apache.poi.sl.usermodel.ShapeType;
+import org.apache.poi.sl.usermodel.TextShape.TextAutofit;
+import org.apache.poi.sl.usermodel.VerticalAlignment;
+import org.apache.poi.xslf.usermodel.*;
+import org.openxmlformats.schemas.presentationml.x2006.main.CTShape;
+
+import java.awt.Color;
+import java.awt.geom.Rectangle2D;
+
+/**
+ * Renders each pre-wrapped paragraph line into an absolute, non-wrapping text
+ * frame and paints inline chips and graphics at their measured span boxes.
+ *
+ * @since 2.1.0
+ */
+public final class PptxParagraphFragmentRenderHandler
+        implements PptxFragmentRenderHandler<ParagraphFragmentPayload> {
+
+    private static final double FRAME_EPSILON = 0.1;
+
+    /** Creates the paragraph renderer. */
+    public PptxParagraphFragmentRenderHandler() {
+    }
+
+    @Override
+    public Class<ParagraphFragmentPayload> payloadType() {
+        return ParagraphFragmentPayload.class;
+    }
+
+    @Override
+    public void render(PlacedFragment fragment,
+                       ParagraphFragmentPayload payload,
+                       PptxRenderEnvironment environment) {
+        FontLibrary fonts = environment.fonts();
+        double innerX = fragment.x() + payload.padding().left();
+        double innerWidth = Math.max(0.0, fragment.width() - payload.padding().horizontal());
+        double cursorTop = fragment.y() + fragment.height() - payload.padding().top();
+
+        for (ParagraphLine line : payload.lines()) {
+            double baselineY = cursorTop - line.lineHeight() + line.baselineOffsetFromBottom();
+            if (payload.verticalAlign() != TextVerticalAlign.DEFAULT) {
+                baselineY += verticalSeatShift(line, fonts, payload.verticalAlign());
+            }
+            double lineX = switch (payload.align()) {
+                case RIGHT -> innerX + innerWidth - line.width();
+                case CENTER -> innerX + (innerWidth - line.width()) / 2.0;
+                case LEFT -> innerX;
+            };
+            renderLine(fragment.pageIndex(), line, lineX, baselineY, cursorTop, payload, fonts, environment);
+            cursorTop -= line.lineHeight() + payload.lineGap();
+        }
+    }
+
+    private static void renderLine(int pageIndex,
+                                   ParagraphLine line,
+                                   double lineX,
+                                   double baselineY,
+                                   double lineTop,
+                                   ParagraphFragmentPayload payload,
+                                   FontLibrary fonts,
+                                   PptxRenderEnvironment environment) {
+        if (line.spans().isEmpty()) {
+            return;
+        }
+        XSLFSlide slide = environment.slide(pageIndex);
+        // PowerPoint seats one shared baseline per paragraph using its largest
+        // run, so one shared frame is only safe while every plain run agrees on
+        // font size; chips, inline graphics, and mixed sizes go through
+        // per-span absolute frames whose tops already encode their own ascent.
+        boolean usesAbsoluteSpans = mixesFontSizes(line)
+                || line.spans().stream().anyMatch(span ->
+                !(span instanceof ParagraphTextSpan textSpan) || textSpan.background() != null);
+        XSLFTextParagraph paragraph = null;
+        if (!usesAbsoluteSpans) {
+            double top = environment.canvasHeight() - baselineY - line.textAscent();
+            XSLFTextBox lineBox = newTextBox(slide,
+                    new Rectangle2D.Double(lineX, top,
+                            Math.max(FRAME_EPSILON, line.width() + FRAME_EPSILON),
+                            Math.max(FRAME_EPSILON, line.textLineHeight())));
+            setShapeName(lineBox, "GraphCompose Text Line");
+            paragraph = lineBox.getTextParagraphs().get(0);
+            removePlaceholderRuns(paragraph);
+            paragraph.setTextAlign(org.apache.poi.sl.usermodel.TextParagraph.TextAlign.LEFT);
+            paragraph.setLineSpacing(100.0);
+            paragraph.setSpaceBefore(0.0);
+            paragraph.setSpaceAfter(0.0);
+        }
+
+        double cursorX = lineX;
+        for (ParagraphSpan span : line.spans()) {
+            if (span instanceof ParagraphTextSpan textSpan) {
+                String text = sanitized(fonts, textSpan);
+                if (textSpan.background() == null) {
+                    if (paragraph == null) {
+                        renderTextSpan(slide, textSpan, text, cursorX, baselineY, fonts,
+                                environment.canvasHeight(), environment);
+                    } else {
+                        addRun(paragraph, text, textSpan.textStyle(), environment);
+                    }
+                } else {
+                    renderChip(slide, textSpan, text, cursorX, baselineY, line, fonts, environment);
+                }
+            } else if (span instanceof ParagraphImageSpan imageSpan) {
+                renderImage(slide, imageSpan, cursorX, baselineY, line, environment);
+            } else if (span instanceof ParagraphShapeSpan shapeSpan) {
+                renderShape(slide, shapeSpan, cursorX, baselineY, line, environment.canvasHeight());
+            } else if (span instanceof ParagraphSvgSpan svgSpan) {
+                renderSvg(slide, svgSpan, cursorX, baselineY, line, environment);
+            }
+            renderExternalLinkOverlay(slide, spanLinkTarget(span), cursorX, span.width(),
+                    lineTop, line, environment);
+            cursorX += span.width();
+        }
+        // Paragraph-level links get one hotspot per line, tight to the measured
+        // line box — the same per-line emission the PDF backend uses.
+        renderExternalLinkOverlay(slide, payload.linkTarget(), lineX, line.width(),
+                lineTop, line, environment);
+    }
+
+    /**
+     * Returns whether the line's plain text runs disagree on font size — the
+     * case a single shared PowerPoint frame cannot seat on one baseline.
+     */
+    private static boolean mixesFontSizes(ParagraphLine line) {
+        double size = Double.NaN;
+        for (ParagraphSpan span : line.spans()) {
+            if (span instanceof ParagraphTextSpan textSpan && textSpan.background() == null) {
+                double spanSize = textSpan.textStyle().size();
+                if (Double.isNaN(size)) {
+                    size = spanSize;
+                } else if (spanSize != size) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static com.demcha.compose.document.node.DocumentLinkTarget spanLinkTarget(ParagraphSpan span) {
+        if (span instanceof ParagraphTextSpan textSpan) {
+            return textSpan.linkTarget();
+        }
+        if (span instanceof ParagraphImageSpan imageSpan) {
+            return imageSpan.linkTarget();
+        }
+        if (span instanceof ParagraphShapeSpan shapeSpan) {
+            return shapeSpan.linkTarget();
+        }
+        if (span instanceof ParagraphSvgSpan svgSpan) {
+            return svgSpan.linkTarget();
+        }
+        return null;
+    }
+
+    private static XSLFTextBox newTextBox(XSLFSlide slide, Rectangle2D anchor) {
+        XSLFTextBox box = slide.createTextBox();
+        box.setAnchor(anchor);
+        box.setWordWrap(false);
+        box.setTextAutofit(TextAutofit.NONE);
+        box.setVerticalAlignment(VerticalAlignment.TOP);
+        box.setTopInset(0);
+        box.setRightInset(0);
+        box.setBottomInset(0);
+        box.setLeftInset(0);
+        return box;
+    }
+
+    private static void addRun(XSLFTextParagraph paragraph,
+                               String text,
+                               TextStyle style,
+                               PptxRenderEnvironment environment) {
+        if (text.isEmpty()) {
+            return;
+        }
+        XSLFTextRun run = paragraph.addNewTextRun();
+        run.setText(text);
+        applyStyle(run, style, environment);
+    }
+
+    private static void applyStyle(XSLFTextRun run,
+                                   TextStyle style,
+                                   PptxRenderEnvironment environment) {
+        run.setFontFamily(environment.fontFamily(style.fontName()));
+        run.setFontSize(style.size());
+        run.setFontColor(style.color() == null ? Color.BLACK : style.color());
+        run.setBaselineOffset(environment.baselineOffset(style));
+        run.setBold(PptxFontMapping.isBold(style));
+        run.setItalic(PptxFontMapping.isItalic(style));
+        run.setUnderlined(PptxFontMapping.isUnderline(style));
+        run.setStrikethrough(PptxFontMapping.isStrikethrough(style));
+    }
+
+    private static void renderTextSpan(XSLFSlide slide,
+                                       ParagraphTextSpan span,
+                                       String text,
+                                       double cursorX,
+                                       double baselineY,
+                                       FontLibrary fonts,
+                                       double canvasHeight,
+                                       PptxRenderEnvironment environment) {
+        PdfFont.VerticalMetrics metrics = verticalMetrics(fonts, span);
+        double top = canvasHeight - baselineY - metrics.ascent();
+        XSLFTextBox textBox = newTextBox(slide, new Rectangle2D.Double(
+                cursorX, top, Math.max(FRAME_EPSILON, span.width() + FRAME_EPSILON),
+                Math.max(FRAME_EPSILON, metrics.lineHeight())));
+        setShapeName(textBox, "GraphCompose Inline Text Span");
+        XSLFTextParagraph paragraph = textBox.getTextParagraphs().get(0);
+        removePlaceholderRuns(paragraph);
+        paragraph.setTextAlign(org.apache.poi.sl.usermodel.TextParagraph.TextAlign.LEFT);
+        addRun(paragraph, text, span.textStyle(), environment);
+    }
+
+    private static void renderChip(XSLFSlide slide,
+                                   ParagraphTextSpan span,
+                                   String text,
+                                   double cursorX,
+                                   double baselineY,
+                                   ParagraphLine line,
+                                   FontLibrary fonts,
+                                   PptxRenderEnvironment environment) {
+        if (text.isEmpty()) {
+            return;
+        }
+        InlineBackground background = span.background();
+        DocumentInsets padding = background.padding();
+        double chipBottom = baselineY - line.baselineOffsetFromBottom() - padding.bottom();
+        double chipHeight = line.textLineHeight() + padding.vertical();
+        double canvasHeight = environment.canvasHeight();
+        Rectangle2D chipAnchor = new Rectangle2D.Double(
+                cursorX, canvasHeight - chipBottom - chipHeight, span.width(), chipHeight);
+        XSLFAutoShape chip = slide.createAutoShape();
+        chip.setShapeType(background.cornerRadius() > 0 ? ShapeType.ROUND_RECT : ShapeType.RECT);
+        chip.setAnchor(chipAnchor);
+        if (background.cornerRadius() > 0) {
+            PptxShapeStyle.applyRoundRectAdjust(chip, background.cornerRadius(), span.width(), chipHeight);
+        }
+        chip.setFillColor(background.fill().color());
+        chip.setLineColor(null);
+
+        PdfFont.VerticalMetrics metrics = verticalMetrics(fonts, span);
+        double textTop = canvasHeight - baselineY - metrics.ascent();
+        double textWidth = Math.max(FRAME_EPSILON, span.width() - padding.horizontal());
+        XSLFTextBox textBox = newTextBox(slide, new Rectangle2D.Double(
+                cursorX + padding.left(), textTop, textWidth,
+                Math.max(FRAME_EPSILON, metrics.lineHeight())));
+        setShapeName(textBox, "GraphCompose Inline Chip Text");
+        XSLFTextParagraph paragraph = textBox.getTextParagraphs().get(0);
+        removePlaceholderRuns(paragraph);
+        paragraph.setTextAlign(org.apache.poi.sl.usermodel.TextParagraph.TextAlign.LEFT);
+        addRun(paragraph, text, span.textStyle(), environment);
+    }
+
+    private static void renderExternalLinkOverlay(XSLFSlide slide,
+                                                  com.demcha.compose.document.node.DocumentLinkTarget target,
+                                                  double x,
+                                                  double width,
+                                                  double lineTop,
+                                                  ParagraphLine line,
+                                                  PptxRenderEnvironment environment) {
+        if (!(target instanceof ExternalLinkTarget external) || width <= 0) {
+            return;
+        }
+        XSLFAutoShape hotspot = slide.createAutoShape();
+        hotspot.setShapeType(ShapeType.RECT);
+        hotspot.setAnchor(new Rectangle2D.Double(x,
+                environment.canvasHeight() - lineTop, width, line.lineHeight()));
+        // A fully transparent solid fill keeps the whole rectangle clickable
+        // in slide-show mode. noFill shapes only hit-test their outline.
+        hotspot.setFillColor(new Color(0, 0, 0, 0));
+        hotspot.setLineColor(null);
+        setShapeName(hotspot, "GraphCompose Text Link Hotspot");
+        hotspot.createHyperlink().linkToUrl(external.options().uri());
+    }
+
+    private static void removePlaceholderRuns(XSLFTextParagraph paragraph) {
+        for (XSLFTextRun run : java.util.List.copyOf(paragraph.getTextRuns())) {
+            if (run.getRawText() == null || run.getRawText().isEmpty()) {
+                paragraph.removeTextRun(run);
+            }
+        }
+    }
+
+    private static void setShapeName(XSLFSimpleShape shape, String name) {
+        ((CTShape) shape.getXmlObject()).getNvSpPr().getCNvPr().setName(name);
+    }
+
+    private static void renderImage(XSLFSlide slide,
+                                    ParagraphImageSpan span,
+                                    double cursorX,
+                                    double baselineY,
+                                    ParagraphLine line,
+                                    PptxRenderEnvironment environment) {
+        double bottom = inlineBottom(span.height(), span.alignment(), span.baselineOffset(), baselineY, line);
+        XSLFPictureShape picture = slide.createPicture(environment.resolvePicture(span.imageData()));
+        picture.setAnchor(new Rectangle2D.Double(cursorX,
+                environment.canvasHeight() - bottom - span.height(), span.width(), span.height()));
+    }
+
+    private static void renderShape(XSLFSlide slide,
+                                    ParagraphShapeSpan span,
+                                    double cursorX,
+                                    double baselineY,
+                                    ParagraphLine line,
+                                    double canvasHeight) {
+        if (span.width() <= 0 || span.height() <= 0) {
+            return;
+        }
+        double bottom = inlineBottom(span.height(), span.alignment(), span.baselineOffset(), baselineY, line);
+        for (ResolvedShapeLayer layer : span.layers()) {
+            double width = layer.outline().width();
+            double height = layer.outline().height();
+            Rectangle2D box = new Rectangle2D.Double(
+                    cursorX + (span.width() - width) / 2.0,
+                    canvasHeight - bottom - (span.height() + height) / 2.0,
+                    width, height);
+            PptxInlineGeometry.drawOutline(slide, layer.outline(), box, layer.fillColor(), layer.stroke());
+        }
+    }
+
+    private static void renderSvg(XSLFSlide slide,
+                                  ParagraphSvgSpan span,
+                                  double cursorX,
+                                  double baselineY,
+                                  ParagraphLine line,
+                                  PptxRenderEnvironment environment) {
+        if (span.width() <= 0 || span.height() <= 0) {
+            return;
+        }
+        double bottom = inlineBottom(span.height(), span.alignment(), span.baselineOffset(), baselineY, line);
+        Rectangle2D box = new Rectangle2D.Double(cursorX,
+                environment.canvasHeight() - bottom - span.height(), span.width(), span.height());
+        if (PptxInlineSvgRasterizer.requiresRaster(span)) {
+            PptxCapabilityNotes.inlineSvgRasterized();
+            if (span.layers().stream().anyMatch(layer ->
+                    layer.fillPaint() != null || layer.strokePaint() != null)) {
+                PptxCapabilityNotes.gradientApproximated();
+            }
+            XSLFPictureShape picture = slide.createPicture(
+                    environment.resolvePicture(PptxInlineSvgRasterizer.rasterize(span)));
+            picture.setAnchor(box);
+            return;
+        }
+        for (ResolvedSvgLayer layer : span.layers()) {
+            if (layer.fillPaint() != null || layer.strokePaint() != null) {
+                PptxCapabilityNotes.gradientApproximated();
+            }
+            Color fill = layer.fillPaint() == null
+                    ? layer.fillColor() : layer.fillPaint().primaryColor().color();
+            com.demcha.compose.engine.components.content.shape.Stroke stroke = layer.stroke();
+            if (stroke != null && layer.strokePaint() != null) {
+                stroke = new com.demcha.compose.engine.components.content.shape.Stroke(
+                        layer.strokePaint().primaryColor().color(), stroke.width());
+            }
+            PptxInlineGeometry.drawPath(slide,
+                    PptxInlineGeometry.path(layer.segments(), box), fill, stroke);
+        }
+    }
+
+    private static double inlineBottom(double height,
+                                       InlineImageAlignment alignment,
+                                       double baselineOffset,
+                                       double baselineY,
+                                       ParagraphLine line) {
+        double lineBottom = baselineY - line.baselineOffsetFromBottom();
+        double base = switch (alignment == null ? InlineImageAlignment.CENTER : alignment) {
+            case BASELINE -> baselineY;
+            case CENTER -> lineBottom + (line.lineHeight() - height) / 2.0;
+            case TEXT_TOP -> baselineY + line.textAscent() - height;
+            case TEXT_BOTTOM -> lineBottom;
+        };
+        return base + baselineOffset;
+    }
+
+    private static String sanitized(FontLibrary fonts, ParagraphTextSpan span) {
+        PdfFont font = fonts.getFont(span.textStyle().fontName(), PdfFont.class).orElseThrow();
+        return font.sanitizeForRender(span.textStyle(), span.text());
+    }
+
+    private static PdfFont.VerticalMetrics verticalMetrics(FontLibrary fonts,
+                                                           ParagraphTextSpan span) {
+        PdfFont font = fonts.getFont(span.textStyle().fontName(), PdfFont.class).orElseThrow();
+        return font.verticalMetrics(span.textStyle());
+    }
+
+    private static double verticalSeatShift(ParagraphLine line,
+                                            FontLibrary fonts,
+                                            TextVerticalAlign align) {
+        for (ParagraphSpan span : line.spans()) {
+            if (span instanceof ParagraphTextSpan textSpan) {
+                PdfFont font = fonts.getFont(textSpan.textStyle().fontName(), PdfFont.class).orElse(null);
+                if (font == null) {
+                    return 0;
+                }
+                double capHeight = font.getCapHeight(textSpan.textStyle());
+                double ascent = line.textAscent();
+                double descent = line.baselineOffsetFromBottom();
+                double leading = Math.max(0, line.textLineHeight() - ascent - descent);
+                double capTopToBoxTop = ascent + leading - capHeight;
+                return switch (align) {
+                    case TOP -> capTopToBoxTop;
+                    case CENTER -> (capTopToBoxTop - descent) / 2.0;
+                    case BOTTOM -> -descent;
+                    case DEFAULT -> 0;
+                };
+            }
+        }
+        return 0;
+    }
+}

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxShapeFragmentRenderHandler.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxShapeFragmentRenderHandler.java
@@ -11,10 +11,6 @@ import org.apache.poi.sl.usermodel.ShapeType;
 import org.apache.poi.xslf.usermodel.XSLFAutoShape;
 import org.apache.poi.xslf.usermodel.XSLFConnectorShape;
 import org.apache.poi.xslf.usermodel.XSLFSlide;
-import org.openxmlformats.schemas.drawingml.x2006.main.CTGeomGuide;
-import org.openxmlformats.schemas.drawingml.x2006.main.CTGeomGuideList;
-import org.openxmlformats.schemas.drawingml.x2006.main.CTPresetGeometry2D;
-import org.openxmlformats.schemas.presentationml.x2006.main.CTShape;
 
 import java.awt.geom.Rectangle2D;
 
@@ -71,7 +67,7 @@ public final class PptxShapeFragmentRenderHandler
             double radius = uniformRadius(payload.cornerRadius(), anchor.width, anchor.height);
             if (radius > 0) {
                 shape.setShapeType(ShapeType.ROUND_RECT);
-                applyRoundRectAdjust(shape, radius, Math.min(anchor.width, anchor.height));
+                PptxShapeStyle.applyRoundRectAdjust(shape, radius, anchor.width, anchor.height);
             } else {
                 shape.setShapeType(ShapeType.RECT);
             }
@@ -118,21 +114,6 @@ public final class PptxShapeFragmentRenderHandler
             return 0.0;
         }
         return Math.min(raw, maxAllowed);
-    }
-
-    /**
-     * Stamps the roundRect {@code adj} guide: the radius as a fraction of the
-     * smaller side, in DrawingML's 1/100000 units, capped at the preset's
-     * half-side maximum of 50000.
-     */
-    private static void applyRoundRectAdjust(XSLFAutoShape shape, double radius, double smallerSide) {
-        long adj = Math.round(radius / smallerSide * 100000.0);
-        adj = Math.max(0, Math.min(adj, 50000));
-        CTPresetGeometry2D geometry = ((CTShape) shape.getXmlObject()).getSpPr().getPrstGeom();
-        CTGeomGuideList adjustValues = geometry.isSetAvLst() ? geometry.getAvLst() : geometry.addNewAvLst();
-        CTGeomGuide guide = adjustValues.addNewGd();
-        guide.setName("adj");
-        guide.setFmla("val " + adj);
     }
 
     private static void drawSideBorder(XSLFSlide slide,

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxShapeStyle.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxShapeStyle.java
@@ -5,7 +5,12 @@ import com.demcha.compose.document.style.DocumentLineCap;
 import com.demcha.compose.engine.components.content.shape.Stroke;
 import org.apache.poi.sl.usermodel.StrokeStyle.LineCap;
 import org.apache.poi.sl.usermodel.StrokeStyle.LineDash;
+import org.apache.poi.xslf.usermodel.XSLFAutoShape;
 import org.apache.poi.xslf.usermodel.XSLFSimpleShape;
+import org.openxmlformats.schemas.drawingml.x2006.main.CTGeomGuide;
+import org.openxmlformats.schemas.drawingml.x2006.main.CTGeomGuideList;
+import org.openxmlformats.schemas.drawingml.x2006.main.CTPresetGeometry2D;
+import org.openxmlformats.schemas.presentationml.x2006.main.CTShape;
 
 import java.awt.Color;
 
@@ -45,6 +50,29 @@ final class PptxShapeStyle {
                 && stroke.strokeColor() != null
                 && stroke.strokeColor().color() != null
                 && stroke.width() > 0;
+    }
+
+    /**
+     * Writes the {@code roundRect} adjustment that represents the requested
+     * radius as a fraction of the smaller side. DrawingML clamps that preset at
+     * half the smaller side, matching the PDF geometry contract.
+     */
+    static void applyRoundRectAdjust(XSLFAutoShape shape,
+                                     double radius,
+                                     double width,
+                                     double height) {
+        double smallerSide = Math.min(width, height);
+        if (smallerSide <= 0) {
+            return;
+        }
+        long adjust = Math.round(Math.min(Math.max(radius, 0), smallerSide / 2.0)
+                / smallerSide * 100000.0);
+        CTPresetGeometry2D geometry = ((CTShape) shape.getXmlObject()).getSpPr().getPrstGeom();
+        CTGeomGuideList adjustValues = geometry.isSetAvLst()
+                ? geometry.getAvLst() : geometry.addNewAvLst();
+        CTGeomGuide guide = adjustValues.addNewGd();
+        guide.setName("adj");
+        guide.setFmla("val " + Math.max(0, Math.min(adjust, 50000)));
     }
 
     static void applyLineCap(XSLFSimpleShape shape, DocumentLineCap cap) {

--- a/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxEmbeddedFontTest.java
+++ b/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxEmbeddedFontTest.java
@@ -1,0 +1,38 @@
+package com.demcha.compose.document.backend.fixed.pptx;
+
+import org.apache.poi.common.usermodel.fonts.FontHeader;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PptxEmbeddedFontTest {
+
+    @Test
+    void wrapsRawTrueTypeDataInAnUncompressedEotContainer() throws Exception {
+        byte[] ttf;
+        try (InputStream input = getClass().getResourceAsStream(
+                "/fonts/google/lato/Lato-BoldItalic.ttf")) {
+            assertThat(input).isNotNull();
+            ttf = input.readAllBytes();
+        }
+
+        byte[] eot = PptxEmbeddedFont.wrap(new ByteArrayInputStream(ttf));
+        FontHeader header = new FontHeader();
+        try (InputStream parsed = header.bufferInit(new ByteArrayInputStream(eot))) {
+            assertThat(header.getFamilyName()).isEqualTo("Lato");
+            assertThat(header.getStyleName()).isEqualTo("Bold Italic");
+            assertThat(header.isBold()).isTrue();
+            assertThat(header.isItalic()).isTrue();
+            assertThat(ByteBuffer.wrap(eot).order(ByteOrder.LITTLE_ENDIAN).getInt(8))
+                    .isEqualTo(0x00020001);
+            assertThat(eot).endsWith(ttf);
+            assertThat(parsed.readNBytes(4)).containsExactly(
+                    (byte) eot[0], (byte) eot[1], (byte) eot[2], (byte) eot[3]);
+        }
+    }
+}

--- a/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxFixedLayoutBackendTest.java
+++ b/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxFixedLayoutBackendTest.java
@@ -5,6 +5,7 @@ import com.demcha.compose.document.api.DocumentSession;
 import com.demcha.compose.document.dsl.DocumentDsl;
 import com.demcha.compose.document.dsl.EllipseBuilder;
 import com.demcha.compose.document.dsl.LineBuilder;
+import com.demcha.compose.document.dsl.BarcodeBuilder;
 import com.demcha.compose.document.exceptions.UnsupportedNodeCapabilityException;
 import com.demcha.compose.document.layout.LayoutGraph;
 import com.demcha.compose.document.backend.fixed.FixedLayoutRenderContext;
@@ -150,10 +151,10 @@ class PptxFixedLayoutBackendTest {
         try (DocumentSession session = GraphCompose.document()
                 .pageSize(300, 200)
                 .create()) {
-            session.pageFlow(page -> page.module("m", module -> module.paragraph("text")));
+            session.add(new BarcodeBuilder().data("still unsupported").qrCode().size(40, 40).build());
             assertThatThrownBy(() -> session.render(new PptxFixedLayoutBackend()))
                     .isInstanceOf(UnsupportedNodeCapabilityException.class)
-                    .hasMessageContaining("ParagraphFragmentPayload");
+                    .hasMessageContaining("BarcodeFragmentPayload");
         }
     }
 }

--- a/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxGeometryAssertions.java
+++ b/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxGeometryAssertions.java
@@ -92,6 +92,8 @@ final class PptxGeometryAssertions {
                                           List<FontFamilyDefinition> customFonts) throws Exception {
         try (XMLSlideShow show = new XMLSlideShow(new ByteArrayInputStream(pptxBytes));
              PdfMeasurementResources measurement = PdfMeasurementResources.open(customFonts)) {
+            java.util.Map<com.demcha.compose.font.FontName, PptxViewerMetrics.ViewerFontMetrics> embedded =
+                    viewerMetricsByFamily(customFonts);
             List<ExpectedTextLine> expected = new ArrayList<>();
             List<ExpectedLinkHotspot> expectedLinks = new ArrayList<>();
             for (PlacedFragment fragment : graph.fragments()) {
@@ -143,7 +145,8 @@ final class PptxGeometryAssertions {
                         }
                         expected.add(new ExpectedTextLine(fragment.pageIndex(),
                                 new Rectangle2D.Double(lineX,
-                                        graph.canvas().height() - baselineY - line.textAscent(),
+                                        graph.canvas().height() - baselineY
+                                                - sharedViewerAscent(line, measurement, embedded),
                                         line.width() + 0.1, line.textLineHeight()),
                                 "GraphCompose Text Line", text.toString()));
                     }
@@ -157,7 +160,9 @@ final class PptxGeometryAssertions {
                                 String sanitized = font.sanitizeForRender(
                                         textSpan.textStyle(), textSpan.text());
                                 PdfFont.VerticalMetrics metrics = font.verticalMetrics(textSpan.textStyle());
-                                double top = graph.canvas().height() - baselineY - metrics.ascent();
+                                double top = graph.canvas().height() - baselineY
+                                        - expectedViewerAscent(textSpan.textStyle(),
+                                                metrics.ascent(), measurement, embedded);
                                 if (textSpan.background() == null) {
                                     expected.add(new ExpectedTextLine(fragment.pageIndex(),
                                             new Rectangle2D.Double(cursorX, top,
@@ -379,6 +384,52 @@ final class PptxGeometryAssertions {
 
     private static double pathY(Rectangle2D box, double normalized) {
         return box.getY() + (1.0 - normalized) * box.getHeight();
+    }
+
+    private static java.util.Map<com.demcha.compose.font.FontName, PptxViewerMetrics.ViewerFontMetrics>
+            viewerMetricsByFamily(List<FontFamilyDefinition> customFonts) {
+        java.util.Map<com.demcha.compose.font.FontName, PptxViewerMetrics.ViewerFontMetrics> metrics =
+                new java.util.LinkedHashMap<>();
+        for (FontFamilyDefinition family : customFonts) {
+            family.fontSourceSet().ifPresent(sources ->
+                    metrics.put(family.name(), PptxViewerMetrics.load(family, sources)));
+        }
+        return metrics;
+    }
+
+    /** Mirrors the production seat: frame top = baseline − viewer ascent (largest plain run). */
+    private static double sharedViewerAscent(
+            ParagraphLine line,
+            PdfMeasurementResources measurement,
+            java.util.Map<com.demcha.compose.font.FontName, PptxViewerMetrics.ViewerFontMetrics> embedded) {
+        double ascent = 0;
+        for (ParagraphSpan span : line.spans()) {
+            if (span instanceof ParagraphTextSpan textSpan && textSpan.background() == null) {
+                ascent = Math.max(ascent, expectedViewerAscent(
+                        textSpan.textStyle(), line.textAscent(), measurement, embedded));
+            }
+        }
+        return ascent > 0 ? ascent : line.textAscent();
+    }
+
+    private static double expectedViewerAscent(
+            com.demcha.compose.engine.components.content.text.TextStyle style,
+            double fallbackAscent,
+            PdfMeasurementResources measurement,
+            java.util.Map<com.demcha.compose.font.FontName, PptxViewerMetrics.ViewerFontMetrics> embedded) {
+        PdfFont font = measurement.fontLibrary().getFont(style.fontName(), PdfFont.class).orElse(null);
+        if (font == null || style.size() <= 0) {
+            return fallbackAscent;
+        }
+        double pdfRatio = font.verticalMetrics(style).ascent() / style.size();
+        PptxViewerMetrics.ViewerFontMetrics custom = embedded.get(style.fontName());
+        double ratio = custom == null
+                ? com.demcha.compose.document.backend.fixed.pptx.handlers.PptxFontMapping
+                        .viewerAscentRatio(style.fontName(), pdfRatio)
+                : custom.ascent(
+                        com.demcha.compose.document.backend.fixed.pptx.handlers.PptxFontMapping.isBold(style),
+                        com.demcha.compose.document.backend.fixed.pptx.handlers.PptxFontMapping.isItalic(style));
+        return ratio * style.size();
     }
 
     /** Mirrors the handler's shared-frame gate: mixed plain-run sizes force per-span frames. */

--- a/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxGeometryAssertions.java
+++ b/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxGeometryAssertions.java
@@ -2,15 +2,26 @@ package com.demcha.compose.document.backend.fixed.pptx;
 
 import com.demcha.compose.document.layout.LayoutGraph;
 import com.demcha.compose.document.layout.PlacedFragment;
-import com.demcha.compose.document.layout.payloads.EllipseFragmentPayload;
-import com.demcha.compose.document.layout.payloads.LineFragmentPayload;
-import com.demcha.compose.document.layout.payloads.ShapeFragmentPayload;
+import com.demcha.compose.document.layout.payloads.*;
+import com.demcha.compose.document.node.ExternalLinkTarget;
+import com.demcha.compose.document.node.InlineImageAlignment;
+import com.demcha.compose.document.node.TextVerticalAlign;
+import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.document.style.ShapeOutline;
+import com.demcha.compose.document.backend.fixed.pdf.PdfMeasurementResources;
+import com.demcha.compose.engine.render.pdf.PdfFont;
+import com.demcha.compose.font.FontFamilyDefinition;
 import org.apache.poi.util.Units;
 import org.apache.poi.xslf.usermodel.XMLSlideShow;
 import org.apache.poi.xslf.usermodel.XSLFShape;
 import org.apache.poi.xslf.usermodel.XSLFSlide;
+import org.apache.poi.xslf.usermodel.XSLFTextBox;
+import org.apache.poi.xslf.usermodel.XSLFAutoShape;
+import org.apache.poi.xslf.usermodel.XSLFFreeformShape;
+import org.apache.poi.xslf.usermodel.XSLFPictureShape;
 
 import java.awt.geom.Rectangle2D;
+import java.awt.geom.Path2D;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -70,6 +81,427 @@ final class PptxGeometryAssertions {
                 }
             }
         }
+    }
+
+    static void assertTextGeometryMatches(LayoutGraph graph, byte[] pptxBytes) throws Exception {
+        assertTextGeometryMatches(graph, pptxBytes, List.of());
+    }
+
+    static void assertTextGeometryMatches(LayoutGraph graph,
+                                          byte[] pptxBytes,
+                                          List<FontFamilyDefinition> customFonts) throws Exception {
+        try (XMLSlideShow show = new XMLSlideShow(new ByteArrayInputStream(pptxBytes));
+             PdfMeasurementResources measurement = PdfMeasurementResources.open(customFonts)) {
+            List<ExpectedTextLine> expected = new ArrayList<>();
+            List<ExpectedLinkHotspot> expectedLinks = new ArrayList<>();
+            for (PlacedFragment fragment : graph.fragments()) {
+                if (!(fragment.payload() instanceof ParagraphFragmentPayload payload)) {
+                    continue;
+                }
+                double innerX = fragment.x() + payload.padding().left();
+                double innerWidth = fragment.width() - payload.padding().horizontal();
+                double cursorTop = fragment.y() + fragment.height() - payload.padding().top();
+                for (ParagraphLine line : payload.lines()) {
+                    double baselineY = cursorTop - line.lineHeight() + line.baselineOffsetFromBottom();
+                    baselineY += verticalSeatShift(line, measurement, payload.verticalAlign());
+                    double lineX = switch (payload.align()) {
+                        case RIGHT -> innerX + innerWidth - line.width();
+                        case CENTER -> innerX + (innerWidth - line.width()) / 2.0;
+                        case LEFT -> innerX;
+                    };
+                    double linkCursorX = lineX;
+                    for (ParagraphSpan span : line.spans()) {
+                        if (spanLinkTarget(span) instanceof ExternalLinkTarget external
+                                && span.width() > 0) {
+                            expectedLinks.add(new ExpectedLinkHotspot(fragment.pageIndex(),
+                                    new Rectangle2D.Double(linkCursorX,
+                                            graph.canvas().height() - cursorTop,
+                                            span.width(), line.lineHeight()),
+                                    external.options().uri()));
+                        }
+                        linkCursorX += span.width();
+                    }
+                    if (payload.linkTarget() instanceof ExternalLinkTarget paragraphLink
+                            && line.width() > 0 && !line.spans().isEmpty()) {
+                        expectedLinks.add(new ExpectedLinkHotspot(fragment.pageIndex(),
+                                new Rectangle2D.Double(lineX,
+                                        graph.canvas().height() - cursorTop,
+                                        line.width(), line.lineHeight()),
+                                paragraphLink.options().uri()));
+                    }
+                    boolean usesAbsoluteSpans = mixesFontSizes(line)
+                            || line.spans().stream().anyMatch(span ->
+                            !(span instanceof ParagraphTextSpan textSpan) || textSpan.background() != null);
+                    if (!usesAbsoluteSpans && !line.spans().isEmpty()) {
+                        StringBuilder text = new StringBuilder();
+                        for (var span : line.spans()) {
+                            if (span instanceof ParagraphTextSpan textSpan) {
+                                PdfFont font = measurement.fontLibrary()
+                                        .getFont(textSpan.textStyle().fontName(), PdfFont.class).orElseThrow();
+                                text.append(font.sanitizeForRender(textSpan.textStyle(), textSpan.text()));
+                            }
+                        }
+                        expected.add(new ExpectedTextLine(fragment.pageIndex(),
+                                new Rectangle2D.Double(lineX,
+                                        graph.canvas().height() - baselineY - line.textAscent(),
+                                        line.width() + 0.1, line.textLineHeight()),
+                                "GraphCompose Text Line", text.toString()));
+                    }
+
+                    if (usesAbsoluteSpans) {
+                        double cursorX = lineX;
+                        for (var span : line.spans()) {
+                            if (span instanceof ParagraphTextSpan textSpan) {
+                                PdfFont font = measurement.fontLibrary()
+                                        .getFont(textSpan.textStyle().fontName(), PdfFont.class).orElseThrow();
+                                String sanitized = font.sanitizeForRender(
+                                        textSpan.textStyle(), textSpan.text());
+                                PdfFont.VerticalMetrics metrics = font.verticalMetrics(textSpan.textStyle());
+                                double top = graph.canvas().height() - baselineY - metrics.ascent();
+                                if (textSpan.background() == null) {
+                                    expected.add(new ExpectedTextLine(fragment.pageIndex(),
+                                            new Rectangle2D.Double(cursorX, top,
+                                                    Math.max(0.1, textSpan.width() + 0.1),
+                                                    Math.max(0.1, metrics.lineHeight())),
+                                            "GraphCompose Inline Text Span", sanitized));
+                                } else if (!sanitized.isEmpty()) {
+                                    DocumentInsets padding = textSpan.background().padding();
+                                    expected.add(new ExpectedTextLine(fragment.pageIndex(),
+                                            new Rectangle2D.Double(cursorX + padding.left(), top,
+                                                    Math.max(0.1,
+                                                            textSpan.width() - padding.horizontal()),
+                                                    Math.max(0.1, metrics.lineHeight())),
+                                            "GraphCompose Inline Chip Text", sanitized));
+                                }
+                            }
+                            cursorX += span.width();
+                        }
+                    }
+                    cursorTop -= line.lineHeight() + payload.lineGap();
+                }
+            }
+
+            List<ActualTextLine> actual = new ArrayList<>();
+            for (int page = 0; page < show.getSlides().size(); page++) {
+                for (XSLFShape shape : show.getSlides().get(page).getShapes()) {
+                    if (shape instanceof XSLFTextBox textBox
+                            && isMeasuredTextShape(textBox.getShapeName())) {
+                        actual.add(new ActualTextLine(page, textBox.getAnchor(),
+                                textBox.getShapeName(), textBox.getText()));
+                    }
+                }
+            }
+            assertThat(actual).hasSize(expected.size());
+            for (int i = 0; i < expected.size(); i++) {
+                ExpectedTextLine want = expected.get(i);
+                ActualTextLine got = actual.get(i);
+                assertThat(got.pageIndex).isEqualTo(want.pageIndex);
+                assertThat(got.shapeName).as("text shape %d name", i).isEqualTo(want.shapeName);
+                assertRectangle(got.anchor, want.anchor, "text line " + i);
+                assertThat(got.text).as("text line %d sanitized content", i).isEqualTo(want.text);
+            }
+
+            List<ActualLinkHotspot> actualLinks = new ArrayList<>();
+            for (int page = 0; page < show.getSlides().size(); page++) {
+                for (XSLFShape shape : show.getSlides().get(page).getShapes()) {
+                    if (shape instanceof XSLFAutoShape autoShape
+                            && "GraphCompose Text Link Hotspot".equals(shape.getShapeName())) {
+                        assertThat(autoShape.getHyperlink())
+                                .as("external link hotspot on slide %d", page)
+                                .isNotNull();
+                        assertThat(autoShape.getFillColor()).isNotNull();
+                        actualLinks.add(new ActualLinkHotspot(page, autoShape.getAnchor(),
+                                autoShape.getHyperlink().getAddress(),
+                                autoShape.getFillColor().getAlpha()));
+                    }
+                }
+            }
+            assertThat(actualLinks).hasSize(expectedLinks.size());
+            for (int i = 0; i < expectedLinks.size(); i++) {
+                ExpectedLinkHotspot want = expectedLinks.get(i);
+                ActualLinkHotspot got = actualLinks.get(i);
+                assertThat(got.pageIndex).isEqualTo(want.pageIndex);
+                assertRectangle(got.anchor, want.anchor, "external link hotspot " + i);
+                assertThat(got.address).isEqualTo(want.address);
+                assertThat(got.alpha).as("external link hotspot %d transparency", i).isZero();
+            }
+        }
+    }
+
+    /**
+     * Checks chip, image, and inline vector anchors for paragraph-only
+     * fixtures. It deliberately ignores text frames, then compares the
+     * remaining slide shapes to span geometry re-derived from the graph.
+     */
+    static void assertInlineSpanAnchorsMatch(LayoutGraph graph, byte[] pptxBytes) throws Exception {
+        assertInlineSpanAnchorsMatch(graph, pptxBytes, List.of());
+    }
+
+    static void assertInlineSpanAnchorsMatch(LayoutGraph graph,
+                                             byte[] pptxBytes,
+                                             List<FontFamilyDefinition> customFonts) throws Exception {
+        List<ExpectedInlineShape> expected = new ArrayList<>();
+        try (PdfMeasurementResources measurement = PdfMeasurementResources.open(customFonts)) {
+            for (PlacedFragment fragment : graph.fragments()) {
+                if (!(fragment.payload() instanceof ParagraphFragmentPayload payload)) {
+                    continue;
+                }
+                double innerX = fragment.x() + payload.padding().left();
+                double innerWidth = fragment.width() - payload.padding().horizontal();
+                double cursorTop = fragment.y() + fragment.height() - payload.padding().top();
+                for (ParagraphLine line : payload.lines()) {
+                    double baselineY = cursorTop - line.lineHeight() + line.baselineOffsetFromBottom();
+                    baselineY += verticalSeatShift(line, measurement, payload.verticalAlign());
+                    double lineX = switch (payload.align()) {
+                        case RIGHT -> innerX + innerWidth - line.width();
+                        case CENTER -> innerX + (innerWidth - line.width()) / 2.0;
+                        case LEFT -> innerX;
+                    };
+                    double cursorX = lineX;
+                    for (ParagraphSpan span : line.spans()) {
+                        if (span instanceof ParagraphTextSpan text && text.background() != null) {
+                            DocumentInsets padding = text.background().padding();
+                            double bottom = baselineY - line.baselineOffsetFromBottom() - padding.bottom();
+                            double height = line.textLineHeight() + padding.vertical();
+                            expected.add(new ExpectedInlineShape(fragment.pageIndex(), XSLFAutoShape.class,
+                                    new Rectangle2D.Double(cursorX,
+                                            graph.canvas().height() - bottom - height,
+                                            text.width(), height)));
+                        } else if (span instanceof ParagraphImageSpan image) {
+                            double bottom = inlineBottom(image.height(), image.alignment(),
+                                    image.baselineOffset(), baselineY, line);
+                            expected.add(new ExpectedInlineShape(fragment.pageIndex(), XSLFPictureShape.class,
+                                    new Rectangle2D.Double(cursorX,
+                                            graph.canvas().height() - bottom - image.height(),
+                                            image.width(), image.height())));
+                        } else if (span instanceof ParagraphShapeSpan shape) {
+                            double bottom = inlineBottom(shape.height(), shape.alignment(),
+                                    shape.baselineOffset(), baselineY, line);
+                            for (ResolvedShapeLayer layer : shape.layers()) {
+                                ShapeOutline outline = layer.outline();
+                                Class<? extends XSLFShape> type = outline instanceof ShapeOutline.Polygon
+                                        || outline instanceof ShapeOutline.Path
+                                        ? XSLFFreeformShape.class : XSLFAutoShape.class;
+                                Rectangle2D.Double box = new Rectangle2D.Double(
+                                        cursorX + (shape.width() - outline.width()) / 2.0,
+                                        graph.canvas().height() - bottom
+                                                - (shape.height() + outline.height()) / 2.0,
+                                        outline.width(), outline.height());
+                                expected.add(new ExpectedInlineShape(fragment.pageIndex(), type,
+                                        type == XSLFFreeformShape.class
+                                                ? freeformBounds(outline, box) : box));
+                            }
+                        } else if (span instanceof ParagraphSvgSpan svg) {
+                            double bottom = inlineBottom(svg.height(), svg.alignment(),
+                                    svg.baselineOffset(), baselineY, line);
+                            Rectangle2D anchor = new Rectangle2D.Double(cursorX,
+                                    graph.canvas().height() - bottom - svg.height(),
+                                    svg.width(), svg.height());
+                            // This helper's fixtures use full-box simple SVG paths. Complex SVG
+                            // fallback is covered independently by PptxInlineSvgRasterizerTest.
+                            for (ResolvedSvgLayer layer : svg.layers()) {
+                                expected.add(new ExpectedInlineShape(fragment.pageIndex(),
+                                        XSLFFreeformShape.class,
+                                        pathBounds(layer.segments(), anchor)));
+                            }
+                        }
+                        cursorX += span.width();
+                    }
+                    cursorTop -= line.lineHeight() + payload.lineGap();
+                }
+            }
+        }
+
+        List<ActualInlineShape> actual = new ArrayList<>();
+        try (XMLSlideShow show = new XMLSlideShow(new ByteArrayInputStream(pptxBytes))) {
+            for (int page = 0; page < show.getSlides().size(); page++) {
+                for (XSLFShape shape : show.getSlides().get(page).getShapes()) {
+                    if (!(shape instanceof XSLFTextBox)) {
+                        actual.add(new ActualInlineShape(page, shape.getClass(), shape.getAnchor()));
+                    }
+                }
+            }
+        }
+        assertThat(actual).hasSize(expected.size());
+        for (int i = 0; i < expected.size(); i++) {
+            ExpectedInlineShape want = expected.get(i);
+            ActualInlineShape got = actual.get(i);
+            assertThat(got.pageIndex).isEqualTo(want.pageIndex);
+            assertThat(want.type).as("inline shape %d type", i).isAssignableFrom(got.type);
+            assertRectangle(got.anchor, want.anchor, "inline shape " + i);
+        }
+    }
+
+    private static Rectangle2D freeformBounds(ShapeOutline outline, Rectangle2D box) {
+        if (outline instanceof ShapeOutline.Path path) {
+            return pathBounds(path.segments(), box);
+        }
+        if (outline instanceof ShapeOutline.Polygon polygon) {
+            Path2D.Double path = new Path2D.Double();
+            for (int i = 0; i < polygon.points().size(); i++) {
+                var point = polygon.points().get(i);
+                double x = box.getX() + point.x() * box.getWidth();
+                double y = box.getY() + (1.0 - point.y()) * box.getHeight();
+                if (i == 0) {
+                    path.moveTo(x, y);
+                } else {
+                    path.lineTo(x, y);
+                }
+            }
+            path.closePath();
+            return path.getBounds2D();
+        }
+        return box;
+    }
+
+    private static Rectangle2D pathBounds(List<com.demcha.compose.document.style.DocumentPathSegment> segments,
+                                          Rectangle2D box) {
+        Path2D.Double path = new Path2D.Double();
+        for (var segment : segments) {
+            if (segment instanceof com.demcha.compose.document.style.DocumentPathSegment.MoveTo move) {
+                path.moveTo(pathX(box, move.x()), pathY(box, move.y()));
+            } else if (segment instanceof com.demcha.compose.document.style.DocumentPathSegment.LineTo line) {
+                path.lineTo(pathX(box, line.x()), pathY(box, line.y()));
+            } else if (segment instanceof com.demcha.compose.document.style.DocumentPathSegment.CubicTo curve) {
+                path.curveTo(pathX(box, curve.control1X()), pathY(box, curve.control1Y()),
+                        pathX(box, curve.control2X()), pathY(box, curve.control2Y()),
+                        pathX(box, curve.x()), pathY(box, curve.y()));
+            } else if (segment instanceof com.demcha.compose.document.style.DocumentPathSegment.Close) {
+                path.closePath();
+            }
+        }
+        return path.getBounds2D();
+    }
+
+    private static double pathX(Rectangle2D box, double normalized) {
+        return box.getX() + normalized * box.getWidth();
+    }
+
+    private static double pathY(Rectangle2D box, double normalized) {
+        return box.getY() + (1.0 - normalized) * box.getHeight();
+    }
+
+    /** Mirrors the handler's shared-frame gate: mixed plain-run sizes force per-span frames. */
+    private static boolean mixesFontSizes(ParagraphLine line) {
+        double size = Double.NaN;
+        for (ParagraphSpan span : line.spans()) {
+            if (span instanceof ParagraphTextSpan textSpan && textSpan.background() == null) {
+                double spanSize = textSpan.textStyle().size();
+                if (Double.isNaN(size)) {
+                    size = spanSize;
+                } else if (spanSize != size) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private static com.demcha.compose.document.node.DocumentLinkTarget spanLinkTarget(ParagraphSpan span) {
+        if (span instanceof ParagraphTextSpan textSpan) {
+            return textSpan.linkTarget();
+        }
+        if (span instanceof ParagraphImageSpan imageSpan) {
+            return imageSpan.linkTarget();
+        }
+        if (span instanceof ParagraphShapeSpan shapeSpan) {
+            return shapeSpan.linkTarget();
+        }
+        if (span instanceof ParagraphSvgSpan svgSpan) {
+            return svgSpan.linkTarget();
+        }
+        return null;
+    }
+
+    private static boolean isMeasuredTextShape(String name) {
+        return "GraphCompose Text Line".equals(name)
+                || "GraphCompose Inline Text Span".equals(name)
+                || "GraphCompose Inline Chip Text".equals(name);
+    }
+
+    private static double verticalSeatShift(ParagraphLine line,
+                                            PdfMeasurementResources measurement,
+                                            TextVerticalAlign align) {
+        if (align == TextVerticalAlign.DEFAULT) {
+            return 0;
+        }
+        for (var span : line.spans()) {
+            if (span instanceof ParagraphTextSpan textSpan) {
+                PdfFont font = measurement.fontLibrary()
+                        .getFont(textSpan.textStyle().fontName(), PdfFont.class).orElseThrow();
+                double capHeight = font.getCapHeight(textSpan.textStyle());
+                double descent = line.baselineOffsetFromBottom();
+                double leading = Math.max(0,
+                        line.textLineHeight() - line.textAscent() - descent);
+                double capTopToBoxTop = line.textAscent() + leading - capHeight;
+                return switch (align) {
+                    case TOP -> capTopToBoxTop;
+                    case CENTER -> (capTopToBoxTop - descent) / 2.0;
+                    case BOTTOM -> -descent;
+                    case DEFAULT -> 0;
+                };
+            }
+        }
+        return 0;
+    }
+
+    private static double inlineBottom(double height,
+                                       InlineImageAlignment alignment,
+                                       double baselineOffset,
+                                       double baselineY,
+                                       ParagraphLine line) {
+        double lineBottom = baselineY - line.baselineOffsetFromBottom();
+        double base = switch (alignment == null ? InlineImageAlignment.CENTER : alignment) {
+            case BASELINE -> baselineY;
+            case CENTER -> lineBottom + (line.lineHeight() - height) / 2.0;
+            case TEXT_TOP -> baselineY + line.textAscent() - height;
+            case TEXT_BOTTOM -> lineBottom;
+        };
+        return base + baselineOffset;
+    }
+
+    private static void assertRectangle(Rectangle2D actual, Rectangle2D expected, String label) {
+        assertThat(actual.getX()).as(label + " x").isCloseTo(expected.getX(),
+                org.assertj.core.data.Offset.offset(EPSILON_PT));
+        assertThat(actual.getY()).as(label + " y").isCloseTo(expected.getY(),
+                org.assertj.core.data.Offset.offset(EPSILON_PT));
+        assertThat(actual.getWidth()).as(label + " width").isCloseTo(expected.getWidth(),
+                org.assertj.core.data.Offset.offset(EPSILON_PT));
+        assertThat(actual.getHeight()).as(label + " height").isCloseTo(expected.getHeight(),
+                org.assertj.core.data.Offset.offset(EPSILON_PT));
+    }
+
+    private record ExpectedTextLine(int pageIndex,
+                                    Rectangle2D anchor,
+                                    String shapeName,
+                                    String text) {
+    }
+
+    private record ActualTextLine(int pageIndex,
+                                  Rectangle2D anchor,
+                                  String shapeName,
+                                  String text) {
+    }
+
+    private record ExpectedLinkHotspot(int pageIndex,
+                                       Rectangle2D anchor,
+                                       String address) {
+    }
+
+    private record ActualLinkHotspot(int pageIndex,
+                                     Rectangle2D anchor,
+                                     String address,
+                                     int alpha) {
+    }
+
+    private record ExpectedInlineShape(int pageIndex,
+                                       Class<? extends XSLFShape> type,
+                                       Rectangle2D anchor) {
+    }
+
+    private record ActualInlineShape(int pageIndex,
+                                     Class<?> type,
+                                     Rectangle2D anchor) {
     }
 
     /**

--- a/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxParagraphFragmentRenderHandlerTest.java
+++ b/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxParagraphFragmentRenderHandlerTest.java
@@ -85,6 +85,12 @@ class PptxParagraphFragmentRenderHandlerTest {
                 // the glyphs. Seat compensation lives in the frame top instead.
                 assertThat(runs).noneMatch(XSLFTextRun::isSuperscript);
                 assertThat(runs).noneMatch(XSLFTextRun::isSubscript);
+                // Kerning must stay off: the engine measured unkerned advances,
+                // and PowerPoint would otherwise auto-kern text above ~12pt.
+                assertThat(runs).allMatch(run ->
+                        run.getXmlObject() instanceof org.openxmlformats.schemas.drawingml.x2006.main.CTRegularTextRun ctRun
+                                && ctRun.isSetRPr() && ctRun.getRPr().isSetKern()
+                                && ctRun.getRPr().getKern() == 0);
 
                 XSLFAutoShape linkHotspot = show.getSlides().get(0).getShapes().stream()
                         .filter(XSLFAutoShape.class::isInstance)

--- a/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxParagraphFragmentRenderHandlerTest.java
+++ b/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxParagraphFragmentRenderHandlerTest.java
@@ -80,7 +80,11 @@ class PptxParagraphFragmentRenderHandlerTest {
                         .isEqualTo(Color.BLACK);
                 assertThat(linked.isUnderlined()).isFalse();
                 assertThat(runs).allMatch(run -> "Arial".equals(run.getFontFamily()));
-                assertThat(runs).allMatch(XSLFTextRun::isSuperscript);
+                // No run may carry the DrawingML baseline attribute: PowerPoint
+                // renders any non-zero baseline as super/subscript and SHRINKS
+                // the glyphs. Seat compensation lives in the frame top instead.
+                assertThat(runs).noneMatch(XSLFTextRun::isSuperscript);
+                assertThat(runs).noneMatch(XSLFTextRun::isSubscript);
 
                 XSLFAutoShape linkHotspot = show.getSlides().get(0).getShapes().stream()
                         .filter(XSLFAutoShape.class::isInstance)

--- a/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxParagraphFragmentRenderHandlerTest.java
+++ b/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxParagraphFragmentRenderHandlerTest.java
@@ -1,0 +1,300 @@
+package com.demcha.compose.document.backend.fixed.pptx;
+
+import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.api.DocumentSession;
+import com.demcha.compose.document.dsl.ParagraphBuilder;
+import com.demcha.compose.document.image.DocumentImageData;
+import com.demcha.compose.document.layout.LayoutGraph;
+import com.demcha.compose.document.node.TextAlign;
+import com.demcha.compose.document.node.TextVerticalAlign;
+import com.demcha.compose.document.style.DocumentColor;
+import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.document.style.DocumentTextStyle;
+import com.demcha.compose.document.svg.SvgIcon;
+import com.demcha.compose.font.FontName;
+import com.demcha.compose.font.FontFamilyDefinition;
+import org.apache.poi.sl.usermodel.TextShape.TextAutofit;
+import org.apache.poi.sl.usermodel.PaintStyle;
+import org.apache.poi.sl.draw.DrawPaint;
+import org.apache.poi.xslf.usermodel.XMLSlideShow;
+import org.apache.poi.xslf.usermodel.XSLFAutoShape;
+import org.apache.poi.xslf.usermodel.XSLFFreeformShape;
+import org.apache.poi.xslf.usermodel.XSLFPictureShape;
+import org.apache.poi.xslf.usermodel.XSLFTextBox;
+import org.apache.poi.xslf.usermodel.XSLFTextRun;
+import org.openxmlformats.schemas.presentationml.x2006.main.CTShape;
+import org.junit.jupiter.api.Test;
+
+import javax.imageio.ImageIO;
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PptxParagraphFragmentRenderHandlerTest {
+
+    @Test
+    void preservesResolvedLineFramesSanitizedTextStylesAndExternalLinks() throws Exception {
+        try (DocumentSession session = GraphCompose.document()
+                .pageSize(420, 260)
+                .margin(DocumentInsets.of(20))
+                .create()) {
+            session.pageFlow().name("Text")
+                    .spacing(8)
+                    .addParagraph(p -> p.rich(r -> r
+                            .plain("Plain ")
+                            .bold("bold ")
+                            .italic("italic ")
+                            .underline("under ")
+                            .strikethrough("strike ")
+                            .link("docs", "https://example.com")
+                            .plain(" unsupported: 😀")))
+                    .addParagraph(p -> p.text("right aligned").align(TextAlign.RIGHT))
+                    .addParagraph(p -> p.text("centered").align(TextAlign.CENTER))
+                    .build();
+
+            LayoutGraph graph = session.render(new GraphCapturingBackend());
+            byte[] pptx = session.render(new PptxFixedLayoutBackend());
+            PptxGeometryAssertions.assertTextGeometryMatches(graph, pptx);
+
+            try (XMLSlideShow show = new XMLSlideShow(new ByteArrayInputStream(pptx))) {
+                List<XSLFTextBox> boxes = show.getSlides().get(0).getShapes().stream()
+                        .filter(XSLFTextBox.class::isInstance)
+                        .map(XSLFTextBox.class::cast)
+                        .toList();
+                assertThat(boxes).hasSize(3);
+                List<XSLFTextRun> runs = boxes.get(0).getTextParagraphs().get(0).getTextRuns();
+                assertThat(runs).anyMatch(XSLFTextRun::isBold);
+                assertThat(runs).anyMatch(XSLFTextRun::isItalic);
+                assertThat(runs).anyMatch(XSLFTextRun::isUnderlined);
+                assertThat(runs).anyMatch(XSLFTextRun::isStrikethrough);
+                XSLFTextRun linked = runs.stream().filter(run -> "docs".equals(run.getRawText()))
+                        .findFirst().orElseThrow();
+                assertThat(linked.getHyperlink()).isNull();
+                assertThat(linked.getFontColor()).isInstanceOf(PaintStyle.SolidPaint.class);
+                PaintStyle.SolidPaint linkedPaint = (PaintStyle.SolidPaint) linked.getFontColor();
+                assertThat(DrawPaint.applyColorTransform(linkedPaint.getSolidColor()))
+                        .isEqualTo(Color.BLACK);
+                assertThat(linked.isUnderlined()).isFalse();
+                assertThat(runs).allMatch(run -> "Arial".equals(run.getFontFamily()));
+                assertThat(runs).allMatch(XSLFTextRun::isSuperscript);
+
+                XSLFAutoShape linkHotspot = show.getSlides().get(0).getShapes().stream()
+                        .filter(XSLFAutoShape.class::isInstance)
+                        .map(XSLFAutoShape.class::cast)
+                        .filter(shape -> "GraphCompose Text Link Hotspot".equals(shape.getShapeName()))
+                        .findFirst().orElseThrow();
+                assertThat(linkHotspot.getHyperlink().getAddress())
+                        .isEqualTo("https://example.com");
+                assertThat(linkHotspot.getAnchor().getWidth()).isPositive();
+                assertThat(linkHotspot.getAnchor().getHeight()).isPositive();
+            }
+        }
+    }
+
+    @Test
+    void paintsChipImageShapeAndSvgAtMeasuredInlinePositions() throws Exception {
+        byte[] png = onePixelPng();
+        SvgIcon icon = SvgIcon.parse("""
+                <svg viewBox="0 0 10 10"><path fill="#2563eb" d="M0 0 L10 0 L5 10 Z"/></svg>
+                """);
+        try (DocumentSession session = GraphCompose.document()
+                .pageSize(420, 180)
+                .margin(DocumentInsets.of(20))
+                .create()) {
+            session.add(new ParagraphBuilder().rich(r -> r
+                    .plain("A ")
+                    .chip(" READY ", DocumentColor.WHITE, DocumentColor.ROYAL_BLUE)
+                    .plain(" ")
+                    .image(DocumentImageData.fromBytes(png), 12, 12)
+                    .plain(" ")
+                    .checkbox(12, true, DocumentColor.DARK_GRAY, DocumentColor.ROYAL_BLUE)
+                    .plain(" ")
+                    .svgIcon(icon, 12)
+                    .plain(" done"))
+                    .textStyle(DocumentTextStyle.builder().fontName(FontName.HELVETICA).size(11).build())
+                    .build());
+
+            LayoutGraph graph = session.render(new GraphCapturingBackend());
+            byte[] pptx = session.render(new PptxFixedLayoutBackend());
+            PptxGeometryAssertions.assertInlineSpanAnchorsMatch(graph, pptx);
+            try (XMLSlideShow show = new XMLSlideShow(new ByteArrayInputStream(pptx))) {
+                var shapes = show.getSlides().get(0).getShapes();
+                assertThat(shapes).anyMatch(XSLFPictureShape.class::isInstance);
+                assertThat(shapes).anyMatch(XSLFFreeformShape.class::isInstance);
+                assertThat(shapes.stream().filter(XSLFAutoShape.class::isInstance).count())
+                        .as("chip plus checkbox layers")
+                        .isGreaterThanOrEqualTo(2);
+                // A chip/graphics line renders per-span absolute frames only —
+                // no empty shared line box is left behind.
+                assertThat(shapes).noneMatch(shape -> shape instanceof XSLFTextBox box
+                        && "GraphCompose Text Line".equals(box.getShapeName()));
+                assertThat(shapes).anyMatch(shape -> shape instanceof XSLFTextBox box
+                        && "GraphCompose Inline Text Span".equals(box.getShapeName()));
+                assertThat(shapes).anyMatch(shape -> shape instanceof XSLFTextBox box
+                        && "GraphCompose Inline Chip Text".equals(box.getShapeName()));
+                assertThat(shapes.stream()
+                        .filter(XSLFAutoShape.class::isInstance)
+                        .map(XSLFAutoShape.class::cast)
+                        .filter(shape -> shape.getShapeType() == org.apache.poi.sl.usermodel.ShapeType.ROUND_RECT)
+                        .map(shape -> ((CTShape) shape.getXmlObject()).getSpPr().getPrstGeom()
+                                .getAvLst().getGdArray(0).getFmla()))
+                        .as("the checkbox frame keeps its 0.18 × size radius")
+                        .contains("val 18000");
+            }
+        }
+    }
+
+    @Test
+    void emitsEveryPreWrappedLineAsANonWrappingAbsoluteFrame() throws Exception {
+        try (DocumentSession session = GraphCompose.document()
+                .pageSize(180, 240)
+                .margin(DocumentInsets.of(20))
+                .create()) {
+            session.add(new ParagraphBuilder().text(
+                    "This deliberately narrow paragraph wraps into several measured lines "
+                            + "without asking PowerPoint to reflow any text.").build());
+
+            LayoutGraph graph = session.render(new GraphCapturingBackend());
+            var payload = graph.fragments().stream()
+                    .map(fragment -> fragment.payload())
+                    .filter(com.demcha.compose.document.layout.payloads.ParagraphFragmentPayload.class::isInstance)
+                    .map(com.demcha.compose.document.layout.payloads.ParagraphFragmentPayload.class::cast)
+                    .findFirst().orElseThrow();
+            assertThat(payload.lines().size()).isGreaterThan(2);
+
+            byte[] pptx = session.render(new PptxFixedLayoutBackend());
+            PptxGeometryAssertions.assertTextGeometryMatches(graph, pptx);
+            try (XMLSlideShow show = new XMLSlideShow(new ByteArrayInputStream(pptx))) {
+                List<XSLFTextBox> lineBoxes = show.getSlides().get(0).getShapes().stream()
+                        .filter(XSLFTextBox.class::isInstance)
+                        .map(XSLFTextBox.class::cast)
+                        .filter(box -> "GraphCompose Text Line".equals(box.getShapeName()))
+                        .toList();
+                assertThat(lineBoxes).hasSize(payload.lines().size());
+                assertThat(lineBoxes).allSatisfy(box -> {
+                    assertThat(box.getWordWrap()).isFalse();
+                    assertThat(box.getTextAutofit()).isEqualTo(TextAutofit.NONE);
+                    assertThat(box.getTopInset()).isZero();
+                    assertThat(box.getRightInset()).isZero();
+                    assertThat(box.getBottomInset()).isZero();
+                    assertThat(box.getLeftInset()).isZero();
+                });
+            }
+        }
+    }
+
+    @Test
+    void alignsMixedSizesAndUsesRegisteredViewerFontFamily() throws Exception {
+        FontName customName = FontName.of("ParityCustom");
+        FontFamilyDefinition customFont = FontFamilyDefinition.classpath(
+                        customName, "fonts/google/lato/Lato-Regular.ttf")
+                .boldResource("fonts/google/lato/Lato-Bold.ttf")
+                .italicResource("fonts/google/lato/Lato-Italic.ttf")
+                .boldItalicResource("fonts/google/lato/Lato-BoldItalic.ttf")
+                .wordFamily("Lato")
+                .build();
+        DocumentTextStyle large = DocumentTextStyle.builder()
+                .fontName(customName).size(20).build();
+        DocumentTextStyle small = DocumentTextStyle.builder()
+                .fontName(customName).size(9).build();
+        byte[] png = onePixelPng();
+
+        try (DocumentSession session = GraphCompose.document()
+                .registerFontFamily(customFont)
+                .pageSize(360, 180)
+                .margin(DocumentInsets.of(20))
+                .create()) {
+            session.add(new ParagraphBuilder().rich(r -> r
+                            .style("Large", large)
+                            .style(" small", small)
+                            .image(DocumentImageData.fromBytes(png), 12, 12)
+                            .style(" baseline", small))
+                    .verticalAlign(TextVerticalAlign.CENTER)
+                    .build());
+
+            LayoutGraph graph = session.render(new GraphCapturingBackend());
+            byte[] pptx = session.render(new PptxFixedLayoutBackend());
+            PptxGeometryAssertions.assertTextGeometryMatches(graph, pptx, List.of(customFont));
+            PptxGeometryAssertions.assertInlineSpanAnchorsMatch(graph, pptx, List.of(customFont));
+
+            try (XMLSlideShow show = new XMLSlideShow(new ByteArrayInputStream(pptx))) {
+                assertThat(show.getFonts()).singleElement().satisfies(font -> {
+                    assertThat(font.getTypeface()).isEqualTo("Lato");
+                    assertThat(font.getFacets()).hasSize(4);
+                });
+                List<XSLFTextBox> spans = show.getSlides().get(0).getShapes().stream()
+                        .filter(XSLFTextBox.class::isInstance)
+                        .map(XSLFTextBox.class::cast)
+                        .filter(box -> "GraphCompose Inline Text Span".equals(box.getShapeName()))
+                        .toList();
+                assertThat(spans).hasSizeGreaterThanOrEqualTo(3);
+                assertThat(spans).allSatisfy(box -> assertThat(
+                        box.getTextParagraphs().get(0).getTextRuns().get(0).getFontFamily())
+                        .isEqualTo("Lato"));
+                assertThat(spans).allSatisfy(box -> assertThat(
+                        box.getTextParagraphs().get(0).getTextRuns().get(0).isSuperscript())
+                        .as("the identical embedded/PDF font metrics need no synthetic shift")
+                        .isFalse());
+                assertThat(spans.stream().map(box -> box.getAnchor().getY()).distinct().count())
+                        .as("20pt and 9pt spans use their own ascent but share one baseline")
+                        .isEqualTo(2);
+                assertThat(spans.stream()
+                        .map(box -> box.getTextParagraphs().get(0).getTextRuns().get(0).getFontSize()))
+                        .contains(20.0, 9.0);
+            }
+        }
+    }
+
+    @Test
+    void usesRasterFallbackForExactSvgStrokeStylesAndPrimaryStrokePaintForNativePaths()
+            throws Exception {
+        SvgIcon dashed = SvgIcon.parse("""
+                <svg viewBox="0 0 10 10">
+                  <path fill="none" stroke="#2563eb" stroke-width="1"
+                        stroke-dasharray="2 1" stroke-linecap="round"
+                        d="M2 5 L8 5"/>
+                </svg>
+                """);
+        SvgIcon gradientStroke = SvgIcon.parse("""
+                <svg viewBox="0 0 10 10">
+                  <defs><linearGradient id="g"><stop offset="0" stop-color="#ff0000"/>
+                    <stop offset="1" stop-color="#0000ff"/></linearGradient></defs>
+                  <path fill="none" stroke="url(#g)" stroke-width="1" d="M2 5 L8 5"/>
+                </svg>
+                """);
+        try (DocumentSession session = GraphCompose.document()
+                .pageSize(240, 140)
+                .margin(DocumentInsets.of(20))
+                .create()) {
+            session.add(new ParagraphBuilder().rich(r -> r
+                    .plain("A ").svgIcon(dashed, 16).plain(" B ")
+                    .svgIcon(gradientStroke, 16)).build());
+
+            byte[] pptx = session.render(new PptxFixedLayoutBackend());
+            try (XMLSlideShow show = new XMLSlideShow(new ByteArrayInputStream(pptx))) {
+                var shapes = show.getSlides().get(0).getShapes();
+                assertThat(shapes.stream().filter(XSLFPictureShape.class::isInstance).count())
+                        .as("dashed/capped SVG uses the exact transparent raster fallback")
+                        .isEqualTo(1);
+                XSLFFreeformShape nativeGradient = shapes.stream()
+                        .filter(XSLFFreeformShape.class::isInstance)
+                        .map(XSLFFreeformShape.class::cast)
+                        .findFirst().orElseThrow();
+                assertThat(nativeGradient.getLineColor()).isEqualTo(Color.RED);
+            }
+        }
+    }
+
+    private static byte[] onePixelPng() throws Exception {
+        BufferedImage image = new BufferedImage(1, 1, BufferedImage.TYPE_INT_ARGB);
+        image.setRGB(0, 0, Color.RED.getRGB());
+        try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            ImageIO.write(image, "png", output);
+            return output.toByteArray();
+        }
+    }
+}

--- a/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxTextParityDemoTest.java
+++ b/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxTextParityDemoTest.java
@@ -1,0 +1,154 @@
+package com.demcha.compose.document.backend.fixed.pptx;
+
+import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.api.DocumentSession;
+import com.demcha.compose.document.image.DocumentImageData;
+import com.demcha.compose.document.layout.LayoutGraph;
+import com.demcha.compose.document.node.TextAlign;
+import com.demcha.compose.document.style.DocumentColor;
+import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.document.style.DocumentTextDecoration;
+import com.demcha.compose.document.style.DocumentTextStyle;
+import com.demcha.compose.document.svg.SvgIcon;
+import com.demcha.compose.font.FontFamilyDefinition;
+import com.demcha.compose.font.FontName;
+import com.demcha.compose.testing.layout.LayoutSnapshotAssertions;
+import org.apache.poi.xslf.usermodel.XMLSlideShow;
+import org.apache.poi.xslf.usermodel.XSLFSlide;
+import org.junit.jupiter.api.Test;
+
+import javax.imageio.ImageIO;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Produces the reviewable PDF/PPTX text-fidelity pair and advisory previews. */
+class PptxTextParityDemoTest {
+
+    private static final double SCALE = 2.0;
+    private static final FontName DEMO_FONT = FontName.of("PptxParityLato");
+    private static final FontFamilyDefinition DEMO_FONT_FAMILY = FontFamilyDefinition.classpath(
+                    DEMO_FONT, "fonts/google/lato/Lato-Regular.ttf")
+            .boldResource("fonts/google/lato/Lato-Bold.ttf")
+            .italicResource("fonts/google/lato/Lato-Italic.ttf")
+            .boldItalicResource("fonts/google/lato/Lato-BoldItalic.ttf")
+            .wordFamily("Lato")
+            .build();
+
+    @Test
+    void writesTextFidelityDemoPairAndLocksItsLayout() throws Exception {
+        Path output = Path.of("target", "visual-tests", "pptx-parity", "text-fidelity");
+        Files.createDirectories(output);
+
+        try (DocumentSession session = composeDemo()) {
+            LayoutSnapshotAssertions.assertMatches(session,
+                    Path.of("src", "test", "resources", "layout-snapshots"),
+                    Path.of("target", "visual-tests", "layout-snapshots"),
+                    "text-fidelity", "pptx-parity");
+
+            LayoutGraph graph = session.render(new GraphCapturingBackend());
+            byte[] pdf = session.toPdfBytes();
+            byte[] pptx = session.render(new PptxFixedLayoutBackend());
+            Files.write(output.resolve("text-fidelity.pdf"), pdf);
+            Files.write(output.resolve("text-fidelity.pptx"), pptx);
+            PptxGeometryAssertions.assertTextGeometryMatches(
+                    graph, pptx, List.of(DEMO_FONT_FAMILY));
+
+            List<BufferedImage> pdfPages = session.toImages((int) Math.round(72 * SCALE));
+            try (XMLSlideShow show = new XMLSlideShow(new ByteArrayInputStream(pptx))) {
+                assertThat(show.getSlides()).hasSameSizeAs(pdfPages);
+                for (int i = 0; i < pdfPages.size(); i++) {
+                    ImageIO.write(pdfPages.get(i), "png",
+                            output.resolve("text-fidelity-page-" + (i + 1) + ".pdf.png").toFile());
+                    ImageIO.write(rasterize(show.getSlides().get(i),
+                                    show.getPageSize().width, show.getPageSize().height),
+                            "png", output.resolve("text-fidelity-page-" + (i + 1) + ".pptx.png").toFile());
+                }
+            }
+        }
+    }
+
+    private static DocumentSession composeDemo() throws Exception {
+        DocumentSession session = GraphCompose.document()
+                .registerFontFamily(DEMO_FONT_FAMILY)
+                .pageSize(540, 300)
+                .margin(DocumentInsets.of(28))
+                .create();
+        DocumentTextStyle body = DocumentTextStyle.builder()
+                .fontName(DEMO_FONT).size(14).build();
+        SvgIcon icon = SvgIcon.parse("""
+                <svg viewBox="0 0 10 10"><path fill="#2563eb" d="M0 0 L10 0 L5 10 Z"/></svg>
+                """);
+        byte[] png = onePixelPng();
+        session.pageFlow().name("TextFidelity").spacing(13)
+                .addParagraph(p -> p.text("PPTX fixed-layout text fidelity")
+                        .textStyle(DocumentTextStyle.builder()
+                                .fontName(DEMO_FONT).size(22)
+                                .decoration(DocumentTextDecoration.BOLD)
+                                .color(DocumentColor.rgb(15, 23, 42)).build()))
+                .addParagraph(p -> p.rich(r -> r
+                        .plain("One measured line: ")
+                        .bold("bold")
+                        .plain(" · ")
+                        .italic("italic")
+                        .plain(" · ")
+                        .underline("underlined")
+                        .plain(" · ")
+                        .strikethrough("struck")
+                        .plain(" · ")
+                        .link("external link", "https://graphcompose.dev"))
+                        .textStyle(body))
+                .addParagraph(p -> p.rich(r -> r
+                        .plain("Inline geometry ")
+                        .chip(" READY ", DocumentColor.WHITE, DocumentColor.ROYAL_BLUE)
+                        .plain("  ")
+                        .image(DocumentImageData.fromBytes(png), 15, 15)
+                        .plain("  ")
+                        .checkbox(15, true, DocumentColor.DARK_GRAY, DocumentColor.ROYAL_BLUE)
+                        .plain("  ")
+                        .svgIcon(icon, 15)
+                        .plain(" stays on the shared baseline."))
+                        .textStyle(body))
+                .addParagraph(p -> p.text("Right-aligned frame uses the resolved line width.")
+                        .align(TextAlign.RIGHT)
+                        .textStyle(DocumentTextStyle.builder().fontName(DEMO_FONT).size(13).build()))
+                .addParagraph(p -> p.text("Unsupported glyph sanitizes exactly like PDF: 😀")
+                        .align(TextAlign.CENTER)
+                        .textStyle(DocumentTextStyle.builder().fontName(DEMO_FONT).size(11).build()))
+                .build();
+        return session;
+    }
+
+    private static byte[] onePixelPng() throws Exception {
+        BufferedImage image = new BufferedImage(1, 1, BufferedImage.TYPE_INT_RGB);
+        image.setRGB(0, 0, Color.ORANGE.getRGB());
+        try (ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            ImageIO.write(image, "png", output);
+            return output.toByteArray();
+        }
+    }
+
+    private static BufferedImage rasterize(XSLFSlide slide, int width, int height) {
+        BufferedImage image = new BufferedImage((int) Math.round(width * SCALE),
+                (int) Math.round(height * SCALE), BufferedImage.TYPE_INT_RGB);
+        Graphics2D graphics = image.createGraphics();
+        try {
+            graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+            graphics.setColor(Color.WHITE);
+            graphics.fillRect(0, 0, image.getWidth(), image.getHeight());
+            graphics.scale(SCALE, SCALE);
+            slide.draw(graphics);
+        } finally {
+            graphics.dispose();
+        }
+        return image;
+    }
+}

--- a/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxFontMappingTest.java
+++ b/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxFontMappingTest.java
@@ -1,0 +1,35 @@
+package com.demcha.compose.document.backend.fixed.pptx.handlers;
+
+import com.demcha.compose.engine.components.content.text.TextDecoration;
+import com.demcha.compose.engine.components.content.text.TextStyle;
+import com.demcha.compose.font.FontName;
+import org.junit.jupiter.api.Test;
+
+import java.awt.Color;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PptxFontMappingTest {
+
+    @Test
+    void mapsStandardFamiliesToMetricCompatibleViewerFonts() {
+        assertThat(PptxFontMapping.familyFor(FontName.HELVETICA_BOLD)).isEqualTo("Arial");
+        assertThat(PptxFontMapping.familyFor(FontName.TIMES_ITALIC)).isEqualTo("Times New Roman");
+        assertThat(PptxFontMapping.familyFor(FontName.COURIER)).isEqualTo("Courier New");
+        assertThat(PptxFontMapping.familyFor(FontName.of("Acme-Sans"))).isEqualTo("Acme-Sans");
+        assertThat(PptxFontMapping.familyFor(FontName.of("Acme-Sans-Bold"))).isEqualTo("Acme-Sans");
+    }
+
+    @Test
+    void combinesDecorationWithFaceSuffixes() {
+        TextStyle boldFace = new TextStyle(FontName.HELVETICA_BOLD, 12,
+                TextDecoration.DEFAULT, Color.BLACK);
+        TextStyle decorated = new TextStyle(FontName.HELVETICA, 12,
+                TextDecoration.BOLD_ITALIC, Color.BLACK);
+
+        assertThat(PptxFontMapping.isBold(boldFace)).isTrue();
+        assertThat(PptxFontMapping.isItalic(boldFace)).isFalse();
+        assertThat(PptxFontMapping.isBold(decorated)).isTrue();
+        assertThat(PptxFontMapping.isItalic(decorated)).isTrue();
+    }
+}

--- a/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxInlineSvgRasterizerTest.java
+++ b/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxInlineSvgRasterizerTest.java
@@ -1,0 +1,107 @@
+package com.demcha.compose.document.backend.fixed.pptx.handlers;
+
+import com.demcha.compose.document.layout.payloads.ParagraphSvgSpan;
+import com.demcha.compose.document.layout.payloads.ResolvedSvgLayer;
+import com.demcha.compose.document.node.InlineImageAlignment;
+import com.demcha.compose.document.style.DocumentDashPattern;
+import com.demcha.compose.document.style.DocumentLineCap;
+import com.demcha.compose.document.style.DocumentLineJoin;
+import com.demcha.compose.document.style.DocumentPathSegment;
+import com.demcha.compose.engine.components.content.ImageData;
+import com.demcha.compose.engine.components.content.shape.Stroke;
+import org.junit.jupiter.api.Test;
+
+import javax.imageio.ImageIO;
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.io.ByteArrayInputStream;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PptxInlineSvgRasterizerTest {
+
+    @Test
+    void keepsSimpleInBoundsLayersNative() {
+        ParagraphSvgSpan span = span(layer(rectangle(0.1, 0.1, 0.9, 0.9), null,
+                DocumentDashPattern.NONE, DocumentLineCap.BUTT, DocumentLineJoin.MITER));
+
+        assertThat(PptxInlineSvgRasterizer.requiresRaster(span)).isFalse();
+    }
+
+    @Test
+    void selectsFallbackForViewBoxBleedClipsAndExactStrokeStyles() {
+        ParagraphSvgSpan offCanvas = span(layer(rectangle(-0.2, 0, 1.2, 1), null,
+                DocumentDashPattern.NONE, DocumentLineCap.BUTT, DocumentLineJoin.MITER));
+        ParagraphSvgSpan clipped = span(layer(rectangle(0, 0, 1, 1),
+                rectangle(0, 0, 0.5, 1), DocumentDashPattern.NONE,
+                DocumentLineCap.BUTT, DocumentLineJoin.MITER));
+        ParagraphSvgSpan styledStroke = span(new ResolvedSvgLayer(
+                List.of(DocumentPathSegment.moveTo(0.1, 0.5),
+                        DocumentPathSegment.lineTo(0.9, 0.5)),
+                null, null, new Stroke(Color.BLACK, 1), null,
+                DocumentDashPattern.of(2, 1), DocumentLineCap.ROUND,
+                DocumentLineJoin.BEVEL, null));
+
+        assertThat(PptxInlineSvgRasterizer.requiresRaster(offCanvas)).isTrue();
+        assertThat(PptxInlineSvgRasterizer.requiresRaster(clipped)).isTrue();
+        assertThat(PptxInlineSvgRasterizer.requiresRaster(styledStroke)).isTrue();
+    }
+
+    @Test
+    void rasterFallbackAppliesLayerClipInsideImplicitViewBox() throws Exception {
+        ParagraphSvgSpan span = span(layer(rectangle(-0.2, 0, 1.2, 1),
+                rectangle(0, 0, 0.5, 1), DocumentDashPattern.NONE,
+                DocumentLineCap.BUTT, DocumentLineJoin.MITER));
+
+        ImageData imageData = PptxInlineSvgRasterizer.rasterize(span);
+        var image = ImageIO.read(new ByteArrayInputStream(imageData.getBytes()));
+
+        assertThat(new Color(image.getRGB(image.getWidth() / 4, image.getHeight() / 2), true).getAlpha())
+                .isGreaterThan(200);
+        assertThat(new Color(image.getRGB(image.getWidth() * 3 / 4, image.getHeight() / 2), true).getAlpha())
+                .isZero();
+    }
+
+    @Test
+    void mapsExactDashCapAndJoinIntoRasterStroke() {
+        ResolvedSvgLayer layer = new ResolvedSvgLayer(
+                List.of(DocumentPathSegment.moveTo(0.1, 0.5),
+                        DocumentPathSegment.lineTo(0.9, 0.5)),
+                null, null, new Stroke(Color.BLACK, 1), null,
+                DocumentDashPattern.of(2, 1), DocumentLineCap.ROUND,
+                DocumentLineJoin.BEVEL, null);
+
+        BasicStroke stroke = PptxInlineSvgRasterizer.awtStroke(1, layer);
+
+        assertThat(stroke.getDashArray()).containsExactly(2.0f, 1.0f);
+        assertThat(stroke.getEndCap()).isEqualTo(BasicStroke.CAP_ROUND);
+        assertThat(stroke.getLineJoin()).isEqualTo(BasicStroke.JOIN_BEVEL);
+    }
+
+    private static ParagraphSvgSpan span(ResolvedSvgLayer layer) {
+        return new ParagraphSvgSpan(List.of(layer), 20, 20,
+                InlineImageAlignment.CENTER, 0, null);
+    }
+
+    private static ResolvedSvgLayer layer(List<DocumentPathSegment> segments,
+                                          List<DocumentPathSegment> clip,
+                                          DocumentDashPattern dash,
+                                          DocumentLineCap cap,
+                                          DocumentLineJoin join) {
+        return new ResolvedSvgLayer(segments, Color.RED, null, null, null,
+                dash, cap, join, clip);
+    }
+
+    private static List<DocumentPathSegment> rectangle(double left,
+                                                       double bottom,
+                                                       double right,
+                                                       double top) {
+        return List.of(
+                DocumentPathSegment.moveTo(left, bottom),
+                DocumentPathSegment.lineTo(right, bottom),
+                DocumentPathSegment.lineTo(right, top),
+                DocumentPathSegment.lineTo(left, top),
+                DocumentPathSegment.close());
+    }
+}

--- a/render-pptx/src/test/resources/layout-snapshots/pptx-parity/text-fidelity.json
+++ b/render-pptx/src/test/resources/layout-snapshots/pptx-parity/text-fidelity.json
@@ -1,0 +1,197 @@
+{
+  "formatVersion" : "2.0",
+  "canvas" : {
+    "pageWidth" : 540.0,
+    "pageHeight" : 300.0,
+    "innerWidth" : 484.0,
+    "innerHeight" : 244.0,
+    "margin" : {
+      "top" : 28.0,
+      "right" : 28.0,
+      "bottom" : 28.0,
+      "left" : 28.0
+    }
+  },
+  "totalPages" : 1,
+  "nodes" : [ {
+    "path" : "TextFidelity[0]",
+    "entityName" : "TextFidelity",
+    "entityKind" : "ContainerNode",
+    "parentPath" : null,
+    "childIndex" : 0,
+    "depth" : 1,
+    "layer" : 1,
+    "computedX" : 28.0,
+    "computedY" : 131.2,
+    "placementX" : 28.0,
+    "placementY" : 131.2,
+    "placementWidth" : 484.0,
+    "placementHeight" : 140.8,
+    "startPage" : 0,
+    "endPage" : 0,
+    "contentWidth" : 484.0,
+    "contentHeight" : 140.8,
+    "margin" : {
+      "top" : 0.0,
+      "right" : 0.0,
+      "bottom" : 0.0,
+      "left" : 0.0
+    },
+    "padding" : {
+      "top" : 0.0,
+      "right" : 0.0,
+      "bottom" : 0.0,
+      "left" : 0.0
+    }
+  }, {
+    "path" : "TextFidelity[0]/ParagraphNode[0]",
+    "entityName" : null,
+    "entityKind" : "ParagraphNode",
+    "parentPath" : "TextFidelity[0]",
+    "childIndex" : 0,
+    "depth" : 2,
+    "layer" : 2,
+    "computedX" : 28.0,
+    "computedY" : 245.6,
+    "placementX" : 28.0,
+    "placementY" : 245.6,
+    "placementWidth" : 298.364,
+    "placementHeight" : 26.4,
+    "startPage" : 0,
+    "endPage" : 0,
+    "contentWidth" : 298.364,
+    "contentHeight" : 26.4,
+    "margin" : {
+      "top" : 0.0,
+      "right" : 0.0,
+      "bottom" : 0.0,
+      "left" : 0.0
+    },
+    "padding" : {
+      "top" : 0.0,
+      "right" : 0.0,
+      "bottom" : 0.0,
+      "left" : 0.0
+    }
+  }, {
+    "path" : "TextFidelity[0]/ParagraphNode[1]",
+    "entityName" : null,
+    "entityKind" : "ParagraphNode",
+    "parentPath" : "TextFidelity[0]",
+    "childIndex" : 1,
+    "depth" : 2,
+    "layer" : 2,
+    "computedX" : 28.0,
+    "computedY" : 215.8,
+    "placementX" : 28.0,
+    "placementY" : 215.8,
+    "placementWidth" : 401.226,
+    "placementHeight" : 16.8,
+    "startPage" : 0,
+    "endPage" : 0,
+    "contentWidth" : 401.226,
+    "contentHeight" : 16.8,
+    "margin" : {
+      "top" : 0.0,
+      "right" : 0.0,
+      "bottom" : 0.0,
+      "left" : 0.0
+    },
+    "padding" : {
+      "top" : 0.0,
+      "right" : 0.0,
+      "bottom" : 0.0,
+      "left" : 0.0
+    }
+  }, {
+    "path" : "TextFidelity[0]/ParagraphNode[2]",
+    "entityName" : null,
+    "entityKind" : "ParagraphNode",
+    "parentPath" : "TextFidelity[0]",
+    "childIndex" : 2,
+    "depth" : 2,
+    "layer" : 2,
+    "computedX" : 28.0,
+    "computedY" : 186.0,
+    "placementX" : 28.0,
+    "placementY" : 186.0,
+    "placementWidth" : 409.972,
+    "placementHeight" : 16.8,
+    "startPage" : 0,
+    "endPage" : 0,
+    "contentWidth" : 409.972,
+    "contentHeight" : 16.8,
+    "margin" : {
+      "top" : 0.0,
+      "right" : 0.0,
+      "bottom" : 0.0,
+      "left" : 0.0
+    },
+    "padding" : {
+      "top" : 0.0,
+      "right" : 0.0,
+      "bottom" : 0.0,
+      "left" : 0.0
+    }
+  }, {
+    "path" : "TextFidelity[0]/ParagraphNode[3]",
+    "entityName" : null,
+    "entityKind" : "ParagraphNode",
+    "parentPath" : "TextFidelity[0]",
+    "childIndex" : 3,
+    "depth" : 2,
+    "layer" : 2,
+    "computedX" : 28.0,
+    "computedY" : 157.4,
+    "placementX" : 28.0,
+    "placementY" : 157.4,
+    "placementWidth" : 484.0,
+    "placementHeight" : 15.6,
+    "startPage" : 0,
+    "endPage" : 0,
+    "contentWidth" : 484.0,
+    "contentHeight" : 15.6,
+    "margin" : {
+      "top" : 0.0,
+      "right" : 0.0,
+      "bottom" : 0.0,
+      "left" : 0.0
+    },
+    "padding" : {
+      "top" : 0.0,
+      "right" : 0.0,
+      "bottom" : 0.0,
+      "left" : 0.0
+    }
+  }, {
+    "path" : "TextFidelity[0]/ParagraphNode[4]",
+    "entityName" : null,
+    "entityKind" : "ParagraphNode",
+    "parentPath" : "TextFidelity[0]",
+    "childIndex" : 4,
+    "depth" : 2,
+    "layer" : 2,
+    "computedX" : 28.0,
+    "computedY" : 131.2,
+    "placementX" : 28.0,
+    "placementY" : 131.2,
+    "placementWidth" : 484.0,
+    "placementHeight" : 13.2,
+    "startPage" : 0,
+    "endPage" : 0,
+    "contentWidth" : 484.0,
+    "contentHeight" : 13.2,
+    "margin" : {
+      "top" : 0.0,
+      "right" : 0.0,
+      "bottom" : 0.0,
+      "left" : 0.0
+    },
+    "padding" : {
+      "top" : 0.0,
+      "right" : 0.0,
+      "bottom" : 0.0,
+      "left" : 0.0
+    }
+  } ]
+}


### PR DESCRIPTION
## Why

The fixed-layout PPTX backend renders vector shapes but no text — and text is where geometry identity is hardest: PowerPoint lays out flowing text with the viewer's fonts, so naive paragraph export re-wraps and drifts. The engine already resolves every line (width, line height, ascent, baseline offset, measured spans) before any backend runs; the backend's job is to make PowerPoint incapable of re-layout.

## What changed

- `PptxParagraphFragmentRenderHandler`: each pre-wrapped `ParagraphLine` renders as an absolute, wrap-disabled, no-autofit, zero-inset text frame whose top sits at `baselineY − ascent`. A line whose plain runs share one font size renders as a single frame; chips, inline graphics, and mixed run sizes switch to per-span absolute frames — PowerPoint seats one shared baseline per paragraph from its largest run, so a shared frame is only safe when every run agrees on size.
- Sanitization lockstep: every emitted string passes through `PdfFont.sanitizeForRender` from the same measurement library that produced the `LayoutGraph` (opened via the `BackendProviders.fontMetrics()` seam per render pass), so glyph substitution matches measured widths exactly — the demo's 😀 renders as the same `?` in both formats. This is why `graph-compose-render-pdf` becomes a compile dependency.
- Run styling: standard-14 family mapping (Helvetica → Arial, Times → Times New Roman, Courier → Courier New — metric-compatible), bold/italic/underline/strike, color, size, and a DrawingML per-run baseline shift that compensates the PDF-descriptor-vs-viewer-font ascent difference so text sits on the measured baseline even without embedding.
- Font embedding: registered document families embed as EOT-wrapped programs (`PptxEmbeddedFont`, `fontbox` reads the OpenType metadata) when their `fsType` license bits allow; restricted or unreadable fonts degrade to a plain family-name reference with a one-time warning instead of failing a render the PDF backend would complete. Viewer ascent ratios for embedded fonts come from the actual font program.
- Inline content on the shared baseline: chips (rounded fill band + padded text frame at the PDF handler's geometry), raster images, vector shape layers (`PptxInlineGeometry`; distinct per-corner radii approximate with the top-left radius, one-time note), and SVG icons — simple layers stay native custom geometry, arbitrary clips / off-viewBox art rasterize to a transparent PNG (`PptxInlineSvgRasterizer`), gradients draw their primary colour.
- External hyperlinks emit transparent measured hotspots — span-level for every span kind (text, image, shape, SVG) and one per-line hotspot for paragraph-level links — instead of run hyperlinks, so PowerPoint cannot restyle the resolved text with its hyperlink theme.
- Capability matrix rows flip with the implementing classes and honest caveats; CHANGELOG extended.

## Verification

`./mvnw -B -ntp clean verify` (full 10-module reactor gate) → **BUILD SUCCESS**; render-pptx suite grows 13 → **26** tests.

- `PptxParagraphFragmentRenderHandlerTest` + `PptxGeometryAssertions.assertTextGeometryMatches` — line, absolute-span, chip, and inline-graphic anchors re-read through POI against the captured `LayoutGraph`: real wrapping across a narrow column, mixed font sizes (forced per-span frames), vertical seating, custom fonts, rich styles, links, SVG fallback, exact inline corner radii.
- `PptxEmbeddedFontTest` — EOT wrapper structure and license gating.
- `PptxTextParityDemoTest` — locks the demo's layout with a backend-neutral snapshot (`LayoutSnapshotAssertions`) and writes the reviewable pair + per-page PNGs under `render-pptx/target/visual-tests/pptx-parity/text-fidelity/`; a manual PowerPoint export of the embedded-font deck matches the PDF page (POI's `Graphics2D` preview is advisory — it substitutes fonts the AWT pipeline lacks).

## Notes

- Depends on the `toImages` embedded-font rasterization fix (#406): the demo previews rasterize the PDF side through `session.toImages`, which garbled embedded fonts before that fix. This branch is stacked on it.
- Intra-line glyph shaping in PowerPoint still depends on the viewer resolving the referenced/embedded family; frame geometry is engine-owned either way, so nothing reflows.
- Internal (anchor) links, bookmarks, tables, block images, and clip/transform markers remain on the incremental path; the capability matrix is the live status.

**Lane:** canonical (document.backend.fixed.pptx) — backend surface; engine, layout, and the PDF paint path untouched.

Stacked on #406 (toImages embedded-font fix) — merge #406 first.
