### PR TITLE
perf(render-pdf): reuse one alpha graphics state per distinct value across the render pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,17 @@ follow semantic versioning; release dates are ISO 8601.
   reloads before rasterizing; standard-14-only documents are unaffected apart
   from the marginal serialization cost.
 
+### Internal
+
+- The PDF backend reuses one `PDExtendedGraphicsState` per distinct
+  (channel, alpha) pair for the whole render pass (each section of a
+  combined document runs its own pass) — `PdfRenderEnvironment` now owns
+  the shared states the alpha helpers emit. PDFBox maps repeated
+  writes of the same instance to one `/ExtGState` resource entry, so a page's
+  resource dictionary stays bounded by the number of distinct alpha values
+  instead of growing with every translucent draw. Fully opaque documents
+  still carry no `/ExtGState` resources at all.
+
 ### Documentation
 
 - `docs/architecture/backend-capability-matrix.md` — a per-capability matrix

--- a/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/PdfRenderEnvironment.java
+++ b/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/PdfRenderEnvironment.java
@@ -7,6 +7,7 @@ import com.demcha.compose.font.FontLibrary;
 import org.apache.pdfbox.pdmodel.PDDocument;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.graphics.image.PDImageXObject;
+import org.apache.pdfbox.pdmodel.graphics.state.PDExtendedGraphicsState;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,6 +36,8 @@ public final class PdfRenderEnvironment {
     private final PdfRenderSession session;
     private final int pageIndexOffset;
     private final Map<String, PDImageXObject> imageCache = new HashMap<>();
+    private final Map<Float, PDExtendedGraphicsState> fillAlphaStates = new HashMap<>();
+    private final Map<Float, PDExtendedGraphicsState> strokeAlphaStates = new HashMap<>();
     private final List<BookmarkRecord> bookmarkRecords = new ArrayList<>();
     private final Map<String, AnchorDestination> anchorDestinations = new LinkedHashMap<>();
     private final List<DeferredInternalLink> deferredInternalLinks = new ArrayList<>();
@@ -105,6 +108,44 @@ public final class PdfRenderEnvironment {
      */
     public org.apache.pdfbox.pdmodel.PDPage documentPage(int localPageIndex) {
         return document.getPage(localPageIndex + pageIndexOffset);
+    }
+
+    /**
+     * Returns the shared graphics state carrying a non-stroking alpha
+     * constant, minting one per distinct value on first use.
+     *
+     * <p>PDFBox maps repeated writes of the <em>same</em>
+     * {@link PDExtendedGraphicsState} instance to one {@code /ExtGState}
+     * resource entry per page, so sharing instances keeps a page's resource
+     * dictionary bounded by the number of distinct alpha values instead of
+     * growing with every translucent draw. Callers must treat the returned
+     * state as immutable.</p>
+     *
+     * @param alpha non-stroking alpha constant in {@code [0, 1]}
+     * @return shared graphics state owned by the current render pass
+     */
+    public PDExtendedGraphicsState fillAlphaState(float alpha) {
+        return fillAlphaStates.computeIfAbsent(alpha, value -> {
+            PDExtendedGraphicsState state = new PDExtendedGraphicsState();
+            state.setNonStrokingAlphaConstant(value);
+            return state;
+        });
+    }
+
+    /**
+     * Returns the shared graphics state carrying a stroking alpha constant,
+     * minting one per distinct value on first use. Sharing semantics match
+     * {@link #fillAlphaState(float)}.
+     *
+     * @param alpha stroking alpha constant in {@code [0, 1]}
+     * @return shared graphics state owned by the current render pass
+     */
+    public PDExtendedGraphicsState strokeAlphaState(float alpha) {
+        return strokeAlphaStates.computeIfAbsent(alpha, value -> {
+            PDExtendedGraphicsState state = new PDExtendedGraphicsState();
+            state.setStrokingAlphaConstant(value);
+            return state;
+        });
     }
 
     /**

--- a/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfAlphaSupport.java
+++ b/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfAlphaSupport.java
@@ -1,5 +1,6 @@
 package com.demcha.compose.document.backend.fixed.pdf.handlers;
 
+import com.demcha.compose.document.backend.fixed.pdf.PdfRenderEnvironment;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
 import org.apache.pdfbox.pdmodel.graphics.state.PDExtendedGraphicsState;
 
@@ -11,10 +12,16 @@ import java.io.IOException;
  *
  * <p>PDFBox's {@code setNonStrokingColor}/{@code setStrokingColor} silently
  * drop the alpha component, so translucent fills/strokes need an
- * {@link PDExtendedGraphicsState} alpha constant. Both helpers are no-ops for
- * fully opaque colours, which keeps existing documents byte-identical. Callers
- * must wrap usage in {@code saveGraphicsState()} / {@code restoreGraphicsState()}
- * so the alpha never leaks into later fragments.</p>
+ * {@link PDExtendedGraphicsState} alpha constant. Both colour helpers are
+ * no-ops for fully opaque colours, which keeps existing documents
+ * byte-identical. Callers must wrap usage in {@code saveGraphicsState()} /
+ * {@code restoreGraphicsState()} so the alpha never leaks into later
+ * fragments.</p>
+ *
+ * <p>The graphics states come from the render environment's per-pass cache —
+ * one shared instance per distinct (channel, alpha) pair — so a page's
+ * {@code /ExtGState} resources stay bounded by the number of distinct alpha
+ * values instead of growing with every translucent draw.</p>
  *
  * @author Artem Demchyshyn
  * @since 1.8.0
@@ -27,15 +34,18 @@ final class PdfAlphaSupport {
     /**
      * Sets the non-stroking (fill) alpha constant when the colour is translucent.
      *
-     * @param stream page content stream inside a saved graphics state
-     * @param color  fill colour, possibly carrying alpha
+     * @param environment render environment owning the shared graphics states
+     * @param stream      page content stream inside a saved graphics state
+     * @param color       fill colour, possibly carrying alpha
      * @throws IOException when the graphics-state write fails
      */
-    static void applyFillAlpha(PDPageContentStream stream, Color color) throws IOException {
+    static void applyFillAlpha(PdfRenderEnvironment environment,
+                               PDPageContentStream stream,
+                               Color color) throws IOException {
         if (color == null || color.getAlpha() >= 255) {
             return;
         }
-        setFillAlpha(stream, color.getAlpha() / 255f);
+        setFillAlpha(environment, stream, color.getAlpha() / 255f);
     }
 
     /**
@@ -43,29 +53,31 @@ final class PdfAlphaSupport {
      * used by the paragraph text state, which must also RESTORE opacity (the
      * {@code gs} survives {@code ET} and nested draws inherit it).
      *
-     * @param stream page content stream
-     * @param alpha  alpha constant in [0, 1]
+     * @param environment render environment owning the shared graphics states
+     * @param stream      page content stream
+     * @param alpha       alpha constant in [0, 1]
      * @throws IOException when the graphics-state write fails
      */
-    static void setFillAlpha(PDPageContentStream stream, float alpha) throws IOException {
-        PDExtendedGraphicsState state = new PDExtendedGraphicsState();
-        state.setNonStrokingAlphaConstant(alpha);
-        stream.setGraphicsStateParameters(state);
+    static void setFillAlpha(PdfRenderEnvironment environment,
+                             PDPageContentStream stream,
+                             float alpha) throws IOException {
+        stream.setGraphicsStateParameters(environment.fillAlphaState(alpha));
     }
 
     /**
      * Sets the stroking alpha constant when the colour is translucent.
      *
-     * @param stream page content stream inside a saved graphics state
-     * @param color  stroke colour, possibly carrying alpha
+     * @param environment render environment owning the shared graphics states
+     * @param stream      page content stream inside a saved graphics state
+     * @param color       stroke colour, possibly carrying alpha
      * @throws IOException when the graphics-state write fails
      */
-    static void applyStrokeAlpha(PDPageContentStream stream, Color color) throws IOException {
+    static void applyStrokeAlpha(PdfRenderEnvironment environment,
+                                 PDPageContentStream stream,
+                                 Color color) throws IOException {
         if (color == null || color.getAlpha() >= 255) {
             return;
         }
-        PDExtendedGraphicsState state = new PDExtendedGraphicsState();
-        state.setStrokingAlphaConstant(color.getAlpha() / 255f);
-        stream.setGraphicsStateParameters(state);
+        stream.setGraphicsStateParameters(environment.strokeAlphaState(color.getAlpha() / 255f));
     }
 }

--- a/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfEllipseFragmentRenderHandler.java
+++ b/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfEllipseFragmentRenderHandler.java
@@ -68,7 +68,7 @@ public final class PdfEllipseFragmentRenderHandler
         float y = (float) fragment.y();
         float width = (float) fragment.width();
         float height = (float) fragment.height();
-        PdfShapeGeometry.fillAndStrokePath(stream, payload.fillColor(), payload.stroke(),
+        PdfShapeGeometry.fillAndStrokePath(stream, environment, payload.fillColor(), payload.stroke(),
                 s -> drawEllipse(s, x, y, width, height));
     }
 }

--- a/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfLineFragmentRenderHandler.java
+++ b/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfLineFragmentRenderHandler.java
@@ -42,7 +42,7 @@ public final class PdfLineFragmentRenderHandler
         PDPageContentStream stream = environment.pageSurface(fragment.pageIndex());
         stream.saveGraphicsState();
         try {
-            PdfAlphaSupport.applyStrokeAlpha(stream, stroke.strokeColor().color());
+            PdfAlphaSupport.applyStrokeAlpha(environment, stream, stroke.strokeColor().color());
             stream.setStrokingColor(stroke.strokeColor().color());
             stream.setLineWidth((float) stroke.width());
             PdfShapeGeometry.applyDashPattern(stream, payload.dashPattern());

--- a/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfParagraphFragmentRenderHandler.java
+++ b/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfParagraphFragmentRenderHandler.java
@@ -127,6 +127,7 @@ public final class PdfParagraphFragmentRenderHandler
      * overflows the line box like a browser highlight without enlarging it.
      */
     private static boolean renderChip(PDPageContentStream stream,
+                                   PdfRenderEnvironment environment,
                                    FontLibrary fonts,
                                    ParagraphTextSpan span,
                                    double cursorX,
@@ -146,7 +147,7 @@ public final class PdfParagraphFragmentRenderHandler
         Color fill = background.fill() == null ? null : background.fill().color();
         if (fill != null && chipWidth > 0 && chipHeight > 0) {
             float radius = (float) Math.min(background.cornerRadius(), Math.min(chipWidth, chipHeight) / 2.0f);
-            PdfShapeGeometry.fillAndStrokePath(stream, fill, null, s ->
+            PdfShapeGeometry.fillAndStrokePath(stream, environment, fill, null, s ->
                     PdfShapeFragmentRenderHandler.drawRoundedRectangle(
                             s, (float) cursorX, chipBottom, chipWidth, chipHeight, radius, radius, radius, radius));
         }
@@ -161,6 +162,7 @@ public final class PdfParagraphFragmentRenderHandler
     }
 
     private static void renderShape(PDPageContentStream stream,
+                                    PdfRenderEnvironment environment,
                                     ParagraphShapeSpan span,
                                     double cursorX,
                                     double baselineY,
@@ -188,7 +190,7 @@ public final class PdfParagraphFragmentRenderHandler
             // checkmark sits inside its larger checkbox frame.
             float lx = (float) (cursorX + (width - outline.width()) / 2.0);
             float ly = (float) (bottom + (height - outline.height()) / 2.0);
-            PdfShapeGeometry.fillAndStrokePath(stream, layer.fillColor(), layer.stroke(), s -> {
+            PdfShapeGeometry.fillAndStrokePath(stream, environment, layer.fillColor(), layer.stroke(), s -> {
                 if (outline instanceof ShapeOutline.Ellipse) {
                     PdfEllipseFragmentRenderHandler.drawEllipse(s, lx, ly, lw, lh);
                 } else if (outline instanceof ShapeOutline.Rectangle) {
@@ -284,7 +286,7 @@ public final class PdfParagraphFragmentRenderHandler
             // q...Q block, so track the last-written pair and re-emit Tf/rg only
             // when a span actually changes them — a single-style paragraph then
             // emits one setFont + one setNonStrokingColor instead of one per span.
-            TextRenderState textState = new TextRenderState();
+            TextRenderState textState = new TextRenderState(environment);
             double cursorTop = contentTop;
             for (int lineIndex = 0; lineIndex < payload.lines().size(); lineIndex++) {
                 ParagraphLine line = payload.lines().get(lineIndex);
@@ -340,7 +342,7 @@ public final class PdfParagraphFragmentRenderHandler
                             inTextBlock = false;
                         }
                         textState.resetAlpha(stream);
-                        boolean chipPainted = renderChip(stream, fonts, textSpan, cursorX, baselineY, line, textState);
+                        boolean chipPainted = renderChip(stream, environment, fonts, textSpan, cursorX, baselineY, line, textState);
                         textState.invalidate();
                         if (chipPainted && PdfTextDecorations.drawsMark(textSpan.textStyle().decoration())) {
                             DocumentInsets pad = textSpan.background().padding();
@@ -411,7 +413,7 @@ public final class PdfParagraphFragmentRenderHandler
                         inTextBlock = false;
                     }
                     textState.resetAlpha(stream);
-                    renderShape(stream, shapeSpan, cursorX, baselineY,
+                    renderShape(stream, environment, shapeSpan, cursorX, baselineY,
                             line.textAscent(), line.baselineOffsetFromBottom(), line.lineHeight());
                     textState.invalidate();
                     cursorX += shapeSpan.width();
@@ -436,7 +438,7 @@ public final class PdfParagraphFragmentRenderHandler
             // Marks inherit the ambient alpha into their q..Q, so restore
             // opacity first; each mark then applies its own colour's alpha.
             textState.resetAlpha(stream);
-            PdfTextDecorations.draw(stream, decorations);
+            PdfTextDecorations.draw(environment, stream, decorations);
         }
     }
 
@@ -458,6 +460,7 @@ public final class PdfParagraphFragmentRenderHandler
      * the persisted text state (inline images, shapes).
      */
     private static final class TextRenderState {
+        private final PdfRenderEnvironment environment;
         private PDFont font;
         private float size = Float.NaN;
         private Color color;
@@ -466,6 +469,10 @@ public final class PdfParagraphFragmentRenderHandler
         // own q..Q, so the alpha WE set is what survives — invalidate() must
         // not reset it.
         private float alpha = 1f;
+
+        TextRenderState(PdfRenderEnvironment environment) {
+            this.environment = environment;
+        }
 
         void applyFont(PDPageContentStream stream, PDFont newFont, float newSize) throws IOException {
             if (newFont != font || newSize != size) {
@@ -482,7 +489,7 @@ public final class PdfParagraphFragmentRenderHandler
                     // setNonStrokingColor drops the alpha channel, so a
                     // translucent run carries it as a graphics-state constant
                     // (the gs operator is legal inside a text object).
-                    PdfAlphaSupport.setFillAlpha(stream, newAlpha);
+                    PdfAlphaSupport.setFillAlpha(environment, stream, newAlpha);
                     alpha = newAlpha;
                 }
                 stream.setNonStrokingColor(newColor);
@@ -499,7 +506,7 @@ public final class PdfParagraphFragmentRenderHandler
          */
         void resetAlpha(PDPageContentStream stream) throws IOException {
             if (alpha != 1f) {
-                PdfAlphaSupport.setFillAlpha(stream, 1f);
+                PdfAlphaSupport.setFillAlpha(environment, stream, 1f);
                 alpha = 1f;
                 // The next translucent run must re-emit its gs even when its
                 // colour is unchanged.

--- a/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfPathPainter.java
+++ b/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfPathPainter.java
@@ -109,7 +109,7 @@ final class PdfPathPainter {
                                        DocumentLineCap lineCap,
                                        DocumentLineJoin lineJoin) throws IOException {
         if (fillPaint == null && strokePaint == null) {
-            PdfShapeGeometry.fillAndStrokePath(stream, fillColor, stroke,
+            PdfShapeGeometry.fillAndStrokePath(stream, environment, fillColor, stroke,
                     dashPattern, lineCap, lineJoin,
                     s -> PdfShapeGeometry.addPathSegments(s, x, y, width, height, segments));
             return;
@@ -131,7 +131,7 @@ final class PdfPathPainter {
                     stream.restoreGraphicsState();
                 }
             } else if (fillColor != null) {
-                PdfShapeGeometry.fillAndStrokePath(stream, fillColor, null, null,
+                PdfShapeGeometry.fillAndStrokePath(stream, environment, fillColor, null, null,
                         s -> PdfShapeGeometry.addPathSegments(s, x, y, width, height, segments));
             }
 
@@ -150,7 +150,7 @@ final class PdfPathPainter {
                 PdfShapeGeometry.addPathSegments(stream, x, y, width, height, segments);
                 stream.stroke();
             } else if (hasStrokeWidth && stroke.strokeColor() != null) {
-                PdfShapeGeometry.fillAndStrokePath(stream, null, stroke,
+                PdfShapeGeometry.fillAndStrokePath(stream, environment, null, stroke,
                         dashPattern, lineCap, lineJoin,
                         s -> PdfShapeGeometry.addPathSegments(s, x, y, width, height, segments));
             }

--- a/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfPolygonFragmentRenderHandler.java
+++ b/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfPolygonFragmentRenderHandler.java
@@ -40,7 +40,7 @@ public final class PdfPolygonFragmentRenderHandler
         float y = (float) fragment.y();
         float width = (float) fragment.width();
         float height = (float) fragment.height();
-        PdfShapeGeometry.fillAndStrokePath(stream, payload.fillColor(), payload.stroke(),
+        PdfShapeGeometry.fillAndStrokePath(stream, environment, payload.fillColor(), payload.stroke(),
                 s -> PdfShapeGeometry.addPolygonPath(s, x, y, width, height, payload.points()));
     }
 }

--- a/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfShapeFragmentRenderHandler.java
+++ b/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfShapeFragmentRenderHandler.java
@@ -25,6 +25,7 @@ public final class PdfShapeFragmentRenderHandler
     }
 
     private static void drawSideBorder(PDPageContentStream stream,
+                                       PdfRenderEnvironment environment,
                                        Stroke side,
                                        float x1, float y1, float x2, float y2) throws IOException {
         if (side == null || side.strokeColor() == null || side.width() <= 0) {
@@ -32,7 +33,7 @@ public final class PdfShapeFragmentRenderHandler
         }
         stream.saveGraphicsState();
         try {
-            PdfAlphaSupport.applyStrokeAlpha(stream, side.strokeColor().color());
+            PdfAlphaSupport.applyStrokeAlpha(environment, stream, side.strokeColor().color());
             stream.setStrokingColor(side.strokeColor().color());
             stream.setLineWidth((float) side.width());
             stream.moveTo(x1, y1);
@@ -129,7 +130,7 @@ public final class PdfShapeFragmentRenderHandler
                     stream.restoreGraphicsState();
                 }
             } else if (hasFill) {
-                PdfAlphaSupport.applyFillAlpha(stream, payload.fillColor());
+                PdfAlphaSupport.applyFillAlpha(environment, stream, payload.fillColor());
                 stream.setNonStrokingColor(payload.fillColor());
                 if (anyRounded) {
                     drawRoundedRectangle(stream, x, y, width, height,
@@ -143,12 +144,12 @@ public final class PdfShapeFragmentRenderHandler
             if (hasSideBorders) {
                 // Per-side borders override the uniform rectangle stroke; rounded
                 // corners are not combined with mixed-side borders in v1.3.
-                drawSideBorder(stream, payload.sideBorders().top(), x, y + height, x + width, y + height);
-                drawSideBorder(stream, payload.sideBorders().right(), x + width, y + height, x + width, y);
-                drawSideBorder(stream, payload.sideBorders().bottom(), x, y, x + width, y);
-                drawSideBorder(stream, payload.sideBorders().left(), x, y + height, x, y);
+                drawSideBorder(stream, environment, payload.sideBorders().top(), x, y + height, x + width, y + height);
+                drawSideBorder(stream, environment, payload.sideBorders().right(), x + width, y + height, x + width, y);
+                drawSideBorder(stream, environment, payload.sideBorders().bottom(), x, y, x + width, y);
+                drawSideBorder(stream, environment, payload.sideBorders().left(), x, y + height, x, y);
             } else if (hasStroke) {
-                PdfAlphaSupport.applyStrokeAlpha(stream, payload.stroke().strokeColor().color());
+                PdfAlphaSupport.applyStrokeAlpha(environment, stream, payload.stroke().strokeColor().color());
                 stream.setStrokingColor(payload.stroke().strokeColor().color());
                 stream.setLineWidth((float) payload.stroke().width());
                 if (anyRounded) {

--- a/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfShapeGeometry.java
+++ b/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfShapeGeometry.java
@@ -1,5 +1,6 @@
 package com.demcha.compose.document.backend.fixed.pdf.handlers;
 
+import com.demcha.compose.document.backend.fixed.pdf.PdfRenderEnvironment;
 import com.demcha.compose.document.style.DocumentDashPattern;
 import com.demcha.compose.document.style.DocumentLineCap;
 import com.demcha.compose.document.style.DocumentLineJoin;
@@ -28,24 +29,26 @@ final class PdfShapeGeometry {
      * render handler. No-op when neither a fill nor a visible stroke is present.
      */
     static void fillAndStrokePath(PDPageContentStream stream,
+                                  PdfRenderEnvironment environment,
                                   Color fillColor,
                                   Stroke stroke,
                                   PathEmitter path) throws IOException {
-        fillAndStrokePath(stream, fillColor, stroke, null, path);
+        fillAndStrokePath(stream, environment, fillColor, stroke, null, path);
     }
 
     /**
-     * Variant of {@link #fillAndStrokePath(PDPageContentStream, Color, Stroke, PathEmitter)}
+     * Variant of {@link #fillAndStrokePath(PDPageContentStream, PdfRenderEnvironment, Color, Stroke, PathEmitter)}
      * with an optional dash pattern applied to the stroke inside the saved
      * graphics state ({@code null} or {@link DocumentDashPattern#NONE} keeps
      * the stroke solid).
      */
     static void fillAndStrokePath(PDPageContentStream stream,
+                                  PdfRenderEnvironment environment,
                                   Color fillColor,
                                   Stroke stroke,
                                   DocumentDashPattern dashPattern,
                                   PathEmitter path) throws IOException {
-        fillAndStrokePath(stream, fillColor, stroke, dashPattern, null, null, path);
+        fillAndStrokePath(stream, environment, fillColor, stroke, dashPattern, null, null, path);
     }
 
     /**
@@ -54,6 +57,7 @@ final class PdfShapeGeometry {
      * every existing call site stays byte-identical.
      */
     static void fillAndStrokePath(PDPageContentStream stream,
+                                  PdfRenderEnvironment environment,
                                   Color fillColor,
                                   Stroke stroke,
                                   DocumentDashPattern dashPattern,
@@ -71,14 +75,14 @@ final class PdfShapeGeometry {
         stream.saveGraphicsState();
         try {
             if (hasStroke) {
-                PdfAlphaSupport.applyStrokeAlpha(stream, stroke.strokeColor().color());
+                PdfAlphaSupport.applyStrokeAlpha(environment, stream, stroke.strokeColor().color());
                 stream.setStrokingColor(stroke.strokeColor().color());
                 stream.setLineWidth((float) stroke.width());
                 applyDashPattern(stream, dashPattern);
                 applyStrokeStyle(stream, lineCap, lineJoin);
             }
             if (hasFill) {
-                PdfAlphaSupport.applyFillAlpha(stream, fillColor);
+                PdfAlphaSupport.applyFillAlpha(environment, stream, fillColor);
                 stream.setNonStrokingColor(fillColor);
             }
             path.emit(stream);

--- a/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfTableRowFragmentRenderHandler.java
+++ b/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfTableRowFragmentRenderHandler.java
@@ -67,7 +67,7 @@ public final class PdfTableRowFragmentRenderHandler
         for (TableResolvedCell cell : payload.cells()) {
             double cellX = fragment.x() + cell.x();
             double cellY = fragment.y() + cell.yOffset();
-            renderCellFill(stream, cell, cellX, cellY);
+            renderCellFill(stream, environment, cell, cellX, cellY);
         }
     }
 
@@ -93,12 +93,13 @@ public final class PdfTableRowFragmentRenderHandler
             // coordinates so the cell rectangle covers all the rows it
             // merges instead of overflowing above the starting row.
             double cellY = fragment.y() + cell.yOffset();
-            renderCellBorders(stream, cell, cellX, cellY, fragment.width(), payload.startsPageFragment());
-            renderCellText(stream, fonts, cell, cellX, cellY);
+            renderCellBorders(stream, environment, cell, cellX, cellY, fragment.width(), payload.startsPageFragment());
+            renderCellText(stream, environment, fonts, cell, cellX, cellY);
         }
     }
 
     private void renderCellFill(PDPageContentStream stream,
+                                PdfRenderEnvironment environment,
                                 TableResolvedCell cell,
                                 double cellX,
                                 double cellY) throws IOException {
@@ -106,7 +107,7 @@ public final class PdfTableRowFragmentRenderHandler
             if (cell.width() > 0 && cell.height() > 0) {
                 stream.saveGraphicsState();
                 try {
-                    PdfAlphaSupport.applyFillAlpha(stream, cell.style().fillColor());
+                    PdfAlphaSupport.applyFillAlpha(environment, stream, cell.style().fillColor());
                     stream.setNonStrokingColor(cell.style().fillColor());
                     stream.addRect((float) cellX, (float) cellY, (float) cell.width(), (float) cell.height());
                     stream.fill();
@@ -118,6 +119,7 @@ public final class PdfTableRowFragmentRenderHandler
     }
 
     private void renderCellBorders(PDPageContentStream stream,
+                                   PdfRenderEnvironment environment,
                                    TableResolvedCell cell,
                                    double cellX,
                                    double cellY,
@@ -135,7 +137,7 @@ public final class PdfTableRowFragmentRenderHandler
         stream.saveGraphicsState();
         try {
             double strokeWidth = cell.style().stroke().width();
-            PdfAlphaSupport.applyStrokeAlpha(stream, cell.style().stroke().strokeColor().color());
+            PdfAlphaSupport.applyStrokeAlpha(environment, stream, cell.style().stroke().strokeColor().color());
             stream.setStrokingColor(cell.style().stroke().strokeColor().color());
             stream.setLineWidth((float) strokeWidth);
             // Default butt caps. Adjacent cells' perpendicular borders
@@ -178,6 +180,7 @@ public final class PdfTableRowFragmentRenderHandler
     }
 
     private void renderCellText(PDPageContentStream stream,
+                                PdfRenderEnvironment environment,
                                 FontLibrary fonts,
                                 TableResolvedCell cell,
                                 double cellX,
@@ -187,7 +190,7 @@ public final class PdfTableRowFragmentRenderHandler
 
         stream.saveGraphicsState();
         try {
-            PdfAlphaSupport.applyFillAlpha(stream, cell.style().textStyle().color());
+            PdfAlphaSupport.applyFillAlpha(environment, stream, cell.style().textStyle().color());
             stream.setFont(font.fontType(cell.style().textStyle().decoration()), (float) cell.style().textStyle().size());
             stream.setNonStrokingColor(cell.style().textStyle().color());
             List<PdfTextDecorations.Segment> decorations = null;
@@ -215,7 +218,7 @@ public final class PdfTableRowFragmentRenderHandler
                 }
             }
             if (decorations != null) {
-                PdfTextDecorations.draw(stream, decorations);
+                PdfTextDecorations.draw(environment, stream, decorations);
             }
         } finally {
             stream.restoreGraphicsState();

--- a/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfTextDecorations.java
+++ b/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfTextDecorations.java
@@ -1,5 +1,6 @@
 package com.demcha.compose.document.backend.fixed.pdf.handlers;
 
+import com.demcha.compose.document.backend.fixed.pdf.PdfRenderEnvironment;
 import com.demcha.compose.engine.components.content.text.TextDecoration;
 import org.apache.pdfbox.pdmodel.PDPageContentStream;
 
@@ -68,7 +69,9 @@ final class PdfTextDecorations {
      * Paints every collected mark. Each segment runs in its own graphics
      * state, so the fill colour and alpha never leak into later content.
      */
-    static void draw(PDPageContentStream stream, List<Segment> segments) throws IOException {
+    static void draw(PdfRenderEnvironment environment,
+                     PDPageContentStream stream,
+                     List<Segment> segments) throws IOException {
         for (Segment segment : segments) {
             if (segment.width() <= 0) {
                 continue;
@@ -79,7 +82,7 @@ final class PdfTextDecorations {
                     : segment.baselineY() + STRIKETHROUGH_OFFSET_EM * segment.fontSize();
             stream.saveGraphicsState();
             try {
-                PdfAlphaSupport.applyFillAlpha(stream, segment.color());
+                PdfAlphaSupport.applyFillAlpha(environment, stream, segment.color());
                 stream.setNonStrokingColor(segment.color());
                 stream.addRect((float) segment.x(),
                         (float) (markY - thickness / 2.0),

--- a/render-pdf/src/test/java/com/demcha/compose/document/backend/fixed/pdf/PdfAlphaGraphicsStateResourceTest.java
+++ b/render-pdf/src/test/java/com/demcha/compose/document/backend/fixed/pdf/PdfAlphaGraphicsStateResourceTest.java
@@ -1,0 +1,216 @@
+package com.demcha.compose.document.backend.fixed.pdf;
+
+import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.api.DocumentSession;
+import com.demcha.compose.document.dsl.LineBuilder;
+import com.demcha.compose.document.dsl.PageBreakBuilder;
+import com.demcha.compose.document.dsl.ParagraphBuilder;
+import com.demcha.compose.document.dsl.TableBuilder;
+import com.demcha.compose.document.style.DocumentColor;
+import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.document.style.DocumentStroke;
+import com.demcha.compose.document.style.DocumentTextStyle;
+import com.demcha.compose.document.table.DocumentTableStyle;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.cos.COSName;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.graphics.state.PDExtendedGraphicsState;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Alpha writes reuse one shared {@code PDExtendedGraphicsState} per distinct
+ * (channel, alpha) pair for the whole render pass, so a page's
+ * {@code /ExtGState} resources stay bounded by the number of distinct alpha
+ * values instead of growing with every translucent draw — and fully opaque
+ * documents carry no {@code /ExtGState} resources at all.
+ */
+class PdfAlphaGraphicsStateResourceTest {
+
+    private static byte[] render(Consumer<DocumentSession> content) throws Exception {
+        try (DocumentSession session = GraphCompose.document()
+                .pageSize(400, 400)
+                .margin(DocumentInsets.of(20))
+                .create()) {
+            content.accept(session);
+            return session.toPdfBytes();
+        }
+    }
+
+    private static List<PDExtendedGraphicsState> extGStates(PDPage page) {
+        List<PDExtendedGraphicsState> states = new ArrayList<>();
+        for (COSName name : page.getResources().getExtGStateNames()) {
+            states.add(page.getResources().getExtGState(name));
+        }
+        return states;
+    }
+
+    @Test
+    void alternatingTranslucentRunsShareOneStatePerDistinctAlpha() throws Exception {
+        DocumentTextStyle opaque = DocumentTextStyle.builder().size(12).build();
+        DocumentTextStyle faded = DocumentTextStyle.builder().size(12)
+                .color(DocumentColor.rgba(0, 0, 0, 100)).build();
+        byte[] pdf = render(session -> {
+            ParagraphBuilder paragraph = new ParagraphBuilder().name("Runs");
+            for (int i = 0; i < 8; i++) {
+                paragraph.inlineText("DARK", opaque).inlineText(" dim ", faded);
+            }
+            session.add(paragraph.build());
+        });
+        try (PDDocument document = Loader.loadPDF(pdf)) {
+            List<PDExtendedGraphicsState> states = extGStates(document.getPage(0));
+            // 16 alpha flips reuse two constants: 100/255 and the 1.0 reset.
+            assertThat(states)
+                    .as("distinct fill alphas, not one resource per alpha flip")
+                    .hasSize(2);
+            assertThat(states)
+                    .extracting(PDExtendedGraphicsState::getNonStrokingAlphaConstant)
+                    .containsExactlyInAnyOrder(100f / 255f, 1f);
+        }
+    }
+
+    @Test
+    void fillAndStrokeChannelsKeepSeparateStates() throws Exception {
+        byte[] pdf = render(session -> {
+            session.add(new ParagraphBuilder().name("Fill")
+                    .text("dim text")
+                    .textStyle(DocumentTextStyle.builder().size(12)
+                            .color(DocumentColor.rgba(0, 0, 0, 100)).build())
+                    .build());
+            session.add(new LineBuilder().name("Stroke")
+                    .horizontal(200).thickness(3)
+                    .color(DocumentColor.rgba(0, 0, 0, 100))
+                    .build());
+        });
+        try (PDDocument document = Loader.loadPDF(pdf)) {
+            List<PDExtendedGraphicsState> states = extGStates(document.getPage(0));
+            // Same alpha value, but the non-stroking and stroking constants
+            // live in separate shared states (plus the text run's 1.0 reset
+            // before the line fragment is not emitted — the paragraph's q..Q
+            // restores opacity, so only the two translucent states remain).
+            assertThat(states).hasSize(2);
+            assertThat(states)
+                    .extracting(PDExtendedGraphicsState::getNonStrokingAlphaConstant)
+                    .containsExactlyInAnyOrder(100f / 255f, null);
+            assertThat(states)
+                    .extracting(PDExtendedGraphicsState::getStrokingAlphaConstant)
+                    .containsExactlyInAnyOrder(100f / 255f, null);
+        }
+    }
+
+    @Test
+    void repeatedTranslucentStrokesAcrossConsumersShareOneState() throws Exception {
+        // Three lines and a bordered table all stroke with the same rgba —
+        // the old per-emission minting registered one /ExtGState each.
+        byte[] pdf = render(session -> {
+            for (int i = 0; i < 3; i++) {
+                session.add(new LineBuilder().name("Rule" + i)
+                        .horizontal(200).thickness(3)
+                        .color(DocumentColor.rgba(0, 0, 0, 100))
+                        .build());
+            }
+            session.add(new TableBuilder().name("Borders")
+                    .defaultCellStyle(DocumentTableStyle.builder()
+                            .stroke(DocumentStroke.of(DocumentColor.rgba(0, 0, 0, 100), 3))
+                            .build())
+                    .row("")
+                    .build());
+        });
+        try (PDDocument document = Loader.loadPDF(pdf)) {
+            List<PDExtendedGraphicsState> states = extGStates(document.getPage(0));
+            assertThat(states)
+                    .as("one shared stroking state, not one per stroked consumer")
+                    .hasSize(1);
+            assertThat(states.get(0).getStrokingAlphaConstant()).isEqualTo(100f / 255f);
+        }
+    }
+
+    @Test
+    void repeatedTranslucentFillsAcrossRowsShareOneState() throws Exception {
+        // Six cell fills with the same rgba exercise the colour-based
+        // applyFillAlpha path (shapes, table paint, chips, marks) — the old
+        // per-emission minting registered one /ExtGState per row.
+        byte[] pdf = render(session -> {
+            TableBuilder table = new TableBuilder().name("Fills")
+                    .defaultCellStyle(DocumentTableStyle.builder()
+                            .fillColor(DocumentColor.rgba(0, 0, 160, 100))
+                            .stroke(DocumentStroke.of(DocumentColor.WHITE, 0))
+                            .build());
+            for (int i = 0; i < 6; i++) {
+                table.row("");
+            }
+            session.add(table.build());
+        });
+        try (PDDocument document = Loader.loadPDF(pdf)) {
+            List<PDExtendedGraphicsState> states = extGStates(document.getPage(0));
+            assertThat(states)
+                    .as("one shared fill state, not one per translucent cell fill")
+                    .hasSize(1);
+            assertThat(states.get(0).getNonStrokingAlphaConstant()).isEqualTo(100f / 255f);
+        }
+    }
+
+    @Test
+    void anOpaqueDocumentCarriesNoExtGStateResources() throws Exception {
+        // Text, line, and table paint each have their own opaque early-return
+        // — one document pins all of them at the resource level.
+        byte[] pdf = render(session -> {
+            session.add(new ParagraphBuilder().name("Opaque")
+                    .text("plain opaque text")
+                    .textStyle(DocumentTextStyle.builder().size(12).build())
+                    .build());
+            session.add(new LineBuilder().name("Rule")
+                    .horizontal(200).thickness(3)
+                    .color(DocumentColor.rgb(0, 0, 0))
+                    .build());
+            session.add(new TableBuilder().name("Table")
+                    .defaultCellStyle(DocumentTableStyle.builder()
+                            .fillColor(DocumentColor.rgb(230, 230, 240))
+                            .stroke(DocumentStroke.of(DocumentColor.rgb(0, 0, 0), 1))
+                            .build())
+                    .row("cell")
+                    .build());
+        });
+        try (PDDocument document = Loader.loadPDF(pdf)) {
+            assertThat(extGStates(document.getPage(0)))
+                    .as("opaque documents stay byte-identical — no alpha resources")
+                    .isEmpty();
+        }
+    }
+
+    @Test
+    void sharedStatesRegisterPerPageInAMultiPageDocument() throws Exception {
+        DocumentTextStyle faded = DocumentTextStyle.builder().size(12)
+                .color(DocumentColor.rgba(0, 0, 0, 100)).build();
+        byte[] pdf = render(session -> {
+            session.add(new ParagraphBuilder().name("First")
+                    .text("dim on page one").textStyle(faded).build());
+            session.add(new PageBreakBuilder().name("Break").build());
+            session.add(new ParagraphBuilder().name("Second")
+                    .text("dim on page two").textStyle(faded).build());
+            session.add(new PageBreakBuilder().name("Break2").build());
+            session.add(new ParagraphBuilder().name("Third")
+                    .text("opaque on page three")
+                    .textStyle(DocumentTextStyle.builder().size(12).build())
+                    .build());
+        });
+        try (PDDocument document = Loader.loadPDF(pdf)) {
+            assertThat(document.getNumberOfPages()).isEqualTo(3);
+            for (int pageIndex = 0; pageIndex < 2; pageIndex++) {
+                assertThat(extGStates(document.getPage(pageIndex)))
+                        .extracting(PDExtendedGraphicsState::getNonStrokingAlphaConstant)
+                        .containsExactly(100f / 255f);
+            }
+            // Shared states register only on the pages that use them — an
+            // eager cache that pre-registers every state would leave a stray
+            // entry on the opaque page.
+            assertThat(extGStates(document.getPage(2))).isEmpty();
+        }
+    }
+}


### PR DESCRIPTION
Closes #419.

## Why

Every alpha write in the PDF backend minted a fresh `PDExtendedGraphicsState` and registered it with the page resources. PDFBox dedupes resource entries by object identity, so each emission became a new `/ExtGState` dictionary — a document with N alternating translucent runs, or an N-row table with translucent cell fills, carried O(N) identical dictionaries instead of one per distinct alpha value. Not a correctness problem (readers coalesce identical states), but unbounded resource growth on exactly the documents that use translucency the most.

## What

- `PdfRenderEnvironment` owns two per-render-pass caches — non-stroking and stroking — handing out one shared `PDExtendedGraphicsState` per distinct alpha constant (`fillAlphaState`/`strokeAlphaState`, minted on first use, treated as immutable). Reusing the instance makes PDFBox map every emission to the same resource entry, and the same instance registers per page as pages use it, so multi-page documents stay valid. Each section of a combined document runs its own pass with its own environment.
- `PdfAlphaSupport` keeps its API shape (translucent-only `applyFillAlpha`/`applyStrokeAlpha`, explicit `setFillAlpha` for the paragraph text state) but now emits the environment's shared states; the environment threads through the remaining call sites that didn't already carry it — `PdfShapeGeometry.fillAndStrokePath`, `PdfTextDecorations.draw`, the table cell helpers, the paragraph `TextRenderState`, chip and inline-shape rendering.
- Fully opaque documents still emit no alpha operators and carry zero `/ExtGState` resources — the translucent-only guards are untouched, so existing output stays byte-identical.

## Verification

- New `PdfAlphaGraphicsStateResourceTest` (6 structural tests on the reopened PDF): 16 alpha flips across alternating runs collapse to exactly 2 fill states (the translucent value + the 1.0 reset); three lines and a bordered table sharing one rgba collapse to exactly 1 stroking state; six translucent cell fills collapse to exactly 1 non-stroking state (the colour-based `applyFillAlpha` path shapes, chips, and marks also take); fill and stroke channels keep separate single-channel states; an opaque text+line+table document carries zero `/ExtGState` entries; and in a 3-page document the shared state registers only on the two pages that use it, with the opaque page staying empty. The dedup tests fail on the previous per-emission minting.
- `PdfDecorationAndAlphaRenderTest` (12 raster tests) stays green — translucency, decoration marks, and the reset-before-nested-draw rule render unchanged.
- Full reactor gate green: `clean verify` across core, render-pdf, render-docx, render-pptx, templates, testing, root, bundle, qa, coverage — the qa visual-regression suites confirm no shipped template's pixels moved.