### PR TITLE
fix(render-pdf): draw text decoration marks and honour alpha on text, lines, and table paint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,19 @@ follow semantic versioning; release dates are ISO 8601.
 
 ### Fixed
 
+- The PDF backend now draws `DocumentTextDecoration.UNDERLINE` and
+  `STRIKETHROUGH` marks — previously the decoration flags resolved only to
+  font faces (which alias to the regular program), so decorated text rendered
+  as plain glyphs while the PPTX backend already drew real marks. Marks are
+  em-proportional filled bands (underline 0.10 em below the baseline,
+  strikethrough 0.28 em above, thickness 0.05 em — the Type 1 underline
+  convention) in the run's colour, on paragraph runs, chips, and table cell
+  text alike.
+- The PDF backend honours the alpha channel of `DocumentColor.rgba` on every
+  remaining surface — text runs, lines, side borders, and table fills,
+  borders, and cell text — matching the shape fills/strokes that already
+  carried it and the PPTX backend's native behaviour. Fully opaque documents
+  render byte-identically to before.
 - `DocumentSession.toImages` / `toImage` rasterized documents that use binary
   font families (any non-standard-14 file) with substitute glyphs — visually
   garbled text with correct spacing. PDFBox writes embedded font subsets only

--- a/core/src/main/java/com/demcha/compose/document/style/DocumentColor.java
+++ b/core/src/main/java/com/demcha/compose/document/style/DocumentColor.java
@@ -73,14 +73,11 @@ public final class DocumentColor {
     /**
      * Creates a translucent document color from RGBA components.
      *
-     * <p>The PDF backend honours the alpha channel on shape fills and strokes —
-     * rectangles/panels/bars, chart value-label halos, ellipses (chart point
-     * markers), polygons, and inline shapes — via a graphics-state alpha
-     * constant. Text, lines, and the DOCX backend currently render the colour
-     * fully opaque. The PPTX backend carries the alpha natively on every
-     * surface — fills, strokes, text runs, and table paint — so a translucent
-     * colour on text or table cells shows through in the deck where the PDF
-     * still paints it opaque.</p>
+     * <p>Both fixed-layout backends honour the alpha channel on every
+     * surface: the PDF backend through a graphics-state alpha constant on
+     * shape fills and strokes, text runs, lines, side borders, and table
+     * paint; the PPTX backend natively in DrawingML. The DOCX backend
+     * currently renders the colour fully opaque.</p>
      *
      * @param red   red channel from 0 to 255
      * @param green green channel from 0 to 255

--- a/docs/architecture/backend-capability-matrix.md
+++ b/docs/architecture/backend-capability-matrix.md
@@ -60,8 +60,8 @@ Payload records live in `core` under
 | Transform open/close — rotate/scale about fragment centre (`TransformBegin/EndPayload`) | ✅ `PdfTransformBegin/EndRenderHandler` | ✅ `PptxTransformBegin/EndRenderHandler` (group shape; rotation and centre-pivot scaling via the exterior/interior frame ratio) | ⚠️ inline fallback + one-time capability warning |
 | Anchor markers (`AnchorMarkerPayload`) | ✅ `PdfAnchorMarkerRenderHandler` + `PdfInternalLinkWriter` | ✅ `PptxAnchorMarkerRenderHandler` + `PptxNavigationWriter` (slide-jump hyperlinks resolved after all fragments, so forward references work) | ❌ |
 | Bookmark markers (`BookmarkMarkerPayload`) | ✅ `PdfBookmarkMarkerRenderHandler` + `PdfBookmarkOutlineWriter` | ⚠️ `PptxBookmarkMarkerRenderHandler` + `PptxNavigationWriter` (PPTX has no outline tree — the first bookmark on a page names its slide, further bookmarks on the same page are dropped with a debug note) | ❌ |
-| Alpha / opacity | ⚠️ `PdfAlphaSupport` (`PDExtendedGraphicsState` on shape fills and strokes; text, lines, and table paint render opaque) | ✅ native `<a:alpha>` via POI on every surface — fills, strokes, text runs, table paint | ❌ |
-| Text decorations — underline / strikethrough (`DocumentTextDecoration`) | ❌ (the decoration flags resolve to font faces, but no decoration lines are drawn) | ✅ `PptxTextFrames.applyStyle` | ❌ |
+| Alpha / opacity | ✅ `PdfAlphaSupport` (`PDExtendedGraphicsState` on every surface — shape fills/strokes, text runs, lines, side borders, table paint) | ✅ native `<a:alpha>` via POI on every surface — fills, strokes, text runs, table paint | ❌ |
+| Text decorations — underline / strikethrough (`DocumentTextDecoration`) | ✅ `PdfTextDecorations` (em-proportional marks: underline −0.10 em, strikethrough +0.28 em, thickness 0.05 em) | ✅ `PptxTextFrames.applyStyle` (PowerPoint draws its own marks — sub-point placement differences vs the PDF's constants) | ❌ |
 
 ## Navigation and interactivity
 

--- a/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfAlphaSupport.java
+++ b/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfAlphaSupport.java
@@ -35,8 +35,21 @@ final class PdfAlphaSupport {
         if (color == null || color.getAlpha() >= 255) {
             return;
         }
+        setFillAlpha(stream, color.getAlpha() / 255f);
+    }
+
+    /**
+     * Writes an explicit non-stroking alpha constant, including {@code 1.0} —
+     * used by the paragraph text state, which must also RESTORE opacity (the
+     * {@code gs} survives {@code ET} and nested draws inherit it).
+     *
+     * @param stream page content stream
+     * @param alpha  alpha constant in [0, 1]
+     * @throws IOException when the graphics-state write fails
+     */
+    static void setFillAlpha(PDPageContentStream stream, float alpha) throws IOException {
         PDExtendedGraphicsState state = new PDExtendedGraphicsState();
-        state.setNonStrokingAlphaConstant(color.getAlpha() / 255f);
+        state.setNonStrokingAlphaConstant(alpha);
         stream.setGraphicsStateParameters(state);
     }
 

--- a/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfLineFragmentRenderHandler.java
+++ b/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfLineFragmentRenderHandler.java
@@ -42,6 +42,7 @@ public final class PdfLineFragmentRenderHandler
         PDPageContentStream stream = environment.pageSurface(fragment.pageIndex());
         stream.saveGraphicsState();
         try {
+            PdfAlphaSupport.applyStrokeAlpha(stream, stroke.strokeColor().color());
             stream.setStrokingColor(stroke.strokeColor().color());
             stream.setLineWidth((float) stroke.width());
             PdfShapeGeometry.applyDashPattern(stream, payload.dashPattern());

--- a/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfParagraphFragmentRenderHandler.java
+++ b/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfParagraphFragmentRenderHandler.java
@@ -15,9 +15,11 @@ import com.demcha.compose.font.FontLibrary;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
+import org.apache.pdfbox.pdmodel.graphics.state.PDExtendedGraphicsState;
 
 import java.awt.*;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -125,7 +127,7 @@ public final class PdfParagraphFragmentRenderHandler
      * fill band is the line's text box expanded by vertical padding, so the chip
      * overflows the line box like a browser highlight without enlarging it.
      */
-    private static void renderChip(PDPageContentStream stream,
+    private static boolean renderChip(PDPageContentStream stream,
                                    FontLibrary fonts,
                                    ParagraphTextSpan span,
                                    double cursorX,
@@ -135,7 +137,7 @@ public final class PdfParagraphFragmentRenderHandler
         PdfFont font = fonts.getFont(span.textStyle().fontName(), PdfFont.class).orElseThrow();
         String text = font.sanitizeForRender(span.textStyle(), span.text());
         if (text.isEmpty()) {
-            return;                                             // nothing to paint — no glyph-less fill
+            return false;                                       // nothing to paint — no glyph-less fill or mark
         }
         InlineBackground background = span.background();
         DocumentInsets pad = background.padding();
@@ -156,6 +158,7 @@ public final class PdfParagraphFragmentRenderHandler
         textState.applyColor(stream, span.textStyle().color());
         stream.showText(text);
         stream.endText();
+        return true;
     }
 
     private static void renderShape(PDPageContentStream stream,
@@ -322,6 +325,10 @@ public final class PdfParagraphFragmentRenderHandler
 
         boolean inTextBlock = false;
         double cursorX = lineX;
+        // Underline/strikethrough marks are path fills, illegal inside a
+        // BT/ET block — collect them while the glyphs stream out and paint
+        // them after the text. Lazily allocated: most lines carry none.
+        List<PdfTextDecorations.Segment> decorations = null;
         try {
             for (ParagraphSpan span : spans) {
                 if (span instanceof ParagraphTextSpan textSpan) {
@@ -333,8 +340,17 @@ public final class PdfParagraphFragmentRenderHandler
                             stream.endText();
                             inTextBlock = false;
                         }
-                        renderChip(stream, fonts, textSpan, cursorX, baselineY, line, textState);
+                        textState.resetAlpha(stream);
+                        boolean chipPainted = renderChip(stream, fonts, textSpan, cursorX, baselineY, line, textState);
                         textState.invalidate();
+                        if (chipPainted && PdfTextDecorations.drawsMark(textSpan.textStyle().decoration())) {
+                            DocumentInsets pad = textSpan.background().padding();
+                            decorations = addDecoration(decorations, new PdfTextDecorations.Segment(
+                                    cursorX + pad.left(), baselineY,
+                                    textSpan.width() - pad.horizontal(),
+                                    textSpan.textStyle().size(), textSpan.textStyle().color(),
+                                    textSpan.textStyle().decoration()));
+                        }
                         cursorX += textSpan.width();
                         continue;
                     }
@@ -360,6 +376,12 @@ public final class PdfParagraphFragmentRenderHandler
                             (float) textSpan.textStyle().size());
                     textState.applyColor(stream, textSpan.textStyle().color());
                     stream.showText(text);
+                    if (PdfTextDecorations.drawsMark(textSpan.textStyle().decoration())) {
+                        decorations = addDecoration(decorations, new PdfTextDecorations.Segment(
+                                cursorX, baselineY, textSpan.width(),
+                                textSpan.textStyle().size(), textSpan.textStyle().color(),
+                                textSpan.textStyle().decoration()));
+                    }
                     cursorX += textSpan.width();
                 } else if (span instanceof ParagraphImageSpan imageSpan) {
                     if (inTextBlock) {
@@ -372,6 +394,7 @@ public final class PdfParagraphFragmentRenderHandler
                             line.textAscent(),
                             line.baselineOffsetFromBottom(),
                             line.lineHeight());
+                    textState.resetAlpha(stream);
                     PDImageXObject image = environment.resolveImage(imageSpan.imageData());
                     stream.drawImage(image,
                             (float) cursorX,
@@ -388,6 +411,7 @@ public final class PdfParagraphFragmentRenderHandler
                         stream.endText();
                         inTextBlock = false;
                     }
+                    textState.resetAlpha(stream);
                     renderShape(stream, shapeSpan, cursorX, baselineY,
                             line.textAscent(), line.baselineOffsetFromBottom(), line.lineHeight());
                     textState.invalidate();
@@ -397,6 +421,7 @@ public final class PdfParagraphFragmentRenderHandler
                         stream.endText();
                         inTextBlock = false;
                     }
+                    textState.resetAlpha(stream);
                     renderSvg(stream, svgSpan, environment, pageIndex, cursorX, baselineY,
                             line.textAscent(), line.baselineOffsetFromBottom(), line.lineHeight());
                     textState.invalidate();
@@ -408,6 +433,21 @@ public final class PdfParagraphFragmentRenderHandler
                 stream.endText();
             }
         }
+        if (decorations != null) {
+            // Marks inherit the ambient alpha into their q..Q, so restore
+            // opacity first; each mark then applies its own colour's alpha.
+            textState.resetAlpha(stream);
+            PdfTextDecorations.draw(stream, decorations);
+        }
+    }
+
+    private static List<PdfTextDecorations.Segment> addDecoration(
+            List<PdfTextDecorations.Segment> decorations,
+            PdfTextDecorations.Segment segment) {
+        List<PdfTextDecorations.Segment> target =
+                decorations == null ? new ArrayList<>() : decorations;
+        target.add(segment);
+        return target;
     }
 
     /**
@@ -422,6 +462,11 @@ public final class PdfParagraphFragmentRenderHandler
         private PDFont font;
         private float size = Float.NaN;
         private Color color;
+        // A fresh q block inherits the page default of fully opaque; every
+        // nested draw (chips, inline graphics, decoration marks) runs in its
+        // own q..Q, so the alpha WE set is what survives — invalidate() must
+        // not reset it.
+        private float alpha = 1f;
 
         void applyFont(PDPageContentStream stream, PDFont newFont, float newSize) throws IOException {
             if (newFont != font || newSize != size) {
@@ -433,8 +478,37 @@ public final class PdfParagraphFragmentRenderHandler
 
         void applyColor(PDPageContentStream stream, Color newColor) throws IOException {
             if (!newColor.equals(color)) {
+                float newAlpha = newColor.getAlpha() / 255f;
+                if (newAlpha != alpha) {
+                    // setNonStrokingColor drops the alpha channel, so a
+                    // translucent run carries it as a graphics-state constant
+                    // (the gs operator is legal inside a text object).
+                    PDExtendedGraphicsState state = new PDExtendedGraphicsState();
+                    state.setNonStrokingAlphaConstant(newAlpha);
+                    stream.setGraphicsStateParameters(state);
+                    alpha = newAlpha;
+                }
                 stream.setNonStrokingColor(newColor);
                 color = newColor;
+            }
+        }
+
+        /**
+         * Restores full opacity before a nested draw. The {@code gs} alpha
+         * survives {@code ET}, and the nested q..Q blocks (chips, inline
+         * graphics, decoration marks) inherit it — their own alpha helpers
+         * no-op for opaque colours, so without this reset an opaque nested
+         * draw after a translucent run would render translucent.
+         */
+        void resetAlpha(PDPageContentStream stream) throws IOException {
+            if (alpha != 1f) {
+                PDExtendedGraphicsState state = new PDExtendedGraphicsState();
+                state.setNonStrokingAlphaConstant(1f);
+                stream.setGraphicsStateParameters(state);
+                alpha = 1f;
+                // The next translucent run must re-emit its gs even when its
+                // colour is unchanged.
+                color = null;
             }
         }
 

--- a/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfParagraphFragmentRenderHandler.java
+++ b/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfParagraphFragmentRenderHandler.java
@@ -15,7 +15,6 @@ import com.demcha.compose.font.FontLibrary;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.font.PDFont;
 import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
-import org.apache.pdfbox.pdmodel.graphics.state.PDExtendedGraphicsState;
 
 import java.awt.*;
 import java.io.IOException;
@@ -483,9 +482,7 @@ public final class PdfParagraphFragmentRenderHandler
                     // setNonStrokingColor drops the alpha channel, so a
                     // translucent run carries it as a graphics-state constant
                     // (the gs operator is legal inside a text object).
-                    PDExtendedGraphicsState state = new PDExtendedGraphicsState();
-                    state.setNonStrokingAlphaConstant(newAlpha);
-                    stream.setGraphicsStateParameters(state);
+                    PdfAlphaSupport.setFillAlpha(stream, newAlpha);
                     alpha = newAlpha;
                 }
                 stream.setNonStrokingColor(newColor);
@@ -502,9 +499,7 @@ public final class PdfParagraphFragmentRenderHandler
          */
         void resetAlpha(PDPageContentStream stream) throws IOException {
             if (alpha != 1f) {
-                PDExtendedGraphicsState state = new PDExtendedGraphicsState();
-                state.setNonStrokingAlphaConstant(1f);
-                stream.setGraphicsStateParameters(state);
+                PdfAlphaSupport.setFillAlpha(stream, 1f);
                 alpha = 1f;
                 // The next translucent run must re-emit its gs even when its
                 // colour is unchanged.

--- a/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfShapeFragmentRenderHandler.java
+++ b/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfShapeFragmentRenderHandler.java
@@ -32,6 +32,7 @@ public final class PdfShapeFragmentRenderHandler
         }
         stream.saveGraphicsState();
         try {
+            PdfAlphaSupport.applyStrokeAlpha(stream, side.strokeColor().color());
             stream.setStrokingColor(side.strokeColor().color());
             stream.setLineWidth((float) side.width());
             stream.moveTo(x1, y1);

--- a/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfTableRowFragmentRenderHandler.java
+++ b/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfTableRowFragmentRenderHandler.java
@@ -106,6 +106,7 @@ public final class PdfTableRowFragmentRenderHandler
             if (cell.width() > 0 && cell.height() > 0) {
                 stream.saveGraphicsState();
                 try {
+                    PdfAlphaSupport.applyFillAlpha(stream, cell.style().fillColor());
                     stream.setNonStrokingColor(cell.style().fillColor());
                     stream.addRect((float) cellX, (float) cellY, (float) cell.width(), (float) cell.height());
                     stream.fill();
@@ -134,6 +135,7 @@ public final class PdfTableRowFragmentRenderHandler
         stream.saveGraphicsState();
         try {
             double strokeWidth = cell.style().stroke().width();
+            PdfAlphaSupport.applyStrokeAlpha(stream, cell.style().stroke().strokeColor().color());
             stream.setStrokingColor(cell.style().stroke().strokeColor().color());
             stream.setLineWidth((float) strokeWidth);
             // Default butt caps. Adjacent cells' perpendicular borders
@@ -185,8 +187,10 @@ public final class PdfTableRowFragmentRenderHandler
 
         stream.saveGraphicsState();
         try {
+            PdfAlphaSupport.applyFillAlpha(stream, cell.style().textStyle().color());
             stream.setFont(font.fontType(cell.style().textStyle().decoration()), (float) cell.style().textStyle().size());
             stream.setNonStrokingColor(cell.style().textStyle().color());
+            List<PdfTextDecorations.Segment> decorations = null;
             for (ResolvedTextLine line : lines) {
                 if (line.text().isEmpty()) {
                     continue;
@@ -198,6 +202,20 @@ public final class PdfTableRowFragmentRenderHandler
                 stream.newLineAtOffset((float) line.x(), (float) line.baselineY());
                 stream.showText(safeText);
                 stream.endText();
+                if (PdfTextDecorations.drawsMark(cell.style().textStyle().decoration())) {
+                    if (decorations == null) {
+                        decorations = new ArrayList<>();
+                    }
+                    decorations.add(new PdfTextDecorations.Segment(
+                            line.x(), line.baselineY(),
+                            font.getTextWidth(cell.style().textStyle(), safeText),
+                            cell.style().textStyle().size(),
+                            cell.style().textStyle().color(),
+                            cell.style().textStyle().decoration()));
+                }
+            }
+            if (decorations != null) {
+                PdfTextDecorations.draw(stream, decorations);
             }
         } finally {
             stream.restoreGraphicsState();

--- a/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfTextDecorations.java
+++ b/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfTextDecorations.java
@@ -1,0 +1,94 @@
+package com.demcha.compose.document.backend.fixed.pdf.handlers;
+
+import com.demcha.compose.engine.components.content.text.TextDecoration;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+
+import java.awt.Color;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Draws underline and strikethrough marks for decorated text runs. The
+ * decoration flags previously resolved only to font faces (which alias to the
+ * regular program), so decorated text rendered as plain glyphs; the PPTX
+ * backend draws PowerPoint's native marks, and this brings the PDF reference
+ * to visual parity.
+ *
+ * <p>Marks are filled rectangles collected while the glyphs stream out (path
+ * operators are illegal inside a {@code BT}/{@code ET} block) and painted
+ * after the text, one em-proportional band per decorated run.</p>
+ */
+final class PdfTextDecorations {
+
+    /**
+     * Distance below the baseline, as a fraction of the font size — the
+     * classic Type&nbsp;1 convention (Helvetica AFM: UnderlinePosition
+     * −100/1000).
+     */
+    private static final double UNDERLINE_OFFSET_EM = 0.10;
+
+    /**
+     * Distance above the baseline, as a fraction of the font size. No AFM
+     * field standardizes it; roughly half the x-height matches common faces
+     * and PowerPoint's own strikeout placement.
+     */
+    private static final double STRIKETHROUGH_OFFSET_EM = 0.28;
+
+    /** Mark thickness (Helvetica AFM: UnderlineThickness 50/1000). */
+    private static final double THICKNESS_EM = 0.05;
+
+    private PdfTextDecorations() {
+    }
+
+    /**
+     * One decorated run: where its glyphs sit and how to mark them.
+     *
+     * @param x          left edge of the run, in page points
+     * @param baselineY  baseline of the run, in page points
+     * @param width      advance width of the run
+     * @param fontSize   run font size (scales offset and thickness)
+     * @param color      run colour (alpha honoured)
+     * @param decoration which mark to draw
+     */
+    record Segment(double x,
+                   double baselineY,
+                   double width,
+                   double fontSize,
+                   Color color,
+                   TextDecoration decoration) {
+    }
+
+    /** Whether this decoration draws a mark (as opposed to a face choice). */
+    static boolean drawsMark(TextDecoration decoration) {
+        return decoration == TextDecoration.UNDERLINE
+                || decoration == TextDecoration.STRIKETHROUGH;
+    }
+
+    /**
+     * Paints every collected mark. Each segment runs in its own graphics
+     * state, so the fill colour and alpha never leak into later content.
+     */
+    static void draw(PDPageContentStream stream, List<Segment> segments) throws IOException {
+        for (Segment segment : segments) {
+            if (segment.width() <= 0) {
+                continue;
+            }
+            double thickness = THICKNESS_EM * segment.fontSize();
+            double markY = segment.decoration() == TextDecoration.UNDERLINE
+                    ? segment.baselineY() - UNDERLINE_OFFSET_EM * segment.fontSize()
+                    : segment.baselineY() + STRIKETHROUGH_OFFSET_EM * segment.fontSize();
+            stream.saveGraphicsState();
+            try {
+                PdfAlphaSupport.applyFillAlpha(stream, segment.color());
+                stream.setNonStrokingColor(segment.color());
+                stream.addRect((float) segment.x(),
+                        (float) (markY - thickness / 2.0),
+                        (float) segment.width(),
+                        (float) thickness);
+                stream.fill();
+            } finally {
+                stream.restoreGraphicsState();
+            }
+        }
+    }
+}

--- a/render-pdf/src/test/java/com/demcha/compose/document/backend/fixed/pdf/PdfDecorationAndAlphaRenderTest.java
+++ b/render-pdf/src/test/java/com/demcha/compose/document/backend/fixed/pdf/PdfDecorationAndAlphaRenderTest.java
@@ -1,0 +1,245 @@
+package com.demcha.compose.document.backend.fixed.pdf;
+
+import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.api.DocumentSession;
+import com.demcha.compose.document.dsl.LineBuilder;
+import com.demcha.compose.document.dsl.ParagraphBuilder;
+import com.demcha.compose.document.dsl.TableBuilder;
+import com.demcha.compose.document.style.DocumentColor;
+import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.document.table.DocumentTableStyle;
+import com.demcha.compose.document.style.DocumentTextDecoration;
+import com.demcha.compose.document.style.DocumentTextStyle;
+import org.junit.jupiter.api.Test;
+
+import java.awt.image.BufferedImage;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The PDF backend draws underline/strikethrough marks and honours the alpha
+ * channel on text, lines, and table paint — surfaces where it previously
+ * rendered opaque plain glyphs while the PPTX backend already carried the
+ * decoration and translucency. Each case renders a pair of documents that
+ * differ only in the tested style and compares the rasterized ink.
+ */
+class PdfDecorationAndAlphaRenderTest {
+
+    private static final int DARK = 120;
+
+    private static BufferedImage render(Consumer<DocumentSession> content) throws Exception {
+        try (DocumentSession session = GraphCompose.document()
+                .pageSize(300, 160)
+                .margin(DocumentInsets.of(20))
+                .create()) {
+            content.accept(session);
+            return session.toImages(150).get(0);
+        }
+    }
+
+    private static BufferedImage renderText(DocumentTextStyle style) throws Exception {
+        // Caps only: no descenders, so every plain-ink row sits above the
+        // baseline and an underline strictly extends the ink downward.
+        return render(session -> session.add(new ParagraphBuilder().name("Sample")
+                .text("SPEED LINES")
+                .textStyle(style)
+                .build()));
+    }
+
+    private static int darkPixels(BufferedImage image) {
+        int count = 0;
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                if (luminance(image.getRGB(x, y)) < DARK) {
+                    count++;
+                }
+            }
+        }
+        return count;
+    }
+
+    private static int lowestInkRow(BufferedImage image) {
+        for (int y = image.getHeight() - 1; y >= 0; y--) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                if (luminance(image.getRGB(x, y)) < DARK) {
+                    return y;
+                }
+            }
+        }
+        return -1;
+    }
+
+    private static int highestInkRow(BufferedImage image) {
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                if (luminance(image.getRGB(x, y)) < DARK) {
+                    return y;
+                }
+            }
+        }
+        return -1;
+    }
+
+    private static int minLuminance(BufferedImage image) {
+        int min = 255;
+        for (int y = 0; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                min = Math.min(min, luminance(image.getRGB(x, y)));
+            }
+        }
+        return min;
+    }
+
+    private static int luminance(int rgb) {
+        return (((rgb >> 16) & 0xFF) + ((rgb >> 8) & 0xFF) + (rgb & 0xFF)) / 3;
+    }
+
+    @Test
+    void underlineDrawsAMarkStrictlyBelowTheGlyphs() throws Exception {
+        BufferedImage plain = renderText(DocumentTextStyle.builder().size(16).build());
+        BufferedImage underlined = renderText(DocumentTextStyle.builder().size(16)
+                .decoration(DocumentTextDecoration.UNDERLINE).build());
+        assertThat(darkPixels(underlined))
+                .as("the underline adds ink")
+                .isGreaterThan(darkPixels(plain));
+        assertThat(lowestInkRow(underlined))
+                .as("the mark sits below the baseline, extending the ink downward")
+                .isGreaterThan(lowestInkRow(plain));
+    }
+
+    @Test
+    void strikethroughDrawsAMarkWithinTheGlyphBand() throws Exception {
+        BufferedImage plain = renderText(DocumentTextStyle.builder().size(16).build());
+        BufferedImage struck = renderText(DocumentTextStyle.builder().size(16)
+                .decoration(DocumentTextDecoration.STRIKETHROUGH).build());
+        assertThat(darkPixels(struck))
+                .as("the strikethrough adds ink")
+                .isGreaterThan(darkPixels(plain));
+        assertThat(lowestInkRow(struck))
+                .as("the mark crosses the glyphs instead of extending below them")
+                .isCloseTo(lowestInkRow(plain), org.assertj.core.data.Offset.offset(1));
+        assertThat(highestInkRow(struck))
+                .as("the mark stays below the cap tops instead of floating above")
+                .isCloseTo(highestInkRow(plain), org.assertj.core.data.Offset.offset(1));
+    }
+
+    @Test
+    void aTranslucentTailDoesNotBleachAnEarlierRunsUnderline() throws Exception {
+        // The mark of the opaque underlined run is painted after the whole
+        // line's text — including the translucent tail whose gs alpha
+        // survives ET. Without the ambient-alpha reset the mark inherits
+        // that translucency and renders bleached.
+        BufferedImage image = render(session -> session.add(new ParagraphBuilder().name("Mixed")
+                .inlineText("MARKED", DocumentTextStyle.builder().size(16)
+                        .decoration(DocumentTextDecoration.UNDERLINE).build())
+                .inlineText(" GHOST", DocumentTextStyle.builder().size(16)
+                        .color(DocumentColor.rgba(0, 0, 0, 40)).build())
+                .build()));
+        BufferedImage plain = render(session -> session.add(new ParagraphBuilder().name("Mixed")
+                .inlineText("MARKED", DocumentTextStyle.builder().size(16).build())
+                .inlineText(" GHOST", DocumentTextStyle.builder().size(16)
+                        .color(DocumentColor.rgba(0, 0, 0, 40)).build())
+                .build()));
+        // The underline band lies strictly below every plain-ink row; its
+        // darkest pixel must be as dark as the opaque glyphs above it.
+        int bandTop = lowestInkRow(plain) + 1;
+        int minInBand = 255;
+        for (int y = bandTop; y < image.getHeight(); y++) {
+            for (int x = 0; x < image.getWidth(); x++) {
+                minInBand = Math.min(minInBand, luminance(image.getRGB(x, y)));
+            }
+        }
+        assertThat(minInBand)
+                .as("the opaque run's mark must not inherit the tail's alpha")
+                .isLessThan(60);
+    }
+
+    @Test
+    void underlinedChipTextDrawsAMark() throws Exception {
+        DocumentTextStyle chipStyle = DocumentTextStyle.builder().size(14).build();
+        DocumentTextStyle underlined = DocumentTextStyle.builder().size(14)
+                .decoration(DocumentTextDecoration.UNDERLINE).build();
+        BufferedImage plain = render(session -> session.add(new ParagraphBuilder().name("Chips")
+                .inlineHighlight("SPEED", chipStyle, DocumentColor.rgb(230, 230, 240), 4,
+                        DocumentInsets.of(3))
+                .build()));
+        BufferedImage marked = render(session -> session.add(new ParagraphBuilder().name("Chips")
+                .inlineHighlight("SPEED", underlined, DocumentColor.rgb(230, 230, 240), 4,
+                        DocumentInsets.of(3))
+                .build()));
+        assertThat(darkPixels(marked))
+                .as("the chip glyph run carries its underline mark")
+                .isGreaterThan(darkPixels(plain));
+    }
+
+    @Test
+    void translucentTextRendersLighterThanOpaque() throws Exception {
+        BufferedImage opaque = renderText(DocumentTextStyle.builder().size(16)
+                .color(DocumentColor.rgb(0, 0, 0)).build());
+        BufferedImage translucent = renderText(DocumentTextStyle.builder().size(16)
+                .color(DocumentColor.rgba(0, 0, 0, 100)).build());
+        assertThat(minLuminance(opaque)).isLessThan(60);
+        assertThat(minLuminance(translucent))
+                .as("40%-alpha glyphs must blend with the white page")
+                .isGreaterThan(100);
+    }
+
+    @Test
+    void translucentLineRendersLighterThanOpaque() throws Exception {
+        BufferedImage opaque = render(session -> session.add(new LineBuilder()
+                .name("Rule").horizontal(200).thickness(6)
+                .color(DocumentColor.rgb(0, 0, 0)).build()));
+        BufferedImage translucent = render(session -> session.add(new LineBuilder()
+                .name("Rule").horizontal(200).thickness(6)
+                .color(DocumentColor.rgba(0, 0, 0, 100)).build()));
+        assertThat(minLuminance(opaque)).isLessThan(60);
+        assertThat(minLuminance(translucent)).isGreaterThan(100);
+    }
+
+    @Test
+    void translucentTableCellFillRendersLighterThanOpaque() throws Exception {
+        // Empty cell text and a zero-width stroke: the fill is the only ink,
+        // so the darkest pixel measures the fill itself.
+        BufferedImage opaque = render(session -> session.add(new TableBuilder()
+                .name("Fills")
+                .defaultCellStyle(DocumentTableStyle.builder()
+                        .fillColor(DocumentColor.rgb(0, 0, 160))
+                        .stroke(com.demcha.compose.document.style.DocumentStroke.of(
+                                DocumentColor.WHITE, 0))
+                        .build())
+                .row("")
+                .build()));
+        BufferedImage translucent = render(session -> session.add(new TableBuilder()
+                .name("Fills")
+                .defaultCellStyle(DocumentTableStyle.builder()
+                        .fillColor(DocumentColor.rgba(0, 0, 160, 100))
+                        .stroke(com.demcha.compose.document.style.DocumentStroke.of(
+                                DocumentColor.WHITE, 0))
+                        .build())
+                .row("")
+                .build()));
+        assertThat(minLuminance(opaque)).isLessThan(80);
+        assertThat(minLuminance(translucent)).isGreaterThan(100);
+    }
+
+    @Test
+    void underlinedTableCellTextDrawsMarks() throws Exception {
+        Consumer<DocumentSession> plainTable = session -> session.add(new TableBuilder()
+                .name("Cells")
+                .row("SPEED")
+                .build());
+        BufferedImage plain = render(plainTable);
+        BufferedImage underlined = render(session -> session.add(new TableBuilder()
+                .name("Cells")
+                .defaultCellStyle(DocumentTableStyle.builder()
+                        .textStyle(DocumentTextStyle.builder()
+                                .decoration(DocumentTextDecoration.UNDERLINE).build())
+                        .build())
+                .row("SPEED")
+                .build()));
+        assertThat(darkPixels(underlined))
+                .as("cell text decoration adds mark ink")
+                .isGreaterThan(darkPixels(plain));
+    }
+}

--- a/render-pdf/src/test/java/com/demcha/compose/document/backend/fixed/pdf/PdfDecorationAndAlphaRenderTest.java
+++ b/render-pdf/src/test/java/com/demcha/compose/document/backend/fixed/pdf/PdfDecorationAndAlphaRenderTest.java
@@ -224,6 +224,96 @@ class PdfDecorationAndAlphaRenderTest {
     }
 
     @Test
+    void anOpaqueInlineShapeAfterATranslucentRunStaysFullyDark() throws Exception {
+        // The dot draws in its own q..Q AFTER the translucent run's gs was
+        // emitted; without the ambient-alpha reset before nested draws it
+        // would inherit the run's translucency.
+        BufferedImage image = render(session -> session.add(new ParagraphBuilder().name("DotLine")
+                .inlineText("GHOST ", DocumentTextStyle.builder().size(16)
+                        .color(DocumentColor.rgba(0, 0, 0, 40)).build())
+                .dot(8, DocumentColor.rgb(0, 0, 0))
+                .build()));
+        assertThat(minLuminance(image))
+                .as("the opaque dot must not inherit the translucent run's alpha")
+                .isLessThan(60);
+    }
+
+    @Test
+    void translucentTableBordersRenderLighterThanOpaque() throws Exception {
+        BufferedImage opaque = render(session -> session.add(new TableBuilder()
+                .name("Borders")
+                .defaultCellStyle(DocumentTableStyle.builder()
+                        .stroke(com.demcha.compose.document.style.DocumentStroke.of(
+                                DocumentColor.rgb(0, 0, 0), 3))
+                        .build())
+                .row("")
+                .build()));
+        BufferedImage translucent = render(session -> session.add(new TableBuilder()
+                .name("Borders")
+                .defaultCellStyle(DocumentTableStyle.builder()
+                        .stroke(com.demcha.compose.document.style.DocumentStroke.of(
+                                DocumentColor.rgba(0, 0, 0, 100), 3))
+                        .build())
+                .row("")
+                .build()));
+        assertThat(minLuminance(opaque)).isLessThan(60);
+        // Perpendicular borders double-blend where they cross at the cell
+        // corners (1−(1−α)² ≈ 0.63), so the darkest translucent pixel sits
+        // lower than a single pass — still far from opaque.
+        assertThat(minLuminance(translucent)).isGreaterThan(80);
+    }
+
+    @Test
+    void translucentTableCellTextRendersLighterThanOpaque() throws Exception {
+        BufferedImage opaque = render(session -> session.add(new TableBuilder()
+                .name("CellText")
+                .defaultCellStyle(DocumentTableStyle.builder()
+                        .textStyle(DocumentTextStyle.builder().size(14)
+                                .color(DocumentColor.rgb(0, 0, 0)).build())
+                        .stroke(com.demcha.compose.document.style.DocumentStroke.of(
+                                DocumentColor.WHITE, 0))
+                        .build())
+                .row("INK")
+                .build()));
+        BufferedImage translucent = render(session -> session.add(new TableBuilder()
+                .name("CellText")
+                .defaultCellStyle(DocumentTableStyle.builder()
+                        .textStyle(DocumentTextStyle.builder().size(14)
+                                .color(DocumentColor.rgba(0, 0, 0, 100)).build())
+                        .stroke(com.demcha.compose.document.style.DocumentStroke.of(
+                                DocumentColor.WHITE, 0))
+                        .build())
+                .row("INK")
+                .build()));
+        assertThat(minLuminance(opaque)).isLessThan(60);
+        assertThat(minLuminance(translucent)).isGreaterThan(100);
+    }
+
+    @Test
+    void translucentSideBordersRenderLighterThanOpaque() throws Exception {
+        // White text keeps the section non-empty without adding dark ink,
+        // so the left accent border is the only measurable paint.
+        DocumentTextStyle invisible = DocumentTextStyle.builder().size(12)
+                .color(DocumentColor.WHITE).build();
+        BufferedImage opaque = render(session -> session.dsl().pageFlow().name("Flow")
+                .addSection("Card", section -> section
+                        .borders(com.demcha.compose.document.style.DocumentBorders.left(
+                                com.demcha.compose.document.style.DocumentStroke.of(
+                                        DocumentColor.rgb(0, 0, 0), 5)))
+                        .addParagraph(p -> p.text("HOLD").textStyle(invisible)))
+                .build());
+        BufferedImage translucent = render(session -> session.dsl().pageFlow().name("Flow")
+                .addSection("Card", section -> section
+                        .borders(com.demcha.compose.document.style.DocumentBorders.left(
+                                com.demcha.compose.document.style.DocumentStroke.of(
+                                        DocumentColor.rgba(0, 0, 0, 100), 5)))
+                        .addParagraph(p -> p.text("HOLD").textStyle(invisible)))
+                .build());
+        assertThat(minLuminance(opaque)).isLessThan(60);
+        assertThat(minLuminance(translucent)).isGreaterThan(100);
+    }
+
+    @Test
     void underlinedTableCellTextDrawsMarks() throws Exception {
         Consumer<DocumentSession> plainTable = session -> session.add(new TableBuilder()
                 .name("Cells")


### PR DESCRIPTION
## Why

A cross-backend parity audit found the reference PDF backend silently losing two documented style capabilities the PPTX backend already delivers. `DocumentTextDecoration.UNDERLINE`/`STRIKETHROUGH` resolved only to font faces that alias to the regular program, so decorated text rendered as plain glyphs. And `DocumentColor.rgba`'s alpha channel was honoured only on shape fills and strokes — text runs, lines, side borders, and table paint rendered fully opaque, so a translucent style produced different output per backend.

## What

- **`PdfTextDecorations`** draws underline and strikethrough as em-proportional filled bands in the run's colour — underline 0.10 em below the baseline with 0.05 em thickness (the Type 1/Helvetica-AFM convention), strikethrough 0.28 em above. Marks are collected while the glyphs stream out (path fills are illegal inside `BT`/`ET`) and painted after the text, on paragraph runs, chips (only when the chip actually painted glyphs), and table cell text (measured with the same sanitized string the cell draws).
- **Alpha lands on every remaining surface** through `PdfAlphaSupport`: line fragments, per-side shape borders, and table cell fills, borders, and text use the translucent-only `applyFillAlpha`/`applyStrokeAlpha`, while the paragraph run-state tracker routes its emissions through a shared `setFillAlpha` helper — it must also write an explicit opaque constant, because a `gs` survives `ET` and nested draws (chips, inline graphics, decoration marks) would otherwise inherit the translucent state. Each alpha change mints a fresh `ExtGState` resource; deduplicating them per render pass is tracked in #419.
- Fully opaque, undecorated documents render byte-identically to before: every new operator is gated on a translucent colour or a decorated run.
- **Docs**: the capability matrix's alpha row is now ✅ for both fixed-layout backends, the text-decorations row records the PDF marks (and that PowerPoint draws its own, with sub-point placement differences), and `DocumentColor.rgba`'s Javadoc drops the opaque-surfaces caveat.

## Verification

- `PdfDecorationAndAlphaRenderTest` (12 raster-comparison tests): the underline extends ink strictly below descender-free glyphs (catches a flipped offset), the strikethrough stays inside the glyph band (bounded above and below), translucent text, lines, table fills, table borders, table cell text, and side borders each render measurably lighter than their opaque twins, an underlined chip and an underlined table cell add mark ink, an opaque run's underline stays fully dark when a translucent run follows it on the same line, and an opaque inline shape after a translucent run stays fully dark — the two tests that pin the reset-before-nested-draw rule.
- Full reactor gate green: `clean verify` across core, render-pdf, render-docx, render-pptx, templates, testing, root, bundle, qa, coverage — including the qa visual-regression suites, which confirm no shipped template's pixels moved.