### PR TITLE
docs: bring the release-facing surfaces up to 2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </p>
 
 > **Release status** &mdash;
-> 🟢 **Latest stable**: [v2.0.0](https://github.com/DemchaAV/GraphCompose/releases/tag/v2.0.0) &mdash; the **module-first** release: the engine is now a lean `graph-compose-core` with opt-in `render-pdf` / `render-docx` backends, while `graph-compose` stays a drop-in for PDF. **[Migrating to 2.0 &darr;](docs/migration/v2.0.0-modules.md)**
+> 🟢 **Latest stable**: [v2.1.0](https://github.com/DemchaAV/GraphCompose/releases/tag/v2.1.0) &mdash; the **PowerPoint** release: `graph-compose-render-pptx` turns the same resolved layout into an editable deck &mdash; one page per slide, geometry-identical to the PDF, text and panels as native shapes. Ships as `@Beta`. **[What each backend supports &darr;](docs/architecture/backend-capability-matrix.md)**
 
 > &nbsp;·&nbsp; ⬆️ **Upgrading from 1.x?** `graph-compose` stays a drop-in for PDF with no code change; see the [2.0 modules migration guide](./docs/migration/v2.0.0-modules.md)
 > &nbsp;·&nbsp; See [API stability policy](./docs/api-stability.md) for tier definitions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ Security fixes are issued for the latest minor release. Older minors do not rece
 
 | Version | Supported |
 |---------|-----------|
-| 1.9.x   | Yes — actively patched |
-| < 1.9   | No — upgrade required (see [CHANGELOG.md](CHANGELOG.md) for per-version migration notes) |
+| 2.1.x   | Yes — actively patched |
+| < 2.1   | No — upgrade required (see [CHANGELOG.md](CHANGELOG.md) for per-version migration notes, and the [2.0 modules migration guide](docs/migration/v2.0.0-modules.md) for the 1.x → 2.x step) |
 
 ## Reporting a vulnerability
 

--- a/web/index.html
+++ b/web/index.html
@@ -76,11 +76,11 @@
         "featureList": [
           "Semantic node tree DSL (ParagraphNode, TableNode, SectionNode, LayerStackNode, CanvasLayerNode)",
           "Atomic pagination with row-by-row table splitting",
-          "14 CV presets and 14 letter pairs out of the box",
-          "Theme tokens via BusinessTheme.modern() / classic() / executive()",
+          "16 CV presets and 15 matching cover letters out of the box",
+          "Theme tokens via BrandTheme.modernProfessional() / executive() / boxedClassic()",
           "Markdown-aware bodies (bold, italic) in every paragraph and list block",
-          "PDFBox-backed render pipeline plus a DOCX backend for editable output",
-          "819-test verify gate with layout snapshots and pixel-diff visual parity"
+          "PDFBox-backed render pipeline, an editable PowerPoint backend geometry-identical to the PDF, and a semantic DOCX backend",
+          "Full-reactor verify gate with layout snapshots and pixel-diff visual parity"
         ]
       },
       {
@@ -172,6 +172,7 @@
         <h1 id="hero-title">Java PDF layout engine for structured business documents.</h1>
         <p class="hero-lead">Describe documents. Render polished PDFs. A semantic layout engine for Java services that need <b>structured, paginated, theme-driven</b> output &mdash; CVs, invoices, proposals, reports.</p>
         <p class="hero-text">No drawing API. No pixel arithmetic. You compose <code>ParagraphNode</code>, <code>TableNode</code>, <code>SectionNode</code>; GraphCompose handles measurement, pagination, fonts, and PDFBox rendering.</p>
+        <p class="hero-text">The same resolved layout also renders to an <b>editable PowerPoint deck</b> &mdash; one page per slide, geometry-identical to the PDF, text and panels as native shapes. Opt in with <code>graph-compose-render-pptx</code> (<code>@Beta</code>).</p>
         <div class="hero-actions">
           <a class="button button-primary" href="#showcase">Browse Examples</a>
           <a class="button button-secondary" href="https://github.com/DemchaAV/GraphCompose">Source on GitHub</a>
@@ -212,12 +213,12 @@
           <p>Tables split row-by-row, rows are atomic, layer stacks atomic. No manual page math.</p>
         </div>
         <div>
-          <h3>14 CV presets, 14 letter pairs</h3>
-          <p>Every preset is one final class with a one-liner <code>create(BusinessTheme)</code> factory.</p>
+          <h3>16 CV presets, 15 matching letters</h3>
+          <p>Every preset is one final class with a one-liner <code>create(BrandTheme)</code> factory.</p>
         </div>
         <div>
           <h3>Tested at every layer</h3>
-          <p>819 green tests, layout snapshots per preset, pixel-diff visual parity gate, public-API leak guards.</p>
+          <p>A full-reactor verify gate on every push: layout snapshots per preset, pixel-diff visual parity, public-API leak guards.</p>
         </div>
       </div>
     </section>
@@ -286,7 +287,7 @@
 
           <h3 id="templates-section">Templates</h3>
 
-          <h4>CV (14 presets)</h4>
+          <h4>CV</h4>
           <ul>
             <li><a href="showcase/pdf/templates/cv/cv-modern-professional-v2.pdf">Modern Professional CV</a></li>
             <li><a href="showcase/pdf/templates/cv/cv-nordic-clean-v2.pdf">Nordic Clean CV</a></li>
@@ -304,7 +305,7 @@
             <li><a href="showcase/pdf/templates/cv/cv-monogram-sidebar-v2.pdf">Monogram Sidebar CV</a></li>
           </ul>
 
-          <h4>Cover Letter (14 paired layouts)</h4>
+          <h4>Cover Letter</h4>
           <ul>
             <li><a href="showcase/pdf/templates/coverletter/cover-letter-modern-professional-v2.pdf">Cover Letter (canonical)</a></li>
             <li><a href="showcase/pdf/templates/coverletter/cover-letter-modern-professional-v2.pdf">Modern Professional letter</a></li>
@@ -359,7 +360,7 @@
       <ol class="pipeline" aria-label="Document pipeline">
         <li><strong>Semantic DSL.</strong> You build a tree of <code>ParagraphNode</code>, <code>TableNode</code>, <code>SectionNode</code>, <code>LayerStackNode</code>, <code>CanvasLayerNode</code>.</li>
         <li><strong>Layout pass.</strong> The engine resolves measurements, pagination, decoration, overlays. Output is a <code>LayoutGraph</code> &mdash; geometry only, no draw calls.</li>
-        <li><strong>Render backend.</strong> The <code>FixedLayoutBackend</code> consumes placed fragments. Default: <code>PdfFixedLayoutBackend</code> via PDFBox. DOCX backend exists for editable output.</li>
+        <li><strong>Render backend.</strong> The <code>FixedLayoutBackend</code> consumes placed fragments. Default: <code>PdfFixedLayoutBackend</code> via PDFBox. <code>PptxFixedLayoutBackend</code> consumes the same fragments, so a deck is geometry-identical to the PDF by construction. A semantic DOCX backend maps the node tree instead, with much narrower coverage.</li>
       </ol>
     </section>
 
@@ -379,7 +380,7 @@
         </article>
         <article class="feature-card">
           <h3>Theme tokens, not magic numbers</h3>
-          <p><code>BusinessTheme.modern()</code> / <code>.classic()</code> / <code>.executive()</code> set palette, typography, table styles. Override one or all.</p>
+          <p><code>BrandTheme.modernProfessional()</code> / <code>.executive()</code> / <code>.boxedClassic()</code> set palette, typography, table styles. Override one or all. Ships in <code>graph-compose-templates</code>.</p>
         </article>
         <article class="feature-card">
           <h3>Markdown-aware bodies</h3>


### PR DESCRIPTION
## Why

Three pages a visitor reaches before they ever see code, all describing an earlier release. None is rewritten by `cut-release.ps1` — the script owns version *tokens* (poms, install snippets, the hero badge, JSON-LD `softwareVersion`), and every claim below is prose it deliberately leaves alone.

## README

The stable-release banner named v2.0.0 and its module split. It now names v2.1.0 and what the release is actually about, pointing at the capability matrix instead of the 2.0 migration guide — which the README still links from six other places, so nothing is lost.

## SECURITY.md

The supported-versions table said **`1.9.x` — actively patched**. It had stayed there across two majors, while the sentence directly above it says fixes go to the latest minor release. The table said one thing and the policy said another.

## The showcase site

**PowerPoint appeared nowhere on it** — zero mentions — even though the gallery has been serving decks since the twin examples landed, and five cards already render a "Get PPTX" button from the manifest. The hero, the pipeline description, and the JSON-LD `featureList` all described a PDF-only engine.

**It told visitors to call an API they cannot obtain.** `BusinessTheme.modern()` appeared in the feature grid *and* in the JSON-LD feature list. That type ships only in the `examples` module, which is not published — and [README.md:96](README.md) has stated since 2.0 that `BusinessTheme` is gone and names its replacement. The project's two public faces contradicted each other on the theming entry point. Replaced with the real one, `BrandTheme` from `graph-compose-templates`, using factories that exist.

**Counts:**

| Claim | Reality |
|---|---|
| "14 CV presets and 14 letter pairs" | 16 CV presets, 15 with a matching cover letter (`MinimalUnderlined` has none) |
| "Cover Letter (14 paired layouts)" heading | over a `<noscript>` list of **five** entries |
| "819 green tests" | long past; the reactor is far larger |

The two `<noscript>` headers now describe the selection they head instead of claiming a catalogue total, and the test count is replaced by the gate it stood for so it cannot rot again. `50+ runnable examples` is left as-is — the manifest carries 87, so it is true and conservative.

## Deliberately not changed

The page `<title>`, `<h1>`, and `<meta name="description">` still read "Java PDF layout engine". PDF is the production backend and PPTX ships `@Beta`, so the one-line positioning is a maintainer call rather than a correctness fix — same reason the GitHub repository description and topics are untouched.

## Verification

`./mvnw -B -ntp clean verify` over the eight-module reactor — BUILD SUCCESS, 0 failures, `VersionConsistencyGuardTest` green (12 tests). Site served locally and re-read after the edits: no console errors, every one of the 39 `showcase/` links resolves on disk, no stale string survives in the rendered DOM, PPTX now appears 9 times, and the 5 "Get PPTX" gallery buttons match the 5 manifest entries.