### PR TITLE
fix(pdf): resolve a chip against its own base, not against having one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,20 @@ follow semantic versioning; release dates are ISO 8601.
   is where anything asking where a particular word was drawn now has to look; the
   engine's own tests read it there.
 
+- **A chip that opens on Latin still draws its Hebrew the way it reads.** A chip takes
+  its direction from its first character, and that character settles only where the chip
+  sits in the line — not what the chip holds. One opening on Latin is a left-to-right
+  run that may still carry Hebrew or Arabic, and the PDF skipped the bidirectional
+  resolution for it entirely, handing the content stream logical order: drawn left to
+  right, the word came out backwards.
+
+  The direction is now the *base* the resolution runs against rather than the question
+  of whether to run it, so a chip is resolved whenever its text needs it. A chip that is
+  wholly right-to-left is unchanged, and so is one holding no such script at all. The
+  slide backend needs nothing here: against a left-to-right base nothing inside such a
+  chip resolves to a right-to-left level, so there is never anything to mirror, and
+  PowerPoint orders the letters itself.
+
 - **A deck carries the bundled fonts it drew with.** A family a caller registers has
   always been embedded; a family this library *ships* — Amiri for Arabic, David Libre for
   Hebrew, the Noto faces for Georgian and Armenian, Gothic A1 for Hangul — was only warned

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,10 +144,15 @@ follow semantic versioning; release dates are ISO 8601.
 
   The direction is now the *base* the resolution runs against rather than the question
   of whether to run it, so a chip is resolved whenever its text needs it. A chip that is
-  wholly right-to-left is unchanged, and so is one holding no such script at all. The
-  slide backend needs nothing here: against a left-to-right base nothing inside such a
-  chip resolves to a right-to-left level, so there is never anything to mirror, and
-  PowerPoint orders the letters itself.
+  wholly right-to-left is unchanged, and so is one holding no such script at all.
+
+  The slide backend has the same gap for the same reason, and it shows in the
+  punctuation rather than the letters: PowerPoint orders the Hebrew itself, but a
+  neutral standing between two right-to-left words takes their level even under a
+  left-to-right base, and PowerPoint does not mirror what it places. A chip reading
+  `a בית > ספר` now reaches the slide as `a בית < ספר`, so the comparison faces the way
+  the line reads; a bracket enclosing Hebrew swaps for the same reason, while everything
+  the left-to-right base owns is left as typed.
 
 - **A deck carries the bundled fonts it drew with.** A family a caller registers has
   always been embedded; a family this library *ships* — Amiri for Arabic, David Libre for

--- a/core/src/main/java/com/demcha/compose/engine/text/bidi/BidiVisualOrder.java
+++ b/core/src/main/java/com/demcha/compose/engine/text/bidi/BidiVisualOrder.java
@@ -32,6 +32,12 @@ public final class BidiVisualOrder {
     private BidiVisualOrder() {
     }
 
+    private static BidiParagraphResolver.BaseDirection baseOf(boolean rightToLeft) {
+        return rightToLeft
+                ? BidiParagraphResolver.BaseDirection.RIGHT_TO_LEFT
+                : BidiParagraphResolver.BaseDirection.LEFT_TO_RIGHT;
+    }
+
     /**
      * Mirrors only the characters that resolve to a right-to-left level, keeping
      * logical order.
@@ -49,15 +55,17 @@ public final class BidiVisualOrder {
      * <p>For a single-level right-to-left run this is {@link BidiMirroring#mirror},
      * unchanged.</p>
      *
-     * @param text run text in logical order
+     * @param text            run text in logical order
+     * @param rightToLeftBase the run's own base direction — the level its neutrals
+     *                        resolve against, which for a chip is the direction the
+     *                        line gave it
      * @return the same order with paired punctuation at right-to-left levels swapped
      */
-    public static String mirrorRightToLeftLevels(String text) {
+    public static String mirrorRightToLeftLevels(String text, boolean rightToLeftBase) {
         if (text == null || text.isEmpty()) {
             return "";
         }
-        int[] levels = BidiParagraphResolver.levelsFor(
-                text, BidiParagraphResolver.BaseDirection.RIGHT_TO_LEFT);
+        int[] levels = BidiParagraphResolver.levelsFor(text, baseOf(rightToLeftBase));
         if (levels.length == 0) {
             return text;
         }
@@ -87,15 +95,21 @@ public final class BidiVisualOrder {
      * right-to-left level at all is returned unchanged — drawing it as written is
      * already correct.</p>
      *
-     * @param text run text in logical order
+     * <p>The base direction is the run's own, not the paragraph's. A chip takes its
+     * direction from its first character, and that character decides only where the
+     * chip sits in the line: one opening on Latin is a left-to-right run that may
+     * still hold Hebrew, and resolving it against the wrong base puts that Hebrew on
+     * the wrong side of what surrounds it.</p>
+     *
+     * @param text            run text in logical order
+     * @param rightToLeftBase the run's own base direction
      * @return the text as a left-to-right drawing order
      */
-    public static String visualize(String text) {
+    public static String visualize(String text, boolean rightToLeftBase) {
         if (text == null || text.isEmpty()) {
             return "";
         }
-        int[] levels = BidiParagraphResolver.levelsFor(
-                text, BidiParagraphResolver.BaseDirection.RIGHT_TO_LEFT);
+        int[] levels = BidiParagraphResolver.levelsFor(text, baseOf(rightToLeftBase));
         if (levels.length == 0) {
             return text;
         }

--- a/core/src/main/java/com/demcha/compose/engine/text/bidi/BidiVisualOrder.java
+++ b/core/src/main/java/com/demcha/compose/engine/text/bidi/BidiVisualOrder.java
@@ -4,8 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Turns one atomic right-to-left run into the exact string a backend draws, level by
- * level.
+ * Turns one atomic run into the exact string a backend draws, level by level.
  *
  * <p>A plain span never needs this: the wrapper splits it wherever its characters
  * resolve to a different embedding level, so each piece is single-level and reversing
@@ -16,11 +15,18 @@ import java.util.List;
  * {@code (b < a)}, the comparison inverted, because the left-to-right interior was
  * reversed and mirrored along with the brackets that enclose it.</p>
  *
- * <p>This class re-resolves the run's own levels (right-to-left base, matching the
- * flag the caller holds), reorders the level runs visually, and reverses and mirrors
- * only the right-to-left ones — UAX #9's L2 and L4 applied to the one span the wrapper
- * could not split. For a single-level run the result is identical to reversing and
- * mirroring the whole string, so the transform is safe for every chip, not only the
+ * <p>Both entry points re-resolve the run's own levels against <em>the base the caller
+ * passes</em> — the run's direction, which for a chip is its first character's and says
+ * only where the chip sits in the line. A left-to-right base does not mean a
+ * left-to-right run: Hebrew inside such a chip still resolves to level 1, and a neutral
+ * standing between two Hebrew words takes their level too. The base decides how those
+ * runs are ordered and where the neutrals fall, not whether any exist.</p>
+ *
+ * <p>{@link #visualize} applies UAX #9's L2 and L4 — reorder, reverse, mirror — for a
+ * backend that draws characters in the order it is handed them. {@link
+ * #mirrorRightToLeftLevels} applies L4 alone, for one that runs the algorithm itself
+ * and only skips the mirroring. For a single-level run each is identical to the
+ * whole-string treatment it replaced, so both are safe for every chip, not only the
  * mixed ones.</p>
  *
  * <p>Ownership: shared engine foundation.</p>

--- a/core/src/test/java/com/demcha/compose/engine/text/bidi/BidiVisualOrderTest.java
+++ b/core/src/test/java/com/demcha/compose/engine/text/bidi/BidiVisualOrderTest.java
@@ -25,14 +25,14 @@ class BidiVisualOrderTest {
         // is left-to-right level and must come through exactly as written. The two
         // effects cancel on the brackets, so the visual string equals the logical one —
         // which is precisely what reversing the whole span destroys.
-        assertThat(BidiVisualOrder.visualize("(a > b)")).isEqualTo("(a > b)");
+        assertThat(BidiVisualOrder.visualize("(a > b)", true)).isEqualTo("(a > b)");
     }
 
     @Test
     void aSingleLevelRunIsReversedAndMirroredWhole() {
         // For homogeneous text the transform must agree with the treatment plain spans
         // always had: reverse by cluster, mirror the pairs.
-        assertThat(BidiVisualOrder.visualize("(" + HEBREW + ")"))
+        assertThat(BidiVisualOrder.visualize("(" + HEBREW + ")", true))
                 .isEqualTo("(" + HEBREW_REVERSED + ")");
     }
 
@@ -40,7 +40,7 @@ class BidiVisualOrderTest {
     void digitsInsideARightToLeftRunStayForward() {
         // Digits resolve to the left-to-right level even in Hebrew text: the year in
         // "ב-2026" reads forwards. Reversed whole, it would not.
-        assertThat(BidiVisualOrder.visualize(HEBREW + " 123"))
+        assertThat(BidiVisualOrder.visualize(HEBREW + " 123", true))
                 .isEqualTo("123 " + HEBREW_REVERSED);
     }
 
@@ -50,21 +50,35 @@ class BidiVisualOrderTest {
         // right-to-left characters are reordered by what they are, not by what the
         // paragraph declares, so a pre-reordered string would come back re-reversed.
         // Only the mirroring is done for it, and only on the levels L4 touches.
-        assertThat(BidiVisualOrder.mirrorRightToLeftLevels("(a > b)"))
+        assertThat(BidiVisualOrder.mirrorRightToLeftLevels("(a > b)", true))
                 .describedAs("brackets sit at the right-to-left level and swap; the "
                         + "interior's comparison does not")
                 .isEqualTo(")a > b(");
-        assertThat(BidiVisualOrder.mirrorRightToLeftLevels("(" + HEBREW + ")"))
+        assertThat(BidiVisualOrder.mirrorRightToLeftLevels("(" + HEBREW + ")", true))
                 .describedAs("a single-level run is the whole-string mirror, unchanged")
                 .isEqualTo(BidiMirroring.mirror("(" + HEBREW + ")"));
-        assertThat(BidiVisualOrder.mirrorRightToLeftLevels(HEBREW + " 2026"))
+        assertThat(BidiVisualOrder.mirrorRightToLeftLevels(HEBREW + " 2026", true))
                 .describedAs("nothing mirrors, nothing reorders — the letters stay "
                         + "logical for the viewer's own engine")
                 .isEqualTo(HEBREW + " 2026");
-        assertThat(BidiVisualOrder.mirrorRightToLeftLevels("plain latin"))
+        assertThat(BidiVisualOrder.mirrorRightToLeftLevels("plain latin", true))
                 .isEqualTo("plain latin");
-        assertThat(BidiVisualOrder.mirrorRightToLeftLevels("")).isEmpty();
-        assertThat(BidiVisualOrder.mirrorRightToLeftLevels(null)).isEmpty();
+        assertThat(BidiVisualOrder.mirrorRightToLeftLevels("", true)).isEmpty();
+        assertThat(BidiVisualOrder.mirrorRightToLeftLevels(null, true)).isEmpty();
+    }
+
+    @Test
+    void aLeftToRightBaseKeepsItsHebrewOnTheSideThatBaseGivesIt() {
+        // The base is the run's own, not the paragraph's: a chip opening on Latin is a
+        // left-to-right run that may still hold Hebrew. Resolved against the wrong base
+        // — or not resolved at all, which is what a direction-flag gate did — the word
+        // is handed over in logical order and drawn backwards.
+        assertThat(BidiVisualOrder.visualize("a " + HEBREW, false))
+                .describedAs("Latin first, then the Hebrew reversed for drawing")
+                .isEqualTo("a " + HEBREW_REVERSED);
+        assertThat(BidiVisualOrder.visualize(HEBREW + " a", false))
+                .describedAs("the run still reads left to right overall")
+                .isEqualTo(HEBREW_REVERSED + " a");
     }
 
     @Test
@@ -72,8 +86,8 @@ class BidiVisualOrderTest {
         // The flag the caller holds comes from paragraph context; if the run's own
         // analysis finds nothing right-to-left, drawing it as written is already
         // correct and the transform must not invent a reversal.
-        assertThat(BidiVisualOrder.visualize("plain latin")).isEqualTo("plain latin");
-        assertThat(BidiVisualOrder.visualize("")).isEmpty();
-        assertThat(BidiVisualOrder.visualize(null)).isEmpty();
+        assertThat(BidiVisualOrder.visualize("plain latin", true)).isEqualTo("plain latin");
+        assertThat(BidiVisualOrder.visualize("", true)).isEmpty();
+        assertThat(BidiVisualOrder.visualize(null, true)).isEmpty();
     }
 }

--- a/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfParagraphFragmentRenderHandler.java
+++ b/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/handlers/PdfParagraphFragmentRenderHandler.java
@@ -11,6 +11,7 @@ import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.document.style.InlineBackground;
 import com.demcha.compose.document.style.ShapeOutline;
 import com.demcha.compose.engine.text.bidi.BidiMirroring;
+import com.demcha.compose.engine.text.bidi.BidiParagraphResolver;
 import com.demcha.compose.engine.text.bidi.BidiText;
 import com.demcha.compose.engine.text.bidi.BidiVisualOrder;
 import com.demcha.compose.engine.render.pdf.PdfFont;
@@ -149,8 +150,14 @@ public final class PdfParagraphFragmentRenderHandler
         String sanitizedLogical = font.sanitizeForRender(span.textStyle(), span.text());
         String text = sanitizedLogical;
         String written = null;
-        if (span.rightToLeft()) {
-            text = BidiVisualOrder.visualize(sanitizedLogical);
+        // Not gated on the chip's own direction: that flag is its FIRST character's, and
+        // it settles where the chip sits in the line, not what the chip holds. A chip
+        // opening on Latin is a left-to-right run that may still carry Hebrew, and
+        // skipping the resolution handed that Hebrew to the content stream logically —
+        // drawn left to right, the word came out backwards. The flag is the base the
+        // resolution runs against, not the question of whether to run it.
+        if (span.rightToLeft() || BidiParagraphResolver.requiresBidi(sanitizedLogical)) {
+            text = BidiVisualOrder.visualize(sanitizedLogical, span.rightToLeft());
             written = PdfActualText.writtenTextOf(span);
             environment.markReorderedText();
         }

--- a/render-pdf/src/test/java/com/demcha/compose/document/backend/fixed/pdf/PdfRtlChipTest.java
+++ b/render-pdf/src/test/java/com/demcha/compose/document/backend/fixed/pdf/PdfRtlChipTest.java
@@ -31,6 +31,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class PdfRtlChipTest {
 
+    /** Shares no letter with the line's own Hebrew, so a glyph lookup is unambiguous. */
+    private static final String HEBREW = "בית";
+
     @Test
     void aMixedChipKeepsItsOperandsInReadingOrder() throws Exception {
         List<DrawnGlyphs.Glyph> glyphs = DrawnGlyphs.leftToRight(renderChipLine("(a > b)"));
@@ -61,6 +64,26 @@ class PdfRtlChipTest {
                 .isNotNegative();
         assertThat(two).describedAs("2 before 0, as written").isLessThan(zero);
         assertThat(zero).describedAs("0 before 6, as written").isLessThan(six);
+    }
+
+    @Test
+    void aChipThatOpensOnLatinStillDrawsItsHebrewInReadingOrder() throws Exception {
+        // The chip takes its direction from its first character, and that character
+        // decides only where the chip sits in the line — not what its interior holds.
+        // A chip opening on Latin is flagged left-to-right, so the whole span skipped
+        // the resolution, and the Hebrew inside it was handed to the content stream
+        // logically: drawn left to right, the word came out backwards.
+        List<DrawnGlyphs.Glyph> glyphs = DrawnGlyphs.leftToRight(renderChipLine("a " + HEBREW));
+
+        int lastLetterFirst = indexOfFirst(glyphs, HEBREW.substring(HEBREW.length() - 1));
+        int firstLetterFirst = indexOfFirst(glyphs, HEBREW.substring(0, 1));
+        assertThat(firstLetterFirst)
+                .describedAs("the Hebrew is on the page; glyphs were %s", glyphs)
+                .isNotNegative();
+        assertThat(lastLetterFirst)
+                .describedAs("a Hebrew word reads right to left, so its LAST letter is "
+                        + "drawn leftmost; glyphs were %s", glyphs)
+                .isLessThan(firstLetterFirst);
     }
 
     private static int indexOfFirst(List<DrawnGlyphs.Glyph> glyphs, String character) {

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxParagraphFragmentRenderHandler.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxParagraphFragmentRenderHandler.java
@@ -250,8 +250,14 @@ public final class PptxParagraphFragmentRenderHandler
         // chip's left-to-right interior, where nothing mirrors, and turned "a > b"
         // into "a < b" in the only copy of the text the file has. For a single-level
         // chip this is the whole-string mirror it always had.
+        // Gated on the chip's own direction, and that is enough here: a chip opening on
+        // Latin is a left-to-right run, and against a left-to-right base nothing inside
+        // it resolves to a right-to-left level — even brackets enclosing Hebrew stay
+        // put, so there is nothing to mirror. Its Hebrew still reads correctly because
+        // PowerPoint orders the letters itself. (The PDF has no such engine, which is
+        // why the same chip must be resolved there — see PdfParagraphFragmentRenderHandler.)
         String chipText = span.rightToLeft()
-                ? BidiVisualOrder.mirrorRightToLeftLevels(text)
+                ? BidiVisualOrder.mirrorRightToLeftLevels(text, true)
                 : text;
         PptxTextFrames.addRun(PptxTextFrames.preparedParagraph(textBox, span.rightToLeft()),
                 chipText, span.textStyle(), environment);

--- a/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxParagraphFragmentRenderHandler.java
+++ b/render-pptx/src/main/java/com/demcha/compose/document/backend/fixed/pptx/handlers/PptxParagraphFragmentRenderHandler.java
@@ -11,6 +11,7 @@ import com.demcha.compose.document.style.InlineBackground;
 import com.demcha.compose.engine.render.pdf.PdfFont;
 import com.demcha.compose.engine.text.bidi.ArabicShaper;
 import com.demcha.compose.engine.text.bidi.BidiMirroring;
+import com.demcha.compose.engine.text.bidi.BidiParagraphResolver;
 import com.demcha.compose.engine.text.bidi.BidiVisualOrder;
 import com.demcha.compose.font.FontLibrary;
 import org.apache.poi.sl.usermodel.ShapeType;
@@ -250,14 +251,17 @@ public final class PptxParagraphFragmentRenderHandler
         // chip's left-to-right interior, where nothing mirrors, and turned "a > b"
         // into "a < b" in the only copy of the text the file has. For a single-level
         // chip this is the whole-string mirror it always had.
-        // Gated on the chip's own direction, and that is enough here: a chip opening on
-        // Latin is a left-to-right run, and against a left-to-right base nothing inside
-        // it resolves to a right-to-left level — even brackets enclosing Hebrew stay
-        // put, so there is nothing to mirror. Its Hebrew still reads correctly because
-        // PowerPoint orders the letters itself. (The PDF has no such engine, which is
-        // why the same chip must be resolved there — see PdfParagraphFragmentRenderHandler.)
-        String chipText = span.rightToLeft()
-                ? BidiVisualOrder.mirrorRightToLeftLevels(text, true)
+        // The flag is the base the mirroring resolves against, not the question of
+        // whether to mirror. It is the chip's FIRST character's, and a chip opening on
+        // Latin still carries whatever follows: a neutral standing between two
+        // right-to-left words takes their level even under a left-to-right base, so it
+        // is one of the characters PowerPoint places but does not mirror. "a בית > ספר"
+        // must reach the slide as "a בית < ספר" or the comparison is drawn facing the
+        // wrong way. Ordering stays PowerPoint's — only the mirroring is done for it.
+        boolean needsResolution =
+                span.rightToLeft() || BidiParagraphResolver.requiresBidi(text);
+        String chipText = needsResolution
+                ? BidiVisualOrder.mirrorRightToLeftLevels(text, span.rightToLeft())
                 : text;
         PptxTextFrames.addRun(PptxTextFrames.preparedParagraph(textBox, span.rightToLeft()),
                 chipText, span.textStyle(), environment);

--- a/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxRightToLeftFrameTest.java
+++ b/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxRightToLeftFrameTest.java
@@ -195,25 +195,43 @@ class PptxRightToLeftFrameTest {
     }
 
     @Test
-    void aChipThatOpensOnLatinKeepsItsHebrewLogicalAndUnmirrored() throws Exception {
-        // Pins a contract this backend already keeps, not a defect it once had: the
-        // chip's flag is its first character's, so this one is left-to-right, declares
-        // nothing, and is handed over untouched — PowerPoint orders the Hebrew inside
-        // it from the letters themselves. It is here because the PDF needed a real fix
-        // for the same input, and the next person to touch that seam should see, in
-        // this suite, that the slide's answer is to leave it alone: against a
-        // left-to-right base nothing in such a chip resolves to a right-to-left level,
-        // so there is never anything to mirror.
-        List<XSLFTextParagraph> chipFrames = paragraphsOf(
-                renderHighlightLine("a בית")).stream()
-                .filter(paragraph -> paragraph.getText().contains("בית"))
+    void aChipThatOpensOnLatinCarriesNothingToMirrorWhenItHoldsOnlyLetters() throws Exception {
+        // The chip's flag is its first character's, so this one is left-to-right. Its
+        // Hebrew still needs no help: PowerPoint orders the letters itself, and with no
+        // neutral in the chip there is nothing to mirror for it either.
+        assertThat(storedChipOf("a בית", "בית"))
+                .describedAs("logical order, nothing swapped")
+                .isEqualTo("a בית");
+    }
+
+    @Test
+    void aChipThatOpensOnLatinStillMirrorsANeutralBetweenTwoHebrewWords() throws Exception {
+        // The reason the chip's flag cannot gate the mirroring. A neutral standing
+        // between two right-to-left words takes THEIR level even under a left-to-right
+        // base, so it is one of the characters PowerPoint places but does not mirror.
+        // Left unmirrored, the comparison is drawn facing the wrong way on the slide.
+        assertThat(storedChipOf("a בית > ספר", "בית"))
+                .describedAs("the comparison is pre-mirrored for PowerPoint")
+                .isEqualTo("a בית < ספר");
+    }
+
+    @Test
+    void aChipThatOpensOnLatinMirrorsOnlyItsRightToLeftLevelPunctuation() throws Exception {
+        // And only that: brackets enclosing Hebrew take the Hebrew's level and swap,
+        // while everything the left-to-right base owns is left exactly as typed.
+        assertThat(storedChipOf("a בית (ספר)", "בית"))
+                .describedAs("brackets swapped, the Latin opening untouched")
+                .isEqualTo("a בית )ספר(");
+    }
+
+    /** The text stored for the chip frame carrying {@code marker}. */
+    private static String storedChipOf(String chipText, String marker) throws Exception {
+        List<XSLFTextParagraph> frames = paragraphsOf(renderHighlightLine(chipText)).stream()
+                .filter(paragraph -> paragraph.getText().contains(marker))
                 .toList();
 
-        assertThat(chipFrames).describedAs("the chip's own frame is found").isNotEmpty();
-        assertThat(chipFrames).allSatisfy(paragraph ->
-                assertThat(paragraph.getText())
-                        .describedAs("logical order, nothing swapped")
-                        .isEqualTo("a בית"));
+        assertThat(frames).describedAs("the chip's own frame is found").hasSize(1);
+        return frames.get(0).getText();
     }
 
     private static boolean declaresRightToLeft(XSLFTextParagraph paragraph) {

--- a/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxRightToLeftFrameTest.java
+++ b/render-pptx/src/test/java/com/demcha/compose/document/backend/fixed/pptx/PptxRightToLeftFrameTest.java
@@ -194,6 +194,28 @@ class PptxRightToLeftFrameTest {
                         .isEqualTo(")" + "שנה" + "("));
     }
 
+    @Test
+    void aChipThatOpensOnLatinKeepsItsHebrewLogicalAndUnmirrored() throws Exception {
+        // Pins a contract this backend already keeps, not a defect it once had: the
+        // chip's flag is its first character's, so this one is left-to-right, declares
+        // nothing, and is handed over untouched — PowerPoint orders the Hebrew inside
+        // it from the letters themselves. It is here because the PDF needed a real fix
+        // for the same input, and the next person to touch that seam should see, in
+        // this suite, that the slide's answer is to leave it alone: against a
+        // left-to-right base nothing in such a chip resolves to a right-to-left level,
+        // so there is never anything to mirror.
+        List<XSLFTextParagraph> chipFrames = paragraphsOf(
+                renderHighlightLine("a בית")).stream()
+                .filter(paragraph -> paragraph.getText().contains("בית"))
+                .toList();
+
+        assertThat(chipFrames).describedAs("the chip's own frame is found").isNotEmpty();
+        assertThat(chipFrames).allSatisfy(paragraph ->
+                assertThat(paragraph.getText())
+                        .describedAs("logical order, nothing swapped")
+                        .isEqualTo("a בית"));
+    }
+
     private static boolean declaresRightToLeft(XSLFTextParagraph paragraph) {
         var properties = paragraph.getXmlObject().getPPr();
         return properties != null && properties.isSetRtl() && properties.getRtl();


### PR DESCRIPTION
## Why

A chip takes its direction from its first character, and that character settles only *where the chip sits in the line* — not what the chip holds. `PdfParagraphFragmentRenderHandler.renderChip` read that flag as the question of whether to resolve the span at all:

```java
if (span.rightToLeft()) { text = BidiVisualOrder.visualize(sanitizedLogical); }
```

So a chip opening on Latin — `"a בית"` inside a right-to-left paragraph — is flagged left-to-right, skips the resolution entirely, and its Hebrew reaches the content stream in logical order. A PDF draws characters in the order it is given them, so the word is drawn backwards. The chip is the only span exposed to this: everything else is split at level boundaries by `ParagraphWrapping` and arrives single-level.

This is the other half of the atomicity gap [#548](https://github.com/DemchaAV/GraphCompose/pull/548) closed. That PR fixed the chip whose flag is right-to-left; this one fixes the chip whose flag is left-to-right and whose *contents* are not.

## What changed

The direction is now the **base** the resolution runs against, not the question of whether to run it. `BidiVisualOrder.visualize` and `mirrorRightToLeftLevels` take that base instead of assuming right-to-left, and the PDF resolves a chip whenever `BidiParagraphResolver.requiresBidi` says its text needs it. Against a left-to-right base the Hebrew inside the chip is its own right-to-left run and is reversed; the Latin around it stays put. A wholly right-to-left chip is unchanged (same reverse-and-mirror it already had), and one carrying no such script is untouched.

`BidiVisualOrder` is unreleased — it ships in `2.2.0-SNAPSHOT` — so the signature moves without a compatibility question.

**The slide backend has the same gap, and gets the same fix.** PowerPoint orders the Hebrew itself, so the letters need no help — but a neutral standing between two right-to-left words takes *their* level even under a left-to-right base, and PowerPoint does not mirror what it places. `a בית > ספר` reached the slide with its comparison facing the wrong way. Its gate is now `span.rightToLeft() || requiresBidi(text)` with the flag as the base, matching the PDF path.

An earlier revision of this PR claimed the opposite — that nothing inside such a chip resolves to a right-to-left level, so PPTX needed nothing. That was generalised from four probe samples (`a בית`, `a (בית)`, `(בית) a`, `a בית (x)`) which all happen to be no-ops: a mirrorable neutral only takes the right-to-left level when it stands *between* two right-to-left runs, and none of the four had one. The claim was false and the revision removed a correct fix; both are restored here.

## Verification

`./mvnw clean verify` over the full reactor — all 13 modules, `BUILD SUCCESS`. render-pdf 210, render-pptx 114, qa (visual baselines) 734.

Five cases. Four are checked against the state they are meant to catch; the fifth is a contract pin and is marked as one:

| Case | Red without the fix |
|---|---|
| `BidiVisualOrderTest.aLeftToRightBaseKeepsItsHebrewOnTheSideThatBaseGivesIt` | yes — make `baseOf` ignore its argument |
| `PdfRtlChipTest.aChipThatOpensOnLatinStillDrawsItsHebrewInReadingOrder` | yes — restore the `span.rightToLeft()` gate |
| `PptxRightToLeftFrameTest.aChipThatOpensOnLatinStillMirrorsANeutralBetweenTwoHebrewWords` | yes — restore the `span.rightToLeft()` gate |
| `PptxRightToLeftFrameTest.aChipThatOpensOnLatinMirrorsOnlyItsRightToLeftLevelPunctuation` | yes — same |
| `PptxRightToLeftFrameTest.aChipThatOpensOnLatinCarriesNothingToMirrorWhenItHoldsOnlyLetters` | **no** — and it says so in its own comment |

Only the last PPTX case is a contract pin rather than a regression guard — a chip of letters only is genuinely untouched either way, and its comment says so. The two carrying a mirrored character are real guards.

The PDF case reads the drawn glyphs by position (`DrawnGlyphs`) rather than extracted text — extraction goes through `ActualText` and the font's `ToUnicode` map, both of which deliberately answer with what the author wrote whichever order the page drew, so they cannot see this bug.

No shipped example or visual baseline pairs a chip with right-to-left text, so committed previews are untouched by construction.


