### PR TITLE
docs: stop offering an examples-local type, and drop the counts that keep rotting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,25 @@ follow semantic versioning; release dates are ISO 8601.
 
 ### Documentation
 
+- **The example catalogue stops offering a type that ships nowhere.** Its entry-point
+  table introduced the cover letter as a `BusinessTheme.modern()` document, and
+  `BusinessTheme` is a record local to the examples module — a reader adding the
+  dependency and reaching for it finds nothing to import. The rows and prose now say
+  what the examples demonstrate, the advanced section that quotes the helper says
+  plainly that it is examples-local and names `BrandTheme` as the shipping equivalent,
+  and a guard rejects the factory-call form on any README while leaving the quotation
+  of an example's own source alone.
+- **The last hardcoded counts are gone.** The catalogue was described as "~53 PDFs"
+  with a "curated 39-PDF subset"; it generates 91 and commits 62, and 39 is how many
+  are *not* committed. The banner caption stated a line count for the example it links,
+  and named the module graph by a version the image itself no longer shows. All four
+  numbers are removed rather than corrected — each had been reconciled before and
+  drifted again within two months.
+- **The contributing guide's commit examples match the convention it asks for.** It
+  pointed at two subjects from the 1.5 line as the shape to copy, while 26 of the last
+  30 commits are Conventional Commits and the pull-request template requires that shape
+  in a title. The four that are not are merges and the release commit — machine-made,
+  never a contributor's.
 - **Documented headings render bold, and say why.** Six snippets across the
   getting-started guide, the root README and the theme, timeline, rich-text and
   preset-authoring recipes set `fontName(FontName.HELVETICA_BOLD)` without a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,11 +127,13 @@ follow semantic versioning; release dates are ISO 8601.
   and a guard rejects the factory-call form on any README while leaving the quotation
   of an example's own source alone.
 - **The last hardcoded counts are gone.** The catalogue was described as "~53 PDFs"
-  with a "curated 39-PDF subset"; it generates 91 and commits 62, and 39 is how many
-  are *not* committed. The banner caption stated a line count for the example it links,
-  and named the module graph by a version the image itself no longer shows. All four
-  numbers are removed rather than corrected — each had been reconciled before and
-  drifted again within two months.
+  with a "curated 39-PDF subset". It generates 91; 62 are committed as previews, and 39
+  of the generated ones are not — the two figures do not subtract, because ten committed
+  previews come from examples the runner no longer produces. Both had been reconciled by
+  hand in June and were wrong again by August. The banner caption stated a line count for
+  the example it links, and named the module graph by a version the image itself no
+  longer shows; those two were written once and were simply never revisited. All four are
+  removed rather than corrected.
 - **The contributing guide's commit examples match the convention it asks for.** It
   pointed at two subjects from the 1.5 line as the shape to copy, while 26 of the last
   30 commits are Conventional Commits and the pull-request template requires that shape

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,19 +126,17 @@ follow semantic versioning; release dates are ISO 8601.
   plainly that it is examples-local and names `BrandTheme` as the shipping equivalent,
   and a guard rejects the factory-call form on any README while leaving the quotation
   of an example's own source alone.
-- **The last hardcoded counts are gone.** The catalogue was described as "~53 PDFs"
-  with a "curated 39-PDF subset". It generates 91; 62 are committed as previews, and 39
-  of the generated ones are not — the two figures do not subtract, because ten committed
-  previews come from examples the runner no longer produces. Both had been reconciled by
-  hand in June and were wrong again by August. The banner caption stated a line count for
-  the example it links, and named the module graph by a version the image itself no
-  longer shows; those two were written once and were simply never revisited. All four are
-  removed rather than corrected.
+- **The last hardcoded counts are gone.** The example catalogue named a number of
+  generated documents and a number of committed previews; both sat well below the real
+  inventory, having been reconciled by hand once already and drifted again since. The
+  banner caption stated a line count for the example it links, and named the module graph
+  by a version the image itself no longer shows. All four are removed rather than
+  corrected — a count in prose has no owner and nothing to keep it true, so correcting
+  one only resets the clock.
 - **The contributing guide's commit examples match the convention it asks for.** It
-  pointed at two subjects from the 1.5 line as the shape to copy, while 26 of the last
-  30 commits are Conventional Commits and the pull-request template requires that shape
-  in a title. The four that are not are merges and the release commit — machine-made,
-  never a contributor's.
+  pointed at two subjects from the 1.5 line as the shape to copy, while the repository
+  has moved to Conventional Commits and the pull-request template requires that shape in
+  a title. The examples are two real recent subjects instead.
 - **Documented headings render bold, and say why.** Six snippets across the
   getting-started guide, the root README and the theme, timeline, rich-text and
   preset-authoring recipes set `fontName(FontName.HELVETICA_BOLD)` without a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Almost all work targets **`develop`**, the ongoing 2.x line. The `1.x` branch ta
    git checkout -b feature/short-description
    ```
    Use `feature/...` for new functionality, `fix/...` for bug fixes, and `docs/...` for documentation-only changes. Issue-prefixed names (`42/fix/short-description`) are also welcome &mdash; convenient when the branch closes a specific issue.
-3. **Commit small, focused changes.** Each commit message should describe the *why*, not just the *what*. Recent commits on `develop` (`Prepare v1.5.0 release`, `Align public docs with the canonical surface`) are reasonable length and structure templates.
+3. **Commit small, focused changes.** Subjects follow Conventional Commits — `type(scope): the concrete effect` — the same shape the [pull request template](.github/pull_request_template.md) asks of a PR title. Say the *why*, not only the *what*. `git log --oneline -20` on `develop` is the reference; `fix(font): the donut-centre KPI renders the weight it declares` and `ci(guards): run every guard the job names, and compile docs-only pull requests` are the shape.
 4. **Run the validation gate locally** before opening a PR:
    ```bash
    ./mvnw -B -ntp clean verify

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 </p>
 
 <p align="center">
-  <sub>☝ This banner is itself a GraphCompose document — <a href="./assets/readme/examples/engine-deck-v2.pdf"><b>view the full module-first deck (PDF)</b></a>, rendered by <a href="./examples/src/main/java/com/demcha/examples/flagships/EngineDeckV2Example.java"><code>EngineDeckV2Example</code></a>: the 2.0 module graph, native vector charts, and real comparative benchmarks, all drawn by the engine. It renders its own marketing.</sub>
+  <sub>☝ This banner is itself a GraphCompose document — <a href="./assets/readme/examples/engine-deck-v2.pdf"><b>view the full module-first deck (PDF)</b></a>, rendered by <a href="./examples/src/main/java/com/demcha/examples/flagships/EngineDeckV2Example.java"><code>EngineDeckV2Example</code></a>: the module graph, native vector charts, and real comparative benchmarks, all drawn by the engine. It renders its own marketing.</sub>
 </p>
 
 ## One source → a PDF <i>and</i> an editable PowerPoint deck
@@ -77,7 +77,7 @@ try (DocumentSession doc = GraphCompose.document(Path.of("twin-output.pdf"))
   <img src="./assets/readme/twin-output-editing.png" alt="The generated deck open in PowerPoint with the headline text frame selected for editing" width="820"/>
 </p>
 <p align="center">
-  <sub>☝ The generated deck open in PowerPoint — the headline is a selected, editable text frame, and the ribbon is live because the slide is built from native shapes. Artifacts: <a href="./assets/readme/examples/twin-output.pdf"><b>PDF</b></a> · <a href="./assets/readme/examples/twin-output.pptx"><b>PPTX</b></a> · <a href="./examples/src/main/java/com/demcha/examples/flagships/TwinOutputExample.java"><b>source</b></a> (<code>TwinOutputExample</code>, ~370 lines, page included).</sub>
+  <sub>☝ The generated deck open in PowerPoint — the headline is a selected, editable text frame, and the ribbon is live because the slide is built from native shapes. Artifacts: <a href="./assets/readme/examples/twin-output.pdf"><b>PDF</b></a> · <a href="./assets/readme/examples/twin-output.pptx"><b>PPTX</b></a> · <a href="./examples/src/main/java/com/demcha/examples/flagships/TwinOutputExample.java"><b>source</b></a> (<code>TwinOutputExample</code>, one page, source included).</sub>
 </p>
 
 ## Why GraphCompose

--- a/examples/README.md
+++ b/examples/README.md
@@ -34,10 +34,10 @@ Generated PDFs land in `examples/target/generated-pdfs/`. The same
 
 `GenerateAllExamples` renders the whole catalogue in one pass — the CV and
 cover-letter presets plus invoices, proposals, a schedule, the feature
-demos, and the flagships. The showcase site surfaces the full generated
-catalogue (~53 PDFs); a curated 39-PDF subset is committed under
-[`assets/readme/examples/`](../assets/readme/examples/) for the previews
-linked below.
+demos, and the flagships. The showcase site publishes the whole generated
+catalogue; a curated subset is committed under
+[`assets/readme/examples/`](../assets/readme/examples/) so the previews
+linked below open straight from GitHub.
 
 ## Gallery — pick by your goal
 
@@ -58,7 +58,7 @@ are with the canonical DSL, then jump to its detailed section below.
 |---|---|---|
 | [CV — single template](#cv-single-template) | One CV via `ModernProfessional.create()` on a `CvDocument` | [PDF](../assets/readme/examples/cv-modern-professional.pdf) · [Source](src/main/java/com/demcha/examples/templates/cv/CvFileExample.java) |
 | [Invoice — cinematic V2](#invoice-cinematic-v2) | `ModernInvoice + BrandTheme.invoiceModern()` — the recommended invoice path | [PDF](../assets/readme/examples/invoice-cinematic.pdf) · [Source](src/main/java/com/demcha/examples/templates/invoice/InvoiceCinematicFileExample.java) |
-| [Cover Letter](#cover-letter) | One-page `BusinessTheme.modern()` cover letter with section presets | [PDF](../assets/readme/examples/cover-letter.pdf) · [Source](src/main/java/com/demcha/examples/templates/coverletter/CoverLetterFileExample.java) |
+| [Cover Letter](#cover-letter) | One-page cover letter composed in the canonical DSL, section presets carrying the hierarchy | [PDF](../assets/readme/examples/cover-letter.pdf) · [Source](src/main/java/com/demcha/examples/templates/coverletter/CoverLetterFileExample.java) |
 | [Module-first Profile](#module-first-profile) | Authoring directly against `DocumentSession.module(...).paragraph(...)` — DSL-direct, no template | [PDF](../assets/readme/examples/module-first-profile.pdf) · [Source](src/main/java/com/demcha/examples/flagships/ModuleFirstFileExample.java) |
 | **Engine Showcase** | Single-page cinematic brand promo — semantic-graph → polished-PDFs visual metaphor with rounded clip frame, magazine headline lockup, KPI cards, capability columns; source of the README hero image | [Source](src/main/java/com/demcha/examples/flagships/EngineShowcase.java) |
 | **Engine Deck** | Multi-page **landscape** capability deck — page 1 is a banner infographic (DSL code → engine → backends → **real rendered-document thumbnails**), then an authoring-pipeline walkthrough, and two pages of **real benchmark data** (GraphCompose vs iText 9 vs JasperReports) loaded from a bundled result file and drawn as tables + native charts; the landscape companion to Engine Showcase. The same composition also renders as a **geometry-identical PowerPoint deck** (one page = one editable slide) through `buildPptx(Path)` | [PDF](../assets/readme/examples/engine-deck.pdf) · [Source](src/main/java/com/demcha/examples/flagships/EngineDeckExample.java) · [PPTX source](src/main/java/com/demcha/examples/flagships/EngineDeckPptxExample.java) |
@@ -138,10 +138,11 @@ are with the canonical DSL, then jump to its detailed section below.
 
 ### Cover letter
 
-A one-page modern cover letter — `BusinessTheme.modern()` drives every
-colour and font choice; section presets (`softPanel`, `accentLeft`,
-`accentTop`) carry the visual hierarchy; opening rich-text strip
-highlights the candidate's headline.
+A one-page modern cover letter composed straight in the canonical DSL.
+Section presets (`softPanel`, `accentLeft`, `accentTop`) carry the visual
+hierarchy and an opening rich-text strip highlights the candidate's
+headline; the palette and fonts come from a theme record the example
+declares for itself.
 
 <!-- doc-example-ignore: quotes a runnable example; the source it is taken from is compiled and executed by the examples module -->
 ```java
@@ -1130,10 +1131,14 @@ The same composition also emits an editable PowerPoint deck (`BusinessReportPptx
 ### Master showcase
 
 Fictional "Q2 sample report" combining the canonical surface
-end-to-end: `BusinessTheme` + page background + hero with rotated
+end-to-end: a theme record + page background + hero with rotated
 shape container + branded QR + executive summary + zebra-striped
 totals table + accent-bordered highlight cards + Code 128 footer
 barcode. Reference it when composing your own multi-page documents.
+
+The `BusinessTheme` record it uses is a helper local to this module, not
+library API — the shipping equivalent is `BrandTheme` and the layered
+presets. Declare your own record the same way, or start from `BrandTheme`.
 
 The same composition also emits an editable PowerPoint deck (`MasterShowcasePptxExample` — each page becomes one slide; rich text, the advanced table, and chrome stay native shapes, and only the rotated clip-masked seal and the barcodes rasterise).
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -141,8 +141,8 @@ are with the canonical DSL, then jump to its detailed section below.
 A one-page modern cover letter composed straight in the canonical DSL.
 Section presets (`softPanel`, `accentLeft`, `accentTop`) carry the visual
 hierarchy and an opening rich-text strip highlights the candidate's
-headline; the palette and fonts come from a theme record the example
-declares for itself.
+headline. Its colours come from a theme helper local to this module, not
+from library API — the shipping equivalent is `BrandTheme`.
 
 <!-- doc-example-ignore: quotes a runnable example; the source it is taken from is compiled and executed by the examples module -->
 ```java

--- a/qa/src/test/java/com/demcha/documentation/ExamplesLocalTypeGuardTest.java
+++ b/qa/src/test/java/com/demcha/documentation/ExamplesLocalTypeGuardTest.java
@@ -8,97 +8,163 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Keeps a helper that lives only in the examples module out of the reader's path.
  *
- * <p>{@code BusinessTheme} is declared in {@code com.demcha.examples.support.theme} and
- * ships in none of the published artifacts. Twenty-one examples use it, and quoting it
- * while explaining those examples is honest — a reader who opens the source will find
- * it. Writing {@code BusinessTheme.modern()} in an entry-point table is not: the call
- * form reads as the way to theme a document, and the reader discovers otherwise only
- * after adding the dependency and failing to import it. That is how the cover-letter
- * row presented an examples-local record as the theming API.</p>
+ * <p>{@code BusinessTheme} and its neighbours are declared in
+ * {@code com.demcha.examples.support.theme} and ship in none of the published artifacts.
+ * Eighteen examples use them, and quoting one while explaining those examples is honest —
+ * a reader who opens the source will find it. Writing {@code BusinessTheme.modern()} in
+ * an entry-point table is not: the call form reads as the way to theme a document, and
+ * the reader discovers otherwise only after adding the dependency and failing to import
+ * it. That is how the cover-letter row presented an examples-local record as the theming
+ * API.</p>
  *
- * <p>So the rule is about the form, not the name: no factory call on a type that ships
- * nowhere, in prose, on any README. Inside a {@code java} fence the same call is fine —
- * the fence quotes an example's own source, and stripping the type from it would make
- * the quotation false.</p>
+ * <p>Two forms are rejected, for different reasons. A <em>call</em> anywhere in prose
+ * offers the type as something to invoke. The bare <em>name</em> in a table row offers it
+ * as what that row's document is made of — the same claim in fewer words, and exactly how
+ * the defect was written. Everywhere else in prose the bare name is allowed, because
+ * these pages have to be able to describe the examples they document.</p>
+ *
+ * <p>Inside a {@code java} fence both forms are fine: a fence quotes an example's own
+ * source, and editing the type out of a quotation would make the quotation false.</p>
  */
 class ExamplesLocalTypeGuardTest {
 
     private static final Path PROJECT_ROOT = RepoPaths.repoRoot();
 
     /**
-     * Types a reader cannot import from any published artifact. Shared in spirit with
-     * {@code CanonicalSurfaceGuardTest.FORBIDDEN_IN_API_GUIDANCE}, which bans the name
-     * outright on the pages that teach the API; here only the call form is banned,
-     * because these pages also describe the examples that legitimately use it.
+     * The helper package whose types a reader cannot import. Read from the source tree
+     * rather than listed: it holds five public types today, two of them with static
+     * factories, and a list would have covered whichever one was noticed first.
      */
-    private static final List<String> EXAMPLES_LOCAL_TYPES = List.of("BusinessTheme");
+    private static final Path EXAMPLES_LOCAL_PACKAGE =
+            PROJECT_ROOT.resolve("examples/src/main/java/com/demcha/examples/support/theme");
 
     @Test
-    void noReadmeOffersAFactoryCallOnATypeThatShipsNowhere() throws IOException {
-        List<Path> readmes = PublishedDocs.readmes(PROJECT_ROOT);
-
-        assertThat(readmes)
-                .describedAs("no README was resolved — the scan moved and this guard covers nothing")
-                .isNotEmpty();
-
+    void noReadmeOffersATypeThatShipsNowhereAsTheWayToDoSomething() throws IOException {
+        List<String> types = examplesLocalTypes();
         Set<String> violations = new TreeSet<>();
-        for (Path readme : readmes) {
-            String prose = withoutFencedBlocks(Files.readAllLines(readme, StandardCharsets.UTF_8));
-            for (String type : EXAMPLES_LOCAL_TYPES) {
-                if (prose.contains(type + ".")) {
-                    violations.add(PROJECT_ROOT.relativize(readme).toString().replace('\\', '/')
-                            + " offers " + type + ".…()");
+
+        for (Path readme : PublishedDocs.readmes(PROJECT_ROOT)) {
+            List<String> prose = prose(Files.readAllLines(readme, StandardCharsets.UTF_8));
+            String rel = relative(readme);
+            for (String type : types) {
+                Pattern call = Pattern.compile("\\b" + Pattern.quote(type) + "\\s*\\.\\s*\\w+\\s*\\(");
+                Pattern bareName = Pattern.compile("\\b" + Pattern.quote(type) + "\\b");
+                for (String line : prose) {
+                    if (call.matcher(line).find()) {
+                        violations.add(rel + " calls " + type + " in prose");
+                    } else if (line.stripLeading().startsWith("|") && bareName.matcher(line).find()) {
+                        violations.add(rel + " names " + type + " in a table row");
+                    }
                 }
             }
         }
 
         assertThat(violations)
-                .describedAs("a factory call on a type that ships in no artifact reads as the "
-                        + "supported way to do something; the reader finds out it is not only "
-                        + "after adding the dependency. Describe what the example demonstrates, "
-                        + "or name the shipping equivalent")
+                .describedAs("a type that ships in no artifact — offered as something to call, or "
+                        + "as what a row's document is made of — reads as the supported way to do "
+                        + "it, and the reader finds out otherwise only after adding the dependency. "
+                        + "Describe what the example demonstrates, or name the shipping equivalent")
                 .isEmpty();
     }
 
     /**
-     * Guard-the-guard: the scan must actually see prose. A fence-stripper that swallowed
-     * the whole file would leave every assertion above trivially satisfied.
+     * Guard-the-guard: prose is what gets scanned, and it is the larger half.
+     *
+     * <p>Comparing the two halves rather than checking a threshold is deliberate. A fixed
+     * floor is satisfied by the fenced content on its own — some 23k characters of it
+     * across these READMEs — so a stripper that kept the fences and dropped the prose
+     * would clear any floor low enough to be safe, and the rule would then be policing
+     * the one place it exists to leave alone.</p>
      */
     @Test
-    void theScanReadsProseAndNotOnlyFences() throws IOException {
+    void theScanReadsProseAndNotFences() throws IOException {
         int prose = 0;
+        int fenced = 0;
         for (Path readme : PublishedDocs.readmes(PROJECT_ROOT)) {
-            prose += withoutFencedBlocks(Files.readAllLines(readme, StandardCharsets.UTF_8)).length();
+            List<String> lines = Files.readAllLines(readme, StandardCharsets.UTF_8);
+            prose += length(prose(lines));
+            fenced += length(fenced(lines));
         }
 
+        assertThat(fenced)
+                .describedAs("no fenced content found across the READMEs — fence detection is not "
+                        + "detecting fences, nothing is being exempted, and the comparison below "
+                        + "proves nothing")
+                .isPositive();
         assertThat(prose)
-                .describedAs("stripping the fenced blocks left almost nothing to scan — the "
-                        + "fence detection is swallowing prose and the guard is passing vacuously")
-                .isGreaterThan(20_000);
+                .describedAs("the scanned half must be the prose, which outweighs the code on "
+                        + "these pages by roughly five to one. A smaller number here means the "
+                        + "split is inverted: the rule would be reading the quotations it exists "
+                        + "to permit and skipping the sentences it exists to police")
+                .isGreaterThan(fenced);
     }
 
-    /** The document with every fenced block removed, so only prose is searched. */
-    private static String withoutFencedBlocks(List<String> lines) {
-        StringBuilder prose = new StringBuilder();
+    @Test
+    void theHelperPackageIsWhereTheGuardThinksItIs() throws IOException {
+        assertThat(examplesLocalTypes())
+                .describedAs("no types found in %s — the examples-local helpers moved and this "
+                        + "guard is checking the READMEs against an empty list",
+                        relative(EXAMPLES_LOCAL_PACKAGE))
+                .isNotEmpty()
+                .contains("BusinessTheme");
+    }
+
+    /** The types declared in the examples module's theme helper package. */
+    private static List<String> examplesLocalTypes() throws IOException {
+        if (!Files.isDirectory(EXAMPLES_LOCAL_PACKAGE)) {
+            return List.of();
+        }
+        try (Stream<Path> files = Files.list(EXAMPLES_LOCAL_PACKAGE)) {
+            return files.map(path -> path.getFileName().toString())
+                    .filter(name -> name.endsWith(".java"))
+                    .map(name -> name.substring(0, name.length() - ".java".length()))
+                    .filter(name -> !name.equals("package-info"))
+                    .sorted()
+                    .toList();
+        }
+    }
+
+    private static List<String> prose(List<String> lines) {
+        return partition(lines, false);
+    }
+
+    private static List<String> fenced(List<String> lines) {
+        return partition(lines, true);
+    }
+
+    /** The lines inside fenced blocks, or the lines outside them. Fence markers are neither. */
+    private static List<String> partition(List<String> lines, boolean wantFenced) {
+        List<String> kept = new ArrayList<>();
         boolean inFence = false;
         for (String line : lines) {
-            if (line.trim().startsWith("```")) {
+            if (line.stripLeading().startsWith("```")) {
                 inFence = !inFence;
                 continue;
             }
-            if (!inFence) {
-                prose.append(line).append('\n');
+            if (inFence == wantFenced) {
+                kept.add(line);
             }
         }
-        return prose.toString();
+        return kept;
+    }
+
+    private static int length(List<String> lines) {
+        return lines.stream().mapToInt(line -> line.length() + 1).sum();
+    }
+
+    private static String relative(Path path) {
+        return PROJECT_ROOT.relativize(path).toString().replace('\\', '/');
     }
 }

--- a/qa/src/test/java/com/demcha/documentation/ExamplesLocalTypeGuardTest.java
+++ b/qa/src/test/java/com/demcha/documentation/ExamplesLocalTypeGuardTest.java
@@ -18,25 +18,27 @@ import java.util.stream.Stream;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Keeps a helper that lives only in the examples module out of the reader's path.
+ * Keeps helpers that live only in the examples module out of the reader's path.
  *
  * <p>{@code BusinessTheme} and its neighbours are declared in
  * {@code com.demcha.examples.support.theme} and ship in none of the published artifacts.
- * Eighteen examples use them, and quoting one while explaining those examples is honest —
- * a reader who opens the source will find it. Writing {@code BusinessTheme.modern()} in
- * an entry-point table is not: the call form reads as the way to theme a document, and
- * the reader discovers otherwise only after adding the dependency and failing to import
- * it. That is how the cover-letter row presented an examples-local record as the theming
- * API.</p>
+ * Explaining an example that uses one is honest — a reader who opens the source will find
+ * it. Writing {@code BusinessTheme.modern()} in an entry-point table is not: it reads as
+ * the way to theme a document, and the reader discovers otherwise only after adding the
+ * dependency and failing to import it. That is how the cover-letter row presented an
+ * examples-local record as the theming API.</p>
  *
- * <p>Two forms are rejected, for different reasons. A <em>call</em> anywhere in prose
- * offers the type as something to invoke. The bare <em>name</em> in a table row offers it
- * as what that row's document is made of — the same claim in fewer words, and exactly how
- * the defect was written. Everywhere else in prose the bare name is allowed, because
- * these pages have to be able to describe the examples they document.</p>
+ * <p>What is rejected is <em>using</em> the type: a call, a constructor, a method
+ * reference, a member access. The bare name in prose stays legal, because these pages
+ * have to be able to name the thing they are describing — except in a table row, where a
+ * bare name is a claim about what that row's document is made of, which is the same
+ * offer in fewer words and is how the defect was written.</p>
  *
- * <p>Inside a {@code java} fence both forms are fine: a fence quotes an example's own
- * source, and editing the type out of a quotation would make the quotation false.</p>
+ * <p>Code blocks are scanned like everything else. A fenced snippet is the most
+ * copy-pasted thing on the page, so exempting fences wholesale would leave the rule
+ * policing only the form nobody copies. The single exemption is a fence introduced by a
+ * {@code doc-example-ignore} marker, which already has to carry a written reason and is
+ * how a page quotes an example's own source verbatim.</p>
  */
 class ExamplesLocalTypeGuardTest {
 
@@ -44,26 +46,45 @@ class ExamplesLocalTypeGuardTest {
 
     /**
      * The helper package whose types a reader cannot import. Read from the source tree
-     * rather than listed: it holds five public types today, two of them with static
-     * factories, and a list would have covered whichever one was noticed first.
+     * rather than listed: it holds five public types today, and a list would have covered
+     * whichever one was noticed first.
      */
     private static final Path EXAMPLES_LOCAL_PACKAGE =
             PROJECT_ROOT.resolve("examples/src/main/java/com/demcha/examples/support/theme");
 
+    /** Pages whose subject is what a past release contained. Mirrors the canonical guard. */
+    private static final List<String> HISTORICAL_RECORD_PREFIXES = List.of(
+            "CHANGELOG.md", "docs/adr/", "docs/archive/", "docs/migration/",
+            "docs/private/", "docs/roadmaps/", "docs/templates/v1-classic/");
+
+    /**
+     * The decision guide between the removed template surfaces and the layered ones. It
+     * names {@code BusinessTheme.X()} beside its replacement {@code BrandTheme.X()} on
+     * purpose — and the type it means is the canonical record 2.0 removed, which happens
+     * to share a name with the examples-local helper. Naming the old surface is the
+     * document's whole job; the canonical guard allows it here for the same reason.
+     */
+    private static final Set<String> MIGRATION_INVENTORY =
+            Set.of("docs/templates/which-template-system.md");
+
+    /** A marker that exempts the fence below it, with a reason, on a published page. */
+    private static final Pattern QUOTED_SOURCE_MARKER =
+            Pattern.compile("^<!--\\s*doc-example-ignore:\\s*\\S.*-->\\s*$");
+
     @Test
-    void noReadmeOffersATypeThatShipsNowhereAsTheWayToDoSomething() throws IOException {
+    void noPublishedPageOffersATypeThatShipsNowhere() throws IOException {
         List<String> types = examplesLocalTypes();
         Set<String> violations = new TreeSet<>();
 
-        for (Path readme : PublishedDocs.readmes(PROJECT_ROOT)) {
-            List<String> prose = prose(Files.readAllLines(readme, StandardCharsets.UTF_8));
-            String rel = relative(readme);
+        for (Path page : scannedPages()) {
+            Scan scan = scan(Files.readAllLines(page, StandardCharsets.UTF_8));
+            String rel = relative(page);
             for (String type : types) {
-                Pattern call = Pattern.compile("\\b" + Pattern.quote(type) + "\\s*\\.\\s*\\w+\\s*\\(");
+                Pattern used = usage(type);
                 Pattern bareName = Pattern.compile("\\b" + Pattern.quote(type) + "\\b");
-                for (String line : prose) {
-                    if (call.matcher(line).find()) {
-                        violations.add(rel + " calls " + type + " in prose");
+                for (String line : scan.scanned()) {
+                    if (used.matcher(line).find()) {
+                        violations.add(rel + " uses " + type);
                     } else if (line.stripLeading().startsWith("|") && bareName.matcher(line).find()) {
                         violations.add(rel + " names " + type + " in a table row");
                     }
@@ -72,53 +93,100 @@ class ExamplesLocalTypeGuardTest {
         }
 
         assertThat(violations)
-                .describedAs("a type that ships in no artifact — offered as something to call, or "
-                        + "as what a row's document is made of — reads as the supported way to do "
-                        + "it, and the reader finds out otherwise only after adding the dependency. "
-                        + "Describe what the example demonstrates, or name the shipping equivalent")
+                .describedAs("a type that ships in no artifact — called, constructed, referenced, "
+                        + "or offered as what a row's document is made of — reads as the supported "
+                        + "way to do it, and the reader finds out otherwise only after adding the "
+                        + "dependency. Describe what the example demonstrates, or name the shipping "
+                        + "equivalent. To quote an example's own source verbatim, introduce the "
+                        + "fence with a doc-example-ignore marker saying so")
                 .isEmpty();
     }
 
     /**
-     * Guard-the-guard: prose is what gets scanned, and it is the larger half.
+     * Every use of the type: a call, a constructor, a method reference, a member access.
      *
-     * <p>Comparing the two halves rather than checking a threshold is deliberate. A fixed
-     * floor is satisfied by the fenced content on its own — some 23k characters of it
-     * across these READMEs — so a stripper that kept the fences and dropped the prose
-     * would clear any floor low enough to be safe, and the rule would then be policing
-     * the one place it exists to leave alone.</p>
+     * <p>Restricting the rule to {@code Type.method(} would leave
+     * {@code new BusinessTheme(…)}, {@code BusinessTheme::modern} and
+     * {@code BusinessTheme.DEFAULT} as three unguarded ways to make the same offer. A
+     * member named {@code java} is the one exception — that is a link to the type's own
+     * source file, which is a reader following the trail, not an API being suggested.</p>
+     */
+    private static Pattern usage(String type) {
+        String name = Pattern.quote(type);
+        return Pattern.compile("\\b" + name + "\\s*\\.\\s*(?!java\\b)\\w+"
+                + "|new\\s+" + name + "\\s*[(<]"
+                + "|\\b" + name + "\\s*::");
+    }
+
+    /**
+     * A fence left open swallows the rest of its page.
+     *
+     * <p>Checked per file, because the totals cannot see it: one unbalanced marker turns
+     * everything below it into an exempt block, and the repository's remaining pages keep
+     * every aggregate comfortably in range.</p>
      */
     @Test
-    void theScanReadsProseAndNotFences() throws IOException {
-        int prose = 0;
-        int fenced = 0;
-        for (Path readme : PublishedDocs.readmes(PROJECT_ROOT)) {
-            List<String> lines = Files.readAllLines(readme, StandardCharsets.UTF_8);
-            prose += length(prose(lines));
-            fenced += length(fenced(lines));
+    void noPageLeavesAFenceOpen() throws IOException {
+        Set<String> unbalanced = new TreeSet<>();
+        int scanned = 0;
+        for (Path page : scannedPages()) {
+            Scan scan = scan(Files.readAllLines(page, StandardCharsets.UTF_8));
+            scanned += scan.scanned().size();
+            if (scan.fenceLeftOpen()) {
+                unbalanced.add(relative(page));
+            }
         }
 
-        assertThat(fenced)
-                .describedAs("no fenced content found across the READMEs — fence detection is not "
-                        + "detecting fences, nothing is being exempted, and the comparison below "
-                        + "proves nothing")
+        assertThat(unbalanced)
+                .describedAs("an unclosed code fence exempts every line after it, so the page "
+                        + "stops being checked from that point on and nothing says so")
+                .isEmpty();
+        assertThat(scanned)
+                .describedAs("almost nothing was scanned — the page set or the fence handling "
+                        + "moved and this guard is reading an empty corpus")
+                .isGreaterThan(1_000);
+    }
+
+    /**
+     * The exemption path is exercised. If no page quotes an example's own source any
+     * more, the fence handling is dead code and the next reader will not know it was ever
+     * needed — and a guard whose only escape hatch is untested tends to acquire a wider
+     * one the first time it fires inconveniently.
+     */
+    @Test
+    void quotingAnExamplesOwnSourceStaysPossible() throws IOException {
+        int exempt = 0;
+        for (Path page : scannedPages()) {
+            exempt += scan(Files.readAllLines(page, StandardCharsets.UTF_8)).exempted().size();
+        }
+
+        assertThat(exempt)
+                .describedAs("no fence is exempted anywhere — either the marker mechanism changed "
+                        + "or nothing quotes example source, and the exemption below is untested")
                 .isPositive();
-        assertThat(prose)
-                .describedAs("the scanned half must be the prose, which outweighs the code on "
-                        + "these pages by roughly five to one. A smaller number here means the "
-                        + "split is inverted: the rule would be reading the quotations it exists "
-                        + "to permit and skipping the sentences it exists to police")
-                .isGreaterThan(fenced);
     }
 
     @Test
     void theHelperPackageIsWhereTheGuardThinksItIs() throws IOException {
         assertThat(examplesLocalTypes())
                 .describedAs("no types found in %s — the examples-local helpers moved and this "
-                        + "guard is checking the READMEs against an empty list",
+                        + "guard is checking the documentation against an empty list",
                         relative(EXAMPLES_LOCAL_PACKAGE))
                 .isNotEmpty()
                 .contains("BusinessTheme");
+    }
+
+    /** The published pages this rule applies to. */
+    private static List<Path> scannedPages() throws IOException {
+        List<Path> pages = new ArrayList<>();
+        for (Path page : PublishedDocs.all(PROJECT_ROOT)) {
+            String rel = relative(page);
+            boolean historical = HISTORICAL_RECORD_PREFIXES.stream().anyMatch(rel::startsWith);
+            if (!historical && !MIGRATION_INVENTORY.contains(rel)) {
+                pages.add(page);
+            }
+        }
+        return pages;
     }
 
     /** The types declared in the examples module's theme helper package. */
@@ -136,32 +204,34 @@ class ExamplesLocalTypeGuardTest {
         }
     }
 
-    private static List<String> prose(List<String> lines) {
-        return partition(lines, false);
+    /** What a page contributes: the lines the rule reads, the lines a marker excused, and balance. */
+    private record Scan(List<String> scanned, List<String> exempted, boolean fenceLeftOpen) {
     }
 
-    private static List<String> fenced(List<String> lines) {
-        return partition(lines, true);
-    }
-
-    /** The lines inside fenced blocks, or the lines outside them. Fence markers are neither. */
-    private static List<String> partition(List<String> lines, boolean wantFenced) {
-        List<String> kept = new ArrayList<>();
+    private static Scan scan(List<String> lines) {
+        List<String> scanned = new ArrayList<>();
+        List<String> exempted = new ArrayList<>();
         boolean inFence = false;
+        boolean fenceIsExempt = false;
+        String previous = "";
         for (String line : lines) {
-            if (line.stripLeading().startsWith("```")) {
-                inFence = !inFence;
+            String trimmed = line.stripLeading();
+            if (trimmed.startsWith("```")) {
+                if (inFence) {
+                    inFence = false;
+                    fenceIsExempt = false;
+                } else {
+                    inFence = true;
+                    fenceIsExempt = QUOTED_SOURCE_MARKER.matcher(previous.strip()).matches();
+                }
                 continue;
             }
-            if (inFence == wantFenced) {
-                kept.add(line);
+            (inFence && fenceIsExempt ? exempted : scanned).add(line);
+            if (!trimmed.isEmpty()) {
+                previous = line;
             }
         }
-        return kept;
-    }
-
-    private static int length(List<String> lines) {
-        return lines.stream().mapToInt(line -> line.length() + 1).sum();
+        return new Scan(scanned, exempted, inFence);
     }
 
     private static String relative(Path path) {

--- a/qa/src/test/java/com/demcha/documentation/ExamplesLocalTypeGuardTest.java
+++ b/qa/src/test/java/com/demcha/documentation/ExamplesLocalTypeGuardTest.java
@@ -1,0 +1,104 @@
+package com.demcha.documentation;
+
+import com.demcha.compose.qa.RepoPaths;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Keeps a helper that lives only in the examples module out of the reader's path.
+ *
+ * <p>{@code BusinessTheme} is declared in {@code com.demcha.examples.support.theme} and
+ * ships in none of the published artifacts. Twenty-one examples use it, and quoting it
+ * while explaining those examples is honest — a reader who opens the source will find
+ * it. Writing {@code BusinessTheme.modern()} in an entry-point table is not: the call
+ * form reads as the way to theme a document, and the reader discovers otherwise only
+ * after adding the dependency and failing to import it. That is how the cover-letter
+ * row presented an examples-local record as the theming API.</p>
+ *
+ * <p>So the rule is about the form, not the name: no factory call on a type that ships
+ * nowhere, in prose, on any README. Inside a {@code java} fence the same call is fine —
+ * the fence quotes an example's own source, and stripping the type from it would make
+ * the quotation false.</p>
+ */
+class ExamplesLocalTypeGuardTest {
+
+    private static final Path PROJECT_ROOT = RepoPaths.repoRoot();
+
+    /**
+     * Types a reader cannot import from any published artifact. Shared in spirit with
+     * {@code CanonicalSurfaceGuardTest.FORBIDDEN_IN_API_GUIDANCE}, which bans the name
+     * outright on the pages that teach the API; here only the call form is banned,
+     * because these pages also describe the examples that legitimately use it.
+     */
+    private static final List<String> EXAMPLES_LOCAL_TYPES = List.of("BusinessTheme");
+
+    @Test
+    void noReadmeOffersAFactoryCallOnATypeThatShipsNowhere() throws IOException {
+        List<Path> readmes = PublishedDocs.readmes(PROJECT_ROOT);
+
+        assertThat(readmes)
+                .describedAs("no README was resolved — the scan moved and this guard covers nothing")
+                .isNotEmpty();
+
+        Set<String> violations = new TreeSet<>();
+        for (Path readme : readmes) {
+            String prose = withoutFencedBlocks(Files.readAllLines(readme, StandardCharsets.UTF_8));
+            for (String type : EXAMPLES_LOCAL_TYPES) {
+                if (prose.contains(type + ".")) {
+                    violations.add(PROJECT_ROOT.relativize(readme).toString().replace('\\', '/')
+                            + " offers " + type + ".…()");
+                }
+            }
+        }
+
+        assertThat(violations)
+                .describedAs("a factory call on a type that ships in no artifact reads as the "
+                        + "supported way to do something; the reader finds out it is not only "
+                        + "after adding the dependency. Describe what the example demonstrates, "
+                        + "or name the shipping equivalent")
+                .isEmpty();
+    }
+
+    /**
+     * Guard-the-guard: the scan must actually see prose. A fence-stripper that swallowed
+     * the whole file would leave every assertion above trivially satisfied.
+     */
+    @Test
+    void theScanReadsProseAndNotOnlyFences() throws IOException {
+        int prose = 0;
+        for (Path readme : PublishedDocs.readmes(PROJECT_ROOT)) {
+            prose += withoutFencedBlocks(Files.readAllLines(readme, StandardCharsets.UTF_8)).length();
+        }
+
+        assertThat(prose)
+                .describedAs("stripping the fenced blocks left almost nothing to scan — the "
+                        + "fence detection is swallowing prose and the guard is passing vacuously")
+                .isGreaterThan(20_000);
+    }
+
+    /** The document with every fenced block removed, so only prose is searched. */
+    private static String withoutFencedBlocks(List<String> lines) {
+        StringBuilder prose = new StringBuilder();
+        boolean inFence = false;
+        for (String line : lines) {
+            if (line.trim().startsWith("```")) {
+                inFence = !inFence;
+                continue;
+            }
+            if (!inFence) {
+                prose.append(line).append('\n');
+            }
+        }
+        return prose.toString();
+    }
+}


### PR DESCRIPTION
## Why

Three things in the reader's path said something the code does not.

The example catalogue's entry-point table introduced the cover letter as a `BusinessTheme.modern()` document. `BusinessTheme` is a record in `com.demcha.examples.support.theme` — it ships in none of the published artifacts, and its own `package-info` already says so. A reader who adds the dependency and reaches for it finds nothing to import, and finds that out only after the failed import.

The catalogue named a count of generated documents and a count of committed previews. Both sat well below the real inventory, having been reconciled by hand once already and drifted again since.

The banner caption named "the 2.0 module graph" while the image it captions renders 2.1, and stated a line count for the example it links.

## What

**The examples-local type leaves the entry points.** The Start here row and the section intro say what the example demonstrates; the section states that its colours come from a helper local to this module and names `BrandTheme` as the shipping equivalent.

**`ExamplesLocalTypeGuardTest` polices using the type, across the published documentation.**

*Where it looks*: every published page — the READMEs and the docs tree — minus the pages whose subject is what a past release contained (`docs/adr`, `docs/archive`, `docs/migration`, `docs/roadmaps`, `docs/templates/v1-classic`) and the decision guide that names the removed surface beside its replacement on purpose. The same exemptions the canonical surface guard already uses, for the same reason.

*What it rejects*: a call, a constructor, a method reference, a member access — three unguarded ways to make the same offer is not a rule. A member named `java` is exempt, because that is a link to the type's own source rather than an API being suggested. The bare name stays legal in prose, since these pages have to name what they describe; in a **table row** it does not, because there a bare name is a claim about what that row's document is made of, which is how the defect was written.

*Code blocks are scanned.* A fenced snippet is the most copy-pasted thing on a page, so exempting fences wholesale would leave the rule policing only the form nobody copies. The single exemption is a fence introduced by a `doc-example-ignore` marker, which already carries a written reason — and a test asserts that path is still exercised, so it cannot quietly become dead code.

*An unclosed fence fails per page.* It exempts everything below it, and no aggregate can see one file going quiet.

The type set is read from the helper package rather than listed — five types today, and a list would have covered whichever one was noticed first.

**Four counts are removed, not corrected.** The CHANGELOG entry describing that had itself acquired five figures; those are out too.

## Tests

`qa` gate: 688 tests, `BUILD SUCCESS`. Core guard job as CI runs it: 35 tests, `BUILD SUCCESS`.

| Negative check | Result |
|---|---|
| a tutorial fence offering the type | fails — the fence is scanned |
| a nested page under `docs/` using it | fails — the scan is not README-only |
| `new BusinessTheme(…)` | fails |
| `BusinessTheme::modern` | fails |
| the call form in prose | fails |
| the bare name in an entry-point table row | fails |
| an unclosed fence | fails, names the page |
| a link to the type's own source file | passes — a link is not an offer |
| a `doc-example-ignore` fence quoting example source | passes — and a test keeps that path alive |
