### PR TITLE
chore(deps): bump assertj across all eight smoke setups, and route them to develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,13 @@ updates:
       - "/"
       - "/examples"
       - "/benchmarks"
+      # The release-smoke consumer projects. They were outside every directory
+      # listed here, so updates for them arrived through the default branch
+      # instead — #514 opened against `main`, which is the divergence this
+      # block's target-branch exists to prevent. They are eight deliberately
+      # identical projects, so a bump has to reach all of them: grouping them
+      # under one entry keeps them moving together.
+      - "/scripts/release-smoke/*"
     # Send Maven update PRs to the integration branch, not the
     # default branch. Releases are cut from `develop` then merged
     # to `main`; targeting `main` (the default) made every Dependabot

--- a/scripts/release-smoke/s1-graph-compose/pom.xml
+++ b/scripts/release-smoke/s1-graph-compose/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <gc.version>2.0.0</gc.version>
         <junit.version>5.11.4</junit.version>
-        <assertj.version>3.27.3</assertj.version>
+        <assertj.version>3.27.7</assertj.version>
         <surefire.version>3.5.2</surefire.version>
     </properties>
 

--- a/scripts/release-smoke/s2-core-only/pom.xml
+++ b/scripts/release-smoke/s2-core-only/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <gc.version>2.0.0</gc.version>
         <junit.version>5.11.4</junit.version>
-        <assertj.version>3.27.3</assertj.version>
+        <assertj.version>3.27.7</assertj.version>
         <surefire.version>3.5.2</surefire.version>
         <enforcer.version>3.5.0</enforcer.version>
     </properties>

--- a/scripts/release-smoke/s3-core-render-pdf/pom.xml
+++ b/scripts/release-smoke/s3-core-render-pdf/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <gc.version>2.0.0</gc.version>
         <junit.version>5.11.4</junit.version>
-        <assertj.version>3.27.3</assertj.version>
+        <assertj.version>3.27.7</assertj.version>
         <surefire.version>3.5.2</surefire.version>
     </properties>
 

--- a/scripts/release-smoke/s4-templates/pom.xml
+++ b/scripts/release-smoke/s4-templates/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <gc.version>2.0.0</gc.version>
         <junit.version>5.11.4</junit.version>
-        <assertj.version>3.27.3</assertj.version>
+        <assertj.version>3.27.7</assertj.version>
         <surefire.version>3.5.2</surefire.version>
     </properties>
 

--- a/scripts/release-smoke/s5-testing/pom.xml
+++ b/scripts/release-smoke/s5-testing/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <gc.version>2.0.0</gc.version>
         <junit.version>5.11.4</junit.version>
-        <assertj.version>3.27.3</assertj.version>
+        <assertj.version>3.27.7</assertj.version>
         <surefire.version>3.5.2</surefire.version>
     </properties>
 

--- a/scripts/release-smoke/s6-bundle/pom.xml
+++ b/scripts/release-smoke/s6-bundle/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <gc.version>2.0.0</gc.version>
         <junit.version>5.11.4</junit.version>
-        <assertj.version>3.27.3</assertj.version>
+        <assertj.version>3.27.7</assertj.version>
         <surefire.version>3.5.2</surefire.version>
     </properties>
 

--- a/scripts/release-smoke/s7-core-render-pptx/pom.xml
+++ b/scripts/release-smoke/s7-core-render-pptx/pom.xml
@@ -16,7 +16,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <gc.version>2.0.0</gc.version>
         <junit.version>5.11.4</junit.version>
-        <assertj.version>3.27.3</assertj.version>
+        <assertj.version>3.27.7</assertj.version>
         <surefire.version>3.5.2</surefire.version>
     </properties>
 

--- a/scripts/release-smoke/s8-core-render-docx/pom.xml
+++ b/scripts/release-smoke/s8-core-render-docx/pom.xml
@@ -15,7 +15,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <gc.version>2.0.0</gc.version>
         <junit.version>5.11.4</junit.version>
-        <assertj.version>3.27.3</assertj.version>
+        <assertj.version>3.27.7</assertj.version>
         <surefire.version>3.5.2</surefire.version>
     </properties>
 


### PR DESCRIPTION
## Why

Dependabot opened **#514 against `main`**. That is precisely the divergence the maven
block's `target-branch: develop` exists to prevent — its own comment records it being
fixed in v1.6.8 "after the #111 / #115 episodes". `main` is the release pointer, moved by
fast-forwarding `develop` onto it; a commit landing on `main` directly ends that, and the
next `git push origin develop:main` stops being a fast-forward.

The cause is scope, not the rule: `scripts/release-smoke/` sits outside every directory
the block lists, so updates for those poms arrive through the default branch instead. The
commit-message prefix gives it away — `build(deps-dev)` rather than the configured `deps`.

#514 also bumped **one project of eight**. The smoke setups are deliberately identical
consumers, differing only in which artifacts they depend on. A version moving in one of
them is drift, not an upgrade.

## What

- All eight smoke poms go to assertj **3.27.7** together — the version the engine itself
  already uses.
- The maven block's directory list covers `/scripts/release-smoke/*`, so the next update
  for them targets `develop` like everything else.

## Tests

`./mvnw -B -ntp clean verify` → `BUILD SUCCESS`, and `dependabot.yml` parses with both
entries still routed to `develop`.

The change is in the smoke projects themselves, so the meaningful check is the smoke:
run against the published **2.1.1** train with the bumped version — **8/8 pass**.

## On #514

It should be closed rather than merged or retargeted: retargeting would still leave one
project of eight moved, and this supersedes it with the uniform bump plus the config fix
that stops the next one arriving the same way.
