### PR TITLE
docs(docx): record what the semantic backend drops

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ For a Spring Boot `@RestController` streaming the PDF straight to the response, 
 | Format | Status | Notes |
 |---|---|---|
 | PDF | Production | Fixed-layout backend on PDFBox 3.0. Full DSL coverage. |
-| DOCX | Partial | Semantic export via Apache POI. Unsupported nodes (`shape`, `line`, `ellipse`, `barcode`) are dropped silently &mdash; layout fidelity is best-effort for paragraph / list / table content. |
+| DOCX | Partial | Semantic export via Apache POI &mdash; paragraphs, block images, tables and metadata. Word owns the flow, so drawing nodes (`shape`, `line`, `ellipse`, `barcode`) are dropped silently. Beyond geometry, **hyperlinks, bookmarks, headers/footers and multi-section documents are not implemented** &mdash; see [render-docx](./render-docx/README.md#what-it-maps-and-what-it-does-not). |
 | PPTX | Beta | Fixed-layout export via Apache POI from the same resolved layout &mdash; one page per editable slide with native shapes and text frames; clipped regions land as pixel-exact pictures. First shipped in 2.1, marked `@Beta` while the API shape settles. |
 
 ### Text &amp; internationalization

--- a/core/README.md
+++ b/core/README.md
@@ -9,7 +9,10 @@ it, with **no PDFBox, POI, or template code** on its dependency tree.
 ## When to depend on it
 
 - You want the smallest engine and will **bring your own render backend** — add
-  `graph-compose-render-pdf`, or implement the `FixedLayoutBackendProvider` SPI.
+  `graph-compose-render-pdf`, or implement the `FixedLayoutBackendProvider` SPI. A custom
+  backend needs **both** halves of the SPI: opening a session measures text through a
+  `FontMetricsProvider`, so publish one alongside your backend. `graph-compose-render-pdf`
+  is the only shipped artifact that registers one.
 - You are building a library on top of GraphCompose and don't want to impose a backend
   on your consumers.
 
@@ -27,8 +30,9 @@ try (var doc = GraphCompose.document(out).create()) {
 } // with graph-compose-render-pdf present, buildPdf() / toPdfBytes() / toImages() work
 ```
 
-A core-only classpath asked to render throws `MissingBackendException`, whose message
-names the artifact to add.
+A core-only classpath throws `MissingBackendException` at `create()` — before any render
+call, since the session resolves its font metrics as it opens — and the message names the
+artifact to add.
 
 ## Install
 

--- a/docs/architecture/backend-capability-matrix.md
+++ b/docs/architecture/backend-capability-matrix.md
@@ -43,7 +43,7 @@ Payload records live in `core` under
 
 | Capability (payload) | PDF (fixed) | PPTX (fixed) | DOCX (semantic) |
 |---|---|---|---|
-| Paragraph — pre-wrapped lines, runs, alignment (`ParagraphFragmentPayload`) | ✅ `PdfParagraphFragmentRenderHandler` | ✅ `PptxParagraphFragmentRenderHandler` (one absolute, wrap-disabled frame per measured line) | ✅ semantic paragraphs (`DocxSemanticBackend`) |
+| Paragraph — pre-wrapped lines, runs, alignment (`ParagraphFragmentPayload`) | ✅ `PdfParagraphFragmentRenderHandler` | ✅ `PptxParagraphFragmentRenderHandler` (one absolute, wrap-disabled frame per measured line) | ⚠️ semantic paragraphs (`DocxSemanticBackend`) — every run takes the paragraph's style, so per-run styling and `linkTarget` are dropped |
 | Inline code/badge chips (`InlineBackground` on text spans) | ✅ `PdfParagraphFragmentRenderHandler` | ✅ `PptxParagraphFragmentRenderHandler` | ❌ |
 | Inline images (`ParagraphImageSpan`) | ✅ `PdfParagraphFragmentRenderHandler` | ✅ `PptxParagraphFragmentRenderHandler` | ❌ |
 | Inline vector shapes (`ParagraphShapeSpan`) | ✅ `PdfParagraphFragmentRenderHandler` | ⚠️ `PptxParagraphFragmentRenderHandler` + `PptxInlineGeometry` (distinct per-corner radii render with the top-left radius — single-adjust preset) | ❌ |
@@ -64,7 +64,7 @@ Payload records live in `core` under
 | Anchor markers (`AnchorMarkerPayload`) | ✅ `PdfAnchorMarkerRenderHandler` + `PdfInternalLinkWriter` | ✅ `PptxAnchorMarkerRenderHandler` + `PptxNavigationWriter` (slide-jump hyperlinks resolved after all fragments, so forward references work) | ❌ |
 | Bookmark markers (`BookmarkMarkerPayload`) | ✅ `PdfBookmarkMarkerRenderHandler` + `PdfBookmarkOutlineWriter` | ⚠️ `PptxBookmarkMarkerRenderHandler` + `PptxNavigationWriter` (PPTX has no outline tree — the first bookmark on a page names its slide, further bookmarks on the same page are dropped with a debug note) | ❌ |
 | Alpha / opacity | ✅ `PdfAlphaSupport` (`PDExtendedGraphicsState` on every surface — shape fills/strokes, text runs, lines, side borders, table paint) | ✅ native `<a:alpha>` via POI on every surface — fills, strokes, text runs, table paint | ❌ |
-| Text decorations — underline / strikethrough (`DocumentTextDecoration`) | ✅ `PdfTextDecorations` (em-proportional marks: underline −0.10 em, strikethrough +0.28 em, thickness 0.05 em) | ✅ `PptxTextFrames.applyStyle` (PowerPoint draws its own marks — sub-point placement differences vs the PDF's constants) | ❌ |
+| Text decorations — underline / strikethrough (`DocumentTextDecoration`) | ✅ `PdfTextDecorations` (em-proportional marks: underline −0.10 em, strikethrough +0.28 em, thickness 0.05 em) | ✅ `PptxTextFrames.applyStyle` (PowerPoint draws its own marks — sub-point placement differences vs the PDF's constants) | ⚠️ `DocxSemanticBackend.applyStyle` (underline maps to Word's single underline; `STRIKETHROUGH` is dropped) |
 
 ## Navigation and interactivity
 

--- a/render-docx/README.md
+++ b/render-docx/README.md
@@ -35,8 +35,34 @@ try (var doc = GraphCompose.document().create()) {
 }
 ```
 
-DOCX maps the semantic node graph, not the fixed PDF layout — coverage is narrower than the
-PDF backend.
+## What it maps, and what it does not
+
+DOCX walks the **semantic node graph**, not the fixed PDF layout — Word owns the flow, so
+the page geometry the PDF backend resolves is deliberately ignored. Shapes, gradients,
+clips, transforms and alpha have no DOCX counterpart by design; a document that draws with
+them exports its text and tables, not its drawing.
+
+What maps: paragraphs (runs, alignment), block images (`STRETCH` / `CONTAIN` / `COVER`),
+table rows including row and column spans, and document metadata. Run styling carries font
+family, size, colour, bold, italic and underline.
+
+Beyond geometry, these are **not implemented** even though Word itself can express them —
+check the list before you promise a `.docx` to a reader:
+
+- **Hyperlinks are dropped**, external and internal alike; the link text survives as plain text.
+- **No bookmarks and no navigation outline.**
+- **No repeating headers or footers**, and no watermark layer.
+- **`STRIKETHROUGH` is dropped** — the other decorations map.
+- **No barcodes or QR codes**, and no inline images or code/badge chips inside a paragraph.
+- **Per-run styling in a mixed-style paragraph is flattened.** Every run in a `RichText`
+  paragraph is written with the paragraph's style, so a bold or accent-coloured segment
+  loses its own styling; the text itself is kept.
+- **Multi-section documents export through the fixed-layout backends only** —
+  `renderSections` is not part of the semantic path.
+- **Output is not byte-deterministic**: rendering twice does not produce identical files.
+
+Per-capability detail, with the implementing class for every supported cell:
+[backend capability matrix](../docs/architecture/backend-capability-matrix.md).
 
 ## Install
 


### PR DESCRIPTION
## Why

The DOCX page stated its limits in one sentence — *"coverage is narrower than the PDF backend"* — and the root README's support table named four dropped drawing kinds (`shape`, `line`, `ellipse`, `barcode`). Those are the geometry drops, and they are the ones a reader can predict: Word owns the flow, so fixed-layout drawing has nowhere to go.

Everything a Word reader would actually be **surprised** by went unmentioned on both pages. Verified against `DocxSemanticBackend`:

- **Hyperlinks are dropped entirely** — zero hyperlink code in the module. `InlineTextRun` carries a `linkTarget`; `writeParagraph` never reads it. The label text survives, the destination does not.
- **No bookmarks, no outline, no headers/footers, no watermark** — no `createHeader`/`createFooter`/bookmark call anywhere in the module.
- **Per-run styling is flattened.** `writeParagraph` calls `applyStyle(docRun, node.textStyle())` — the *paragraph's* style — for every run, so a bold or accent-coloured segment inside a `RichText` paragraph exports in the base style.
- **`STRIKETHROUGH` is dropped** — `applyStyle` handles `BOLD` / `ITALIC` / `BOLD_ITALIC` / `UNDERLINE` and lets the rest fall through `default -> {}`.

## Two matrix cells were wrong in opposite directions

| Row | Was | Now | Evidence |
|---|---|---|---|
| Text decorations | ❌ | ⚠️ | `DocxSemanticBackend.applyStyle` maps `UNDERLINE` to Word's single underline; only `STRIKETHROUGH` falls through |
| Paragraph — lines, runs, alignment | ✅ | ⚠️ | runs lose their own `textStyle` and `linkTarget` |

The first understated the backend, the second overstated it. Both are single symbols standing in for a mixed reality.

## Core's bring-your-own-backend route did not work as written

`core/README.md` offered *"add `graph-compose-render-pdf`, or implement the `FixedLayoutBackendProvider` SPI"*. That SPI alone is not enough: `DocumentSession`'s constructor calls `refreshMeasurementServices()` → `BackendProviders.fontMetrics()`, which throws `MissingBackendException` when nothing publishes a `FontMetricsProvider` — and `render-pdf` is the only shipped artifact that does. So a custom backend built to that instruction fails at `create()`, before any render call. The page now names both halves of the SPI, and says the failure happens at `create()` rather than at render time.

`render-docx/README.md` and `scripts/release-smoke/README.md` already stated this correctly; core's page was the one that did not.

## Verified clean

`render-pdf`, `wrapper`, `bundle`, `templates`, `testing`, `examples`, `qa`, `web`, `benchmarks`, `fonts`, `emoji`, `docs`, `docs/recipes`, `release-smoke`, and both template guides. The `testing` snippet resolves to the real `assertMatches(LayoutSnapshot, String)` overload; PDF's one non-✅ matrix row is `n/a` (raster-slide mode, where the PDF raster *is* the source), so "full DSL coverage" holds; version pins are consistent at the pre-cut `2.0.0` with fonts/emoji on their independent `1.0.0`; `docs/templates/v1-classic/` is correctly marked archived.

## Verification

`./mvnw -B -ntp clean verify` over the eight-module reactor — BUILD SUCCESS, 0 failures. `DocumentationSnippetCompileTest` + `DocumentationExamplesTest` re-run against the final file state — 16 tests, 0 failures.