### PR TITLE
ci(dependabot): keep JavaFX on the line that still runs on Java 17

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,14 @@ updates:
       # jackson-bom >= 2.22.1 (or 2.23.0) lands on Central with full module sync.
       - dependency-name: "com.fasterxml.jackson:jackson-bom"
         versions: ["2.22.0"]
+      # JavaFX follows the JDK it was built against: the 21.x line is the last
+      # one that runs on Java 17, and the CI matrix still builds and tests on 17.
+      # A major bump therefore fails qa's compile outright — javafx-controls 26
+      # resolves, but Label / TextArea / FontWeight are not visible to a release-17
+      # compile, so the JavaFX dev-preview tool stops building. Drop this entry
+      # when the matrix's floor moves past 17.
+      - dependency-name: "org.openjfx:*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
## Why

Dependabot proposed JavaFX `21.0.2 -> 26.0.2` in #468, and it fails **Build and run tests (JDK 17)**:

```
qa/src/test/java/com/demcha/compose/devtool/GraphComposeDevTool.java:[615,24] cannot find symbol
  symbol: class TextArea
  ... class Label, variable FontWeight, variable Font
```

JavaFX follows the JDK it was built against; 21.x is the last line that runs on Java 17. `javafx-controls:26` resolves, but its classes are not visible to a `release 17` compile, so the JavaFX dev-preview tool in `qa` stops building. The CI matrix still covers JDK 17, so this bump cannot land while that floor holds.

## What

An ignore entry for `org.openjfx:*` limited to **major** bumps, so patch and minor updates inside 21.x still arrive normally. The comment records the condition for removing it — the matrix floor moving past 17 — rather than leaving a rule nobody dares delete.

#468 is closed by this: without the rule Dependabot re-proposes the same failing bump every Monday.

## Tests

Config-only; the YAML parses. The failure being prevented is reproduced in #468's own CI run, linked above.