### PR TITLE
fix(release-script): install render-pptx before regenerating the showcase

### DIFF
--- a/core/src/test/java/com/demcha/documentation/ReleaseScriptInstallListGuardTest.java
+++ b/core/src/test/java/com/demcha/documentation/ReleaseScriptInstallListGuardTest.java
@@ -1,0 +1,105 @@
+package com.demcha.documentation;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guards the hand-maintained module list that {@code cut-release.ps1} installs
+ * before it runs {@code ShowcaseSync}.
+ *
+ * <p>Step 4 of the release script regenerates {@code web/examples.json} by running
+ * {@code exec:java} in the examples module. By that point every train pom carries
+ * the just-bumped release version, which exists in no repository yet — so each
+ * sibling the examples module depends on at that version must have been installed
+ * into the local cache first. The script does that from a literal list.</p>
+ *
+ * <p>A module added to {@code examples/pom.xml} but not to that list fails the cut
+ * <em>mid-flight</em>, after the version bump has already rewritten every pom,
+ * README and the changelog date, leaving a dirty tree to unwind by hand. That is
+ * how {@code graph-compose-render-pptx} — which the examples gained for the PPTX
+ * twin examples — aborted a 2.1.0 cut. This test fails in CI instead.</p>
+ *
+ * <p>Only dependencies pinned to {@code ${graphcompose.version}} are checked. The
+ * independently-versioned companions ({@code graph-compose-fonts},
+ * {@code graph-compose-emoji}) keep their own release lines and resolve from
+ * Central, so the cut never has to build them.</p>
+ *
+ * <p>The reverse direction is deliberately not asserted: the list legitimately
+ * carries modules the examples reach only transitively — {@code render-pdf} comes
+ * in through the {@code graph-compose} wrapper, and it too is bumped, so it too
+ * must be installed.</p>
+ */
+class ReleaseScriptInstallListGuardTest {
+
+    private static final Path PROJECT_ROOT = RepoRoot.get();
+
+    /** A {@code graph-compose-*} dependency pinned to the train version. */
+    private static final Pattern TRAIN_DEPENDENCY = Pattern.compile(
+            "<artifactId>(graph-compose[a-z-]*)</artifactId>\\s*"
+                    + "<version>\\$\\{graphcompose\\.version}</version>");
+
+    /** The literal PowerShell array the script installs from. */
+    private static final Pattern INSTALL_LIST = Pattern.compile(
+            "\\$exampleSnapshotSiblings\\s*=\\s*@\\(([^)]*)\\)", Pattern.DOTALL);
+
+    @Test
+    void releaseScriptInstallsEveryTrainSiblingTheExamplesDependOn() throws IOException {
+        Set<String> required = examplesTrainSiblings();
+
+        assertThat(required)
+                .describedAs("sanity: the examples module must depend on at least one train sibling — "
+                        + "an empty set would make this guard pass against anything")
+                .isNotEmpty();
+        assertThat(scriptInstallList())
+                .describedAs("cut-release.ps1 must keep $exampleSnapshotSiblings in lockstep with "
+                        + "examples/pom.xml — a train sibling missing here aborts Step 4 of the cut "
+                        + "after the version bump has already rewritten the tree")
+                .containsAll(required);
+    }
+
+    /**
+     * Artifact ids of the train-versioned {@code graph-compose-*} siblings the
+     * examples depend on, ignoring the {@code <parent>} coordinate.
+     */
+    private static Set<String> examplesTrainSiblings() throws IOException {
+        String pom = Files.readString(PROJECT_ROOT.resolve("examples/pom.xml"))
+                .replaceAll("(?s)<parent>.*?</parent>", "");
+        Set<String> ids = new LinkedHashSet<>();
+        Matcher matcher = TRAIN_DEPENDENCY.matcher(pom);
+        while (matcher.find()) {
+            ids.add(matcher.group(1));
+        }
+        return ids;
+    }
+
+    /**
+     * Artifact ids the script installs, derived from the pom paths in its list
+     * ({@code render-pptx/pom.xml} → {@code graph-compose-render-pptx}, and the
+     * directory {@code wrapper/} → the bare {@code graph-compose} coordinate).
+     */
+    private static Set<String> scriptInstallList() throws IOException {
+        String script = Files.readString(PROJECT_ROOT.resolve("scripts/cut-release.ps1"));
+        Matcher list = INSTALL_LIST.matcher(script);
+        assertThat(list.find())
+                .describedAs("cut-release.ps1 no longer declares $exampleSnapshotSiblings — this guard "
+                        + "is reading a list that moved, so it is no longer guarding anything")
+                .isTrue();
+
+        Set<String> ids = new LinkedHashSet<>();
+        Matcher path = Pattern.compile("'([^']+)/pom\\.xml'").matcher(list.group(1));
+        while (path.find()) {
+            String module = path.group(1);
+            ids.add(module.equals("wrapper") ? "graph-compose" : "graph-compose-" + module);
+        }
+        return ids;
+    }
+}

--- a/scripts/cut-release.ps1
+++ b/scripts/cut-release.ps1
@@ -514,8 +514,14 @@ function Run-ShowcaseSync {
     # as a single literal argument.
     $execProp = '"-Dexec.mainClass=com.demcha.examples.support.ShowcaseSync"'
     # The examples module depends on these bumped SNAPSHOT siblings (not on
-    # Central); each must be installed before exec:java can resolve them.
-    $exampleSnapshotSiblings = @('render-pdf/pom.xml', 'wrapper/pom.xml', 'render-docx/pom.xml', 'templates/pom.xml', 'testing/pom.xml')
+    # Central); each must be installed before exec:java can resolve them. Keep
+    # this list in lockstep with examples/pom.xml — a module the examples depend
+    # on but that is missing here fails Step 4 with "Could not find artifact
+    # …:<new version>", because the just-bumped version exists nowhere yet.
+    # ReleaseScriptInstallListGuardTest fails the build if the two drift apart.
+    # render-pptx must follow render-pdf: it depends on it at compile scope.
+    $exampleSnapshotSiblings = @('render-pdf/pom.xml', 'wrapper/pom.xml', 'render-docx/pom.xml',
+                                 'render-pptx/pom.xml', 'templates/pom.xml', 'testing/pom.xml')
     if ($DryRun) {
         Write-Host "    [DRY RUN] $mvnw -B -ntp -DskipTests install -pl :graph-compose-core" -ForegroundColor Yellow
         foreach ($modulePom in $exampleSnapshotSiblings) {


### PR DESCRIPTION
## What happened

The 2.1.0 cut **aborted at Step 4**:

```
[ERROR] Could not resolve dependencies for project io.github.demchaav:graph-compose-examples:jar:2.1.0
[ERROR] dependency: io.github.demchaav:graph-compose-render-pptx:jar:2.1.0 (compile)
[ERROR] 	Could not find artifact … in central
Exception: ShowcaseSync failed (exit 1)
```

No commit and no tag were created — but by that point Step 1 had already rewritten all 13 poms, the root and eight module READMEs, `web/index.html`, the release-smoke defaults, and Step 2 had dated the changelog. 29 modified files to unwind by hand, at the exact moment a release is least forgiving.

## Why

`cut-release.ps1:518` installs the examples module's siblings from a literal list so that `ShowcaseSync` can resolve them at the just-bumped version, which exists in no repository yet:

```powershell
$exampleSnapshotSiblings = @('render-pdf/pom.xml', 'wrapper/pom.xml', 'render-docx/pom.xml',
                             'templates/pom.xml', 'testing/pom.xml')
```

The list predates `render-pptx`. `examples/pom.xml` took a compile dependency on it for the PPTX twin examples, and nothing connected the two. The failure cannot surface before a cut, because it needs a version that only exists mid-cut.

`render-pptx` is inserted after `render-pdf`, which it depends on at compile scope.

## The guard

A literal list that must track another file will drift again — this is the second release-script list to do so. `ReleaseScriptInstallListGuardTest` derives the required set from `examples/pom.xml` and fails the build when the script does not cover it.

Two deliberate scoping decisions, both from what the pom actually says:

- **Only `${graphcompose.version}` dependencies count.** `graph-compose-fonts` and `graph-compose-emoji` sit on independent release lines (`${graphcompose.fonts.version}` / `${graphcompose.emoji.version}`) and resolve from Central, so a cut never builds them. An earlier draft matched every `graph-compose-*` artifactId and demanded those two plus the `<parent>` coordinate — wrong on all three.
- **The reverse direction is not asserted.** The list legitimately carries `render-pdf`, which the examples reach transitively through the `graph-compose` wrapper and which is bumped all the same. A subset assertion would have flagged it.

## Verification

`ReleaseScriptInstallListGuardTest` passes with the fix; reverting just the list entry turns it red, so it is driving the behaviour rather than restating it.

Dry-run across all three modes — the v1.6.5 lesson that a release step working in the default mode is not enough:

| Mode | Exceptions | Installs render-pptx |
|---|---|---|
| `-Version 2.1.0 -DryRun` | 0 | yes |
| `-Version 2.1.0 -DryRun -SkipShowcase` | 0 | no, as intended — the mode skips showcase entirely |
| `-PostReleaseOnly -DryRun` | 0 | yes |