### PR TITLE
chore(release): open the 2.1 development line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,49 @@
 All notable changes to GraphCompose are documented here. Versions
 follow semantic versioning; release dates are ISO 8601.
 
-## v2.1.0 — in progress
+## v2.1.0 — Planned
 
 ### Public API
 
+- **Keep a heading with its content** — `SectionBuilder.keepWithNext()`. A section
+  marked keep-with-next is never left stranded as the last block on a page apart from
+  the content it introduces: when the section plus the first slice of the following
+  block would overflow the remaining page space (but fit on a fresh page), the section
+  relocates to the next page so the heading stays glued to its body. The first slice is
+  a paragraph's first line, a table's repeated header rows plus first body row, or a
+  list's first item, so the rule holds whether the following block is atomic or a
+  page-spanning table or list. Distinct from `keepTogether()`, which relocates a
+  *whole* block — keep-with-next binds only the start of the following block, the right
+  tool for a boxed section title above a long, page-spanning body. Inert when nothing
+  follows (a trailing heading is never moved) and best-effort when the heading plus the
+  first slice cannot share a page. Default off, so layouts that do not opt in are
+  unchanged.
+- `LineBuilder.keepWithNext()` — the line counterpart of
+  `SectionBuilder.keepWithNext()`, so a full-width header rule joins its banner's
+  keep-with-next run and the whole title block (rule + banner + rule) relocates
+  together instead of the banner stranding apart from its rules or its body.
+- Keep-with-next surfaces on the node model as well: `DocumentNode.keepWithNext()`
+  is a new default method (existing implementations keep the `false` default and
+  need no change), and `SectionNode` and `LineNode` each gain a trailing
+  `keepWithNext` record component. Constructor calls are unaffected — both records
+  keep an overload at the previous argument count that defaults the flag to
+  `false` — but the canonical component count changed (`SectionNode` 13 → 14,
+  `LineNode` 17 → 18), so a **record deconstruction pattern** written against the
+  2.0.0 component list must add the new binding to compile.
+- **Single-column CV presets no longer orphan a section title.** Every preset whose
+  sections flow down the page — BoxedSections, MinimalUnderlined, ModernProfessional,
+  Executive, CenteredHeadline, BlueBanner, EditorialBlue, and ClassicSerif — keeps a
+  section heading with the first line of its body across a page break: a standalone
+  header section binds to the following body section (a multi-node rule + banner + rule
+  group binds as one run), and a combined header+body module keeps the heading in a
+  nested keep-with-next group — including Panel's full-width Profile card, whose header
+  now stays with the summary if a long profile splits the card. Multi-column presets
+  place their sections in fixed columns that do not paginate, so no heading can strand
+  there.
+- **The Modern Proposal template no longer orphans a section heading.** Its flowing
+  section bodies, the Timeline and Investment tables, and the Acceptance terms each keep
+  their title with the first line of the block it introduces across a page break — each
+  title now renders in its own keep-with-next section rather than a bare paragraph.
 - **CV entry titles and subtitles accept inline `[text](url)` links.** In the layered
   CV presets, a `[label](url)` in an experience/education entry title or subtitle now
   renders as a clickable hyperlink — the same inline-Markdown convention already used
@@ -303,37 +342,6 @@ for this cycle.
 
 ### Public API
 
-- **Keep a heading with its content** — `SectionBuilder.keepWithNext()`. A section
-  marked keep-with-next is never left stranded as the last block on a page apart from
-  the content it introduces: when the section plus the first slice of the following
-  block would overflow the remaining page space (but fit on a fresh page), the section
-  relocates to the next page so the heading stays glued to its body. The first slice is
-  a paragraph's first line, a table's repeated header rows plus first body row, or a
-  list's first item, so the rule holds whether the following block is atomic or a
-  page-spanning table or list. Distinct from `keepTogether()`, which relocates a
-  *whole* block — keep-with-next binds only the start of the following block, the right
-  tool for a boxed section title above a long, page-spanning body. Inert when nothing
-  follows (a trailing heading is never moved) and best-effort when the heading plus the
-  first slice cannot share a page. Default off, so layouts that do not opt in are
-  unchanged.
-- `LineBuilder.keepWithNext()` — the line counterpart of
-  `SectionBuilder.keepWithNext()`, so a full-width header rule joins its banner's
-  keep-with-next run and the whole title block (rule + banner + rule) relocates
-  together instead of the banner stranding apart from its rules or its body.
-- **Single-column CV presets no longer orphan a section title.** Every preset whose
-  sections flow down the page — BoxedSections, MinimalUnderlined, ModernProfessional,
-  Executive, CenteredHeadline, BlueBanner, EditorialBlue, and ClassicSerif — keeps a
-  section heading with the first line of its body across a page break: a standalone
-  header section binds to the following body section (a multi-node rule + banner + rule
-  group binds as one run), and a combined header+body module keeps the heading in a
-  nested keep-with-next group — including Panel's full-width Profile card, whose header
-  now stays with the summary if a long profile splits the card. Multi-column presets
-  place their sections in fixed columns that do not paginate, so no heading can strand
-  there.
-- **The Modern Proposal template no longer orphans a section heading.** Its flowing
-  section bodies, the Timeline and Investment tables, and the Acceptance terms each keep
-  their title with the first line of the block it introduces across a page break — each
-  title now renders in its own keep-with-next section rather than a bare paragraph.
 - **Reproducible PDF output** (`@Beta`). `PdfFixedLayoutBackend.builder().deterministic(true)`
   (or `.deterministic(Instant)` for an explicit timestamp) pins the document
   CreationDate / ModDate and derives the PDF `/ID` from the document metadata instead

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.demchaav</groupId>
         <artifactId>graph-compose-build</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -32,7 +32,7 @@
         graph-compose and graph-compose-templates dependencies below use
         ${project.version}, so they follow automatically.
     -->
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>GraphCompose Bundle</name>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.demchaav</groupId>
     <artifactId>graph-compose-core</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <name>GraphCompose Core</name>
     <description>A declarative layout engine for programmatic document generation, implemented primarily in Java. This is the lean engine coordinate; depend on the `graph-compose` artifact for the drop-in, PDF-capable install.</description>

--- a/core/src/main/java/com/demcha/compose/document/dsl/LineBuilder.java
+++ b/core/src/main/java/com/demcha/compose/document/dsl/LineBuilder.java
@@ -289,7 +289,7 @@ public final class LineBuilder implements Transformable<LineBuilder> {
      * {@link SectionBuilder#keepWithNext()}.
      *
      * @return this builder
-     * @since 2.0.0
+     * @since 2.1.0
      */
     public LineBuilder keepWithNext() {
         this.keepWithNext = true;
@@ -301,7 +301,7 @@ public final class LineBuilder implements Transformable<LineBuilder> {
      *
      * @param value true to keep the line with the next block
      * @return this builder
-     * @since 2.0.0
+     * @since 2.1.0
      */
     public LineBuilder keepWithNext(boolean value) {
         this.keepWithNext = value;

--- a/core/src/main/java/com/demcha/compose/document/dsl/SectionBuilder.java
+++ b/core/src/main/java/com/demcha/compose/document/dsl/SectionBuilder.java
@@ -60,7 +60,7 @@ public final class SectionBuilder extends AbstractFlowBuilder<SectionBuilder, Se
      * nothing follows the section on the page.
      *
      * @return this builder
-     * @since 2.0.0
+     * @since 2.1.0
      */
     public SectionBuilder keepWithNext() {
         this.keepWithNext = true;
@@ -72,7 +72,7 @@ public final class SectionBuilder extends AbstractFlowBuilder<SectionBuilder, Se
      *
      * @param value true to keep the section with the first line of the next block
      * @return this builder
-     * @since 2.0.0
+     * @since 2.1.0
      */
     public SectionBuilder keepWithNext(boolean value) {
         this.keepWithNext = value;

--- a/core/src/main/java/com/demcha/compose/document/layout/NodeDefinition.java
+++ b/core/src/main/java/com/demcha/compose/document/layout/NodeDefinition.java
@@ -132,7 +132,7 @@ public interface NodeDefinition<E extends DocumentNode> {
      *
      * @param prepared prepared node whose first slice is being measured
      * @return the first slice's height in points
-     * @since 2.0.0
+     * @since 2.1.0
      */
     default double firstSliceHeight(PreparedNode<E> prepared) {
         return prepared.measureResult().height();

--- a/core/src/main/java/com/demcha/compose/document/node/DocumentNode.java
+++ b/core/src/main/java/com/demcha/compose/document/node/DocumentNode.java
@@ -99,7 +99,7 @@ public interface DocumentNode {
      * siblings relocate together, with the break hoisted before the run.</p>
      *
      * @return true to keep this node with the first line of the following block
-     * @since 2.0.0
+     * @since 2.1.0
      */
     default boolean keepWithNext() {
         return false;

--- a/coverage/pom.xml
+++ b/coverage/pom.xml
@@ -29,7 +29,7 @@
     <parent>
         <groupId>io.github.demchaav</groupId>
         <artifactId>graph-compose-build</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>io.github.demchaav</groupId>
         <artifactId>graph-compose-build</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.demchaav</groupId>
     <artifactId>graph-compose-build</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>GraphCompose Build Aggregator</name>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.github.demchaav</groupId>
         <artifactId>graph-compose-build</artifactId>
-        <version>2.0.1-SNAPSHOT</version>
+        <version>2.1.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/render-docx/pom.xml
+++ b/render-docx/pom.xml
@@ -19,7 +19,7 @@
     -->
     <groupId>io.github.demchaav</groupId>
     <artifactId>graph-compose-render-docx</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <name>GraphCompose Render — DOCX</name>
     <description>Semantic DOCX export backend for GraphCompose, backed by Apache POI.</description>

--- a/render-pdf/pom.xml
+++ b/render-pdf/pom.xml
@@ -25,7 +25,7 @@
     -->
     <groupId>io.github.demchaav</groupId>
     <artifactId>graph-compose-render-pdf</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <name>GraphCompose Render — PDF</name>
     <description>The PDFBox-backed PDF render backend for GraphCompose.</description>

--- a/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/PdfRenderEnvironment.java
+++ b/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/PdfRenderEnvironment.java
@@ -123,6 +123,7 @@ public final class PdfRenderEnvironment {
      *
      * @param alpha non-stroking alpha constant in {@code [0, 1]}
      * @return shared graphics state owned by the current render pass
+     * @since 2.1.0
      */
     public PDExtendedGraphicsState fillAlphaState(float alpha) {
         return fillAlphaStates.computeIfAbsent(alpha, value -> {
@@ -139,6 +140,7 @@ public final class PdfRenderEnvironment {
      *
      * @param alpha stroking alpha constant in {@code [0, 1]}
      * @return shared graphics state owned by the current render pass
+     * @since 2.1.0
      */
     public PDExtendedGraphicsState strokeAlphaState(float alpha) {
         return strokeAlphaStates.computeIfAbsent(alpha, value -> {

--- a/render-pptx/pom.xml
+++ b/render-pptx/pom.xml
@@ -19,7 +19,7 @@
     -->
     <groupId>io.github.demchaav</groupId>
     <artifactId>graph-compose-render-pptx</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <name>GraphCompose Render — PPTX</name>
     <description>PPTX render backends for GraphCompose: the coordinate-exact fixed-layout backend (POI XSLF) and the slide-safe semantic export skeleton.</description>

--- a/templates/pom.xml
+++ b/templates/pom.xml
@@ -17,7 +17,7 @@
     -->
     <groupId>io.github.demchaav</groupId>
     <artifactId>graph-compose-templates</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <name>GraphCompose Templates</name>
     <description>Built-in CV, cover-letter, invoice, and proposal document templates for GraphCompose.</description>

--- a/templates/src/main/java/com/demcha/compose/document/templates/core/text/MarkdownInline.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/core/text/MarkdownInline.java
@@ -108,6 +108,7 @@ public final class MarkdownInline {
      * @param text             source string; null treated as empty
      * @param baseStyle        style applied to the transformed runs
      * @param displayTransform transform applied to visible text (never the url)
+     * @since 2.1.0
      */
     public static void appendTransformed(RichText rich, String text,
                                          DocumentTextStyle baseStyle,
@@ -133,6 +134,7 @@ public final class MarkdownInline {
      * @param rich      target rich-text builder
      * @param text      source string; null treated as empty
      * @param baseStyle style applied to the upper-cased runs
+     * @since 2.1.0
      */
     public static void appendUpperCased(RichText rich, String text,
                                         DocumentTextStyle baseStyle) {
@@ -180,6 +182,7 @@ public final class MarkdownInline {
      * @param prefix separator prepended before the value (never a link)
      * @param value  source string; null treated as empty
      * @param style  style applied to the prefix and the value's plain runs
+     * @since 2.1.0
      */
     public static void appendIfPresent(RichText rich, String prefix,
                                        String value,

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -19,7 +19,7 @@
     -->
     <groupId>io.github.demchaav</groupId>
     <artifactId>graph-compose-testing</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <name>GraphCompose Testing</name>
     <description>Consumer testing support for GraphCompose: layout-snapshot assertions and PDF visual regression.</description>

--- a/wrapper/pom.xml
+++ b/wrapper/pom.xml
@@ -22,7 +22,7 @@
     -->
     <groupId>io.github.demchaav</groupId>
     <artifactId>graph-compose</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <name>GraphCompose</name>
     <description>The graph-compose coordinate: a drop-in aggregator over graph-compose-core for a PDF-capable install.</description>


### PR DESCRIPTION
## Why

Five public members that shipped after the `v2.0.0` tag claim `@since 2.0.0`, and their changelog entries sit under the already-dated `## v2.0.0 — 2026-07-13` heading. Both are published artifacts: the javadoc jar on Central is immutable, and that changelog section becomes the GitHub Release notes. A reader upgrading from 2.0.0 is currently told the keep-with-next API had always been there. Five more new public members carry no `@since` at all, and the train poms still say `2.0.1-SNAPSHOT` while every tag, the changelog heading and `docs/api-stability.md` say 2.1.0.

Nothing in the repo catches this: `PublicApiSinceTagCoverageTest` inspects class-level tags only, on a narrow root set, and never compares a tag's *value* to anything.

## What changed

- 13 train poms → `2.1.0-SNAPSHOT`. `fonts/` and `emoji/` are untouched — independent version lines.
- Six wrong `@since 2.0.0` → `2.1.0`: `DocumentNode.keepWithNext`, `SectionBuilder.keepWithNext` and its boolean overload, `LineBuilder.keepWithNext` and its boolean overload, `NodeDefinition.firstSliceHeight`. Each verified absent from `v2.0.0` and `origin/main`; the work landed 2026-07-22, nine days after the tag.
- Five missing tags added: `MarkdownInline.appendTransformed` / `appendUpperCased` / `appendIfPresent`, and `PdfRenderEnvironment.fillAlphaState` / `strokeAlphaState`.
- The four keep-with-next entries move out of the dated v2.0.0 section into v2.1.0, and that section opens as `## v2.1.0 — Planned` — the header form `cut-release.ps1` dates.
- A new entry records what the feature bullets omitted: the new default method on `DocumentNode`, and the trailing `keepWithNext` record component on `SectionNode` (13 → 14) and `LineNode` (17 → 18). Constructor calls keep working through previous-arity overloads, but a **record deconstruction pattern** written against the 2.0.0 component list must add a binding. `breakBuildOnSourceIncompatibleModifications` is `false`, so no gate reports it.

The `SectionNode` / `LineNode` compat constructors deliberately carry **no** `@since`: those signatures were the canonical record constructors at 2.0.0 and have been callable since then.

## Verification

- `./mvnw -B -ntp clean verify` — BUILD SUCCESS, 1508 tests, 0 failures, 15/15 modules.
- `./mvnw -P japicmp verify -pl :graph-compose-core` — green with the gate **active** (`2.1.0-SNAPSHOT` ≠ the 2.0.0 baseline), confirming the cycle is additive.
- `./mvnw javadoc:javadoc` on the six published modules — green.
- `VersionConsistencyGuardTest` 12/12.
- Comparing every `*Node.java` component count against `v2.0.0` confirms exactly two records changed arity.