### PR TITLE
docs(readme): install and a runnable example come before the second showcase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,25 @@ follow semantic versioning; release dates are ISO 8601.
 
 ### Documentation
 
+- **The landing page lets you run it before it finishes selling it.** Ninety-one lines
+  and twelve images stood between the title and `## Installation`, most of them a second
+  showcase: thirty-five lines demonstrating the PowerPoint backend, with two renders and
+  a screenshot, before the reader had seen one line of the authoring API. That section
+  now sits after "Next steps", where a reader who has already written a document can
+  appreciate that the same session emits a deck; install is reached in fifty-two lines
+  and nine images, seven of which are badges. The "Upgrading from 1.x" note moves into
+  Installation, where an upgrader is already headed.
+- **The first snippet a reader copies is a file they can run.** "Hello world" opened
+  with eight imports and eight public types — colours, text styles, a font, a page
+  background, a soft panel, an accent strip — before the reader had rendered anything.
+  It now opens with four types and a complete `Hello.java`: paste, run, get a PDF. The
+  styled version keeps its place directly beneath as "Make it cinematic", which is what
+  it was always demonstrating, and points at the committed preview of the example that
+  renders the whole family. The first-document guide keeps its snippets as statements —
+  three `main` wrappers would bury what it is teaching — and now says so, pointing at
+  the README for the complete file rather than leaving the reader to discover that its
+  code does not compile on its own. Also: the feature map, `docs/capabilities.md`, is
+  now reachable from the landing page rather than only through the documentation index.
 - **The last three documents that put `MissingBackendException` at the render call.**
   An earlier pass moved the module READMEs and the exception's own Javadoc onto
   `create()` and stopped at the repository root, so the troubleshooting entry, the 2.0

--- a/README.md
+++ b/README.md
@@ -23,9 +23,6 @@
 > 🟢 **Latest stable**: [v2.1.0](https://github.com/DemchaAV/GraphCompose/releases/tag/v2.1.0) &mdash; the **PowerPoint** release: `graph-compose-render-pptx` turns the same resolved layout into an editable deck &mdash; one page per slide, geometry-identical to the PDF, text and panels as native shapes. Ships as `@Beta`. **[What each backend supports &darr;](docs/architecture/backend-capability-matrix.md)**
 > &nbsp;·&nbsp; 🟡 **In development**: v2.1.1 on `develop` &mdash; see [CHANGELOG.md](./CHANGELOG.md).
 
-> &nbsp;·&nbsp; ⬆️ **Upgrading from 1.x?** `graph-compose` stays a drop-in for PDF with no code change; see the [2.0 modules migration guide](./docs/migration/v2.0.0-modules.md)
-> &nbsp;·&nbsp; See [API stability policy](./docs/api-stability.md) for tier definitions.
-
 <p align="center">
   <a href="https://demchaav.github.io/GraphCompose/"><b>Live Showcase</b></a>
   &nbsp;·&nbsp;
@@ -42,42 +39,6 @@
 
 <p align="center">
   <sub>☝ This banner is itself a GraphCompose document — <a href="./assets/readme/examples/engine-deck-v2.pdf"><b>view the full module-first deck (PDF)</b></a>, rendered by <a href="./examples/src/main/java/com/demcha/examples/flagships/EngineDeckV2Example.java"><code>EngineDeckV2Example</code></a>: the module graph, native vector charts, and real comparative benchmarks, all drawn by the engine. It renders its own marketing.</sub>
-</p>
-
-## One source → a PDF <i>and</i> an editable PowerPoint deck
-
-The same `DocumentSession` emits both. The PDF backend prints the resolved layout; the PPTX backend (**beta**) rebuilds it as slides. Both consume the same resolved layout graph, so page and slide frames and every positioned element share the same geometry — text, panels, tables, and vectors arrive in PowerPoint as **native, editable shapes**, not screenshots (the page below lands as 69 native shapes; only its clip-masked logo art is a picture). Glyphs are rasterised by the viewer, so the exact text rendering depends on the fonts installed on the viewing machine; see the [backend capability matrix](docs/architecture/backend-capability-matrix.md) for per-feature fidelity.
-
-PowerPoint output needs `graph-compose-render-pptx` on the classpath in addition to `graph-compose`; without it `buildPptx` fails with a `MissingBackendException` naming the artifact. See [Which artifact?](#installation) below.
-
-<!-- doc-example: id=readme-root-one-model-two-outputs mode=method imports=com.demcha.compose.GraphCompose,com.demcha.compose.document.api.DocumentSession,com.demcha.compose.document.api.DocumentPageSize,java.nio.file.Path -->
-```java
-Path deck = Path.of("twin-output.pptx");
-try (DocumentSession doc = GraphCompose.document(Path.of("twin-output.pdf"))
-        .pageSize(DocumentPageSize.SLIDE_16_9)
-        .create()) {
-    // … describe the page (see Hello world below)
-    doc.buildPdf();      // print-ready PDF
-    doc.buildPptx(deck); // editable PowerPoint
-}
-```
-
-<table>
-<tr>
-<td width="50%" align="center"><sub><b>twin-output.pdf</b> — rendered by the PDF backend</sub></td>
-<td width="50%" align="center"><sub><b>twin-output.pptx</b> — the same page, as <b>PowerPoint itself</b> renders it</sub></td>
-</tr>
-<tr>
-<td><img src="./assets/readme/twin-output-pdf.png" alt="The twin-output page rendered from the PDF"/></td>
-<td><img src="./assets/readme/twin-output-pptx.png" alt="The same page exported as a PNG by PowerPoint from the generated .pptx"/></td>
-</tr>
-</table>
-
-<p align="center">
-  <img src="./assets/readme/twin-output-editing.png" alt="The generated deck open in PowerPoint with the headline text frame selected for editing" width="820"/>
-</p>
-<p align="center">
-  <sub>☝ The generated deck open in PowerPoint — the headline is a selected, editable text frame, and the ribbon is live because the slide is built from native shapes. Artifacts: <a href="./assets/readme/examples/twin-output.pdf"><b>PDF</b></a> · <a href="./assets/readme/examples/twin-output.pptx"><b>PPTX</b></a> · <a href="./examples/src/main/java/com/demcha/examples/flagships/TwinOutputExample.java"><b>source</b></a> (<code>TwinOutputExample</code>, one page, source included).</sub>
 </p>
 
 ## Why GraphCompose
@@ -108,6 +69,9 @@ dependencies { implementation("io.github.demchaav:graph-compose:2.1.0") }
 That coordinate renders PDF out of the box: it aggregates the lean `graph-compose-core`
 engine plus the `graph-compose-render-pdf` backend, so existing 1.x callers upgrade with
 **no code change**.
+
+> ⬆️ **Upgrading from 1.x?** `graph-compose` stays a drop-in for PDF with no code change; see the [2.0 modules migration guide](./docs/migration/v2.0.0-modules.md).
+> &nbsp;·&nbsp; See [API stability policy](./docs/api-stability.md) for tier definitions.
 
 <details>
 <summary><b>Which artifact?</b> &mdash; the 2.0 module split, when you want to take less or more</summary>
@@ -162,6 +126,42 @@ pinned to v1.6.5 and earlier but is no longer the documented install option.
 
 ## Hello world
 
+<!-- doc-example: id=readme-root-minimal mode=members -->
+```java
+import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.api.DocumentPageSize;
+import com.demcha.compose.document.api.DocumentSession;
+
+import java.nio.file.Path;
+
+class Hello {
+    public static void main(String[] args) throws Exception {
+        try (DocumentSession document = GraphCompose.document(Path.of("hello.pdf"))
+                .pageSize(DocumentPageSize.A4)
+                .margin(24, 24, 24, 24)
+                .create()) {
+
+            document.pageFlow(page -> page
+                    .module("Summary", module -> module.paragraph("Hello GraphCompose")));
+
+            document.buildPdf();
+        }
+    }
+}
+```
+
+Save it as `Hello.java` and run it — that is the whole file. `create()` opens the session,
+`pageFlow` describes the page, `buildPdf()` writes it: no coordinates, no page-break
+arithmetic.
+
+### Make it cinematic
+
+The same page with the engine's visual primitives: a page background, a soft panel, an
+accent strip and two text styles. Nothing here is a workaround — panels and accents are
+nodes, and the engine places them. [`SectionPresetsExample`](./examples/src/main/java/com/demcha/examples/features/text/SectionPresetsExample.java)
+renders the whole family; its output is committed as
+[section-presets.pdf](./assets/readme/examples/section-presets.pdf).
+
 <!-- doc-example: id=readme-root-hello-world mode=members -->
 ```java
 import com.demcha.compose.GraphCompose;
@@ -215,6 +215,42 @@ For a Spring Boot `@RestController` streaming the PDF straight to the response, 
 - [**Your first document**](./docs/first-document.md) &mdash; the five-minute path from an empty project to a rendered PDF.
 - [**Getting started**](./docs/getting-started.md) &mdash; DSL or templates, and how to choose; the first-render walk-through.
 - [**Examples gallery**](./examples/README.md) &mdash; every runnable example, with a PDF you can preview without building anything.
+
+## One source → a PDF <i>and</i> an editable PowerPoint deck
+
+The same `DocumentSession` emits both. The PDF backend prints the resolved layout; the PPTX backend (**beta**) rebuilds it as slides. Both consume the same resolved layout graph, so page and slide frames and every positioned element share the same geometry — text, panels, tables, and vectors arrive in PowerPoint as **native, editable shapes**, not screenshots (the page below lands as 69 native shapes; only its clip-masked logo art is a picture). Glyphs are rasterised by the viewer, so the exact text rendering depends on the fonts installed on the viewing machine; see the [backend capability matrix](docs/architecture/backend-capability-matrix.md) for per-feature fidelity.
+
+PowerPoint output needs `graph-compose-render-pptx` on the classpath in addition to `graph-compose`; without it `buildPptx` fails with a `MissingBackendException` naming the artifact. See [Which artifact?](#installation) above.
+
+<!-- doc-example: id=readme-root-one-model-two-outputs mode=method imports=com.demcha.compose.GraphCompose,com.demcha.compose.document.api.DocumentSession,com.demcha.compose.document.api.DocumentPageSize,java.nio.file.Path -->
+```java
+Path deck = Path.of("twin-output.pptx");
+try (DocumentSession doc = GraphCompose.document(Path.of("twin-output.pdf"))
+        .pageSize(DocumentPageSize.SLIDE_16_9)
+        .create()) {
+    // … describe the page (see Hello world above)
+    doc.buildPdf();      // print-ready PDF
+    doc.buildPptx(deck); // editable PowerPoint
+}
+```
+
+<table>
+<tr>
+<td width="50%" align="center"><sub><b>twin-output.pdf</b> — rendered by the PDF backend</sub></td>
+<td width="50%" align="center"><sub><b>twin-output.pptx</b> — the same page, as <b>PowerPoint itself</b> renders it</sub></td>
+</tr>
+<tr>
+<td><img src="./assets/readme/twin-output-pdf.png" alt="The twin-output page rendered from the PDF"/></td>
+<td><img src="./assets/readme/twin-output-pptx.png" alt="The same page exported as a PNG by PowerPoint from the generated .pptx"/></td>
+</tr>
+</table>
+
+<p align="center">
+  <img src="./assets/readme/twin-output-editing.png" alt="The generated deck open in PowerPoint with the headline text frame selected for editing" width="820"/>
+</p>
+<p align="center">
+  <sub>☝ The generated deck open in PowerPoint — the headline is a selected, editable text frame, and the ribbon is live because the slide is built from native shapes. Artifacts: <a href="./assets/readme/examples/twin-output.pdf"><b>PDF</b></a> · <a href="./assets/readme/examples/twin-output.pptx"><b>PPTX</b></a> · <a href="./examples/src/main/java/com/demcha/examples/flagships/TwinOutputExample.java"><b>source</b></a> (<code>TwinOutputExample</code>, one page, source included).</sub>
+</p>
 
 ## What's new in 2.0
 
@@ -355,6 +391,7 @@ The index routes by what you are doing — first document, using or authoring a
 template, extending the engine, running in production. The entry points most
 people want directly:
 
+- **Capabilities** — [the feature map](./docs/capabilities.md): every capability with its stability tier and the guide that covers it
 - **Templates** — [layered architecture](./docs/templates/v2-layered/README.md) (CV, cover letter, invoice, proposal on `BrandTheme`) · [which template system?](./docs/templates/which-template-system.md) for callers arriving from a pre-2.0 surface
 - **Recipes** — [the cookbook](./docs/recipes.md): tables, themes, shapes, transforms, page backgrounds, streaming, extending
 - **Operations** — [production rendering](./docs/operations/production-rendering.md) · [layout snapshot testing](./docs/operations/layout-snapshot-testing.md) · [troubleshooting](./docs/troubleshooting.md)

--- a/docs/first-document.md
+++ b/docs/first-document.md
@@ -32,6 +32,11 @@ try (DocumentSession document = GraphCompose.document(Path.of("hello.pdf"))
 }
 ```
 
+Those are statements, not a file: they go inside a method — the
+[README's Hello world](../README.md#hello-world) shows the same program as a complete
+`Hello.java`. Every snippet on this page is written the same way, so the shape you are
+reading is the GraphCompose part and nothing else.
+
 `GraphCompose.document(path)` configures the output; `create()` returns the
 `DocumentSession`. Use try-with-resources so the session is always released, even
 if rendering fails. Inside the session, `pageFlow(...)` is the document body:

--- a/examples/src/main/java/com/demcha/examples/features/text/SectionPresetsExample.java
+++ b/examples/src/main/java/com/demcha/examples/features/text/SectionPresetsExample.java
@@ -16,7 +16,7 @@ import com.demcha.examples.support.ExampleOutputPaths;
 import java.nio.file.Path;
 
 /**
- * Runnable showcase for the v1.4 / v1.5 section preset shortcuts.
+ * Runnable showcase for the section preset shortcuts.
  *
  * <p>Demonstrates {@code pageBackground}, {@code band(color)},
  * {@code softPanel(...)}, {@code headingBar(...)}, {@code accentLeft /


### PR DESCRIPTION
## Why

Ninety-one lines and twelve `<img>` tags stood between the title and `## Installation`. Most of that was a *second* showcase: the "One source → a PDF and an editable PowerPoint deck" section — thirty-five lines, two renders and a PowerPoint screenshot — sitting before the reader had seen a single line of the authoring API. A reader who came for a PDF met a `@Beta` deck exporter first.

And the first snippet they could copy was forty-two lines with eight imports and eight public types, two lines above a link to a tutorial whose own first example is sixteen lines and four types.

## What changed

- The PPTX section moves below `### Next steps`. After a reader has written a document, "the same session also emits a deck" reads as a payoff instead of a detour. `## Installation` moves from line 92 to line 53: **52 lines and 9 images** precede it, seven of the nine being badges. The banner render and `## Why GraphCompose` deliberately stay above it — for a rendering library the output image *is* the reason to keep reading.
- Two directional words invert with the move and are fixed: `See [Which artifact?](#installation) below` → `above`, and the in-fence comment `see Hello world below` → `above`. The third, "the page below", is left alone — its referent travels with the block.
- The "Upgrading from 1.x / API stability" blockquote moves out of the header into `## Installation`, where an upgrader is already headed.
- `## Hello world` now leads with the sixteen-line example, copied verbatim from [docs/first-document.md](docs/first-document.md) so the landing page and the tutorial teach the same first program. The styled block keeps its place directly beneath as `### Make it cinematic` — which is what it was always demonstrating — and points at [`SectionPresetsExample`](examples/src/main/java/com/demcha/examples/features/text/SectionPresetsExample.java) and its committed preview, so the claim is shown rather than asserted.
- `docs/capabilities.md` is linked from `## Documentation`. It had two inbound links in the whole repo, neither from the landing page.

## What I deliberately did not do

**No new PNG of the styled example.** The plan called for one; the repository says no. `CommittedAssetDriftTest` asserts *set equality* on the files directly under `assets/readme/` against `RASTER_FIGURES` — the enumerated register of figures nothing can verify. There is no example that renders a Hello-world page, so a new PNG could only be added by declaring it unverifiable, in the same release whose CHANGELOG states that a committed preview cannot fall behind the code that renders it. `cut-release.ps1` stages only `assets/readme/examples` and the banner, so it would also freeze at whatever version it was first rendered at. Linking an existing, gate-covered preview says the same thing and stays true.

**`## Hello world` keeps its heading text.** [README.md](README.md) links `#hello-world` from the API table, `CanonicalSurfaceGuardTest.publicMarkdownLinksShouldResolve` skips `#` targets, and 13 files link `README.md#installation`. Heading text on this page is effectively public API; the new subheading is added below rather than replacing anything.

## Verification

`./mvnw -B -ntp clean verify` — `BUILD SUCCESS`, exit 0, 692 tests in the closing module.

The guards that constrain this file specifically:

- `DocumentationCoverageTest` (5) — README must contain `GraphCompose.document(`, `DocumentSession`, `document.pageFlow(` and `DocumentTextStyle`. The styled block is the only source of the last two, which is why it is kept intact rather than trimmed; the new minimal fence keeps the variable named `document`, so it carries `document.pageFlow(` as well.
- `DocumentationSnippetCompileTest` (6) — the new fence carries `<!-- doc-example: id=readme-root-minimal mode=method -->`, an id that collides with none of the thirteen in use and sanitizes to a distinct unit name. Its body already compiled elsewhere under `first-document-smallest`.
- `CanonicalSurfaceGuardTest` (11) — every relative link still resolves.
- `DocsBoldFaceGuardTest` (1) — the styled block's `FontName.HELVETICA` + `.decoration(BOLD)` is untouched.

Diff is 71/39 on a 400-line file — checked, because this repo's `autocrlf` will otherwise present a whole-file rewrite.

Lane: docs. No production code, no public API.
