### PR TITLE
feat(templates): render inline links in CV entry titles and subtitles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ follow semantic versioning; release dates are ISO 8601.
 
 ### Public API
 
+- **CV entry titles and subtitles accept inline `[text](url)` links.** In the layered
+  CV presets, a `[label](url)` in an experience/education entry title or subtitle now
+  renders as a clickable hyperlink — the same inline-Markdown convention already used
+  for project rows and body text. Upper-cased and letter-spaced preset titles keep the
+  link too, with the visible label styled and the URL preserved. Where a preset fuses a
+  line that cannot carry a clickable link — the single-line TimelineMinimal excerpt, and
+  the combined subtitle+date meta line of MintEditorial/SidebarPortrait experience
+  entries — the link's label text is shown instead. Titles without inline-Markdown
+  syntax render exactly as before, so the change is backward-compatible.
 - The fixed-layout PPTX backend ships as `@Beta` (Experimental) in its first
   release: the `document.backend.fixed.pptx` packages and the
   `DocumentSession` PPTX convenience methods (`toPptxBytes`, `writePptx`,

--- a/qa/src/test/java/com/demcha/compose/document/templates/cv/components/EntryTitleLinkTest.java
+++ b/qa/src/test/java/com/demcha/compose/document/templates/cv/components/EntryTitleLinkTest.java
@@ -1,0 +1,156 @@
+package com.demcha.compose.document.templates.cv.components;
+
+import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.api.DocumentPageSize;
+import com.demcha.compose.document.api.DocumentSession;
+import com.demcha.compose.document.node.DocumentNode;
+import com.demcha.compose.document.node.ExternalLinkTarget;
+import com.demcha.compose.document.node.InlineRun;
+import com.demcha.compose.document.node.InlineTextRun;
+import com.demcha.compose.document.node.ParagraphNode;
+import com.demcha.compose.document.templates.api.DocumentTemplate;
+import com.demcha.compose.document.templates.cv.data.CvDocument;
+import com.demcha.compose.document.templates.cv.data.CvIdentity;
+import com.demcha.compose.document.templates.cv.data.EntriesSection;
+import com.demcha.compose.document.templates.cv.presets.BlueBanner;
+import com.demcha.compose.document.templates.cv.presets.EngineeringResume;
+import com.demcha.compose.document.templates.cv.presets.ModernProfessional;
+import com.demcha.compose.document.templates.cv.presets.MonogramSidebar;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end wiring for inline-link CV entry titles and subtitles: an entry
+ * whose title or subtitle carries {@code [label](url)} markdown renders as a
+ * clickable link across the shared renderers — the canonical two-column
+ * {@code EntryRenderer} (via {@code ModernProfessional}) and the compact
+ * upper-cased {@code EntryCompactRenderer} (via {@code BlueBanner}). Plain
+ * titles stay plain, so the change is backward-compatible.
+ *
+ * <p>The {@link com.demcha.compose.document.templates.core.text.MarkdownInline}
+ * link/transform primitives are unit-tested separately; this locks the preset
+ * wiring so a refactor cannot silently revert a title to stripped plain text.</p>
+ */
+class EntryTitleLinkTest {
+
+    private static CvDocument docWith(String title, String subtitle) {
+        return CvDocument.builder()
+                .identity(CvIdentity.builder()
+                        .name("Test", "User").jobTitle("Engineer")
+                        .contact("+1 555 0100", "user@example.com", "City").build())
+                .section(EntriesSection.builder("Professional Experience")
+                        .entry(title, subtitle, "2020-2024", "Built things.")
+                        .build())
+                .build();
+    }
+
+    /** Collects every external-link run in the composed document. */
+    private static List<InlineTextRun> linkRuns(DocumentTemplate<CvDocument> template,
+                                                CvDocument doc) {
+        try (DocumentSession document = GraphCompose.document()
+                .pageSize(DocumentPageSize.A4).margin(28, 28, 28, 28).create()) {
+            template.compose(document, doc);
+            List<ParagraphNode> paragraphs = new ArrayList<>();
+            collectParagraphs(document.roots(), paragraphs);
+            List<InlineTextRun> links = new ArrayList<>();
+            for (ParagraphNode paragraph : paragraphs) {
+                for (InlineRun run : paragraph.inlineRuns()) {
+                    if (run instanceof InlineTextRun text
+                            && text.linkTarget() instanceof ExternalLinkTarget) {
+                        links.add(text);
+                    }
+                }
+            }
+            return links;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void collectParagraphs(List<DocumentNode> nodes, List<ParagraphNode> out) {
+        for (DocumentNode node : nodes) {
+            if (node instanceof ParagraphNode paragraph) {
+                out.add(paragraph);
+            }
+            collectParagraphs(node.children(), out);
+        }
+    }
+
+    private static String uri(InlineTextRun run) {
+        return ((ExternalLinkTarget) run.linkTarget()).options().uri();
+    }
+
+    /** Canonical EntryRenderer: a link in the entry title reaches the output. */
+    @Test
+    void entryRendererTitleBecomesLink() {
+        List<InlineTextRun> links = linkRuns(ModernProfessional.create(),
+                docWith("[Acme Corp](https://acme.example)", "Senior Engineer"));
+        assertThat(links).anySatisfy(run -> {
+            assertThat(run.text()).isEqualTo("Acme Corp");
+            assertThat(uri(run)).isEqualTo("https://acme.example");
+        });
+    }
+
+    /** Canonical EntryRenderer: the subtitle is link-aware too. */
+    @Test
+    void entryRendererSubtitleBecomesLink() {
+        List<InlineTextRun> links = linkRuns(ModernProfessional.create(),
+                docWith("Senior Engineer", "[Acme Corp](https://acme.example)"));
+        assertThat(links).anySatisfy(run ->
+                assertThat(uri(run)).isEqualTo("https://acme.example"));
+    }
+
+    /** Compact upper-cased path: the link survives and its label is upper-cased, url intact. */
+    @Test
+    void compactUpperCasedTitleBecomesUpperCasedLink() {
+        List<InlineTextRun> links = linkRuns(BlueBanner.create(),
+                docWith("[Acme Corp](https://acme.example)", "Senior Engineer"));
+        assertThat(links).anySatisfy(run -> {
+            assertThat(run.text()).isEqualTo("ACME CORP");
+            assertThat(uri(run)).isEqualTo("https://acme.example");
+        });
+    }
+
+    /** Hand-rolled per-preset path (upper-cased title built outside the shared renderers). */
+    @Test
+    void handRolledPresetTitleBecomesLink() {
+        List<InlineTextRun> links = linkRuns(MonogramSidebar.create(),
+                docWith("[Acme Corp](https://acme.example)", "Senior Engineer"));
+        assertThat(links).anySatisfy(run -> {
+            assertThat(run.text()).isEqualTo("ACME CORP");
+            assertThat(uri(run)).isEqualTo("https://acme.example");
+        });
+    }
+
+    /** Hand-rolled EngineeringResume role title (non-upper-cased) is link-aware. */
+    @Test
+    void engineeringResumeRoleTitleBecomesLink() {
+        List<InlineTextRun> links = linkRuns(EngineeringResume.create(),
+                docWith("[Acme Corp](https://acme.example)", "Senior Engineer"));
+        assertThat(links).anySatisfy(run -> {
+            assertThat(run.text()).isEqualTo("Acme Corp");
+            assertThat(uri(run)).isEqualTo("https://acme.example");
+        });
+    }
+
+    /**
+     * Backward-compatible: a plain title/subtitle is not rendered as a link. The
+     * header contact block may render its own email/website links, so the control
+     * asserts specifically that the plain entry title and subtitle are not linked.
+     */
+    @Test
+    void plainTitleAndSubtitleAreNotLinks() {
+        assertThat(titleOrSubtitleLinked(ModernProfessional.create())).isFalse();
+        assertThat(titleOrSubtitleLinked(BlueBanner.create())).isFalse();
+    }
+
+    private static boolean titleOrSubtitleLinked(DocumentTemplate<CvDocument> template) {
+        return linkRuns(template, docWith("Senior Engineer", "Acme Corp")).stream()
+                .anyMatch(run -> run.text().equalsIgnoreCase("Senior Engineer")
+                        || run.text().equalsIgnoreCase("Acme Corp"));
+    }
+}

--- a/templates/src/main/java/com/demcha/compose/document/templates/core/text/MarkdownInline.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/core/text/MarkdownInline.java
@@ -5,6 +5,8 @@ import com.demcha.compose.document.node.InlineRun;
 import com.demcha.compose.document.node.InlineTextRun;
 import com.demcha.compose.document.style.DocumentTextStyle;
 
+import java.util.Locale;
+import java.util.function.UnaryOperator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -93,6 +95,60 @@ public final class MarkdownInline {
     }
 
     /**
+     * Expands inline markdown links while applying {@code displayTransform} to the
+     * <em>visible</em> text only: each plain segment and each {@code [label](url)}
+     * link label is passed through the transform, but the link's {@code url} is left
+     * untouched so the hyperlink still resolves. Plain segments are first reduced to
+     * their {@link #plainText(String) plain-text projection}, so a decorative
+     * transform (upper-casing, letter-spacing) never has to cope with emphasis
+     * markers. Used by renderers that display a stylised title (caps, spaced caps)
+     * yet still want {@code [name](url)} to render as a clickable link.
+     *
+     * @param rich             target rich-text builder
+     * @param text             source string; null treated as empty
+     * @param baseStyle        style applied to the transformed runs
+     * @param displayTransform transform applied to visible text (never the url)
+     */
+    public static void appendTransformed(RichText rich, String text,
+                                         DocumentTextStyle baseStyle,
+                                         UnaryOperator<String> displayTransform) {
+        if (text == null || text.isEmpty()) {
+            return;
+        }
+        Matcher matcher = LINK_PATTERN.matcher(text);
+        int cursor = 0;
+        while (matcher.find()) {
+            appendTransformedSegment(rich, text.substring(cursor, matcher.start()),
+                    baseStyle, displayTransform);
+            rich.link(displayTransform.apply(matcher.group(1)), matcher.group(2));
+            cursor = matcher.end();
+        }
+        appendTransformedSegment(rich, text.substring(cursor), baseStyle, displayTransform);
+    }
+
+    /**
+     * Convenience {@link #appendTransformed} that upper-cases the visible text
+     * (link labels and plain segments) while preserving each link's url.
+     *
+     * @param rich      target rich-text builder
+     * @param text      source string; null treated as empty
+     * @param baseStyle style applied to the upper-cased runs
+     */
+    public static void appendUpperCased(RichText rich, String text,
+                                        DocumentTextStyle baseStyle) {
+        appendTransformed(rich, text, baseStyle, s -> s.toUpperCase(Locale.ROOT));
+    }
+
+    private static void appendTransformedSegment(RichText rich, String segment,
+                                                 DocumentTextStyle baseStyle,
+                                                 UnaryOperator<String> displayTransform) {
+        String clean = plainText(segment);
+        if (!clean.isEmpty()) {
+            rich.style(displayTransform.apply(clean), baseStyle);
+        }
+    }
+
+    /**
      * Appends {@code prefix + plainText(value)} only when the
      * plain-text projection is non-blank. Used by renderers that
      * label optional supplementary content like {@code " (since
@@ -109,6 +165,28 @@ public final class MarkdownInline {
         String clean = plainText(value);
         if (!clean.isBlank()) {
             rich.style(prefix + clean, style);
+        }
+    }
+
+    /**
+     * Link-aware counterpart of {@link #appendPlainIfPresent}: when the
+     * plain-text projection of {@code value} is non-blank, appends {@code prefix}
+     * as a plain run and then {@code value} through
+     * {@link #append(RichText, String, DocumentTextStyle)}, so inline
+     * {@code [label](url)} in the supplementary segment renders as a clickable
+     * link instead of being flattened to text.
+     *
+     * @param rich   target rich-text builder
+     * @param prefix separator prepended before the value (never a link)
+     * @param value  source string; null treated as empty
+     * @param style  style applied to the prefix and the value's plain runs
+     */
+    public static void appendIfPresent(RichText rich, String prefix,
+                                       String value,
+                                       DocumentTextStyle style) {
+        if (!plainText(value).isBlank()) {
+            rich.style(prefix, style);
+            append(rich, value, style);
         }
     }
 

--- a/templates/src/main/java/com/demcha/compose/document/templates/cv/components/EntryCompactRenderer.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/cv/components/EntryCompactRenderer.java
@@ -3,13 +3,12 @@ package com.demcha.compose.document.templates.cv.components;
 import com.demcha.compose.document.templates.core.text.MarkdownInline;
 import com.demcha.compose.document.templates.core.text.RichParagraphRenderer;
 
+import com.demcha.compose.document.dsl.RichText;
 import com.demcha.compose.document.dsl.SectionBuilder;
 import com.demcha.compose.document.node.TextAlign;
 import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.cv.data.CvEntry;
-
-import java.util.Locale;
 
 /**
  * Compact entry renderer for editorial/card/rail presets where title,
@@ -59,11 +58,11 @@ public final class EntryCompactRenderer {
                 .addSection("Title", titleColumn -> titleColumn
                         .padding(DocumentInsets.zero())
                         .addParagraph(paragraph -> paragraph
-                                .text(formattedTitle(entry.title(),
-                                        uppercaseTitle))
                                 .textStyle(titleStyle)
                                 .align(TextAlign.LEFT)
-                                .margin(DocumentInsets.zero())))
+                                .margin(DocumentInsets.zero())
+                                .rich(rich -> richTitle(rich, entry.title(),
+                                        titleStyle, uppercaseTitle))))
                 .addSection("Date", dateColumn -> dateColumn
                         .padding(DocumentInsets.zero())
                         .addParagraph(paragraph -> paragraph
@@ -74,10 +73,10 @@ public final class EntryCompactRenderer {
 
         if (!entry.subtitle().isBlank()) {
             host.addParagraph(paragraph -> paragraph
-                    .text(MarkdownInline.plainText(entry.subtitle()))
                     .textStyle(subtitleStyle)
                     .align(TextAlign.LEFT)
-                    .margin(subtitleMargin));
+                    .margin(subtitleMargin)
+                    .rich(rich -> MarkdownInline.append(rich, entry.subtitle(), subtitleStyle)));
         }
         RichParagraphRenderer.render(host, entry.body(), bodyStyle,
                 bodyLineSpacing, bodyMargin);
@@ -106,9 +105,8 @@ public final class EntryCompactRenderer {
                 .align(TextAlign.LEFT)
                 .margin(margin)
                 .rich(rich -> {
-                    rich.style(MarkdownInline.plainText(entry.title()),
-                            titleStyle);
-                    MarkdownInline.appendPlainIfPresent(rich, " / ",
+                    MarkdownInline.append(rich, entry.title(), titleStyle);
+                    MarkdownInline.appendIfPresent(rich, " / ",
                             entry.subtitle(), metaStyle);
                     MarkdownInline.appendPlainIfPresent(rich, " / ",
                             entry.date(), metaStyle);
@@ -140,9 +138,8 @@ public final class EntryCompactRenderer {
                 .align(TextAlign.LEFT)
                 .margin(margin)
                 .rich(rich -> {
-                    rich.style(MarkdownInline.plainText(entry.title()),
-                            titleStyle);
-                    MarkdownInline.appendPlainIfPresent(rich, " / ",
+                    MarkdownInline.append(rich, entry.title(), titleStyle);
+                    MarkdownInline.appendIfPresent(rich, " / ",
                             entry.subtitle(), subtitleStyle);
                     MarkdownInline.appendPlainIfPresent(rich, " / ",
                             entry.date(), dateStyle);
@@ -187,8 +184,7 @@ public final class EntryCompactRenderer {
                 .align(TextAlign.LEFT)
                 .margin(headerMargin)
                 .rich(rich -> {
-                    rich.style(formattedTitle(entry.title(), uppercaseTitle),
-                            titleStyle);
+                    richTitle(rich, entry.title(), titleStyle, uppercaseTitle);
                     if (!entry.date().isBlank()) {
                         rich.style(datePrefix, titleStyle);
                         rich.style(MarkdownInline.plainText(entry.date()),
@@ -197,10 +193,10 @@ public final class EntryCompactRenderer {
                 }));
         if (!entry.subtitle().isBlank()) {
             host.addParagraph(paragraph -> paragraph
-                    .text(MarkdownInline.plainText(entry.subtitle()))
                     .textStyle(subtitleStyle)
                     .align(TextAlign.LEFT)
-                    .margin(subtitleMargin));
+                    .margin(subtitleMargin)
+                    .rich(rich -> MarkdownInline.append(rich, entry.subtitle(), subtitleStyle)));
         }
         RichParagraphRenderer.render(host, entry.body(), bodyStyle,
                 bodyLineSpacing, bodyMargin);
@@ -242,9 +238,8 @@ public final class EntryCompactRenderer {
                 .align(TextAlign.LEFT)
                 .margin(headerMargin)
                 .rich(rich -> {
-                    rich.style(MarkdownInline.plainText(entry.title()),
-                            titleStyle);
-                    MarkdownInline.appendPlainIfPresent(rich, subtitlePrefix,
+                    MarkdownInline.append(rich, entry.title(), titleStyle);
+                    MarkdownInline.appendIfPresent(rich, subtitlePrefix,
                             entry.subtitle(), subtitleStyle);
                     MarkdownInline.appendPlainIfPresent(rich, datePrefix,
                             entry.date(), dateStyle);
@@ -253,8 +248,18 @@ public final class EntryCompactRenderer {
                 bodyLineSpacing, bodyMargin);
     }
 
-    private static String formattedTitle(String title, boolean uppercase) {
-        String clean = MarkdownInline.plainText(title);
-        return uppercase ? clean.toUpperCase(Locale.ROOT) : clean;
+    /**
+     * Appends the entry title to {@code rich}, expanding inline markdown so a
+     * {@code [name](url)} title renders as a clickable link. When
+     * {@code uppercase} is set the visible label is upper-cased while the link
+     * URL is preserved.
+     */
+    private static void richTitle(RichText rich, String title,
+                                  DocumentTextStyle style, boolean uppercase) {
+        if (uppercase) {
+            MarkdownInline.appendUpperCased(rich, title, style);
+        } else {
+            MarkdownInline.append(rich, title, style);
+        }
     }
 }

--- a/templates/src/main/java/com/demcha/compose/document/templates/cv/components/EntryRenderer.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/cv/components/EntryRenderer.java
@@ -5,6 +5,7 @@ import com.demcha.compose.document.node.TextAlign;
 import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.templates.cv.data.CvEntry;
+import com.demcha.compose.document.templates.core.text.MarkdownInline;
 import com.demcha.compose.document.templates.core.theme.BrandTheme;
 
 /**
@@ -54,10 +55,10 @@ public final class EntryRenderer {
                 .addSection("Title", titleColumn -> titleColumn
                         .padding(DocumentInsets.zero())
                         .addParagraph(p -> p
-                                .text(entry.title())
                                 .textStyle(titleStyle)
                                 .align(TextAlign.LEFT)
-                                .margin(DocumentInsets.zero())))
+                                .margin(DocumentInsets.zero())
+                                .rich(rich -> MarkdownInline.append(rich, entry.title(), titleStyle))))
                 .addSection("Date", dateColumn -> dateColumn
                         .padding(DocumentInsets.zero())
                         .addParagraph(p -> p

--- a/templates/src/main/java/com/demcha/compose/document/templates/cv/presets/EngineeringResume.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/cv/presets/EngineeringResume.java
@@ -356,7 +356,7 @@ public final class EngineeringResume {
                                 .lineSpacing(1.0)
                                 .margin(DocumentInsets.bottom(2.3))
                                 .rich(rich -> {
-                                    rich.style(entry.title(), railTitleStyle());
+                                    MarkdownInline.append(rich, entry.title(), railTitleStyle());
                                     if (!entry.date().isBlank()) {
                                         rich.style(" / " + entry.date(),
                                                 railDateStyle());
@@ -437,10 +437,10 @@ public final class EngineeringResume {
                             addRoleHeader(card, entry);
                             if (!entry.subtitle().isBlank()) {
                                 card.addParagraph(paragraph -> paragraph
-                                        .text(MarkdownInline.plainText(
-                                                entry.subtitle()))
                                         .textStyle(subtitleBodyStyle())
-                                        .margin(DocumentInsets.zero()));
+                                        .margin(DocumentInsets.zero())
+                                        .rich(rich -> MarkdownInline.append(rich,
+                                                entry.subtitle(), subtitleBodyStyle())));
                             }
                             if (!entry.body().isBlank()) {
                                 card.addParagraph(paragraph -> paragraph
@@ -526,7 +526,7 @@ public final class EngineeringResume {
                         .textStyle(roleTitleStyle())
                         .margin(DocumentInsets.zero())
                         .rich(rich -> {
-                            rich.style(entry.title(), roleTitleStyle());
+                            MarkdownInline.append(rich, entry.title(), roleTitleStyle());
                             if (!entry.date().isBlank()) {
                                 rich.style(" / " + entry.date(),
                                         roleDateStyle());

--- a/templates/src/main/java/com/demcha/compose/document/templates/cv/presets/MintEditorial.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/cv/presets/MintEditorial.java
@@ -738,17 +738,17 @@ public final class MintEditorial {
                 DocumentTextStyle metaStyle = smallStyle();
                 for (CvEntry entry : entries) {
                     block.addParagraph(p -> p
-                            .text(TextOrnaments.spacedUpper(
-                                    MarkdownInline.plainText(entry.title())))
                             .textStyle(degreeStyle)
                             .align(TextAlign.LEFT)
-                            .margin(DocumentInsets.bottom(5)));
+                            .margin(DocumentInsets.bottom(5))
+                            .rich(rich -> MarkdownInline.appendTransformed(rich, entry.title(),
+                                    degreeStyle, TextOrnaments::spacedUpper)));
                     if (!entry.subtitle().isBlank()) {
                         block.addParagraph(p -> p
-                                .text(MarkdownInline.plainText(entry.subtitle()))
                                 .textStyle(metaStyle)
                                 .align(TextAlign.LEFT)
-                                .margin(DocumentInsets.bottom(5)));
+                                .margin(DocumentInsets.bottom(5))
+                                .rich(rich -> MarkdownInline.append(rich, entry.subtitle(), metaStyle)));
                     }
                     if (!entry.date().isBlank()) {
                         block.addParagraph(p -> p
@@ -894,11 +894,11 @@ public final class MintEditorial {
                 DocumentTextStyle bodyStyle = bodyStyle();
                 for (CvEntry entry : entries) {
                     block.addParagraph(p -> p
-                            .text(TextOrnaments.spacedUpper(
-                                    MarkdownInline.plainText(entry.title())))
                             .textStyle(titleStyle)
                             .align(TextAlign.LEFT)
-                            .margin(DocumentInsets.bottom(5)));
+                            .margin(DocumentInsets.bottom(5))
+                            .rich(rich -> MarkdownInline.appendTransformed(rich, entry.title(),
+                                    titleStyle, TextOrnaments::spacedUpper)));
                     String meta = composeMeta(entry);
                     if (!meta.isBlank()) {
                         block.addParagraph(p -> p
@@ -1187,6 +1187,9 @@ public final class MintEditorial {
     // -- Static helpers ----------------------------------------------------
 
     private static String composeMeta(CvEntry entry) {
+        // Deliberately flattened: this experience subtitle shares one fused meta
+        // line with the date, so an inline [label](url) is reduced to its label
+        // text here (the entry title and the education subtitle still link).
         String subtitle = MarkdownInline.plainText(entry.subtitle());
         String date = MarkdownInline.plainText(entry.date());
         if (subtitle.isBlank()) {

--- a/templates/src/main/java/com/demcha/compose/document/templates/cv/presets/MonogramSidebar.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/cv/presets/MonogramSidebar.java
@@ -489,19 +489,18 @@ public final class MonogramSidebar {
             for (int i = 0; i < Math.min(list.size(), EDUCATION_LIMIT); i++) {
                 CvEntry entry = list.get(i);
                 section.addParagraph(paragraph -> paragraph
-                        .text(MarkdownInline.plainText(entry.title())
-                                .toUpperCase(Locale.ROOT))
                         .textStyle(headingStyle)
                         .align(TextAlign.CENTER)
                         .lineSpacing(1.2)
-                        .margin(DocumentInsets.top(6)));
+                        .margin(DocumentInsets.top(6))
+                        .rich(rich -> MarkdownInline.appendUpperCased(rich, entry.title(), headingStyle)));
                 if (!entry.subtitle().isBlank()) {
                     section.addParagraph(paragraph -> paragraph
-                            .text(MarkdownInline.plainText(entry.subtitle()))
                             .textStyle(subStyle)
                             .align(TextAlign.CENTER)
                             .lineSpacing(1.2)
-                            .margin(DocumentInsets.zero()));
+                            .margin(DocumentInsets.zero())
+                            .rich(rich -> MarkdownInline.append(rich, entry.subtitle(), subStyle)));
                 }
                 if (!entry.date().isBlank()) {
                     section.addParagraph(paragraph -> paragraph
@@ -701,12 +700,11 @@ public final class MonogramSidebar {
             for (int i = 0; i < Math.min(list.size(), EXPERIENCE_LIMIT); i++) {
                 CvEntry entry = list.get(i);
                 section.addParagraph(paragraph -> paragraph
-                        .text(MarkdownInline.plainText(entry.title())
-                                .toUpperCase(Locale.ROOT))
                         .textStyle(positionStyle)
                         .align(TextAlign.LEFT)
                         .lineSpacing(1.15)
-                        .margin(DocumentInsets.top(5)));
+                        .margin(DocumentInsets.top(5))
+                        .rich(rich -> MarkdownInline.appendUpperCased(rich, entry.title(), positionStyle)));
                 if (!entry.date().isBlank()) {
                     section.addParagraph(paragraph -> paragraph
                             .text(TextOrnaments.spacedUpper(

--- a/templates/src/main/java/com/demcha/compose/document/templates/cv/presets/SidebarPortrait.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/cv/presets/SidebarPortrait.java
@@ -498,19 +498,18 @@ public final class SidebarPortrait {
             for (int i = 0; i < Math.min(list.size(), EDUCATION_LIMIT); i++) {
                 CvEntry entry = list.get(i);
                 section.addParagraph(paragraph -> paragraph
-                        .text(MarkdownInline.plainText(entry.title())
-                                .toUpperCase(Locale.ROOT))
                         .textStyle(headingStyle)
                         .align(TextAlign.LEFT)
                         .lineSpacing(1.2)
-                        .margin(DocumentInsets.top(6)));
+                        .margin(DocumentInsets.top(6))
+                        .rich(rich -> MarkdownInline.appendUpperCased(rich, entry.title(), headingStyle)));
                 if (!entry.subtitle().isBlank()) {
                     section.addParagraph(paragraph -> paragraph
-                            .text(MarkdownInline.plainText(entry.subtitle()))
                             .textStyle(metaStyle)
                             .align(TextAlign.LEFT)
                             .lineSpacing(1.2)
-                            .margin(DocumentInsets.zero()));
+                            .margin(DocumentInsets.zero())
+                            .rich(rich -> MarkdownInline.append(rich, entry.subtitle(), metaStyle)));
                 }
                 if (!entry.date().isBlank()) {
                     section.addParagraph(paragraph -> paragraph
@@ -681,11 +680,10 @@ public final class SidebarPortrait {
             for (int i = 0; i < Math.min(list.size(), EXPERIENCE_LIMIT); i++) {
                 CvEntry entry = list.get(i);
                 section.addParagraph(paragraph -> paragraph
-                        .text(MarkdownInline.plainText(entry.title())
-                                .toUpperCase(Locale.ROOT))
                         .textStyle(positionStyle)
                         .align(TextAlign.LEFT)
-                        .margin(DocumentInsets.top(8)));
+                        .margin(DocumentInsets.top(8))
+                        .rich(rich -> MarkdownInline.appendUpperCased(rich, entry.title(), positionStyle)));
 
                 String subtitle = composeSubtitle(entry);
                 if (!subtitle.isBlank()) {
@@ -709,6 +707,9 @@ public final class SidebarPortrait {
         }
 
         private static String composeSubtitle(CvEntry entry) {
+            // Deliberately flattened: this experience subtitle shares one fused meta
+            // line with the date, so an inline [label](url) is reduced to its label
+            // text here (the entry title and the education subtitle still link).
             String sub = MarkdownInline.plainText(entry.subtitle());
             String date = MarkdownInline.plainText(entry.date());
             if (sub.isBlank()) {

--- a/templates/src/main/java/com/demcha/compose/document/templates/cv/presets/TimelineMinimal.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/cv/presets/TimelineMinimal.java
@@ -504,8 +504,11 @@ public final class TimelineMinimal {
             }
         } else if (section instanceof EntriesSection entries) {
             for (CvEntry entry : entries.entries()) {
-                String header = entry.title();
-                String subtitle = entry.subtitle();
+                // Flattened single-line excerpt: strip inline markdown so a
+                // [label](url) title/subtitle shows its label text — this preset
+                // fuses and truncates the line, so it cannot carry a clickable link.
+                String header = MarkdownInline.plainText(entry.title());
+                String subtitle = MarkdownInline.plainText(entry.subtitle());
                 String dates = entry.date();
                 String body = entry.body();
                 StringBuilder line = new StringBuilder();

--- a/templates/src/test/java/com/demcha/compose/document/templates/core/text/MarkdownInlineTest.java
+++ b/templates/src/test/java/com/demcha/compose/document/templates/core/text/MarkdownInlineTest.java
@@ -195,4 +195,72 @@ class MarkdownInlineTest {
         assertThat(a.text()).isEqualTo(b.text()).isEqualTo("hi");
         assertThat(linkUri(a)).isEqualTo(linkUri(b)).isEqualTo("https://h");
     }
+
+    // --- appendUpperCased / appendTransformed: stylised titles keep their link ---
+
+    @Test
+    void appendUpperCasedUpperCasesLabelButLeavesUrlUntouched() {
+        RichText rich = RichText.empty();
+        MarkdownInline.appendUpperCased(rich, "[GraphCompose](https://GC)", BASE);
+
+        List<InlineTextRun> runs = rich.runs().stream()
+                .map(r -> (InlineTextRun) r).toList();
+        assertThat(runs).hasSize(1);
+        assertThat(runs.get(0).text()).isEqualTo("GRAPHCOMPOSE");
+        assertThat(hasExternalLink(runs.get(0))).isTrue();
+        assertThat(linkUri(runs.get(0))).isEqualTo("https://GC");
+    }
+
+    @Test
+    void appendUpperCasedOnPlainTitleMatchesPlainTextUpperCase() {
+        RichText rich = RichText.empty();
+        MarkdownInline.appendUpperCased(rich, "Senior Engineer", BASE);
+
+        String text = rich.runs().stream()
+                .map(r -> ((InlineTextRun) r).text()).reduce("", String::concat);
+        assertThat(text).isEqualTo("SENIOR ENGINEER");
+        assertThat(rich.runs()).allSatisfy(run ->
+                assertThat(((InlineTextRun) run).linkTarget()).isNull());
+    }
+
+    @Test
+    void appendTransformedAppliesTransformToLabelButNotUrl() {
+        RichText rich = RichText.empty();
+        MarkdownInline.appendTransformed(rich, "[ACME](https://acme.example)",
+                BASE, s -> "<" + s + ">");
+
+        InlineTextRun link = rich.runs().stream()
+                .map(r -> (InlineTextRun) r)
+                .filter(MarkdownInlineTest::hasExternalLink)
+                .findFirst().orElseThrow();
+        assertThat(link.text()).isEqualTo("<ACME>");
+        assertThat(linkUri(link)).isEqualTo("https://acme.example");
+    }
+
+    // --- appendIfPresent: link-aware supplementary segment ----------------------
+
+    @Test
+    void appendIfPresentEmitsPrefixThenLinkForNonBlankValue() {
+        RichText rich = RichText.empty();
+        MarkdownInline.appendIfPresent(rich, " / ", "[ACME](https://acme)", BASE);
+
+        List<InlineTextRun> runs = rich.runs().stream()
+                .map(r -> (InlineTextRun) r).toList();
+        String all = runs.stream().map(InlineTextRun::text).reduce("", String::concat);
+        assertThat(all).isEqualTo(" / ACME");
+
+        InlineTextRun link = runs.stream()
+                .filter(MarkdownInlineTest::hasExternalLink)
+                .findFirst().orElseThrow();
+        assertThat(link.text()).isEqualTo("ACME");
+        assertThat(linkUri(link)).isEqualTo("https://acme");
+    }
+
+    @Test
+    void appendIfPresentIsANoOpForBlankOrNullValue() {
+        RichText rich = RichText.empty();
+        MarkdownInline.appendIfPresent(rich, " / ", "   ", BASE);
+        MarkdownInline.appendIfPresent(rich, " / ", null, BASE);
+        assertThat(rich.runs()).isEmpty();
+    }
 }


### PR DESCRIPTION
## Why

CV project rows and body text already render inline `[label](url)` Markdown as
clickable links (since v1.6.8), but experience/education entry **titles** were emitted
as plain text — so a `[name](url)` in an entry title (a project name, an employer)
showed up literally instead of linking. Subtitles were inconsistent: link-aware in the
canonical renderer, stripped in the compact and hand-rolled ones.

## What changed

- `MarkdownInline` gains `appendTransformed(rich, text, style, UnaryOperator<String>)` —
  link-aware, applying the transform to the visible label and plain segments but never
  the URL — plus `appendUpperCased` (now a delegate) and `appendIfPresent` (the
  link-aware counterpart of `appendPlainIfPresent`).
- Entry titles and subtitles route through the link-aware helpers everywhere they
  render: the shared `EntryRenderer` and `EntryCompactRenderer` (all five variants,
  upper-case-aware), and the four presets that hand-roll their own titles —
  `MonogramSidebar`, `SidebarPortrait`, `EngineeringResume`, and `MintEditorial`
  (letter-spaced via `appendTransformed(TextOrnaments::spacedUpper)`). No `CvEntry`
  change.
- `TimelineMinimal` fuses each entry into one truncatable excerpt line and cannot carry
  a clickable link; it now strips the markdown to the label text instead of rendering
  `[..](..)` literally. The fused subtitle+date meta line in the `MintEditorial` /
  `SidebarPortrait` experience entries flattens the same way. Dates stay plain
  (out of scope).
- Backward-compatible: a title with no inline-Markdown syntax renders byte-identically —
  all CV visual-parity and layout snapshots are unchanged (no re-bless).

## Verification

`./mvnw -B -ntp clean verify -pl :graph-compose-templates,:graph-compose-qa -am` →
**BUILD SUCCESS**, qa **666 tests, 0 failures**; CV visual-parity + layout snapshots
unchanged.

- `MarkdownInlineTest` **+5**: URL preserved under upper-casing, transform hits the
  label not the URL, `appendIfPresent` emits prefix + link, blank/null is a no-op, and
  a plain title matches the old `plainText().toUpperCase()`.
- New `EntryTitleLinkTest` **(6)**: a `[label](url)` title becomes a link through
  `EntryRenderer`, the upper-cased `EntryCompactRenderer` (label upper-cased, URL
  intact), and the hand-rolled `MonogramSidebar` + `EngineeringResume` paths; the
  subtitle links too; and a plain-title control (asserted specifically, since the header
  contact block renders its own email/website links).
- A `ModernProfessional` render + PDF link-annotation check confirmed the entry-title
  URIs are present as clickable annotations in the output PDF.

**Lane:** templates (canonical). No engine or public-DSL change; links reuse the existing
`RichText.link` convention (they inherit the title's style, matching project-row links).
