### PR TITLE
fix(templates): keep Panel's full-width Profile card header with its body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -302,8 +302,10 @@ for this cycle.
   section heading with the first line of its body across a page break: a standalone
   header section binds to the following body section (a multi-node rule + banner + rule
   group binds as one run), and a combined header+body module keeps the heading in a
-  nested keep-with-next group. Multi-column presets place their sections in fixed
-  columns that do not paginate, so no heading can strand there.
+  nested keep-with-next group — including Panel's full-width Profile card, whose header
+  now stays with the summary if a long profile splits the card. Multi-column presets
+  place their sections in fixed columns that do not paginate, so no heading can strand
+  there.
 - **Reproducible PDF output** (`@Beta`). `PdfFixedLayoutBackend.builder().deterministic(true)`
   (or `.deterministic(Instant)` for an explicit timestamp) pins the document
   CreationDate / ModDate and derives the PDF `/ID` from the document metadata instead

--- a/qa/src/test/java/com/demcha/compose/document/templates/cv/presets/PresetHeaderKeepWithNextTest.java
+++ b/qa/src/test/java/com/demcha/compose/document/templates/cv/presets/PresetHeaderKeepWithNextTest.java
@@ -108,6 +108,23 @@ class PresetHeaderKeepWithNextTest {
     }
 
     /**
+     * Panel renders each module's header (title + accent strip) in a nested
+     * keep-with-next subsection so its full-width single-column Profile card keeps
+     * the title with the body if a long summary splits the card. Every header
+     * subsection is kept; the card sections that wrap header and body are not (marking
+     * them would bind a card to the next card).
+     */
+    @Test
+    void panelKeepsCardHeaderSubsectionNotCard() {
+        List<DocumentNode> nodes = nodesOf(Panel.create());
+        assertThat(nodes.stream().filter(n -> "Header".equals(n.name())).toList())
+                .isNotEmpty().allMatch(DocumentNode::keepWithNext);
+        assertThat(nodes.stream()
+                .filter(n -> n.name().startsWith("CvV2Panel") && n.name().endsWith("Card")).toList())
+                .isNotEmpty().noneMatch(DocumentNode::keepWithNext);
+    }
+
+    /**
      * End-to-end for the combined-preset shape: a module section whose header is a
      * nested keep-with-next subsection relocates the header with the first line of the
      * body across a page break, rather than stranding it at the page bottom.

--- a/templates/src/main/java/com/demcha/compose/document/templates/cv/presets/Panel.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/cv/presets/Panel.java
@@ -352,7 +352,17 @@ public final class Panel {
 
             private void renderModuleBody(SectionBuilder card, String title,
                                           CvSection section) {
-                card.addParagraph(paragraph -> paragraph
+                // Header (title + accent strip) in a keep-with-next subsection so, when
+                // this is the full-width single-column Profile card and a long summary
+                // splits it across a page break, the title stays with the first line of
+                // the body rather than stranding at the page bottom. The subsection's
+                // spacing matches the card, so placement is unchanged; in the side
+                // columns (fixed Row slots) keep-with-next is inert, so those cards are
+                // byte-identical.
+                card.addSection("Header", header -> header
+                        .keepWithNext()
+                        .spacing(theme.spacing().sectionBodySpacing())
+                        .addParagraph(paragraph -> paragraph
                                 .text(title.toUpperCase(Locale.ROOT))
                                 .textStyle(moduleTitleStyle())
                                 .align(TextAlign.LEFT)
@@ -365,7 +375,7 @@ public final class Panel {
                                 .fillColor(ACCENT)
                                 .cornerRadius(
                                         theme.spacing().accentRuleWidth() / 2.0)
-                                .margin(DocumentInsets.zero()));
+                                .margin(DocumentInsets.zero())));
                 renderCardBody(card, section);
             }
 


### PR DESCRIPTION
## Why

Panel renders its full-width Profile card in the single-column page flow via a
splittable `CardWidget`. Its header — the module title paragraph + accent strip, from
the shared `renderModuleBody` — could strand at a page bottom if a long summary split
the card. #427 wired the other single-column presets to keep-with-next but left this
one, because `renderModuleBody` is shared with Panel's side-column cards, where
marking the whole card would be wrong (it would bind a card to the next card).

## What changed

- `renderModuleBody` wraps the header (title + accent strip) in a nested
  `keepWithNext` subsection whose spacing matches the card, so the header stays with
  the body's first line. In the full-width Profile card (page flow) the header
  relocates with its body across a page break; in the side cards (fixed Row columns)
  keep-with-next is inert, so those cards are untouched. Reuses `SectionNode.keepWithNext`
  — no new API, and the subsection is transparent and spacing-matched, so placement is
  unchanged.

## Verification

Full reactor `clean verify` → **BUILD SUCCESS**. Panel's visual-parity baseline is
**unchanged** (all 16 `CvV2VisualParityTest` cases green — the header subsection does
not shift any pixel). **+1 test** `PresetHeaderKeepWithNextTest.panelKeepsCardHeaderSubsectionNotCard`:
every module header subsection is keep-with-next, and the card sections that wrap
header and body are not.

**Lane:** templates (Panel preset). Follows #427 / #428 — completes the single-column
keep-with-next coverage.
