### PR TITLE
docs: add GitHub Sponsors funding config and README section

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: DemchaAV

--- a/README.md
+++ b/README.md
@@ -402,6 +402,18 @@ people want directly:
 - [**graph-compose-markdown**](https://central.sonatype.com/artifact/io.github.demchaav/graph-compose-markdown) &mdash; a Markdown &rarr; PDF path built on the GraphCompose engine. Hand it a Markdown document and it renders through the same layout, theme, and PDFBox pipeline as the Java DSL &mdash; a companion **input surface** for teams who would rather author in Markdown than call the DSL directly. Published on Maven Central as `io.github.demchaav:graph-compose-markdown`; independent lifecycle, consumes the engine as a dependency.
 - [**graphcompose-ai-flow**](https://github.com/DemchaAV/graphcompose-ai-flow) &mdash; experimental sister project exploring an AI-assisted authoring flow on top of GraphCompose. Independent codebase, separate lifecycle &mdash; nothing in this repo depends on it. Track it if you are interested in agentic document composition driven by the same semantic node model.
 
+## Sponsorship
+
+GraphCompose is MIT-licensed and solo-maintained. If it saves your team work,
+[GitHub Sponsors](https://github.com/sponsors/DemchaAV) funds the unglamorous
+half of keeping it alive &mdash; release engineering, dependency upgrades, the
+visual-regression suite, and issue triage.
+
+Recurring or one-off. No tier gates a feature, nothing here is or will be
+paywalled, and sponsorship buys no queue position: issues stay best-effort for
+everyone alike &mdash; see [SUPPORT.md](./SUPPORT.md) for which channel fits
+which question.
+
 ## License
 
 MIT &mdash; see [`LICENSE`](./LICENSE).


### PR DESCRIPTION
## Why

Nothing in the repository pointed anywhere for funding, so GitHub never rendered the Sponsor button — not in the repository header, not on issues, not on pull requests, which is where it actually gets seen.

## What changed

`.github/FUNDING.yml` with a single `github: DemchaAV` entry enables the button. The Sponsors profile it points at is live at https://github.com/sponsors/DemchaAV.

The README gets a `## Sponsorship` section placed before `## License` rather than near the top. The page is already 400+ lines and dense for a first visit; a funding badge in the first screen competes with the Maven coordinates people arrive for.

The wording is deliberately narrow: sponsorship gates no feature, paywalls nothing, and buys no queue position. `SUPPORT.md` states triage is best-effort with no paid tier, and a funding pitch that implied otherwise would contradict it. `SUPPORT.md` is unchanged.

## Verification

`./mvnw -B -ntp test -Dtest=DocumentationLinkGuardTest -pl :graph-compose-core` — 1 test, 0 failures. Confirms the new relative link into `SUPPORT.md` resolves.
