### PR TITLE
fix(benchmarks): rebuild every branch-versioned module before an A/B run

### DIFF
--- a/docs/operations/benchmarks.md
+++ b/docs/operations/benchmarks.md
@@ -230,10 +230,12 @@ The wrappers above benchmark whatever is currently checked out. To answer "is
 branch B faster or slower than branch A?" fairly on a noisy laptop, use the
 dedicated A/B scripts. They **interleave** the two branches (A,B,A,B,…) so
 thermal drift averages out, **repeat** each branch and compare **medians**, and
-**cool down** between runs. Each branch is rebuilt (`install -pl :graph-compose-core`) before its
-runs so the benchmark measures that branch's engine, and untracked benchmark
-probes are moved aside around the branch switch so they cannot break the other
-branch's compile.
+**cool down** between runs. Each branch is rebuilt before its runs so the benchmark measures that branch:
+the engine, plus `render-pdf` and `templates`, because the benchmarks module
+resolves all three at the branch's own version. Installing only the engine would
+leave both sides sharing whichever backend and template jars happened to be in
+`~/.m2`. Untracked benchmark probes are moved aside around the branch switch so
+they cannot break the other branch's compile.
 
 - **Windows (PowerShell)** — `scripts/ab-bench.ps1`, full suite (latency,
   throughput, scalability, stress, comparative):

--- a/scripts/ab-bench.sh
+++ b/scripts/ab-bench.sh
@@ -164,9 +164,17 @@ build_engine_and_classpath() {
   # version — the normal case for two branches off develop — so every change in
   # the PDF backend or the templates module reports a delta of exactly zero.
   # Guarded by existence: a pre-split layout builds them from the root instead.
+  # render-pdf contributes only its main jar, so skip building its tests too:
+  # -DskipTests still compiles them, and a branch whose render-pdf tests do not
+  # compile would abort the whole A/B at the install step with its output sent to
+  # /dev/null. templates must keep -DskipTests, because the benchmark resolves its
+  # tests-classifier jar and maven.test.skip would not produce one.
   local module
   for module in render-pdf templates; do
-    if [ -f "$module/pom.xml" ]; then
+    [ -f "$module/pom.xml" ] || continue
+    if [ "$module" = "render-pdf" ]; then
+      "$MVNW" -B -ntp -f "$module/pom.xml" -Dmaven.test.skip=true install >/dev/null
+    else
       "$MVNW" -B -ntp -f "$module/pom.xml" -DskipTests install >/dev/null
     fi
   done

--- a/scripts/ab-bench.sh
+++ b/scripts/ab-bench.sh
@@ -157,6 +157,19 @@ build_engine_and_classpath() {
   local engine_pl="."
   [ -f core/pom.xml ] && engine_pl=":graph-compose-core"
   "$MVNW" -B -ntp -DskipTests install -pl "$engine_pl" >/dev/null
+  # The benchmark also resolves render-pdf and templates (plus the templates
+  # tests-classifier jar, which is never published) at the branch's own version,
+  # so those have to be rebuilt per branch as well. Install only the engine and
+  # both sides resolve the SAME jars from ~/.m2 whenever the two branches share a
+  # version — the normal case for two branches off develop — so every change in
+  # the PDF backend or the templates module reports a delta of exactly zero.
+  # Guarded by existence: a pre-split layout builds them from the root instead.
+  local module
+  for module in render-pdf templates; do
+    if [ -f "$module/pom.xml" ]; then
+      "$MVNW" -B -ntp -f "$module/pom.xml" -DskipTests install >/dev/null
+    fi
+  done
   "$MVNW" -B -ntp -f benchmarks/pom.xml test-compile dependency:build-classpath \
           -DincludeScope=test -Dmdep.outputFile=target/benchmark.classpath >/dev/null
   CP="benchmarks/target/test-classes${SEP}benchmarks/target/classes${SEP}$(cat benchmarks/target/benchmark.classpath)"

--- a/scripts/run-benchmarks.ps1
+++ b/scripts/run-benchmarks.ps1
@@ -328,6 +328,22 @@ try {
         & $mavenWrapper "-B" "-ntp" "-DskipTests" "install" "-pl" $enginePl
     }
 
+    # The benchmark also resolves render-pdf and templates (plus the templates
+    # tests-classifier jar, which is never published) at the branch's own
+    # version. Installing only the engine leaves those coming from ~/.m2, so an
+    # A/B between two branches that share a version compares the SAME backend and
+    # template jars on both sides and reports a delta of exactly zero for any
+    # change in them. Guarded by existence: a pre-split layout builds them from
+    # the root instead.
+    foreach ($module in @('render-pdf', 'templates')) {
+        $modulePom = Join-Path $repoRoot "$module/pom.xml"
+        if (Test-Path $modulePom) {
+            Invoke-LoggedCommand -Name "01-install-$module" -Command {
+                & $mavenWrapper "-B" "-ntp" "-f" $modulePom "-DskipTests" "install"
+            }
+        }
+    }
+
     Invoke-LoggedCommand -Name "01-build-classpath" -Command {
         & $mavenWrapper "-B" "-ntp" "-f" $benchmarksPom "test-compile" "dependency:build-classpath" "-DincludeScope=test" "-Dmdep.outputFile=target/benchmark.classpath"
     }


### PR DESCRIPTION
## Why

The A/B scripts installed only the engine module, but `benchmarks/pom.xml` resolves `graph-compose-render-pdf` and `graph-compose-templates` — plus the templates tests-classifier jar, which is deliberately never published — at `${graphcompose.version}`, i.e. the branch's own version.

So both sides of an A/B took those two jars from `~/.m2`. When the compared branches share a version, which is the normal case for two branches cut from `develop`, they took the **same** ones: any change in the PDF backend or the templates module measured a delta of exactly zero. A stale backend jar built against the other branch's core could also throw `NoSuchMethodError` mid-run instead of reporting a number.

## What

`scripts/ab-bench.sh` and `scripts/run-benchmarks.ps1` now install `render-pdf` and `templates` per branch alongside the engine, each guarded by the presence of its pom so a pre-split layout — where the root build produces them — still works. This mirrors the install sequence the CI performance job already uses (`.github/workflows/ci.yml:346-361`).

`graph-compose-fonts` is left alone deliberately: it tracks an independent version line, so it does not change with the branch under test.

## Tests

Both scripts parse clean (`bash -n`, PowerShell AST parser).

The install logic itself was exercised end to end across the layout boundary while investigating engine performance: 8 build-and-measure cycles over `v1.8.0`, `v1.9.1`, `v2.0.0`, `v2.1.0` and `develop`, in a detached worktree. `v1.8.0` predates the module split and has no `render-pdf/` or `templates/` directory, so it takes the guarded-skip path; the 2.x refs take the install path. All eight produced benchmark output.

`scripts/ab-bench.sh` itself was not run end to end here — its own CI smoke (`ab-bench-smoke.yml`) covers that and fires on changes to the script.