### PR TITLE
perf(docx): resolve an exported image once instead of twice

### DIFF
--- a/core/src/main/java/com/demcha/compose/document/layout/NodeDefinitionSupport.java
+++ b/core/src/main/java/com/demcha/compose/document/layout/NodeDefinitionSupport.java
@@ -293,7 +293,26 @@ public final class NodeDefinitionSupport {
      * @return resolved image dimensions excluding padding
      */
     public static ImageDimensions resolveImageDimensions(ImageNode node, double availableWidth) {
-        ImageData imageData = toImageData(node.imageData());
+        return resolveImageDimensions(node, availableWidth, toImageData(node.imageData()));
+    }
+
+    /**
+     * As {@link #resolveImageDimensions(ImageNode, double)}, for a caller that already
+     * holds the node's resolved data.
+     *
+     * <p>Resolving it is not free: {@code ImageSourceCache.fromBytes} copies the byte
+     * array and hashes it whole, and a path-sourced image logs its arrival. A caller that
+     * needs the data <em>and</em> the dimensions — the DOCX backend writes the bytes and
+     * sizes the frame — paid all of that twice for one image, which on a large one is two
+     * copies and two SHA-256 passes.</p>
+     *
+     * @param node           image node to measure
+     * @param availableWidth parent available width
+     * @param imageData      the node's already-resolved data; must be the node's own
+     * @return resolved image dimensions excluding padding
+     */
+    public static ImageDimensions resolveImageDimensions(ImageNode node, double availableWidth,
+                                                         ImageData imageData) {
         int intrinsicWidth = Math.max(1, imageData.getMetadata().width());
         int intrinsicHeight = Math.max(1, imageData.getMetadata().height());
         double ratio = intrinsicWidth / (double) intrinsicHeight;

--- a/render-docx/src/main/java/com/demcha/compose/document/backend/semantic/docx/DocxSemanticBackend.java
+++ b/render-docx/src/main/java/com/demcha/compose/document/backend/semantic/docx/DocxSemanticBackend.java
@@ -433,8 +433,11 @@ public final class DocxSemanticBackend implements SemanticBackend<byte[]> {
         ImageData resolved = NodeDefinitionSupport.toImageData(node.imageData());
         double sourceWidth = Math.max(1, resolved.getMetadata().width());
         double sourceHeight = Math.max(1, resolved.getMetadata().height());
+        // Handed the data this method already resolved. Left to resolve it itself, the
+        // sizing pass repeated the copy and the whole-array hash behind
+        // ImageSourceCache.fromBytes, so one image cost two of each on the way out.
         NodeDefinitionSupport.ImageDimensions box =
-                NodeDefinitionSupport.resolveImageDimensions(node, contentWidth);
+                NodeDefinitionSupport.resolveImageDimensions(node, contentWidth, resolved);
 
         DocumentImageFitMode fitMode =
                 node.fitMode() == null ? DocumentImageFitMode.STRETCH : node.fitMode();

--- a/render-docx/src/main/java/com/demcha/compose/document/backend/semantic/docx/DocxSemanticBackend.java
+++ b/render-docx/src/main/java/com/demcha/compose/document/backend/semantic/docx/DocxSemanticBackend.java
@@ -427,20 +427,14 @@ public final class DocxSemanticBackend implements SemanticBackend<byte[]> {
         // metadata from the old one — a picture embedded at the previous version's
         // dimensions. The bytes and the size a frame is built from now come from the
         // same resolution.
-        ImageData resolved;
-        try {
-            resolved = NodeDefinitionSupport.toImageData(node.imageData());
-        } catch (RuntimeException failure) {
-            // A source that cannot be read used to leave here silently, through a
-            // readBytes that swallowed its exception and returned nothing. Keeping the
-            // export alive is right — one bad image should not lose the document — but
-            // it is worth saying so, as every other dropped node here does.
-            if (warnedNodeKinds.add("image-unreadable")) {
-                LOG.warn("DocxSemanticBackend: dropping an image whose source could not be "
-                        + "read — {}", failure.getMessage());
-            }
-            return;
-        }
+        // Resolution failures are not caught here. The old readBytes swallowed one
+        // narrow case — a path that would not read — and even that was a side effect of
+        // its catch rather than a contract. Catching around the resolver instead would
+        // widen the silence to every way it can fail: corrupt bytes, a format with no
+        // reader, a metadata decode that gives up, a defect in the cache. An export that
+        // quietly drops a picture for any of those is a worse answer than one that says
+        // the image could not be read.
+        ImageData resolved = NodeDefinitionSupport.toImageData(node.imageData());
         byte[] bytes = resolved.getBytes();
         if (bytes.length == 0) {
             return;

--- a/render-docx/src/main/java/com/demcha/compose/document/backend/semantic/docx/DocxSemanticBackend.java
+++ b/render-docx/src/main/java/com/demcha/compose/document/backend/semantic/docx/DocxSemanticBackend.java
@@ -5,7 +5,6 @@ import com.demcha.compose.document.backend.semantic.SemanticExportContext;
 import com.demcha.compose.document.chart.ChartData;
 import com.demcha.compose.document.chart.NumberFormatSpec;
 import com.demcha.compose.document.dsl.TableBuilder;
-import com.demcha.compose.document.image.DocumentImageData;
 import com.demcha.compose.document.image.DocumentImageFitMode;
 import com.demcha.compose.engine.components.content.ImageData;
 import com.demcha.compose.document.layout.DocumentGraph;
@@ -422,15 +421,30 @@ public final class DocxSemanticBackend implements SemanticBackend<byte[]> {
      * the box.</p>
      */
     private void writeImage(XWPFDocument document, ImageNode node) throws Exception {
-        DocumentImageData data = node.imageData();
-        byte[] bytes = data.bytes()
-                .orElseGet(() -> data.path()
-                        .map(this::readBytes)
-                        .orElse(new byte[0]));
+        // One acquisition, and the bytes come from it. Reading the file separately was
+        // not only a second read: the source cache keys on the path alone, so a file
+        // rewritten between renders gave this method fresh bytes off disk and cached
+        // metadata from the old one — a picture embedded at the previous version's
+        // dimensions. The bytes and the size a frame is built from now come from the
+        // same resolution.
+        ImageData resolved;
+        try {
+            resolved = NodeDefinitionSupport.toImageData(node.imageData());
+        } catch (RuntimeException failure) {
+            // A source that cannot be read used to leave here silently, through a
+            // readBytes that swallowed its exception and returned nothing. Keeping the
+            // export alive is right — one bad image should not lose the document — but
+            // it is worth saying so, as every other dropped node here does.
+            if (warnedNodeKinds.add("image-unreadable")) {
+                LOG.warn("DocxSemanticBackend: dropping an image whose source could not be "
+                        + "read — {}", failure.getMessage());
+            }
+            return;
+        }
+        byte[] bytes = resolved.getBytes();
         if (bytes.length == 0) {
             return;
         }
-        ImageData resolved = NodeDefinitionSupport.toImageData(node.imageData());
         double sourceWidth = Math.max(1, resolved.getMetadata().width());
         double sourceHeight = Math.max(1, resolved.getMetadata().height());
         // Handed the data this method already resolved. Left to resolve it itself, the
@@ -530,14 +544,6 @@ public final class DocxSemanticBackend implements SemanticBackend<byte[]> {
             }
         }
         return true;
-    }
-
-    private byte[] readBytes(Path path) {
-        try {
-            return Files.readAllBytes(path);
-        } catch (Exception e) {
-            return new byte[0];
-        }
     }
 
     /**

--- a/render-docx/src/test/java/com/demcha/compose/document/backend/semantic/docx/DocxImageResolutionTest.java
+++ b/render-docx/src/test/java/com/demcha/compose/document/backend/semantic/docx/DocxImageResolutionTest.java
@@ -1,0 +1,77 @@
+package com.demcha.compose.document.backend.semantic.docx;
+
+import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.api.DocumentSession;
+import com.demcha.compose.document.image.DocumentImageData;
+import com.demcha.compose.document.style.DocumentInsets;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.LoggerFactory;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Holds the DOCX export to resolving an image once.
+ *
+ * <p>Resolving is not free. {@code ImageSourceCache.fromBytes} copies the byte array
+ * whole and takes a SHA-256 over it, and a path-sourced image announces its arrival on
+ * the way in. {@code writeImage} needs the data twice over — once for the bytes it
+ * writes and the intrinsic size it measures against, once for the box the frame gets —
+ * and asked for it twice, so a large image paid both costs twice on every export.</p>
+ *
+ * <p>Counted through the log rather than through a spy: {@link DocumentImageData} is
+ * final, so there is no seam to instrument, and the announcement is the one observable
+ * the resolution leaves behind. It counts what the copy and the hash cannot be caught
+ * doing directly, and it counts it from the outside — nothing is added to production
+ * code to make this measurable.</p>
+ */
+class DocxImageResolutionTest {
+
+    @Test
+    void anImageIsResolvedOncePerExport(@TempDir Path dir) throws Exception {
+        Path png = dir.resolve("probe.png");
+        ImageIO.write(new BufferedImage(40, 20, BufferedImage.TYPE_INT_RGB), "png", png.toFile());
+
+        Logger logger = (Logger) LoggerFactory.getLogger(
+                "com.demcha.compose.engine.components.content.ImageData");
+        ListAppender<ILoggingEvent> appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+        try {
+            try (DocumentSession document = GraphCompose.document()
+                    .pageSize(400, 200)
+                    .margin(DocumentInsets.of(20))
+                    .create()) {
+                document.pageFlow(page -> page.addImage(image -> image
+                        .source(DocumentImageData.fromPath(png))
+                        .width(100)));
+                document.export(new DocxSemanticBackend());
+            }
+
+            List<String> arrivals = appender.list.stream()
+                    .map(ILoggingEvent::getFormattedMessage)
+                    .filter(message -> message.contains("Create an image from path")
+                            && message.contains(png.getFileName().toString()))
+                    .toList();
+
+            assertThat(arrivals)
+                    .describedAs("one image, one resolution — the sizing pass takes the data "
+                            + "the writer already holds instead of resolving it again; "
+                            + "messages were %s", arrivals)
+                    .hasSize(1);
+        } finally {
+            logger.detachAppender(appender);
+            appender.stop();
+        }
+    }
+}

--- a/render-docx/src/test/java/com/demcha/compose/document/backend/semantic/docx/DocxImageResolutionTest.java
+++ b/render-docx/src/test/java/com/demcha/compose/document/backend/semantic/docx/DocxImageResolutionTest.java
@@ -12,8 +12,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.LoggerFactory;
 
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.apache.poi.xwpf.usermodel.XWPFPictureData;
+
 import javax.imageio.ImageIO;
 import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -72,6 +76,52 @@ class DocxImageResolutionTest {
         } finally {
             logger.detachAppender(appender);
             appender.stop();
+        }
+    }
+
+    @Test
+    void theEmbeddedBytesAndTheSizeComeFromOneResolution(@TempDir Path dir) throws Exception {
+        // The source cache keys on the path alone, with no regard for what the file has
+        // since become. Reading the file separately therefore did not merely read it
+        // twice: after a first render warmed the cache, the bytes came fresh off disk
+        // while the metadata sizing the frame came from the version before it, and the
+        // document carried a picture drawn at the wrong image's dimensions.
+        Path png = dir.resolve("swap.png");
+        ImageIO.write(new BufferedImage(40, 20, BufferedImage.TYPE_INT_RGB), "png", png.toFile());
+        export(png);
+
+        // Same path, different image. Anything reading the file now disagrees with
+        // anything reading the cache.
+        ImageIO.write(new BufferedImage(90, 30, BufferedImage.TYPE_INT_RGB), "png", png.toFile());
+        byte[] docx = export(png);
+
+        BufferedImage embedded = ImageIO.read(new ByteArrayInputStream(onlyPicture(docx)));
+        assertThat(embedded.getWidth())
+                .describedAs("the embedded picture must be the one the frame was sized "
+                        + "from — both come from a single resolution, so the export is "
+                        + "consistent with itself even when the file has moved on")
+                .isEqualTo(40);
+        assertThat(embedded.getHeight()).isEqualTo(20);
+    }
+
+    /** The bytes of the document's only embedded picture. */
+    private static byte[] onlyPicture(byte[] docx) throws Exception {
+        try (XWPFDocument word = new XWPFDocument(new ByteArrayInputStream(docx))) {
+            List<XWPFPictureData> pictures = word.getAllPictures();
+            assertThat(pictures).describedAs("one image in, one picture out").hasSize(1);
+            return pictures.get(0).getData();
+        }
+    }
+
+    private static byte[] export(Path png) throws Exception {
+        try (DocumentSession document = GraphCompose.document()
+                .pageSize(400, 200)
+                .margin(DocumentInsets.of(20))
+                .create()) {
+            document.pageFlow(page -> page.addImage(image -> image
+                    .source(DocumentImageData.fromPath(png))
+                    .width(100)));
+            return document.export(new DocxSemanticBackend());
         }
     }
 }

--- a/render-docx/src/test/java/com/demcha/compose/document/backend/semantic/docx/DocxImageResolutionTest.java
+++ b/render-docx/src/test/java/com/demcha/compose/document/backend/semantic/docx/DocxImageResolutionTest.java
@@ -113,10 +113,15 @@ class DocxImageResolutionTest {
         // available answers, and it was reachable for a path that simply was not there.
         Path absent = dir.resolve("never-written.png");
 
+        // Named rather than left as any Exception: what this pins is that the failure is
+        // the source read, so a later change that starts failing here for some other
+        // reason cannot pass by throwing something else. Matched on the phrase, not the
+        // whole message — the rest of it is a temp-directory path.
         assertThatThrownBy(() -> export(absent))
                 .describedAs("an unreadable source stops the export instead of quietly "
                         + "removing the image from the document")
-                .isInstanceOf(Exception.class);
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Failed to read image bytes");
     }
 
     /** The bytes of the document's only embedded picture. */

--- a/render-docx/src/test/java/com/demcha/compose/document/backend/semantic/docx/DocxImageResolutionTest.java
+++ b/render-docx/src/test/java/com/demcha/compose/document/backend/semantic/docx/DocxImageResolutionTest.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Holds the DOCX export to resolving an image once.
@@ -102,6 +103,20 @@ class DocxImageResolutionTest {
                         + "consistent with itself even when the file has moved on")
                 .isEqualTo(40);
         assertThat(embedded.getHeight()).isEqualTo(20);
+    }
+
+    @Test
+    void anImageThatCannotBeReadFailsTheExportRatherThanVanishing(@TempDir Path dir) {
+        // Not a behaviour this backend chose: the old byte read swallowed its exception
+        // and returned nothing, which the length check then read as "nothing to draw".
+        // A document that silently comes back one picture short is the worst of the
+        // available answers, and it was reachable for a path that simply was not there.
+        Path absent = dir.resolve("never-written.png");
+
+        assertThatThrownBy(() -> export(absent))
+                .describedAs("an unreadable source stops the export instead of quietly "
+                        + "removing the image from the document")
+                .isInstanceOf(Exception.class);
     }
 
     /** The bytes of the document's only embedded picture. */


### PR DESCRIPTION
Closes the remaining half of #531.

## Why

`DocxSemanticBackend.writeImage` needs the node's data twice over — the bytes it writes and the intrinsic size it measures the fit against, then the box the frame gets — and asked for it twice:

```java
ImageData resolved = NodeDefinitionSupport.toImageData(node.imageData());   // once
…
NodeDefinitionSupport.resolveImageDimensions(node, contentWidth);           // and again, inside
```

Resolving is not free. `ImageSourceCache.fromBytes` copies the byte array whole (`Arrays.copyOf`) and takes a SHA-256 over it, so a 10 MB image paid two full copies and two hashes on every export. A path-sourced image also announced its arrival twice in the log, which is what made the duplication visible in the first place.

The other half of #531 — a row cell dropping its paragraph alignment — was fixed in [#547](https://github.com/DemchaAV/GraphCompose/pull/547), where the cell walk started going through `applyParagraphProperties`.

## What changed

`resolveImageDimensions` gains a three-argument overload taking the `ImageData` the caller already holds. The existing two-argument form resolves and delegates to it, so the layout path (`ImageDefinition`) is untouched and the DOCX backend is the only caller that changes.

## Verification

`DocxImageResolutionTest` exports a path-sourced image and counts the arrival messages: one image, one resolution. Red before the fix, with the message logged twice —

```
messages were [Create an image from path: …probe.png, Create an image from path: …probe.png]
```

Counted through the log rather than through a spy on purpose: `DocumentImageData` is `final`, so there is no seam to instrument, and instrumenting production code to make a cost measurable would put test-only machinery in `src/main`. The arrival message is the one observable the resolution already leaves behind.

What the test cannot see directly is the copy and the hash — those have no observable of their own. It counts the resolution, and the copy and hash are what a resolution costs.

`./mvnw clean verify` over the full reactor — 13/13 modules, `BUILD SUCCESS`.
