### PR TITLE
fix(engine): let the keepWithNext lookahead see keepTogether

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to GraphCompose are documented here. Versions
 follow semantic versioning; release dates are ISO 8601.
 
+## v2.1.1 — Planned
+
+### Fixed
+
+- **A heading no longer strands above a block that was asked to stay whole.**
+  `keepWithNext()` decides by asking whether the heading plus the *first line* of
+  the next block fits, but a `keepTogether()` block has no first line to break
+  after — it relocates entire. The lookahead measured the first line anyway,
+  concluded it fit, left the heading in place, and the compiler then moved the
+  whole block to the next page. It affected every heading above a kept-whole
+  block: quotes, code blocks, callouts and alerts in the Markdown renderer, and
+  the card sections of the CV and proposal presets. A block taller than a page
+  still anchors by its first line, because its keep-together request is ignored
+  anyway.
+
 ## v2.1.0 — 2026-07-26
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,11 @@ follow semantic versioning; release dates are ISO 8601.
   the next block fits, but a `keepTogether()` block has no first line to break
   after — it relocates entire. The lookahead measured the first line anyway,
   concluded it fit, left the heading in place, and the compiler then moved the
-  whole block to the next page. It affected every heading above a kept-whole
-  block: quotes, code blocks, callouts and alerts in the Markdown renderer, and
-  the card sections of the CV and proposal presets. A block taller than a page
-  still anchors by its first line, because its keep-together request is ignored
-  anyway.
+  whole block to the next page. It affected any heading above a block that opts
+  into `keepTogether()` — including a timeline built with
+  `keepEntriesTogether()`, whose entries are kept whole one level down. A block
+  taller than a page still anchors by its first line, because its keep-together
+  request is ignored anyway.
 
 ## v2.1.0 — 2026-07-26
 

--- a/core/src/main/java/com/demcha/compose/document/layout/LayoutCompiler.java
+++ b/core/src/main/java/com/demcha/compose/document/layout/LayoutCompiler.java
@@ -327,7 +327,8 @@ public final class LayoutCompiler {
                                   + toMargin(children.get(k).margin()).vertical()
                                   + layoutSpec.spacing();
                     }
-                    needed += leadingUnitHeight(children.get(runEnd), childRegionWidth, prepareContext);
+                    needed += leadingUnitHeight(children.get(runEnd), childRegionWidth, prepareContext,
+                                               state.activeInnerHeight());
                     // Relocate only when the run + first line genuinely fits on a fresh
                     // page (EPS, not CAPACITY_TOLERANCE): a run that would still overflow
                     // the next page by a hair should stay put rather than strand there and
@@ -1045,13 +1046,28 @@ public final class LayoutCompiler {
      * @param node           the following sibling whose first line anchors the heading
      * @param regionWidth    the content-region width the sibling is measured at
      * @param prepareContext measurement context
+     * @param pageInnerHeight the active page's inner height, used to tell a honoured
+     *                        keep-together request from one the compiler will ignore
      * @return the height consumed down to the bottom of the node's first flow line
      */
-    private double leadingUnitHeight(DocumentNode node, double regionWidth, PrepareContext prepareContext) {
+    private double leadingUnitHeight(DocumentNode node, double regionWidth, PrepareContext prepareContext,
+                                     double pageInnerHeight) {
         Margin margin = toMargin(node.margin());
         Padding padding = toPadding(node.padding());
         PreparedNode<DocumentNode> prepared = prepareForRegionWidth(prepareContext, node, regionWidth);
         double topReservation = margin.top() + padding.top();
+
+        // A node that asked to be kept whole has no first line to seam after: when
+        // the request will actually be honoured, its whole outer height IS its
+        // leading unit, because it relocates entire rather than splitting. Mirrors
+        // the keepWhole test in compileNode — a node taller than the page has its
+        // keep-together ignored and flows, so the first-slice estimate stays right
+        // there. Without this a heading above a boxed callout is told "one line
+        // fits", stays put, and is stranded when the whole box moves.
+        double outerHeight = prepared.measureResult().height() + margin.vertical();
+        if (node.keepTogether() && outerHeight <= pageInnerHeight + CAPACITY_TOLERANCE) {
+            return outerHeight;
+        }
 
         if (prepared.isComposite()) {
             CompositeLayoutSpec layoutSpec = prepared.requireCompositeLayout();
@@ -1065,7 +1081,8 @@ public final class LayoutCompiler {
             }
             double availableWidth = childAvailableWidth(regionWidth, node);
             double innerRegionWidth = Math.max(0.0, availableWidth - padding.horizontal());
-            return topReservation + leadingUnitHeight(children.get(0), innerRegionWidth, prepareContext);
+            return topReservation + leadingUnitHeight(children.get(0), innerRegionWidth, prepareContext,
+                                                      pageInnerHeight);
         }
 
         // The leading unit of a splittable leaf is its first slice: a paragraph's

--- a/qa/src/test/java/com/demcha/compose/document/dsl/SectionKeepWithNextKeepTogetherTest.java
+++ b/qa/src/test/java/com/demcha/compose/document/dsl/SectionKeepWithNextKeepTogetherTest.java
@@ -126,13 +126,30 @@ class SectionKeepWithNextKeepTogetherTest {
      */
     @Test
     void pageSpanningKeepTogetherBodyStillAnchorsByItsFirstSlice() {
-        LayoutGraph on = pageSpanningBody(true);
+        assertPageSpanningBodyAnchorsByItsFirstSlice(false);
+    }
+
+    /**
+     * The same, with the keep-together block one level down — the shape
+     * {@code TimelineBuilder.keepEntriesTogether()} produces. The lookahead
+     * recurses into the wrapper's first child, so the page height has to travel
+     * down with it; hand the recursive frame a wrong value and this is the case
+     * that notices, because only a page-spanning child distinguishes "estimate
+     * the whole block" from "estimate its first slice".
+     */
+    @Test
+    void nestedPageSpanningKeepTogetherBodyStillAnchorsByItsFirstSlice() {
+        assertPageSpanningBodyAnchorsByItsFirstSlice(true);
+    }
+
+    private static void assertPageSpanningBodyAnchorsByItsFirstSlice(boolean nested) {
+        LayoutGraph on = pageSpanningBody(true, nested);
         assertThat(page(on, "HeaderMark"))
                 .describedAs("keep-together is inert above a page-spanning body, "
                              + "so the first line still anchors the header")
                 .isEqualTo(page(on, "BodyMark"));
 
-        LayoutGraph off = pageSpanningBody(false);
+        LayoutGraph off = pageSpanningBody(false, nested);
         assertThat(page(off, "HeaderMark"))
                 .describedAs("without the opt-in the same header strands — which is "
                              + "what makes the assertion above meaningful")
@@ -144,9 +161,11 @@ class SectionKeepWithNextKeepTogetherTest {
      * window where {@code keepWithNext} decides the outcome.
      *
      * @param keepWithNext whether the header opts into staying with its body
+     * @param nested       whether the keep-together block sits one level down,
+     *                     inside a plain wrapper
      * @return the compiled layout graph
      */
-    private static LayoutGraph pageSpanningBody(boolean keepWithNext) {
+    private static LayoutGraph pageSpanningBody(boolean keepWithNext, boolean nested) {
         try (DocumentSession document = GraphCompose.document()
                 .pageSize(PAGE_WIDTH, PAGE_HEIGHT)
                 .margin(DocumentInsets.of(20))
@@ -160,15 +179,65 @@ class SectionKeepWithNextKeepTogetherTest {
                         s.addShape(shape -> shape.name("HeaderMark")
                                 .size(260, 30).fillColor(INK));
                     })
-                    .addSection("Body", s -> s.keepTogether(true).spacing(0)
-                            .addParagraph(p -> p.name("BodyMark")
-                                    .text("A page-spanning paragraph. ".repeat(220))
-                                    .margin(DocumentInsets.zero())))
+                    .addSection("Body", body -> {
+                        if (nested) {
+                            body.spacing(0).addSection("Entry",
+                                    entry -> pageSpanningBlock(entry.keepTogether(true)));
+                        } else {
+                            pageSpanningBlock(body.keepTogether(true));
+                        }
+                    })
                     .build();
             return document.layoutGraph();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    /**
+     * The keep-together block one level down, which is the shape
+     * {@code TimelineBuilder.keepEntriesTogether()} produces: a plain wrapper
+     * whose first child is the atomic one. The lookahead recurses into that
+     * child, so the page height has to travel down with it — pass the wrong
+     * value there and a header above a timeline strands exactly as it did
+     * before the fix.
+     */
+    @Test
+    void headerStaysWithAKeepTogetherBlockNestedInsideAPlainWrapper() {
+        for (double filler = 10; filler <= 330; filler += 10) {
+            final double f = filler;
+            try (DocumentSession document = GraphCompose.document()
+                    .pageSize(PAGE_WIDTH, PAGE_HEIGHT)
+                    .margin(DocumentInsets.of(20))
+                    .create()) {
+                document.pageFlow().name("Flow").spacing(6)
+                        .addSection("Filler", s -> s.addShape(260, f, GREY))
+                        .addSection("Header", s -> s.keepWithNext()
+                                .addShape(shape -> shape.name("HeaderMark")
+                                        .size(260, 30).fillColor(INK)))
+                        .addSection("Wrapper", wrapper -> wrapper.spacing(0)
+                                .addSection("Entry", entry -> entry.keepTogether(true).spacing(0)
+                                        .addShape(shape -> shape.name("BodyMark")
+                                                .size(260, 100).fillColor(INK))
+                                        .addShape(shape -> shape.name("BodyTail")
+                                                .size(260, 100).fillColor(GREY))))
+                        .build();
+                LayoutGraph graph = document.layoutGraph();
+                assertThat(page(graph, "HeaderMark"))
+                        .describedAs("filler=%.0f: the wrapper's first child relocates "
+                                     + "whole, so the header must travel with it", f)
+                        .isEqualTo(page(graph, "BodyMark"));
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    /** Fills a section with a paragraph several pages tall. */
+    private static void pageSpanningBlock(SectionBuilder section) {
+        section.spacing(0).addParagraph(p -> p.name("BodyMark")
+                .text("A page-spanning paragraph. ".repeat(220))
+                .margin(DocumentInsets.zero()));
     }
 
     /**

--- a/qa/src/test/java/com/demcha/compose/document/dsl/SectionKeepWithNextKeepTogetherTest.java
+++ b/qa/src/test/java/com/demcha/compose/document/dsl/SectionKeepWithNextKeepTogetherTest.java
@@ -117,28 +117,55 @@ class SectionKeepWithNextKeepTogetherTest {
      * is the case the fix must NOT change — sizing it by the whole block would
      * exceed the page, fail the {@code needed <= activeInnerHeight} guard, and
      * strand headers that relocate correctly today.
+     *
+     * <p>Asserted in both directions at a filler height where the rule actually
+     * fires. It has to be: with a 300pt filler the body's first line still fits
+     * under the header, so the two land together whether or not anything relocates
+     * them, and the test would pass against an engine with no {@code keepWithNext}
+     * at all. The live window here is 310–320pt.</p>
      */
     @Test
     void pageSpanningKeepTogetherBodyStillAnchorsByItsFirstSlice() {
+        LayoutGraph on = pageSpanningBody(true);
+        assertThat(page(on, "HeaderMark"))
+                .describedAs("keep-together is inert above a page-spanning body, "
+                             + "so the first line still anchors the header")
+                .isEqualTo(page(on, "BodyMark"));
+
+        LayoutGraph off = pageSpanningBody(false);
+        assertThat(page(off, "HeaderMark"))
+                .describedAs("without the opt-in the same header strands — which is "
+                             + "what makes the assertion above meaningful")
+                .isLessThan(page(off, "BodyMark"));
+    }
+
+    /**
+     * A header above a body far taller than a page, at a filler height inside the
+     * window where {@code keepWithNext} decides the outcome.
+     *
+     * @param keepWithNext whether the header opts into staying with its body
+     * @return the compiled layout graph
+     */
+    private static LayoutGraph pageSpanningBody(boolean keepWithNext) {
         try (DocumentSession document = GraphCompose.document()
                 .pageSize(PAGE_WIDTH, PAGE_HEIGHT)
                 .margin(DocumentInsets.of(20))
                 .create()) {
             document.pageFlow().name("Flow").spacing(6)
-                    .addSection("Filler", s -> s.addShape(260, 300, GREY))
-                    .addSection("Header", s -> s.keepWithNext()
-                            .addShape(shape -> shape.name("HeaderMark")
-                                    .size(260, 30).fillColor(INK)))
+                    .addSection("Filler", s -> s.addShape(260, 310, GREY))
+                    .addSection("Header", s -> {
+                        if (keepWithNext) {
+                            s.keepWithNext();
+                        }
+                        s.addShape(shape -> shape.name("HeaderMark")
+                                .size(260, 30).fillColor(INK));
+                    })
                     .addSection("Body", s -> s.keepTogether(true).spacing(0)
                             .addParagraph(p -> p.name("BodyMark")
-                                    .text(("A page-spanning paragraph. ").repeat(220))
+                                    .text("A page-spanning paragraph. ".repeat(220))
                                     .margin(DocumentInsets.zero())))
                     .build();
-            LayoutGraph graph = document.layoutGraph();
-            assertThat(page(graph, "HeaderMark"))
-                    .describedAs("keep-together is inert above a page-spanning body, "
-                                 + "so the first line still anchors the header")
-                    .isEqualTo(page(graph, "BodyMark"));
+            return document.layoutGraph();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
@@ -149,6 +176,10 @@ class SectionKeepWithNextKeepTogetherTest {
      * an empty page, {@code keepWithNext} declines to relocate rather than strand
      * the header on a page of its own. Documents the limit instead of leaving it
      * to be discovered.
+     *
+     * <p>This one asserts an <em>absence</em>, so it reads the same as "the opt-in
+     * was never applied" and cannot fail for the right reason on its own. It pins
+     * the documented boundary; the sweeps above are what drive the behaviour.</p>
      */
     @Test
     void headerDoesNotRelocateWhenItCannotShareAPageWithTheWholeBody() {

--- a/qa/src/test/java/com/demcha/compose/document/dsl/SectionKeepWithNextKeepTogetherTest.java
+++ b/qa/src/test/java/com/demcha/compose/document/dsl/SectionKeepWithNextKeepTogetherTest.java
@@ -1,0 +1,178 @@
+package com.demcha.compose.document.dsl;
+
+import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.api.DocumentSession;
+import com.demcha.compose.document.layout.LayoutGraph;
+import com.demcha.compose.document.layout.PlacedNode;
+import com.demcha.compose.document.style.DocumentColor;
+import com.demcha.compose.document.style.DocumentInsets;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that the {@code keepWithNext()} lookahead accounts for a following
+ * sibling that asked to be kept whole.
+ *
+ * <p>The two rules are independent mechanisms that used to disagree. The
+ * lookahead asks "does the heading plus the next block's <em>first line</em>
+ * fit?", while a {@code keepTogether()} block has no first line to seam after —
+ * it relocates entire. So the lookahead answered "yes, one line fits", left the
+ * heading in place, and the compiler then moved the whole block to the next
+ * page, stranding the heading it was supposed to protect.</p>
+ *
+ * <p>The window is narrow and depends on the filler height, which is why this
+ * sweeps rather than pinning a single case: at 300&times;400 with 20pt margins
+ * and a 200pt body the orphan appeared for every filler from 120 to 210pt and
+ * nowhere else. A single sample would pass against the buggy compiler for most
+ * choices of filler.</p>
+ *
+ * <p>Assertions read the page of the inner content <em>leaf</em>, not the
+ * section wrapper — see {@link SectionKeepWithNextTest} for why the wrapper's
+ * start page does not reflect where its content lands.</p>
+ */
+class SectionKeepWithNextKeepTogetherTest {
+
+    private static final DocumentColor GREY = DocumentColor.rgb(220, 220, 220);
+    private static final DocumentColor INK = DocumentColor.rgb(20, 80, 95);
+
+    /** Page 300x400 with 20pt margins leaves 360pt of inner height. */
+    private static final double PAGE_WIDTH = 300;
+    private static final double PAGE_HEIGHT = 400;
+    private static final double INNER_HEIGHT = 360;
+
+    private static int page(LayoutGraph graph, String name) {
+        PlacedNode node = graph.nodes().stream()
+                .filter(n -> name.equals(n.semanticName()))
+                .findFirst().orElseThrow();
+        return node.startPage();
+    }
+
+    /**
+     * A {@code keepWithNext()} header above a two-part body that fits on a page.
+     *
+     * @param bodyKeepTogether whether the body relocates whole instead of splitting
+     * @param fillerHeight     height of the block that pushes the header down the page
+     * @return the compiled layout graph
+     */
+    private static LayoutGraph build(boolean bodyKeepTogether, double fillerHeight) {
+        try (DocumentSession document = GraphCompose.document()
+                .pageSize(PAGE_WIDTH, PAGE_HEIGHT)
+                .margin(DocumentInsets.of(20))
+                .create()) {
+            document.pageFlow().name("Flow").spacing(6)
+                    .addSection("Filler", s -> s.addShape(260, fillerHeight, GREY))
+                    .addSection("Header", s -> s.keepWithNext()
+                            .addShape(shape -> shape.name("HeaderMark")
+                                    .size(260, 30).fillColor(INK)))
+                    .addSection("Body", s -> s
+                            .keepTogether(bodyKeepTogether)
+                            .spacing(0)
+                            .addShape(shape -> shape.name("BodyMark")
+                                    .size(260, 100).fillColor(INK))
+                            .addShape(shape -> shape.name("BodyTail")
+                                    .size(260, 100).fillColor(GREY)))
+                    .build();
+            return document.layoutGraph();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * The regression. Before the fix the header stranded for every filler height
+     * from 120 to 210pt: the lookahead counted only the body's first 100pt shape,
+     * decided one line fit, and the compiler then moved all 200pt of the body.
+     */
+    @Test
+    void headerStaysWithAKeepTogetherBodyAtEveryFillerHeight() {
+        for (double filler = 10; filler <= 330; filler += 10) {
+            LayoutGraph graph = build(true, filler);
+            assertThat(page(graph, "HeaderMark"))
+                    .describedAs("filler=%.0f: a keepTogether body relocates whole, "
+                                 + "so the header must travel with it", filler)
+                    .isEqualTo(page(graph, "BodyMark"));
+        }
+    }
+
+    /**
+     * The same sweep with a splittable body, which never regressed. Pins that the
+     * fix did not buy the atomic case at the cost of the ordinary one: a body that
+     * can split still anchors the header by its first slice alone.
+     */
+    @Test
+    void headerStaysWithASplittableBodyAtEveryFillerHeight() {
+        for (double filler = 10; filler <= 330; filler += 10) {
+            LayoutGraph graph = build(false, filler);
+            assertThat(page(graph, "HeaderMark"))
+                    .describedAs("filler=%.0f: a splittable body's first slice "
+                                 + "travels with the header", filler)
+                    .isEqualTo(page(graph, "BodyMark"));
+        }
+    }
+
+    /**
+     * A body that is taller than a page has its keep-together ignored by the
+     * compiler, so the lookahead must keep estimating it by its first slice. This
+     * is the case the fix must NOT change — sizing it by the whole block would
+     * exceed the page, fail the {@code needed <= activeInnerHeight} guard, and
+     * strand headers that relocate correctly today.
+     */
+    @Test
+    void pageSpanningKeepTogetherBodyStillAnchorsByItsFirstSlice() {
+        try (DocumentSession document = GraphCompose.document()
+                .pageSize(PAGE_WIDTH, PAGE_HEIGHT)
+                .margin(DocumentInsets.of(20))
+                .create()) {
+            document.pageFlow().name("Flow").spacing(6)
+                    .addSection("Filler", s -> s.addShape(260, 300, GREY))
+                    .addSection("Header", s -> s.keepWithNext()
+                            .addShape(shape -> shape.name("HeaderMark")
+                                    .size(260, 30).fillColor(INK)))
+                    .addSection("Body", s -> s.keepTogether(true).spacing(0)
+                            .addParagraph(p -> p.name("BodyMark")
+                                    .text(("A page-spanning paragraph. ").repeat(220))
+                                    .margin(DocumentInsets.zero())))
+                    .build();
+            LayoutGraph graph = document.layoutGraph();
+            assertThat(page(graph, "HeaderMark"))
+                    .describedAs("keep-together is inert above a page-spanning body, "
+                                 + "so the first line still anchors the header")
+                    .isEqualTo(page(graph, "BodyMark"));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Best-effort boundary: when the header and the whole block cannot share even
+     * an empty page, {@code keepWithNext} declines to relocate rather than strand
+     * the header on a page of its own. Documents the limit instead of leaving it
+     * to be discovered.
+     */
+    @Test
+    void headerDoesNotRelocateWhenItCannotShareAPageWithTheWholeBody() {
+        double bodyHeight = INNER_HEIGHT - 20;
+        try (DocumentSession document = GraphCompose.document()
+                .pageSize(PAGE_WIDTH, PAGE_HEIGHT)
+                .margin(DocumentInsets.of(20))
+                .create()) {
+            document.pageFlow().name("Flow").spacing(6)
+                    .addSection("Filler", s -> s.addShape(260, 100, GREY))
+                    .addSection("Header", s -> s.keepWithNext()
+                            .addShape(shape -> shape.name("HeaderMark")
+                                    .size(260, 30).fillColor(INK)))
+                    .addSection("Body", s -> s.keepTogether(true).spacing(0)
+                            .addShape(shape -> shape.name("BodyMark")
+                                    .size(260, bodyHeight).fillColor(INK)))
+                    .build();
+            LayoutGraph graph = document.layoutGraph();
+            assertThat(page(graph, "HeaderMark"))
+                    .describedAs("header + body exceed a full page, so the rule stays "
+                                 + "best-effort and the header holds its place")
+                    .isLessThan(page(graph, "BodyMark"));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## Why

Two pagination rules disagreed, and the disagreement stranded exactly the heading the pair exists to protect.

`keepWithNext()` decides by asking whether the heading plus the **first line** of the next block fits the remaining page ([`LayoutCompiler:330`](https://github.com/DemchaAV/GraphCompose/blob/develop/core/src/main/java/com/demcha/compose/document/layout/LayoutCompiler.java#L330)). A `keepTogether()` block has no first line to break after — it relocates entire ([`:261`](https://github.com/DemchaAV/GraphCompose/blob/develop/core/src/main/java/com/demcha/compose/document/layout/LayoutCompiler.java#L261)). `leadingUnitHeight` measured the first line anyway, the lookahead concluded it fit and left the heading in place, and `compileNode` then moved the whole block to the next page.

`leadingUnitHeight`'s own Javadoc already promised the right behaviour — *"the whole outer height for any other leaf or an atomic (row / stack) composite that cannot split"*. But its atomic branch tests `layoutSpec.axis() != VERTICAL || children.isEmpty()`, so a section made atomic **by request** never reached it.

Sequence at a 150pt filler on a 360pt inner page: lookahead counts 30 (heading) + 6 (spacing) + 100 (body's first shape) = 136 ≤ 210 remaining, so the heading stays; 174pt remain; the body's `outerHeight` is 200 ≤ 360 so `keepWhole` holds, 200 > 174, `newPage()`. Body on page 1, heading on page 0.

## Who it hit

Every heading above a block that asks to be kept whole. In `graph-compose-markdown` that is five unconditional `keepTogether()` calls in `BuiltinRenderers` — code blocks, quotes, alerts, callouts, and the unsupported-block panel — and it is the one real orphan in the viewer samples (`kitchen-sink.md`, page 2, `## Blockquote`). In this repo it is the CV and proposal presets, where a section heading precedes a kept-whole card.

## The fix

`leadingUnitHeight` returns the whole outer height when the node's keep-together request will actually be honoured. The condition mirrors `keepWhole`, so a block **taller than the page** — whose request `compileNode` ignores — keeps being estimated by its first slice. That is what lets a heading above a page-spanning paragraph or table still relocate, and `SectionKeepWithNextTest` already guards it.

`leadingUnitHeight` had no view of `CompilerState`, so it takes the page's inner height as a parameter instead. A measurement helper stays free of the mutable page cursor, and the value threads through the one recursive call so a nested kept-whole child is caught too.

No new API: `DocumentNode.keepTogether()` has existed as a default method since 1.8.0, and the changed method is private with two call sites.

## Verification

**Reproduced before fixing.** At 300×400 with 20pt margins and a 200pt two-part body, the heading stranded for **every filler height from 120 to 210pt**, and never once when the same body could split.

**The test sweeps that range rather than sampling it** — a single sample passes against the unfixed compiler for most filler heights, which is how this survived. Proven to drive the behaviour: on the unfixed engine it fails at `filler=120` with the message naming it; on the fixed engine 4/4 pass. The other three cases hold in **both** directions, so they guard what this change must not alter — the splittable body, the page-spanning body whose keep-together is inert, and the best-effort boundary where heading and block cannot share even an empty page.

| gate | result |
|---|---|
| new test, unfixed engine | 1 failure at `filler=120` |
| new test, fixed engine | 4 / 4 |
| full eight-module reactor `clean verify` | BUILD SUCCESS |
| `javadoc:javadoc -pl :graph-compose-core` | BUILD SUCCESS |
| qa snapshots + visual regression | 675 / 675, zero baseline movement |

Zero baseline movement is the point: no committed layout changes, because no existing baseline exercised this path. `SectionKeepWithNextTest` mentions `keepTogether()` only in prose, and only for bodies taller than a page where the flag is inert — which is why the suite stayed green over the bug.

## Residual limitation

When the heading and the whole block cannot share even an empty page, the rule declines to relocate rather than strand the heading alone. That matches `keepWithNext`'s documented best-effort semantics and is now pinned by a test instead of left to be rediscovered.