### PR TITLE
docs(templates): lineSpacing is points, not a multiple of the font size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,13 @@ follow semantic versioning; release dates are ISO 8601.
 
 ### Documentation
 
+- **The authoring cheatsheet stops describing `lineSpacing` as a multiple.** Its
+  address-block recipe passed `1.3` and explained it as overriding a default of `1.0` —
+  the reading a CSS `line-height` invites, and the one the number itself suggests.
+  `lineSpacing` is extra space in **points**, defaulting to `0`: a paragraph grows by
+  `(lines - 1) × spacing`, so `1.3` bought a little over one point of air rather than
+  30% more leading, and there was no `1.0` default to override. The recipe now passes a
+  value that does what the prose beside it promises, and the page states the unit.
 - **The chart recipe documents the styling surface it has.** Five settings were named
   nowhere on the page — the three text styles, the donut centre style and the bar width
   ratio — four of them already load-bearing in the flagship examples that put a chart on

--- a/docs/templates/v1-classic/authoring.md
+++ b/docs/templates/v1-classic/authoring.md
@@ -181,14 +181,21 @@ you cheap forks. To brand for your project, hand-build a
 The soft panel sits flush against the accent stripe — round only the
 **right** corners so the join is clean.
 
-### 6.2 Address blocks with `lineSpacing(1.3)`
+### 6.2 Address blocks with `lineSpacing(3)`
 
 ```java
 .addParagraph(p -> p.text(joinAddress(party))
     .textStyle(theme.text().body())
-    .lineSpacing(1.3)               // default 1.0 squashes \n-joined lines
+    .lineSpacing(3)                 // 3pt of air; the default 0 packs \n-joined lines
     .margin(DocumentInsets.zero()))
 ```
+
+`lineSpacing` is **extra space in points**, not a multiple of the font size:
+the paragraph's height grows by `(lines - 1) × spacing`. The default is `0`,
+so an address joined with `\n` renders on consecutive baselines with no extra
+gap between them — the font's own line height and nothing added. Two or three
+points is usually enough to separate the lines without opening a gap that
+reads as a paragraph break.
 
 ### 6.3 Two-column block via `addRow` with weights
 
@@ -337,7 +344,7 @@ public final class StatusReportTemplateV1 implements StatusReportTemplate {
                         .addParagraph(p -> p.text("Summary").textStyle(theme.text().h2()))
                         .addParagraph(p -> p.text(spec.summary())
                                 .textStyle(theme.text().body())
-                                .lineSpacing(1.3)))
+                                .lineSpacing(3)))
 
                 // Metrics table — themed header + zebra + total row + repeating header
                 .addTable(table -> {


### PR DESCRIPTION
## Why

The v1-classic authoring cheatsheet taught `lineSpacing` as a leading multiplier. Its
address-block recipe passed `1.3` with the comment *"default 1.0 squashes \n-joined
lines"* — both halves wrong, and wrong in the direction a reader coming from CSS
`line-height` already leans.

`lineSpacing` is extra space in **points**. `ParagraphBuilder` initialises it to `0.0`
and `TextFlowSupport` applies it as `totalHeight += (lineCount - 1) * gap`, so `1.3`
bought a little over one point of air rather than 30% more leading, and no `1.0`
default ever existed to override.

The page is archived — it carries its own banner saying so, and
`which-template-system.md` lists it under *Historical (archived)*. It is still worth
correcting, because the error is not about the removed surface the banner disclaims:
`ParagraphBuilder.lineSpacing(double)` exists unchanged in 2.x with the same
points-based semantics. The page's stated audience is someone maintaining a pre-2.0
caller, and this sentence would send them into 2.x code with the wrong model of a
method that never changed. "Not updated anymore" is a promise to stop adding new
material, not a licence to leave a false statement standing.

## What

- The recipe passes `3` and says what the unit is: extra points, default `0`, height
  grows by `(lines - 1) × spacing`.
- The same `1.3` in the full template listing further down the page is corrected too —
  leaving it would have kept the misreading one scroll away.
- The section heading no longer advertises `lineSpacing(1.3)` as the address-block
  recipe.

Checked the rest of the public docs for the same claim: `docs/recipes/lists.md`,
`rich-text.md` and `shapes.md` already describe it as a gap and pass point-shaped
values, so this page was the only one teaching the multiplier reading.

## Tests

`./mvnw -B -ntp clean verify` → `BUILD SUCCESS`. No marked snippets on this page, so
the change is prose and sample values only; the guards that read it
(`DocsBoldFaceGuardTest`, `CanonicalSurfaceGuardTest`, link checks) pass.
