### PR TITLE
docs(readme): show the PPTX backend, fix the architecture diagram, drop the dead star chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,13 +350,3 @@ See [CONTRIBUTING](./CONTRIBUTING.md) for the branch-routing table and the full 
 ## License
 
 MIT &mdash; see [`LICENSE`](./LICENSE).
-
-## Star History
-
-<a href="https://www.star-history.com/?repos=DemchaAV%2FGraphCompose&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=DemchaAV/GraphCompose&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=DemchaAV/GraphCompose&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=DemchaAV/GraphCompose&type=date&legend=top-left" />
- </picture>
-</a>

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
   <a href="https://github.com/DemchaAV/GraphCompose/releases/latest"><img src="https://img.shields.io/github/v/release/DemchaAV/GraphCompose?style=for-the-badge&label=Release" alt="Latest release"/></a>
   <a href="https://central.sonatype.com/artifact/io.github.demchaav/graph-compose"><img src="https://img.shields.io/maven-central/v/io.github.demchaav/graph-compose?style=for-the-badge&label=Maven%20Central" alt="Maven Central"/></a>
   <img src="https://img.shields.io/badge/Java-17%2B-orange?style=for-the-badge&logo=openjdk" alt="Java 17+"/>
-  <img src="https://img.shields.io/badge/PDFBox-3.0-red?style=for-the-badge" alt="PDFBox 3.0"/>
+  <img src="https://img.shields.io/badge/PDFBox-3.0-red?style=for-the-badge" alt="PDFBox 3.0 — PDF backend"/>
+  <img src="https://img.shields.io/badge/Apache%20POI-5.5-blueviolet?style=for-the-badge" alt="Apache POI 5.5 — PPTX and DOCX backends"/>
   <img src="https://img.shields.io/badge/License-MIT-blue?style=for-the-badge" alt="MIT License"/>
 </p>
 
@@ -291,7 +292,7 @@ flow.addAligned(HorizontalAlign.RIGHT, anyFixedNode);
 
 ## Architecture
 
-GraphCompose splits into a **public canonical surface** you author against (`com.demcha.compose.document.*`) and an **internal shared engine foundation** (`com.demcha.compose.engine.*`, marked `@Internal`) that resolves geometry, pagination, and rendering behind it. Since 2.0 that boundary is also a **packaging** boundary: the surface and engine ship in `graph-compose-core`, and each render backend is a separate module that registers through a `ServiceLoader` seam. You author intent; the engine resolves the rest.
+GraphCompose splits into a **public canonical surface** you author against (`com.demcha.compose.document.*`) and an **internal shared engine foundation** (`com.demcha.compose.engine.*`, marked `@Internal`) that resolves geometry, pagination, and rendering behind it. Since 2.0 that boundary is also a **packaging** boundary: the surface and engine ship in `graph-compose-core`, and each render backend is a separate module. The **fixed-layout** backends (PDF, PPTX) register through a `ServiceLoader` seam and consume the same resolved `LayoutGraph`, which is why a deck matches the PDF geometrically. The **semantic** DOCX exporter registers nothing — you name it directly, and it walks the node tree without a layout pass. You author intent; the engine resolves the rest.
 
 ```mermaid
 flowchart LR
@@ -300,7 +301,8 @@ flowchart LR
     C --> D["Engine foundation @Internal<br/>measure → paginate → place"]
     D --> E{ServiceLoader}
     E -->|render-pdf| F["PdfFixedLayoutBackend<br/>PDFBox"]
-    E -->|render-docx| G["DocxSemanticBackend<br/>POI"]
+    E -->|render-pptx| G["PptxFixedLayoutBackend<br/>POI · same LayoutGraph as the PDF"]
+    B -.->|render-docx · named directly| I["DocxSemanticBackend<br/>POI · no layout pass"]
     D -.->|layoutSnapshot| H["Deterministic snapshot<br/>(regression tests)"]
 ```
 


### PR DESCRIPTION
## The badge row

It credited **PDFBox 3.0** and nothing for the office formats. The release is about PowerPoint output, and the library that produces it appeared nowhere in the stack row. **Apache POI 5.5** now sits beside PDFBox — it backs both PPTX and DOCX, and it is pinned at `5.5.1` identically in `render-pptx/pom.xml:60` and `render-docx/pom.xml:60`.

The CI / Release / Maven Central badges are shields.io queries, so they move to 2.1.0 on their own once the tag publishes; only Java, PDFBox, POI and License are literals.

## The architecture diagram was wrong in two directions

```
E{ServiceLoader} -->|render-pdf|  PdfFixedLayoutBackend
E{ServiceLoader} -->|render-docx| DocxSemanticBackend      ← wrong
                                  PptxFixedLayoutBackend    ← absent
```

**DOCX is not discovered through the `ServiceLoader`.** `render-docx` publishes no service file at all — the only `META-INF/services` entries in the tree are `render-pdf` (`FixedLayoutBackendProvider` + `FontMetricsProvider`) and `render-pptx` (`FixedLayoutBackendProvider`). The semantic exporter is named directly by the caller: `session.export(new DocxSemanticBackend(), target)`. `scripts/release-smoke/README.md` already states this correctly; the diagram did not.

**PPTX was missing**, though it is the backend the seam actually discovers alongside PDF.

DOCX now branches off the **node tree** rather than the engine, because that is what it consumes: `SemanticBackend.export` takes a `DocumentGraph`, whose own Javadoc calls it the *"Semantic authoring tree for the v2 pipeline"*. It never sees a layout pass — which is the reason it loses geometry, now visible in the shape of the diagram instead of only in prose.

The sentence above the diagram claimed *"each render backend is a separate module that registers through a `ServiceLoader` seam"* — true for the fixed-layout pair, false for DOCX. It now separates the two paths and says why a deck matches the PDF geometrically.

## Verification

`CanonicalSurfaceGuardTest`, `DocumentationCoverageTest`, `VersionConsistencyGuardTest`, `PackageMapGuardTest` — 27 tests, 0 failures. Both new shields URLs return `200 image/svg+xml`. The mermaid change adds one node and one dotted edge using constructs already present in the diagram GitHub renders today.