### PR TITLE
fix(examples): the carousel sets leading in points, not multiples

### DIFF
--- a/examples/src/main/java/com/demcha/examples/flagships/LinkedInCarouselExample.java
+++ b/examples/src/main/java/com/demcha/examples/flagships/LinkedInCarouselExample.java
@@ -230,7 +230,10 @@ public final class LinkedInCarouselExample {
         slide.addParagraph(p -> p
                 .text("One composition.\nTwo formats.")
                 .textStyle(headline(132))
-                .lineSpacing(1.03)
+                // lineSpacing is EXTRA space in points, not a multiplier: the layout
+                // adds it between wrapped lines on top of the font's own line height.
+                // Display type needs proportionally less of it than body copy.
+                .lineSpacing(8 * SCALE)
                 .margin(DocumentInsets.zero()));
         slide.addShape(shape -> shape.size(160 * SCALE, 7 * SCALE).fillColor(VIOLET)
                 .margin(DocumentInsets.symmetric(14, 0)));
@@ -240,7 +243,7 @@ public final class LinkedInCarouselExample {
                       + "backend — so PDF and PowerPoint are the same geometry, "
                       + "not two hand-kept designs.")
                 .textStyle(body(40, ON_DARK_MUTED))
-                .lineSpacing(1.45)
+                .lineSpacing(5 * SCALE)
                 .margin(DocumentInsets.zero()));
         slide.addRow("Formats", row -> {
             row.spacing(14 * SCALE).evenWeights();
@@ -258,7 +261,7 @@ public final class LinkedInCarouselExample {
         slide.addParagraph(p -> p
                 .text("PowerPoint is a\nfirst-class backend.")
                 .textStyle(headline(82))
-                .lineSpacing(1.06)
+                .lineSpacing(6 * SCALE)
                 .margin(DocumentInsets.zero()));
         point(slide, "Fixed layout, not export", MINT,
                 "PptxFixedLayoutBackend implements the same FixedLayoutRenderer "
@@ -318,7 +321,7 @@ public final class LinkedInCarouselExample {
         slide.addParagraph(p -> p
                 .text("Guarantees you\ncan run.")
                 .textStyle(headline(82))
-                .lineSpacing(1.06)
+                .lineSpacing(6 * SCALE)
                 .margin(DocumentInsets.zero()));
         point(slide, "Deterministic layout snapshots", VIOLET_LIGHT,
                 "Every flagship document has its geometry recorded as JSON. A layout "
@@ -420,7 +423,7 @@ public final class LinkedInCarouselExample {
             card.addParagraph(p -> p
                     .text(body)
                     .textStyle(body(28, ON_DARK_MUTED))
-                    .lineSpacing(1.4)
+                    .lineSpacing(4 * SCALE)
                     .margin(DocumentInsets.zero()));
         });
     }
@@ -471,7 +474,7 @@ public final class LinkedInCarouselExample {
             card.addParagraph(p -> p
                     .text(label)
                     .textStyle(body(24, ON_DARK_MUTED))
-                    .lineSpacing(1.25)
+                    .lineSpacing(3 * SCALE)
                     .margin(DocumentInsets.zero()));
         });
     }
@@ -506,7 +509,7 @@ public final class LinkedInCarouselExample {
     private static ParagraphBuilder footnote(ParagraphBuilder p, String text) {
         return p.text(text)
                 .textStyle(body(22, DocumentColor.rgb(130, 139, 170)))
-                .lineSpacing(1.4)
+                .lineSpacing(3 * SCALE)
                 .margin(DocumentInsets.top(6 * SCALE));
     }
 


### PR DESCRIPTION
## Why

Every `lineSpacing` call in the carousel carried a typographic multiplier — `1.03`, `1.06`, `1.25`, `1.4`, `1.45`. The API takes **points**:

- `ParagraphBuilder.lineSpacing` is documented `@param lineSpacing line spacing in points`;
- its default is `private double lineSpacing = 0.0` — a multiplier's default would be `1.0`, and `0.0` would collapse every line onto one;
- `TextFlowSupport:681-689` adds it as `totalHeight += (lineCount - 1) * gap`, on top of the font's own line height.

So the deck asked for one to one-and-a-half points of extra leading on type ranging from 26 pt to 156 pt, and rendered at effectively default leading throughout. That is why every slide read as a wall of text.

## What changed

The values move into the file's own design units and taper with type size, because display faces need proportionally less leading than body copy: `8 * SCALE` on the 132 pt headline, `6` on the 82 pt slide titles, `5` on the 40 pt lead paragraph, `4` on the 28 pt card body, `3` on the chart labels and the footnote. On the 33 pt card body that moves the gap from 1.4 pt to 4.7 pt. A comment at the first site records what the unit is, since the next person will guess the same way.

## Verification

Rendered before and after, rasterized at 110 dpi, and measured the card panels rather than judging by eye:

| card | body lines | before | after | delta |
|---|---|---|---|---|
| 1 | 4 | 391 px | 407 px | +10.5 pt |
| 2 | 3 | 343 px | 353 px | +6.5 pt |
| 3 | 2 | 294 px | 298 px | +2.6 pt |
| 4 | 3 | 342 px | 352 px | +6.5 pt |

Three, two and one inter-line gaps of 3.3 pt each — exactly what the arithmetic predicts, which is the check that the change did what it claims rather than something else.

The deck stays **six slides**; the last card on the tallest slide clears the bottom margin by 193 pt. The three-line wrap of the cover headline is pre-existing — it is in the before render too.

`./mvnw -B -ntp clean verify` — `BUILD SUCCESS`, exit 0, 692 tests in the closing module. `CommittedAssetDriftTest` green: this deck is in `UNPUBLISHED_PREVIEWS`, so no committed asset moves with it.

## A larger finding this exposed — not fixed here

The same misreading is repo-wide. Counting numeric literals in `src/main`:

| module | multiplier-shaped (< 2.0) | point-shaped (≥ 2.0) |
|---|---|---|
| `core` | 1 | 0 |
| `templates` | 34 | 0 |
| `examples` | 55 | 3 |

**Zero** call sites in the engine or the published templates use the API as documented. `TimelineBuilder:287` sets `1.3` on every timeline entry body — that is engine code that ships. All the CV, cover-letter, invoice and proposal presets do the same, so every preset a user renders is running at essentially default leading while its author intended 1.3–1.5×.

`docs/templates/v1-classic/authoring.md:189` is likely where it started: it says *"default 1.0 squashes \n-joined lines"*, which is wrong — the default is `0.0`.

Fixing that is a separate decision with real consequences: correcting 35 call sites in shipped code moves every layout snapshot and visual-regression baseline. Flagged for a call, not folded in here.

Lane: examples. No production code, no public API.
