### PR TITLE
fix(pptx): take the face from the decoration for standard-14 names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,15 @@ shade), while others lose something the format cannot carry — see Known limita
 
 ### Fixed
 
+- **PPTX text no longer overruns the frame the engine measured for it.** A span that
+  named a standard-14 style variant — `Helvetica-Bold`, `Times-Italic` and their
+  siblings — travelled to PowerPoint as a bold or italic run flag. Those names are
+  family aliases: the engine resolves each to its regular base and takes the real face
+  from the span's decoration, so the layout had measured the regular metrics. The viewer
+  then drew a face about 6% wider than its slot, which pushed a chip label past its card
+  and closed the gap between two words of a rich-text heading until they read as one.
+  Run flags now follow the decoration for those families, so a deck renders the same
+  face the PDF does; a binary family still carries its face in its own name.
 - **A large clipped region in a PPTX deck is no longer downscaled.** The raster scale
   was capped only from above, so a clip box wider than 2048 pt rasterized *below*
   native size — an A0-scale composite landed near 44 DPI and read as visibly blurry,

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 </p>
 
 > **Release status** &mdash;
-> 🟢 **Latest stable**: [v2.0.0](https://github.com/DemchaAV/GraphCompose/releases/tag/v2.0.0) &mdash; the **module-first** release: the engine is now a lean `graph-compose-core` with opt-in `render-pdf` / `render-docx` backends, while `graph-compose` stays a drop-in for PDF. **[Migrating to 2.0 &darr;](docs/migration/v2.0.0-modules.md)**
+> 🟢 **Latest stable**: [v2.1.0](https://github.com/DemchaAV/GraphCompose/releases/tag/v2.1.0) &mdash; the **PowerPoint** release: `graph-compose-render-pptx` turns the same resolved layout into an editable deck &mdash; one page per slide, geometry-identical to the PDF, text and panels as native shapes. Ships as `@Beta`. **[What each backend supports &darr;](docs/architecture/backend-capability-matrix.md)**
 
 > &nbsp;·&nbsp; ⬆️ **Upgrading from 1.x?** `graph-compose` stays a drop-in for PDF with no code change; see the [2.0 modules migration guide](./docs/migration/v2.0.0-modules.md)
 > &nbsp;·&nbsp; See [API stability policy](./docs/api-stability.md) for tier definitions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,8 @@ Security fixes are issued for the latest minor release. Older minors do not rece
 
 | Version | Supported |
 |---------|-----------|
-| 1.9.x   | Yes — actively patched |
-| < 1.9   | No — upgrade required (see [CHANGELOG.md](CHANGELOG.md) for per-version migration notes) |
+| 2.1.x   | Yes — actively patched |
+| < 2.1   | No — upgrade required (see [CHANGELOG.md](CHANGELOG.md) for per-version migration notes, and the [2.0 modules migration guide](docs/migration/v2.0.0-modules.md) for the 1.x → 2.x step) |
 
 ## Reporting a vulnerability
 

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxFontMapping.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxFontMapping.java
@@ -98,8 +98,7 @@ public final class PptxFontMapping {
         if (decoration == TextDecoration.BOLD || decoration == TextDecoration.BOLD_ITALIC) {
             return true;
         }
-        return style.fontName() != null
-                && style.fontName().name().toLowerCase(Locale.ROOT).contains("bold");
+        return nameCarriesStyle(style.fontName(), "bold");
     }
 
     /** Returns whether the run selects an italic face. */
@@ -108,8 +107,32 @@ public final class PptxFontMapping {
         if (decoration == TextDecoration.ITALIC || decoration == TextDecoration.BOLD_ITALIC) {
             return true;
         }
-        String name = style.fontName() == null ? "" : style.fontName().name().toLowerCase(Locale.ROOT);
-        return name.contains("italic") || name.contains("oblique");
+        return nameCarriesStyle(style.fontName(), "italic")
+                || nameCarriesStyle(style.fontName(), "oblique");
+    }
+
+    /**
+     * Reports whether a font name's own style suffix should become a run flag.
+     *
+     * <p>Only binary families carry their face in the name. The standard-14
+     * PostScript variants — {@code Helvetica-Bold}, {@code Times-Italic},
+     * {@code Courier-BoldOblique} and their siblings — are <em>family
+     * aliases</em>: the engine resolves each to its regular base family and
+     * then picks the real face from the span's {@link TextDecoration}, so a
+     * span that names one of them without a decoration is measured with the
+     * regular metrics. Turning the suffix into a run flag would ask the viewer
+     * for a bold or italic face the layout never measured, and the placed text
+     * would render wider than the frame the engine sized for it.</p>
+     *
+     * @param fontName logical document font, may be {@code null}
+     * @param token lowercase style token to look for
+     * @return {@code true} when the name may contribute the flag
+     */
+    private static boolean nameCarriesStyle(FontName fontName, String token) {
+        if (fontName == null || standardReplacementFor(fontName) != null) {
+            return false;
+        }
+        return fontName.name().toLowerCase(Locale.ROOT).contains(token);
     }
 
     static boolean isUnderline(TextStyle style) {

--- a/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxFontMappingTest.java
+++ b/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxFontMappingTest.java
@@ -36,15 +36,46 @@ class PptxFontMappingTest {
     }
 
     @Test
-    void combinesDecorationWithFaceSuffixes() {
-        TextStyle boldFace = new TextStyle(FontName.HELVETICA_BOLD, 12,
-                TextDecoration.DEFAULT, Color.BLACK);
+    void decorationDrivesTheFace() {
         TextStyle decorated = new TextStyle(FontName.HELVETICA, 12,
                 TextDecoration.BOLD_ITALIC, Color.BLACK);
 
-        assertThat(PptxFontMapping.isBold(boldFace)).isTrue();
-        assertThat(PptxFontMapping.isItalic(boldFace)).isFalse();
         assertThat(PptxFontMapping.isBold(decorated)).isTrue();
         assertThat(PptxFontMapping.isItalic(decorated)).isTrue();
+    }
+
+    /**
+     * The standard-14 style variants are family aliases: the engine resolves
+     * {@code Helvetica-Bold} to the Helvetica family and takes the face from
+     * the decoration, so a span naming one without a decoration is measured
+     * with the regular metrics. Claiming the flag here would make the viewer
+     * draw a wider face than the frame was sized for.
+     */
+    @Test
+    void standard14FaceSuffixDoesNotBecomeARunFlag() {
+        TextStyle aliasedBold = new TextStyle(FontName.HELVETICA_BOLD, 12,
+                TextDecoration.DEFAULT, Color.BLACK);
+        TextStyle aliasedOblique = new TextStyle(FontName.COURIER_BOLD_OBLIQUE, 12,
+                TextDecoration.DEFAULT, Color.BLACK);
+
+        assertThat(PptxFontMapping.isBold(aliasedBold)).isFalse();
+        assertThat(PptxFontMapping.isItalic(aliasedBold)).isFalse();
+        assertThat(PptxFontMapping.isBold(aliasedOblique)).isFalse();
+        assertThat(PptxFontMapping.isItalic(aliasedOblique)).isFalse();
+    }
+
+    /**
+     * A binary family keeps its own name and is measured as itself, so its
+     * suffix is the only signal of the face and must still travel as a flag.
+     */
+    @Test
+    void binaryFamilySuffixStillCarriesTheFace() {
+        TextStyle bold = new TextStyle(FontName.of("Acme-Sans-Bold"), 12,
+                TextDecoration.DEFAULT, Color.BLACK);
+        TextStyle italic = new TextStyle(FontName.of("Acme-Sans-Italic"), 12,
+                TextDecoration.DEFAULT, Color.BLACK);
+
+        assertThat(PptxFontMapping.isBold(bold)).isTrue();
+        assertThat(PptxFontMapping.isItalic(italic)).isTrue();
     }
 }

--- a/web/index.html
+++ b/web/index.html
@@ -76,11 +76,11 @@
         "featureList": [
           "Semantic node tree DSL (ParagraphNode, TableNode, SectionNode, LayerStackNode, CanvasLayerNode)",
           "Atomic pagination with row-by-row table splitting",
-          "14 CV presets and 14 letter pairs out of the box",
-          "Theme tokens via BusinessTheme.modern() / classic() / executive()",
+          "16 CV presets and 15 matching cover letters out of the box",
+          "Theme tokens via BrandTheme.modernProfessional() / executive() / boxedClassic()",
           "Markdown-aware bodies (bold, italic) in every paragraph and list block",
-          "PDFBox-backed render pipeline plus a DOCX backend for editable output",
-          "819-test verify gate with layout snapshots and pixel-diff visual parity"
+          "PDFBox-backed render pipeline, an editable PowerPoint backend geometry-identical to the PDF, and a semantic DOCX backend",
+          "Full-reactor verify gate with layout snapshots and pixel-diff visual parity"
         ]
       },
       {
@@ -172,6 +172,7 @@
         <h1 id="hero-title">Java PDF layout engine for structured business documents.</h1>
         <p class="hero-lead">Describe documents. Render polished PDFs. A semantic layout engine for Java services that need <b>structured, paginated, theme-driven</b> output &mdash; CVs, invoices, proposals, reports.</p>
         <p class="hero-text">No drawing API. No pixel arithmetic. You compose <code>ParagraphNode</code>, <code>TableNode</code>, <code>SectionNode</code>; GraphCompose handles measurement, pagination, fonts, and PDFBox rendering.</p>
+        <p class="hero-text">The same resolved layout also renders to an <b>editable PowerPoint deck</b> &mdash; one page per slide, geometry-identical to the PDF, text and panels as native shapes. Opt in with <code>graph-compose-render-pptx</code> (<code>@Beta</code>).</p>
         <div class="hero-actions">
           <a class="button button-primary" href="#showcase">Browse Examples</a>
           <a class="button button-secondary" href="https://github.com/DemchaAV/GraphCompose">Source on GitHub</a>
@@ -212,12 +213,12 @@
           <p>Tables split row-by-row, rows are atomic, layer stacks atomic. No manual page math.</p>
         </div>
         <div>
-          <h3>14 CV presets, 14 letter pairs</h3>
-          <p>Every preset is one final class with a one-liner <code>create(BusinessTheme)</code> factory.</p>
+          <h3>16 CV presets, 15 matching letters</h3>
+          <p>Every preset is one final class with a one-liner <code>create(BrandTheme)</code> factory.</p>
         </div>
         <div>
           <h3>Tested at every layer</h3>
-          <p>819 green tests, layout snapshots per preset, pixel-diff visual parity gate, public-API leak guards.</p>
+          <p>A full-reactor verify gate on every push: layout snapshots per preset, pixel-diff visual parity, public-API leak guards.</p>
         </div>
       </div>
     </section>
@@ -286,7 +287,7 @@
 
           <h3 id="templates-section">Templates</h3>
 
-          <h4>CV (14 presets)</h4>
+          <h4>CV</h4>
           <ul>
             <li><a href="showcase/pdf/templates/cv/cv-modern-professional-v2.pdf">Modern Professional CV</a></li>
             <li><a href="showcase/pdf/templates/cv/cv-nordic-clean-v2.pdf">Nordic Clean CV</a></li>
@@ -304,7 +305,7 @@
             <li><a href="showcase/pdf/templates/cv/cv-monogram-sidebar-v2.pdf">Monogram Sidebar CV</a></li>
           </ul>
 
-          <h4>Cover Letter (14 paired layouts)</h4>
+          <h4>Cover Letter</h4>
           <ul>
             <li><a href="showcase/pdf/templates/coverletter/cover-letter-modern-professional-v2.pdf">Cover Letter (canonical)</a></li>
             <li><a href="showcase/pdf/templates/coverletter/cover-letter-modern-professional-v2.pdf">Modern Professional letter</a></li>
@@ -359,7 +360,7 @@
       <ol class="pipeline" aria-label="Document pipeline">
         <li><strong>Semantic DSL.</strong> You build a tree of <code>ParagraphNode</code>, <code>TableNode</code>, <code>SectionNode</code>, <code>LayerStackNode</code>, <code>CanvasLayerNode</code>.</li>
         <li><strong>Layout pass.</strong> The engine resolves measurements, pagination, decoration, overlays. Output is a <code>LayoutGraph</code> &mdash; geometry only, no draw calls.</li>
-        <li><strong>Render backend.</strong> The <code>FixedLayoutBackend</code> consumes placed fragments. Default: <code>PdfFixedLayoutBackend</code> via PDFBox. DOCX backend exists for editable output.</li>
+        <li><strong>Render backend.</strong> The <code>FixedLayoutBackend</code> consumes placed fragments. Default: <code>PdfFixedLayoutBackend</code> via PDFBox. <code>PptxFixedLayoutBackend</code> consumes the same fragments, so a deck is geometry-identical to the PDF by construction. A semantic DOCX backend maps the node tree instead, with much narrower coverage.</li>
       </ol>
     </section>
 
@@ -379,7 +380,7 @@
         </article>
         <article class="feature-card">
           <h3>Theme tokens, not magic numbers</h3>
-          <p><code>BusinessTheme.modern()</code> / <code>.classic()</code> / <code>.executive()</code> set palette, typography, table styles. Override one or all.</p>
+          <p><code>BrandTheme.modernProfessional()</code> / <code>.executive()</code> / <code>.boxedClassic()</code> set palette, typography, table styles. Override one or all. Ships in <code>graph-compose-templates</code>.</p>
         </article>
         <article class="feature-card">
           <h3>Markdown-aware bodies</h3>


### PR DESCRIPTION
## Symptom

Two defects on the same slide of the engine deck, both PPTX-only — the PDF twin is correct:

- a rich-text heading rendered as **`GraphComposeEngine`**, the space between the two words gone;
- the **`Snapshot Tests`** chip label crossed the right border of its card.

## Cause

One bug behind both.

`FontLibrary.resolveBaseFont` maps the nine standard-14 style variants onto their regular base family — `Helvetica-Bold` → `Helvetica` — and `Font.fontType(TextDecoration)` then picks the real face from the span's **decoration**. Name selects the family, decoration selects the face. A span that names `Helvetica-Bold` with no decoration is therefore measured with **regular** metrics, and the PDF backend draws it with the regular program, because it resolves the face through the same call it measures with.

`PptxFontMapping.isBold` instead derived boldness from the font-name **string**, so the run reached PowerPoint with `b="true"`. The viewer honoured it and drew a face wider than the frame the engine had sized.

Measured on the deck's own text, Helvetica-Bold against Helvetica:

| Text | measured | drawn bold | over |
|---|---|---|---|
| `GraphCompose Engine` @13pt | 135.84 pt | 144.47 pt | +6.4% |
| `Snapshot Tests` @8.5pt | 59.06 pt | 63.29 pt | +7.2% |

Why one symptom looked like a lost space and the other like an overflow: an `addRich` span is placed as **one frame per word**, so `GraphCompose` was given a 91.85 pt box while bold needs 97.51 pt, and `Engine` starts 95.30 pt along — the overrun swallowed the 3.5 pt gap. A plain `.text(...)` paragraph is one frame with the space intact, so the chip simply ran 4.2 pt past its 63 pt slot and out of the card.

## Fix

Run flags follow the decoration for standard-14 families — the same rule the rest of the engine already uses. A binary family keeps its own name and is measured as itself, so `Acme-Sans-Bold` still contributes the flag.

## Verification

Deck regenerated and inspected in the OPC: the heading runs now carry `b="false"` with frames unchanged at `x=260.26 w=91.85` and `x=355.63 w=40.57`, and the chip label is `w=59.16` — matching the regular metric the layout measured. Opened in PowerPoint for Windows, exported slide 1, and compared against the PDF: the space is present and the chip label sits inside its card.

Full eight-module reactor `clean verify` — BUILD SUCCESS, 0 failures. `PptxFontMappingTest` gained a case pinning that an aliased name contributes no flag and a case keeping the binary-family behaviour; the previous case asserted the name-string rule without checking it against what the layout measured.

## Note for a follow-up, not in this PR

`fontName(FontName.HELVETICA_BOLD)` is a silent no-op for weight — it selects the family, and the text renders regular in **both** backends. `ChartDefaults`, `HeadingBarStyle`, `TimelineBuilder`, `TimelineMarker` and one preset use that form, as does much of `examples/`. Making the name select a bold face would change every existing PDF and every visual baseline, so it wants its own change rather than a release-week fix.