### PR TITLE
docs(pptx): surface font substitution and say how to avoid it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,8 +185,9 @@ shade), while others lose something the format cannot carry — see Known limita
 - **The examples now show the engine's warnings.** Their logging config silenced
   `com.demcha.compose` entirely, so a reader running a deck example never saw which
   fonts the viewer would substitute or which capability had degraded — the warnings
-  fired into a muted logger. Across all 87 documents the whole suite emits 14 lines,
-  since each warning is deduplicated per family or per kind for a render.
+  fired into a muted logger. The output stays short because every warning is
+  deduplicated before it is logged: a font substitution once per family per render, a
+  capability note once per kind for the process.
 - **`render-pptx` documents how to get a glyph-identical deck.** Geometry matches the
   PDF by construction, but glyphs are drawn by the viewer; the page now states the
   three cases — a standard-14 name travels as a metric-compatible viewer font with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,16 @@ shade), while others lose something the format cannot carry — see Known limita
 
 ### Documentation and examples
 
+- **The examples now show the engine's warnings.** Their logging config silenced
+  `com.demcha.compose` entirely, so a reader running a deck example never saw which
+  fonts the viewer would substitute or which capability had degraded — the warnings
+  fired into a muted logger. Across all 87 documents the whole suite emits 14 lines,
+  since each warning is deduplicated per family or per kind for a render.
+- **`render-pptx` documents how to get a glyph-identical deck.** Geometry matches the
+  PDF by construction, but glyphs are drawn by the viewer; the page now states the
+  three cases — a standard-14 name travels as a metric-compatible viewer font with
+  identical widths and different letterforms, an embeddable binary family travels as
+  itself, and a name-only family depends on the viewer having it installed.
 - **`TwinOutputExample`** — a single 16:9 page written once and emitted twice from the
   same session. The README gains a dual-output section showing the PDF render beside
   PowerPoint's own export of the generated slide, plus the deck open in PowerPoint with

--- a/examples/src/main/resources/logback.xml
+++ b/examples/src/main/resources/logback.xml
@@ -7,7 +7,7 @@
 
     <logger name="org.apache.pdfbox" level="WARN"/>
     <logger name="org.apache.fontbox" level="WARN"/>
-    <logger name="com.demcha.compose" level="OFF"/>
+    <logger name="com.demcha.compose" level="WARN"/>
 
     <root level="ERROR">
         <appender-ref ref="CONSOLE"/>

--- a/render-pptx/README.md
+++ b/render-pptx/README.md
@@ -67,9 +67,9 @@ the slide simply takes that size.
   [#413](https://github.com/DemchaAV/GraphCompose/issues/413).
 - **Glyphs are drawn by the viewer, not by GraphCompose.** Shape frames, line
   boxes and positions are fixed by the layout graph, but the actual glyph
-  rasterisation depends on the fonts installed on the viewing machine. Fonts are
-  embedded where the font's licensing bits allow it; otherwise PowerPoint
-  substitutes, and the backend logs which family was substituted.
+  rasterisation depends on the fonts available to the viewing machine. See
+  [Getting glyph-identical decks](#getting-glyph-identical-decks) for what that
+  costs and how to avoid it.
 - **Byte-for-byte reproducibility is opt-in.** The default path streams the deck
   with live timestamps. Pass
   `PptxFixedLayoutBackend.builder().deterministic(instant)` to pin the core
@@ -92,6 +92,40 @@ the slide simply takes that size.
   equivalent field.
 - **Multi-section documents** render into one deck; the sections must share a
   slide size.
+
+## Getting glyph-identical decks
+
+Geometry is identical to the PDF by construction — both backends consume the
+same resolved layout, and every line is pre-wrapped and absolutely placed, so
+PowerPoint can never reflow content. **Glyphs are the one thing PPTX cannot
+guarantee on its own**, because a deck names its fonts and the viewer draws
+them. Which of the three cases you land in depends on how the font reached the
+document, and the backend warns once per family for the two that are not exact:
+
+| How the font reached the document | In the deck | Glyphs |
+|---|---|---|
+| A standard-14 name (`FontName.HELVETICA`, `TIMES`, `COURIER`) | referenced as its metric-compatible viewer font — Arial, Times New Roman, Courier New | **widths identical, letterforms differ** |
+| A binary family whose licensing bits allow embedding | embedded in the deck | **identical everywhere** |
+| A family registered without binary sources, or one whose bits refuse embedding | referenced by name only | identical **if** the viewer has that font installed, otherwise the viewer substitutes |
+
+So for a deck that matches the PDF glyph for glyph, use a real font program
+rather than a PDF built-in — either a bundled family from `graph-compose-fonts`,
+or your own file registered on the session:
+
+```java
+try (DocumentSession document = GraphCompose.document()
+        .pageSize(DocumentPageSize.SLIDE_16_9)
+        .create()) {
+    document.registerFontFamily(myFamily);   // embedded when licensing allows
+    compose(document);
+    document.buildPptx(Path.of("deck.pptx"));
+}
+```
+
+Every substitution is announced at `WARN` under the key
+`render.pptx.font.substitution`, once per family per render, naming the font the
+document asked for and what the deck will reference instead. Embedded families
+log nothing — silence means the deck carries its own glyphs.
 
 ## When to depend on it
 


### PR DESCRIPTION
## Why

Geometry is identical to the PDF by construction. **Glyphs are the one thing a deck cannot guarantee on its own**, because it names its fonts and the viewer draws them. A reader needs to know that, and needs to know it is avoidable.

The backend already handles the hard half correctly: it warns under a single key `render.pptx.font.substitution`, and each of the four messages names the font asked for, what the deck will reference instead, and what to do about it. Embedded families stay silent, and `PptxFontSubstitutionWarningTest` pins both halves.

Two things stopped that reaching anyone.

## The examples had the engine's logger switched off

`examples/src/main/resources/logback.xml` carried `<logger name="com.demcha.compose" level="OFF"/>`. Running a deck example — the main way people meet this backend — showed nothing at all. The warnings were firing into a muted logger.

Raised to `WARN`. Measured on a full `GenerateAllExamples` run rather than guessed: **93 documents** (87 PDF, 5 PPTX, 1 DOCX) produce **113 console lines**, of which **18** are engine warnings:

| Warning | Lines |
|---|---|
| `render.pptx.font.substitution` | 11 |
| `glyph.missing` | 3 |
| `render.pptx.capability` | 1 |
| `docx.export.shape-container-fallback` / `chart-fallback` | 2 |
| `DocxSemanticBackend: dropping …` | 1 |

It stays that small because each warning is deduplicated before it is logged — a font substitution once per family per render (`PptxRenderEnvironment.substitutionWarned`, an instance field), a capability note once per kind for the process (`PptxCapabilityNotes.WARNED`, static). The deck from #450 emits exactly three lines: Helvetica, Courier, and the per-corner-radius note.

## The module page said it was logged, not what it costs

The old bullet ended at *"the backend logs which family was substituted"* — true, and useless to someone deciding what to do. There is now a **Getting glyph-identical decks** section stating the three cases a font can land in:

| How the font reached the document | In the deck | Glyphs |
|---|---|---|
| a standard-14 name (`HELVETICA`, `TIMES`, `COURIER`) | its metric-compatible viewer font — Arial, Times New Roman, Courier New | widths identical, letterforms differ |
| a binary family whose licensing bits allow embedding | embedded | identical everywhere |
| registered without binaries, or bits refuse embedding | referenced by name | identical only if the viewer has it installed |

with the takeaway spelled out: to match the PDF glyph for glyph, use a real font program — a bundled family from `graph-compose-fonts`, or your own registered with `registerFontFamily` — rather than a PDF built-in. The snippet follows the same shape as the page's existing first-deck example.

## Verification

Full eight-module reactor `clean verify` — BUILD SUCCESS, 0 failures. `GenerateAllExamples` run end to end with the new log level to produce the counts above; no example failed.

Note that the CHANGELOG entry deliberately carries no line count. Any number there is stale the next time an example lands, so it states the dedup rule instead.