### PR TITLE
refactor(fonts): let the font artifact state its own version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -143,7 +143,10 @@ follow semantic versioning; release dates are ISO 8601.
   consumer actually has.
 
   The artifact states that version itself: it ships a small descriptor written at build
-  time, and the engine reads it. The first shape of this carried a map from family folder
+  time, and the engine reads it. Presence is asked separately, of a face the artifact has
+  carried since its first release — the descriptor only ships from 1.1.0, so for the
+  releases published before it a missing descriptor means "too old to say", not "not
+  here", and those two need opposite advice. The first shape of this carried a map from family folder
   to the release that introduced it, which meant the catalog had to remember the
   artifact's history and every new font needed an entry in a class that otherwise knows
   nothing about which fonts exist. Reading the version off the artifact answers the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,8 +139,16 @@ follow semantic versioning; release dates are ISO 8601.
 - **A stale font artifact is now distinguished from a missing one.** Asking for a
   family that a newer `graph-compose-fonts` introduced produced the same message as
   having no font artifact at all — an instruction to add a dependency that was already
-  there. The two causes are now told apart, and the stale case names the version that
-  carries the family.
+  there. The two causes are now told apart, and the stale case names the version the
+  consumer actually has.
+
+  The artifact states that version itself: it ships a small descriptor written at build
+  time, and the engine reads it. The first shape of this carried a map from family folder
+  to the release that introduced it, which meant the catalog had to remember the
+  artifact's history and every new font needed an entry in a class that otherwise knows
+  nothing about which fonts exist. Reading the version off the artifact answers the
+  question that actually helps — *what do you have* rather than *what should you have* —
+  and needs no maintenance as families are added.
 
 ### Templates
 

--- a/core/src/main/java/com/demcha/compose/font/FontFamilyDefinition.java
+++ b/core/src/main/java/com/demcha/compose/font/FontFamilyDefinition.java
@@ -4,9 +4,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Properties;
 
 /**
  * Describes a reusable font family in backend-neutral terms.
@@ -316,8 +316,8 @@ public final class FontFamilyDefinition {
         }
     }
 
-    private record ClasspathFontSource(String resourcePath) implements FontBinarySource {
-        private ClasspathFontSource {
+    record ClasspathFontSource(String resourcePath) implements FontBinarySource {
+        ClasspathFontSource {
             Objects.requireNonNull(resourcePath, "resourcePath");
         }
 
@@ -332,42 +332,54 @@ public final class FontFamilyDefinition {
         }
 
         /**
-         * Families that entered the bundled set after its initial release, mapped
-         * to the fonts-artifact version that first carries them. A resource under
-         * one of these folders is missing for a different reason than the rest:
-         * the artifact is present but predates the family.
+         * Descriptor the fonts artifact ships, naming its own version.
+         *
+         * <p>Reading the version off the artifact is what lets this class say something
+         * true about a consumer's setup without knowing anything about the artifact's
+         * history. The alternative it replaced was a map from family folder to the
+         * version that introduced it — five entries and growing, kept in step by hand,
+         * in a class that otherwise knows nothing about which fonts exist.</p>
          */
-        private static final Map<String, String> FAMILY_MINIMUM_FONTS_VERSION = Map.of(
-                "amiri", "1.1.0",
-                "davidlibre", "1.1.0",
-                "notosansgeorgian", "1.1.0",
-                "notosansarmenian", "1.1.0",
-                "gothica1", "1.1.0");
+        private static final String FONTS_ARTIFACT_DESCRIPTOR = "/fonts/graph-compose-fonts.properties";
 
-        /**
-         * A face that has shipped in every release of the font artifact. Its presence
-         * separates "the artifact is missing" from "the artifact is older than the
-         * family being asked for" — two causes with different fixes.
-         */
-        private static final String LONG_STANDING_FACE = "/fonts/google/lato/Lato-Regular.ttf";
+        /** The fonts artifact's version, or {@code null} when it is not on the classpath. */
+        private static final String BUNDLED_FONTS_VERSION = readBundledFontsVersion();
 
-        /**
-         * Builds the not-found message. For a bundled Google-font resource the
-         * likely cause is that the separately-versioned font artifact is not on
-         * the classpath (the fonts moved out of the core jar in v1.8.0), or that
-         * it is older than the family being requested, so the message points at
-         * the fix instead of a bare path.
-         */
-        private static String missingResourceMessage(String normalizedPath) {
-            String requiredVersion = FAMILY_MINIMUM_FONTS_VERSION.get(familyFolder(normalizedPath));
-            if (requiredVersion != null && fontArtifactIsOnTheClasspath()) {
-                return "Bundled font resource not found: " + normalizedPath
-                        + ". This family ships in io.github.demchaav:graph-compose-fonts "
-                        + requiredVersion + " or newer — upgrade that dependency (or the "
-                        + "io.github.demchaav:graph-compose-bundle aggregate) to use it, "
-                        + "or register your own font with FontFamilyDefinition.";
+        private static String readBundledFontsVersion() {
+            try (InputStream descriptor =
+                         FontFamilyDefinition.class.getResourceAsStream(FONTS_ARTIFACT_DESCRIPTOR)) {
+                if (descriptor == null) {
+                    return null;
+                }
+                Properties properties = new Properties();
+                properties.load(descriptor);
+                String version = properties.getProperty("version");
+                return version == null || version.isBlank() ? null : version.trim();
+            } catch (IOException e) {
+                return null;
             }
-            if (normalizedPath.startsWith("/fonts/google/")) {
+        }
+
+        /**
+         * Builds the not-found message for a bundled font resource.
+         *
+         * <p>Two setups produce a missing bundled font and they need different advice.
+         * The artifact may not be on the classpath at all — the fonts moved out of the
+         * core jar in v1.8.0, and a build that never added the new dependency reaches
+         * here. Or it is present and simply older than the family being asked for, in
+         * which case telling the reader to add a dependency they already have is the one
+         * answer guaranteed not to help.</p>
+         *
+         * <p>The two are told apart by whether the artifact's own descriptor is readable,
+         * and the second case quotes the version the consumer actually has rather than
+         * the version that introduced the family: it is the fact that identifies the
+         * problem, and it needs no list to stay true as families are added.</p>
+         */
+        static String missingResourceMessage(String normalizedPath, String bundledFontsVersion) {
+            if (!normalizedPath.startsWith("/fonts/google/")) {
+                return "Classpath font resource not found: " + normalizedPath;
+            }
+            if (bundledFontsVersion == null) {
                 return "Bundled font resource not found: " + normalizedPath
                         + ". The bundled Google fonts ship in a separate artifact since v1.8.0 — "
                         + "add the dependency io.github.demchaav:graph-compose-fonts (or the "
@@ -375,21 +387,15 @@ public final class FontFamilyDefinition {
                         + "them, or register your own font with FontFamilyDefinition. "
                         + "See https://github.com/DemchaAV/GraphCompose/blob/main/docs/migration/v1.8.0-fonts.md";
             }
-            return "Classpath font resource not found: " + normalizedPath;
+            return "Bundled font resource not found: " + normalizedPath
+                    + ". The io.github.demchaav:graph-compose-fonts on your classpath is "
+                    + bundledFontsVersion + " and does not carry it — upgrade that dependency "
+                    + "(or the io.github.demchaav:graph-compose-bundle aggregate) to a version "
+                    + "that does, or register your own font with FontFamilyDefinition.";
         }
 
-        private static boolean fontArtifactIsOnTheClasspath() {
-            return FontFamilyDefinition.class.getResource(LONG_STANDING_FACE) != null;
-        }
-
-        /** Extracts {@code amiri} from {@code /fonts/google/amiri/Amiri-Regular.ttf}. */
-        private static String familyFolder(String normalizedPath) {
-            if (!normalizedPath.startsWith("/fonts/google/")) {
-                return "";
-            }
-            int start = "/fonts/google/".length();
-            int end = normalizedPath.indexOf('/', start);
-            return end < 0 ? normalizedPath.substring(start) : normalizedPath.substring(start, end);
+        private static String missingResourceMessage(String normalizedPath) {
+            return missingResourceMessage(normalizedPath, BUNDLED_FONTS_VERSION);
         }
 
         @Override

--- a/core/src/main/java/com/demcha/compose/font/FontFamilyDefinition.java
+++ b/core/src/main/java/com/demcha/compose/font/FontFamilyDefinition.java
@@ -339,8 +339,25 @@ public final class FontFamilyDefinition {
          * history. The alternative it replaced was a map from family folder to the
          * version that introduced it — five entries and growing, kept in step by hand,
          * in a class that otherwise knows nothing about which fonts exist.</p>
+         *
+         * <p>Its absence does not mean the artifact is absent. The descriptor itself only
+         * ships from 1.1.0, so every consumer of the one release published before it has
+         * the fonts and no descriptor — which is why presence is asked separately below.</p>
          */
         private static final String FONTS_ARTIFACT_DESCRIPTOR = "/fonts/graph-compose-fonts.properties";
+
+        /**
+         * A face that has shipped in every release of the font artifact, used to answer
+         * whether the artifact is on the classpath <em>at all</em>.
+         *
+         * <p>The descriptor cannot answer that. It is newer than the artifact, so a
+         * missing descriptor is ambiguous — no artifact, or one that predates the
+         * descriptor — and those two need opposite advice: add the dependency, or upgrade
+         * the one you have. Reading the version and detecting presence are two questions,
+         * and only the second can be asked of a release that shipped before either
+         * mechanism existed.</p>
+         */
+        private static final String LONG_STANDING_FACE = "/fonts/google/lato/Lato-Regular.ttf";
 
         /** The fonts artifact's version, or {@code null} when it is not on the classpath. */
         private static final String BUNDLED_FONTS_VERSION = readBundledFontsVersion();
@@ -363,23 +380,28 @@ public final class FontFamilyDefinition {
         /**
          * Builds the not-found message for a bundled font resource.
          *
-         * <p>Two setups produce a missing bundled font and they need different advice.
+         * <p>Three setups produce a missing bundled font and each needs different advice.
          * The artifact may not be on the classpath at all — the fonts moved out of the
          * core jar in v1.8.0, and a build that never added the new dependency reaches
-         * here. Or it is present and simply older than the family being asked for, in
-         * which case telling the reader to add a dependency they already have is the one
-         * answer guaranteed not to help.</p>
+         * here. It may be present and older than the family being asked for, in which
+         * case telling the reader to add a dependency they already have is the one answer
+         * guaranteed not to help. And it may be present, older, and old enough to predate
+         * the descriptor that would have named its version — the state every consumer of
+         * the one release published before that descriptor is in.</p>
          *
-         * <p>The two are told apart by whether the artifact's own descriptor is readable,
-         * and the second case quotes the version the consumer actually has rather than
-         * the version that introduced the family: it is the fact that identifies the
-         * problem, and it needs no list to stay true as families are added.</p>
+         * <p>So presence and version are asked separately. A long-standing face answers
+         * the first for any release ever published; the descriptor answers the second for
+         * those new enough to carry it, and the message quotes the version the consumer
+         * actually has rather than the version that introduced the family — the fact that
+         * identifies the problem, and one that needs no list to stay true.</p>
          */
-        static String missingResourceMessage(String normalizedPath, String bundledFontsVersion) {
+        static String missingResourceMessage(String normalizedPath,
+                                             String bundledFontsVersion,
+                                             boolean fontArtifactPresent) {
             if (!normalizedPath.startsWith("/fonts/google/")) {
                 return "Classpath font resource not found: " + normalizedPath;
             }
-            if (bundledFontsVersion == null) {
+            if (!fontArtifactPresent) {
                 return "Bundled font resource not found: " + normalizedPath
                         + ". The bundled Google fonts ship in a separate artifact since v1.8.0 — "
                         + "add the dependency io.github.demchaav:graph-compose-fonts (or the "
@@ -387,15 +409,19 @@ public final class FontFamilyDefinition {
                         + "them, or register your own font with FontFamilyDefinition. "
                         + "See https://github.com/DemchaAV/GraphCompose/blob/main/docs/migration/v1.8.0-fonts.md";
             }
+            String which = bundledFontsVersion == null
+                    ? "predates 1.1.0"
+                    : "is " + bundledFontsVersion;
             return "Bundled font resource not found: " + normalizedPath
-                    + ". The io.github.demchaav:graph-compose-fonts on your classpath is "
-                    + bundledFontsVersion + " and does not carry it — upgrade that dependency "
+                    + ". The io.github.demchaav:graph-compose-fonts on your classpath "
+                    + which + " and does not carry it — upgrade that dependency "
                     + "(or the io.github.demchaav:graph-compose-bundle aggregate) to a version "
                     + "that does, or register your own font with FontFamilyDefinition.";
         }
 
         private static String missingResourceMessage(String normalizedPath) {
-            return missingResourceMessage(normalizedPath, BUNDLED_FONTS_VERSION);
+            return missingResourceMessage(normalizedPath, BUNDLED_FONTS_VERSION,
+                    FontFamilyDefinition.class.getResource(LONG_STANDING_FACE) != null);
         }
 
         @Override

--- a/core/src/test/java/com/demcha/compose/font/BundledFamiliesTest.java
+++ b/core/src/test/java/com/demcha/compose/font/BundledFamiliesTest.java
@@ -53,12 +53,10 @@ class BundledFamiliesTest {
     }
 
     @Test
-    void aMissingResourceNamesTheFontsVersionForEveryFamilyThatNeedsOne() {
-        // The version map is keyed on the resource folder segment, and those keys are string
-        // literals written independently of the folder names in DefaultFonts. One typo and the
-        // family silently falls back to the generic "add the dependency" message — advice that
-        // is wrong for a consumer who already has the dependency, just an older one. So every
-        // family that needs the diagnostic is driven through it rather than one sample.
+    void aMissingResourceNamesTheVersionOfTheArtifactOnTheClasspath() {
+        // The advice a consumer needs depends on which of two setups they are in, and the
+        // artifact's own descriptor is what tells them apart — no list of which version
+        // introduced which family, which was five entries and one more per font.
         for (FontName family : List.of(FontName.AMIRI, FontName.DAVID_LIBRE,
                 FontName.NOTO_SANS_GEORGIAN, FontName.NOTO_SANS_ARMENIAN, FontName.GOTHIC_A1)) {
             String missingFace = folderOf(family) + "/NoSuchFace.ttf";
@@ -66,15 +64,63 @@ class BundledFamiliesTest {
                     .classpath(FontName.of(family.name() + " Probe"), missingFace)
                     .build();
 
-            // The font artifact is on this test classpath, so a missing face under a family it
-            // should carry means the artifact predates the family — not that it is absent.
             assertThatThrownBy(() -> definition.fontSourceSet().orElseThrow().regular().openStream())
-                    .describedAs("%s resolves under %s, which must be a key the version map "
-                            + "knows", family, missingFace)
+                    .describedAs("%s resolves under %s", family, missingFace)
                     .isInstanceOf(IllegalArgumentException.class)
                     .hasMessageContaining("graph-compose-fonts")
-                    .hasMessageContaining("1.1.0");
+                    .hasMessageContaining(bundledFontsVersion());
         }
+    }
+
+    @Test
+    void theVersionInTheMessageIsTheArtifactsOwnRatherThanAnythingHardcoded() {
+        // Read from the descriptor the fonts module writes at build time, so this stays
+        // true across a version bump without anyone editing a constant.
+        assertThat(bundledFontsVersion())
+                .describedAs("the fonts artifact on the test classpath states its version")
+                .isNotBlank()
+                .matches("[0-9]+[.][0-9]+[.][0-9]+(-.+)?");
+    }
+
+    @Test
+    void anAbsentFontArtifactGetsTheMigrationPointerInstead() {
+        // The branch that could never be exercised before: the artifact is on this test
+        // classpath, so the only way to see the advice a consumer without it receives is
+        // to ask for it directly. Without this the "add the dependency" wording could rot
+        // untouched — it is the message for the setup nobody here is in.
+        String message = FontFamilyDefinition.ClasspathFontSource.missingResourceMessage(
+                "/fonts/google/amiri/Amiri-Regular.ttf", null);
+
+        assertThat(message)
+                .contains("graph-compose-fonts")
+                .contains("v1.8.0")
+                .contains("docs/migration/v1.8.0-fonts.md");
+    }
+
+    @Test
+    void aStaleFontArtifactIsToldWhichVersionItIsRatherThanToAddADependencyItHas() {
+        String message = FontFamilyDefinition.ClasspathFontSource.missingResourceMessage(
+                "/fonts/google/gothica1/GothicA1-Regular.ttf", "1.0.0");
+
+        assertThat(message)
+                .describedAs("naming the version they have is what makes the problem "
+                        + "recognisable; telling them to add a dependency they already "
+                        + "have is the one answer that cannot help")
+                .contains("1.0.0")
+                .doesNotContain("v1.8.0");
+    }
+
+    /** The version the fonts artifact on the classpath reports for itself. */
+    private static String bundledFontsVersion() {
+        java.util.Properties properties = new java.util.Properties();
+        try (java.io.InputStream descriptor = BundledFamiliesTest.class
+                .getResourceAsStream("/fonts/graph-compose-fonts.properties")) {
+            assertThat(descriptor).describedAs("the fonts artifact ships its descriptor").isNotNull();
+            properties.load(descriptor);
+        } catch (java.io.IOException e) {
+            throw new AssertionError(e);
+        }
+        return properties.getProperty("version");
     }
 
     /** {@code fonts/google/amiri} — the folder the family's real faces resolve under. */
@@ -131,19 +177,17 @@ class BundledFamiliesTest {
     }
 
     @Test
-    void aMissingLongStandingFamilyResourceStillPointsAtTheArtifactSplit() {
+    void aMissingFaceOfALongStandingFamilyIsDiagnosedTheSameWay() {
         FontFamilyDefinition definition = FontFamilyDefinition
                 .classpath(FontName.of("Lato Probe"), "fonts/google/lato/Lato-NoSuchFace.ttf")
                 .build();
 
-        // Asserted on the signal the split message carries rather than on the absence of the
-        // version wording: a marker that has to stay absent silently stops guarding anything
-        // once the wording changes.
+        // Lato predates the artifact split, but that says nothing about why one of its
+        // faces is missing here: the artifact is present, so the answer is the same as for
+        // any other family. It used to be told to add a dependency it already had.
         assertThatThrownBy(() -> definition.fontSourceSet().orElseThrow().regular().openStream())
                 .isInstanceOf(IllegalArgumentException.class)
-                .describedAs("a family that predates the split keeps the migration pointer "
-                        + "instead of being diagnosed as a version problem")
-                .hasMessageContaining("v1.8.0")
-                .hasMessageContaining("docs/migration/v1.8.0-fonts.md");
+                .hasMessageContaining(bundledFontsVersion())
+                .hasMessageNotContaining("v1.8.0");
     }
 }

--- a/core/src/test/java/com/demcha/compose/font/BundledFamiliesTest.java
+++ b/core/src/test/java/com/demcha/compose/font/BundledFamiliesTest.java
@@ -89,7 +89,7 @@ class BundledFamiliesTest {
         // to ask for it directly. Without this the "add the dependency" wording could rot
         // untouched — it is the message for the setup nobody here is in.
         String message = FontFamilyDefinition.ClasspathFontSource.missingResourceMessage(
-                "/fonts/google/amiri/Amiri-Regular.ttf", null);
+                "/fonts/google/amiri/Amiri-Regular.ttf", null, false);
 
         assertThat(message)
                 .contains("graph-compose-fonts")
@@ -100,13 +100,30 @@ class BundledFamiliesTest {
     @Test
     void aStaleFontArtifactIsToldWhichVersionItIsRatherThanToAddADependencyItHas() {
         String message = FontFamilyDefinition.ClasspathFontSource.missingResourceMessage(
-                "/fonts/google/gothica1/GothicA1-Regular.ttf", "1.0.0");
+                "/fonts/google/gothica1/GothicA1-Regular.ttf", "1.2.0", true);
 
         assertThat(message)
                 .describedAs("naming the version they have is what makes the problem "
                         + "recognisable; telling them to add a dependency they already "
                         + "have is the one answer that cannot help")
-                .contains("1.0.0")
+                .contains("1.2.0")
+                .doesNotContain("v1.8.0");
+    }
+
+    @Test
+    void anArtifactTooOldToNameItselfIsStillNotToldToAddADependencyItHas() {
+        // The state every consumer of the published 1.0.0 is in: the fonts are on the
+        // classpath and the descriptor that would name their version is not, because the
+        // descriptor ships from 1.1.0. Reading only the descriptor makes that look
+        // identical to having no artifact at all — and sends the one reader who can
+        // actually hit this today to add a dependency they already depend on.
+        String message = FontFamilyDefinition.ClasspathFontSource.missingResourceMessage(
+                "/fonts/google/amiri/Amiri-Regular.ttf", null, true);
+
+        assertThat(message)
+                .describedAs("presence and version are separate questions; only the first "
+                        + "can be asked of a release that shipped before either mechanism")
+                .contains("predates 1.1.0")
                 .doesNotContain("v1.8.0");
     }
 

--- a/fonts/pom.xml
+++ b/fonts/pom.xml
@@ -84,6 +84,27 @@
     </properties>
 
     <build>
+        <resources>
+            <!--
+                Everything except the descriptor, unfiltered. Filtering runs over the
+                bytes of every file it touches, and a font binary does not survive it.
+            -->
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>false</filtering>
+                <excludes>
+                    <exclude>fonts/graph-compose-fonts.properties</exclude>
+                </excludes>
+            </resource>
+            <!-- The one text file, filtered so it carries this module's version. -->
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>fonts/graph-compose-fonts.properties</include>
+                </includes>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/fonts/src/main/resources/fonts/graph-compose-fonts.properties
+++ b/fonts/src/main/resources/fonts/graph-compose-fonts.properties
@@ -1,0 +1,4 @@
+# Written by the build. The artifact states its own version so a consumer that asks
+# for a family it does not carry can be told which version it actually has, instead
+# of being told which version introduced the family by a list someone has to maintain.
+version=${project.version}


### PR DESCRIPTION
## Why

Telling a *stale* font artifact apart from a *missing* one needed the engine to know
which release introduced which family. That was a map from resource folder to version —
five entries by the time the Korean font landed, one more for every font after it —
living in `FontFamilyDefinition`, a class that otherwise knows nothing about which fonts
exist. Adding a family meant remembering to edit it, and forgetting meant falling back to
advice that does not apply: *add a dependency* to a reader who already has it.

Moving that map into a catalog descriptor would relocate the coupling rather than remove
it — the catalog would then be carrying the artifact's release history, which it does not
carry today.

## What

The artifact answers for itself. The `fonts` module writes a small descriptor into its
jar naming its own version, and the engine reads it:

- no descriptor → the artifact is not on the classpath → the message points at the
  v1.8.0 migration note, which is the advice that fits;
- a descriptor → the artifact is present and older than what was asked for → the message
  names **the version the consumer actually has**.

That is the more useful answer as well as the cheaper one. *"The graph-compose-fonts on
your classpath is 1.0.0 and does not carry this"* identifies the problem from the
reader's side; *"this family needs 1.1.0 or newer"* asserts something the engine can only
know by being told — and told again for every font after it.

Gone with the map: the `Lato-Regular.ttf` probe (artifact presence was inferred from one
long-standing face, which happened to work rather than meaning anything) and the path
parsing that extracted a family folder.

**Resource filtering is scoped to the descriptor alone.** Filtering rewrites the bytes of
every file it touches and a font binary does not survive it, so the fonts stay in an
unfiltered resource block that excludes the one text file. Verified against the built jar:
the descriptor carries `version=1.1.0`, `GothicA1-Regular.ttf` is byte-identical to its
source, and all 130 faces are present.

## Tests

- The five bundled families that need the diagnosis are driven through it, asserting the
  version read from the artifact's own descriptor rather than a literal — so this stays
  true across a version bump with nothing to edit.
- Both branches of the message are now tested directly. The absent-artifact branch was
  untestable before, because the artifact is always on the test classpath, which left the
  wording for the one setup nobody here is in free to rot; the builder takes the version
  explicitly so both can be driven.
- A missing face of a long-standing family is diagnosed like any other. That test used to
  assert it received the *add the dependency* advice — which was wrong, since the
  dependency is there.
- Full reactor gate green (`clean verify` across core, render-pdf/docx/pptx, templates,
  testing, qa, coverage).