### PR TITLE
chore(examples): the carousel's value labels read in amber

### DIFF
--- a/examples/src/main/java/com/demcha/examples/flagships/LinkedInCarouselExample.java
+++ b/examples/src/main/java/com/demcha/examples/flagships/LinkedInCarouselExample.java
@@ -502,7 +502,9 @@ public final class LinkedInCarouselExample {
                 .barCornerRadius(DocumentCornerRadius.of(4 * SCALE))
                 .barWidthRatio(0.5)
                 .axisTextStyle(mono(22, ON_DARK_MUTED))
-                .valueLabelTextStyle(mono(25, ON_DARK))
+                // Amber lifts the numbers off the violet bars without a second fill
+                // behind them; on this surface it clears 7.6:1.
+                .valueLabelTextStyle(mono(25, AMBER))
                 // The labels sit over the gridlines, which on this surface read as
                 // strikethroughs across the digits. The halo punches a chip of the
                 // card's own fill out from under each one.


### PR DESCRIPTION
## Why

On the carousel's benchmark slide the value labels used the deck's body colour — a
light neutral one step from the violet bars they sit on and identical to the axis
chrome around them. The numbers are the point of the slide and read as the least
distinct thing on it.

Amber is already the slide's accent: its eyebrow (*MEASURED, NOT CLAIMED*) and its
third ratio tile (*2.7x lighter than Jasper*) are both in it. Moving the labels there
separates them from the bars and ties the measurements into one thread instead of
adding a fourth colour.

## What

`latencyStyle()` sets `valueLabelTextStyle` to amber. Contrast against the card fill
is 7.6:1.

The halo stays the card colour. It exists to cut the gridline out from behind a label
— a coloured chip would turn an invisible fix into a badge, which is a different
design decision than the one asked for here.

## Tests

`./mvnw -B -ntp clean verify` → `BUILD SUCCESS`, with `CommittedAssetDriftTest` green:
the carousel is listed in that guard's `UNPUBLISHED_PREVIEWS`, so no file under
`assets/readme/` moves and none needs re-committing.

Rendered and inspected page 4 of `examples/target/generated-pdfs/flagships/linkedin-carousel.pdf`.
