### PR TITLE
docs: the PowerShell commands run as written

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -211,6 +211,15 @@ follow semantic versioning; release dates are ISO 8601.
 
 ### Documentation
 
+- **The PowerShell commands run as written.** Two pages handed Windows readers a
+  command that fails. PowerShell splits a `-D` flag whose property name contains a dot,
+  passing the native command `-Dexec` and `.mainClass=…` as separate arguments, and
+  Maven then rejects the fragment with `Unknown lifecycle phase ".mainClass=…"`; a flag
+  with no dot before the `=` survives, which is what makes it easy to miss. The
+  examples README compounded it by claiming the bash form works unchanged on
+  PowerShell — the block above it ends a line with `\`, a continuation PowerShell does
+  not have — while pointing at backslash paths, which were never the problem. Both
+  pages now carry the command that was run on PowerShell to check it.
 - **The authoring cheatsheet stops describing `lineSpacing` as a multiple.** Its
   address-block recipe passed `1.3` and explained it as overriding a default of `1.0` —
   the reading a CSS `line-height` invites, and the one the number itself suggests.

--- a/docs/operations/benchmarks.md
+++ b/docs/operations/benchmarks.md
@@ -293,8 +293,13 @@ reference, with the IDE closed:
 
 **Windows (PowerShell):**
 
+A `-D` flag whose property name contains a dot has to be quoted here — unquoted,
+PowerShell hands the native command `-Dmdep` and `.outputFile=…` as two arguments and
+Maven rejects the second as a lifecycle phase. That is why the `java` lines below quote
+theirs too.
+
 ```powershell
-.\mvnw.cmd -B -ntp -f benchmarks\pom.xml test-compile dependency:build-classpath -DincludeScope=test -Dmdep.outputFile=target/benchmark.classpath
+.\mvnw.cmd -B -ntp -f benchmarks\pom.xml test-compile dependency:build-classpath -DincludeScope=test "-Dmdep.outputFile=target/benchmark.classpath"
 $cp = 'benchmarks\target\test-classes;benchmarks\target\classes;' + (Get-Content benchmarks\target\benchmark.classpath -Raw).Trim()
 1..5 | ForEach-Object { & java "-Dgraphcompose.benchmark.profile=full" -cp "$cp" com.demcha.compose.CurrentSpeedBenchmark }
 $runs = Get-ChildItem target\benchmarks\current-speed\run-*.json | Sort-Object Name | Select-Object -Last 5 | ForEach-Object { $_.FullName }

--- a/examples/README.md
+++ b/examples/README.md
@@ -27,8 +27,19 @@ Source path into a class name: drop `src/main/java/` and `.java`, then swap `/` 
 So `src/main/java/com/demcha/examples/flagships/ModuleFirstFileExample.java` becomes
 `com.demcha.examples.flagships.ModuleFirstFileExample`.
 
-Generated PDFs land in `examples/target/generated-pdfs/`. The same `mvnw.cmd` form
-works on Windows PowerShell with backslash paths.
+Generated PDFs land in `examples/target/generated-pdfs/`.
+
+On Windows PowerShell the wrapper is `.\mvnw.cmd` and the command needs two changes,
+neither of them cosmetic. The trailing `\` above is a shell continuation PowerShell does
+not have, so the command must be one line. And `-Dexec.mainClass=…` has to be quoted:
+unquoted, PowerShell splits it and Maven receives `.mainClass=…` as a separate argument,
+failing with `Unknown lifecycle phase ".mainClass=…"`.
+
+```powershell
+.\mvnw.cmd -f examples/pom.xml exec:java "-Dexec.mainClass=com.demcha.examples.flagships.ModuleFirstFileExample"
+```
+
+Forward slashes are fine in the `-f` path; nothing needs converting to backslashes.
 
 To regenerate the **whole catalogue** — roughly a hundred documents, and the output
 directory is emptied first — run the batch entry point. You do not need it to read one


### PR DESCRIPTION
## Why

Two pages hand Windows readers a command that fails.

PowerShell splits a `-D` flag whose property name contains a dot. Probed directly:

```
python -c "import sys; print(sys.argv[1:])" -Dmdep.outputFile=x -DincludeScope=test -Dexec.mainClass=Foo
['-Dmdep', '.outputFile=x', '-DincludeScope=test', '-Dexec', '.mainClass=Foo']
```

Maven then rejects the fragment with `Unknown lifecycle phase ".mainClass=…"`. A flag
without a dot before the `=` survives, which is why this is easy to miss.

`examples/README.md` also told readers *"The same `mvnw.cmd` form works on Windows
PowerShell with backslash paths."* It does not. The bash block above it ends a line with
`\`, which PowerShell has no notion of — it runs `./mvnw` alone and then looks for a
command named `-Dexec.mainClass=…`. And the backslash-paths advice pointed at a
non-problem: forward slashes work fine in `-f`.

`docs/operations/benchmarks.md` quotes the flags on its `java` lines and missed the one
on its `mvnw` line, so the page half-knew.

## What

- `examples/README.md`: replaces the false claim with the PowerShell command, one line,
  flag quoted, and says what goes wrong without each change.
- `docs/operations/benchmarks.md`: quotes `-Dmdep.outputFile=…` and states the rule,
  pointing at the `java` lines below that already follow it.

## Tests

Every command in the diff was run on this machine's PowerShell, before and after:

| Command | As documented | Fixed |
|---|---|---|
| `examples/README.md` run-one-example | `BUILD FAILURE`, `Unknown lifecycle phase ".mainClass=…"` | `PS_EXIT=0`, wrote `module-first-profile.pdf` |
| `benchmarks.md` build-classpath | `BUILD FAILURE` | `BUILD SUCCESS`, wrote `benchmarks/target/benchmark.classpath` |

`./mvnw -B -ntp clean verify` → `BUILD SUCCESS`.
