### PR TITLE
chore: add a GitHub Sponsors funding button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# These are supported funding model platforms
+# https://docs.github.com/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+
+github: DemchaAV


### PR DESCRIPTION
## Why

The library is pulled by engineers at ~119 companies per quarter (Maven Central), several evaluating it in depth, with no way to support the project. A passive `Sponsor` button costs nothing and matches that corporate audience through GitHub Sponsors' org-billing path.

## What

Adds `.github/FUNDING.yml` pointing `github:` at `DemchaAV`, which renders the `Sponsor` button in the repository header.

## Note

The button only lights up once the `DemchaAV` GitHub Sponsors profile is enrolled and active (bank/tax setup via Stripe, done from github.com/sponsors) — the file is inert until then, so this can merge before or after enrollment.