### PR TITLE
chore(release): name the 2.1 line twinned

### DIFF
--- a/examples/src/main/resources/banner.properties
+++ b/examples/src/main/resources/banner.properties
@@ -3,8 +3,15 @@
 # `version` is filled by Maven resource filtering from the reactor
 # ${project.version} at build time (see examples/pom.xml <resources>), so the
 # rendered hero is never a hand-bumped literal and can never drift from the
-# release it was cut from. `codename` is the per-minor release name, set during
-# release prep. cut-release.ps1 re-renders the banner on every tag, stamping the
-# committed assets/readme/repository_showcase_render.png with both values.
+# release it was cut from. cut-release.ps1 re-renders
+# assets/readme/repository_showcase_render.png on every tag so that hero always
+# carries the version it was cut from.
+#
+# `codename` is the per-minor release name and is NOT derived from anything —
+# update it by hand during release prep. It is read only by EngineDeckExample
+# (title, section header, version block, and the footer on every slide); the
+# hero banner renderers do not use it. Nothing regenerates that deck's committed
+# asset, so a stale codename survives a release unnoticed — which is how it sat
+# on the 1.9 name through 2.0.
 version=@project.version@
-codename=navigable
+codename=twinned

--- a/examples/src/test/resources/layout-snapshots/flagships/engine-deck.json
+++ b/examples/src/test/resources/layout-snapshots/flagships/engine-deck.json
@@ -895,11 +895,11 @@
     "computedY" : 503.938,
     "placementX" : 570.0,
     "placementY" : 503.938,
-    "placementWidth" : 59.92,
+    "placementWidth" : 48.244,
     "placementHeight" : 12.95,
     "startPage" : 0,
     "endPage" : 0,
-    "contentWidth" : 59.92,
+    "contentWidth" : 48.244,
     "contentHeight" : 12.95,
     "margin" : {
       "top" : 0.0,


### PR DESCRIPTION
## Why

`examples/src/main/resources/banner.properties` has read `codename=navigable` since the **1.9 line** (`ef135bd2`) — a name that fit the release which added bookmarks and the document outline. It then shipped unchanged with 2.0, and was about to ship again with 2.1.

Nothing derives it and no guard covers it. That is the gap, not the name: `VersionConsistencyGuardTest.readmeBannerVersionDerivesFromProjectVersion` exists precisely because the *version* on that hero once drifted — its Javadoc names the incident, *"the drift that left the banner reading v1.8.0 while the repo was on v1.9.0"*. The line directly beneath it got no such protection and drifted the same way.

`twinned` is what 2.1 actually is: one session, two outputs, same geometry.

## The file's own comment was wrong

It claimed the release script re-renders the hero *"with both values"*. It stamps only the version — **neither `ReadmeBannerRenderer` nor `ReadmeBannerV2Renderer` reads the codename** (zero references in either). The codename is read by `EngineDeckExample` alone: the page title, the section header, the version block, and the footer on every slide. The comment now says that, and says the name is hand-maintained.

## What this PR deliberately does not do

**It does not refresh `assets/readme/examples/engine-deck.pdf`.** That asset is stale in its own right — it is still the **v1.8.0** render, carrying the codename `illustrative` — because `cut-release.ps1` regenerates `web/showcase/**` and the hero banner but nothing under `assets/readme/examples/**`.

Refreshing it now would be worse than leaving it: the deck's title and footer interpolate the raw `VERSION`, so a pre-cut render bakes `GraphCompose · v2.1.0-SNAPSHOT "twinned"` into a public, README-linked PDF. (The version *pill* is safe — `versionBlock()` strips the qualifier.) The refresh belongs after the version bump, and is now written into the release plan's pre-cut list with the exact command.

## Verification

Deck regenerated locally to confirm the value threads through: the pill reads `v2.1.0`, the codename tag reads `twinned`, and the footer reads `GraphCompose · v2.1.0-SNAPSHOT "twinned"` — the last of which is exactly why the artifact is not committed here.

Full eight-module reactor `clean verify` — BUILD SUCCESS, 0 failures, including `VersionConsistencyGuardTest` (which pins the `version` line and is indifferent to the codename).