### PR TITLE
docs(ci): record that security updates ignore target-branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,18 +7,28 @@ updates:
       - "/"
       - "/examples"
       - "/benchmarks"
-      # The release-smoke consumer projects. They were outside every directory
-      # listed here, so updates for them arrived through the default branch
-      # instead — #514 opened against `main`, which is the divergence this
-      # block's target-branch exists to prevent. They are eight deliberately
-      # identical projects, so a bump has to reach all of them: grouping them
-      # under one entry keeps them moving together.
+      # The release-smoke consumer projects: eight deliberately identical
+      # setups, so a bump has to reach all of them and one grouped entry keeps
+      # them moving together. Until they were listed here they had no entry at
+      # all, which is why nothing but a security alert had ever opened a PR
+      # for them.
       - "/scripts/release-smoke/*"
-    # Send Maven update PRs to the integration branch, not the
-    # default branch. Releases are cut from `develop` then merged
-    # to `main`; targeting `main` (the default) made every Dependabot
-    # PR land alongside the latest release and force-diverge from
-    # ongoing dev work — fixed in v1.6.8 after the #111 / #115 episodes.
+    # Send Maven *version* updates to the integration branch, not the default
+    # branch. Releases are cut from `develop` then merged to `main`; targeting
+    # `main` (the default) made every Dependabot PR land alongside the latest
+    # release and force-diverge from ongoing dev work — fixed in v1.6.8 after
+    # the #111 / #115 episodes.
+    #
+    # It does not redirect *security* updates. Those are raised against the
+    # default branch whatever this says, which is how #514 landed on `main`.
+    # Listing a directory above does not change that: the next advisory
+    # touching any of these manifests will open against `main` again. Close it
+    # and carry the bump to `develop` rather than merging it, so the branches
+    # stay in a fast-forward line — #517 is the worked example.
+    #
+    # Setting a non-default target-branch also exempts security updates from
+    # the `labels` and `commit-message` settings below, so those PRs arrive
+    # under Dependabot's defaults and will not match the house style.
     target-branch: develop
     schedule:
       interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,11 +7,13 @@ updates:
       - "/"
       - "/examples"
       - "/benchmarks"
-      # The release-smoke consumer projects: eight deliberately identical
-      # setups, so a bump has to reach all of them and one grouped entry keeps
-      # them moving together. Until they were listed here they had no entry at
-      # all, which is why nothing but a security alert had ever opened a PR
-      # for them.
+      # The release-smoke consumer projects: eight deliberately *different*
+      # setups, one per published coordinate combination, so they must not be
+      # consolidated. What they share is the test scaffolding — junit, assertj
+      # and surefire pinned separately in each — which is why a bump has to be
+      # applied eight times and one grouped entry keeps them moving together.
+      # Until they were listed here they had no entry at all, which is why
+      # nothing but a security alert had ever opened a PR for them.
       - "/scripts/release-smoke/*"
     # Send Maven *version* updates to the integration branch, not the default
     # branch. Releases are cut from `develop` then merged to `main`; targeting


### PR DESCRIPTION
## Why

The comment beside the `release-smoke` directories in `.github/dependabot.yml`
explained #514 landing on `main` as a consequence of those paths sitting
outside every listed directory. That reads as though listing them — which
#517 did — stops it happening again. It does not.

Dependabot raises **security** updates against the default branch whatever
`target-branch` says. GitHub states it in the options reference: setting
`labels` "will also affect pull requests for security updates to the manifest
files of this package manager, unless you use `target-branch` to check for
version updates on a non-default branch", and `commit-message` carries the
same carve-out. #514 is the observable form of the branch half — a security
update, and the only Dependabot PR ever opened for these manifests, landing
on `main` while this file says `develop`.

So the divergence this entry exists to prevent will recur on the next
advisory, and the file currently tells the next reader it cannot.

## What

Replaces the wrong cause with the rule and the handling it implies: close
the PR and carry the bump to `develop` rather than merging it, so `main`
stays a fast-forward of `develop` — which is what #517 did.

Also records that a non-default `target-branch` exempts security updates
from the `labels` and `commit-message` settings, so those PRs arrive under
Dependabot's defaults and will not match the house style.

The second commit corrects a claim inherited from the comment being
replaced. It called the eight release-smoke projects "deliberately identical
setups"; they are deliberately different — one per published coordinate
combination (wrapper, lean core, core plus each render backend, templates,
testing, bundle), with s2 additionally running an enforcer dependency-tree
assertion the others do not. Read literally the old wording invites
consolidating them, which would delete the coverage they exist to provide.
What is identical is the test scaffolding — junit, assertj and surefire
pinned separately in all eight — and that is the real reason a bump has to
be applied eight times.

Comments only. No option value changes.

## Tests

Nothing in the build reads `dependabot.yml`, so there is no guard to extend
and none was added. A guard could assert the file parses and the keys exist,
but every claim here is about GitHub's behaviour, which no local test can
exercise — it would restate the file to itself and stay green whether or
not the prose is true, which is the failure mode that produced the wrong
comment in the first place.

Verified by parsing the file and asserting every option survived both edits:
`version`, the four `directories` entries, `target-branch: develop`,
`labels`, `commit-message`, and both ecosystem entries are byte-for-byte
what they were. `git diff` is confined to the comment blocks.
