### PR TITLE
docs: give coding agents the rules this repository already runs on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         # in qa) run in build-and-test below, which now also covers docs-only PRs.
         run: |
           ./mvnw -B -ntp clean \
-            "-Dtest=EnginePdfBoundaryTest,DocumentationCoverageTest,CanonicalSurfaceGuardTest,PackageMapGuardTest,VersionConsistencyGuardTest,CiGuardListGuardTest,CiGateCoverageGuardTest,CodeQlScopeGuardTest" \
+            "-Dtest=EnginePdfBoundaryTest,DocumentationCoverageTest,CanonicalSurfaceGuardTest,PackageMapGuardTest,VersionConsistencyGuardTest,CiGuardListGuardTest,CiGateCoverageGuardTest,CodeQlScopeGuardTest,AgentsGuideGuardTest" \
             test -pl :graph-compose-core
 
   changes:

--- a/.gitignore
+++ b/.gitignore
@@ -52,7 +52,6 @@ render-pdf/logs/
 /patch-root-position.diff
 /rectangle.pdf
 /Test.pdf
-/AGENTS.md
 
 ### Editor / OS scratch files ###
 *.tmp

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,11 @@ render-pdf/logs/
 /patch-root-position.diff
 /rectangle.pdf
 /Test.pdf
+# Agent config that is not the project's to publish. AGENTS.md is the generic,
+# tool-independent guide and ships; a tool-specific file stays on the machine
+# that uses it, so the repository carries one set of rules rather than one per
+# vendor.
+/CLAUDE.md
 
 ### Editor / OS scratch files ###
 *.tmp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,440 +1,118 @@
 # AGENTS.md
 
-## Purpose
+Operating rules for coding agents working on GraphCompose.
 
-This file defines the operating rules for coding agents working on GraphCompose.
+GraphCompose is a modular Java document layout engine, not a generic Java
+application. Its architecture, module boundaries, public API tiers and
+deterministic layout behaviour are documented — read them before changing them.
+This file does not restate them. It covers what an agent needs that those
+documents do not say, and points at the rest.
 
-GraphCompose is a modular Java document layout engine.
-Changes must preserve its architecture, module boundaries, public API stability,
-deterministic layout behaviour, and backend independence.
+## Read first
 
-Do not treat this repository as a generic Java application.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — contribution flow, branch policy, Java
+  baseline, repository map, architecture lanes, testing expectations
+- [`docs/architecture/overview.md`](docs/architecture/overview.md) — the
+  authoring pipeline and where each stage's responsibility ends
+- [`docs/architecture/package-map.md`](docs/architecture/package-map.md) —
+  package ownership and module layout
+- [`docs/contributing/extension-guide.md`](docs/contributing/extension-guide.md)
+  — how to add a node, builder, definition or backend handler
 
-## Read Before Editing
+Read when the change reaches them:
 
-Before making non-trivial changes, read the relevant repository documentation:
+- [`docs/api-stability.md`](docs/api-stability.md) — before changing public API
+- [`docs/architecture/backend-capability-matrix.md`](docs/architecture/backend-capability-matrix.md)
+  — before changing what a PDF, PPTX or DOCX export can do, and to record it
+- [`docs/adr/`](docs/adr/) — before revisiting a decision already taken
+- [`docs/operations/benchmarks.md`](docs/operations/benchmarks.md) — for
+  layout, render or performance work
+- [`docs/contributing/release-process.md`](docs/contributing/release-process.md)
+  — for release work
 
-- `CONTRIBUTING.md`
-- `docs/architecture/overview.md`
-- `docs/architecture/package-map.md`
-- `docs/contributing/extension-guide.md`
+These documents are the source of truth. Do not copy them into code comments,
+and do not answer from memory of how the engine used to work: prose describing
+an architecture this repository no longer has once survived a full release line,
+green under every guard.
 
-Also read when relevant:
+## Stay inside the task
 
-- `docs/architecture/backend-capability-matrix.md`
-  for PDF, PPTX, or DOCX capability changes
-- `docs/api-stability.md`
-  for public API changes
-- `docs/adr/`
-  for architectural decisions
-- `docs/operations/benchmarks.md`
-  for layout/render/performance changes
-- `docs/contributing/release-process.md`
-  for release-related work
+Do not run release scripts, create tags, change versions, or edit release
+metadata unless the task is release work. A cut is not a side effect of a
+feature branch.
 
-Do not duplicate or replace these documents in code comments.
-Treat them as the repository source of truth.
+Do not refactor code the task does not require. Keep a refactor and a behaviour
+change in separate commits when both are genuinely needed.
 
-## Development Branches
+Before adding a class, builder, abstraction, render handler or template
+component, search for the extension point that already exists. A parallel
+abstraction is cheaper to write and more expensive than anything it saves.
 
-Normal feature and bug-fix work targets `develop`.
+## Working tree hygiene
 
-- `develop` — active 2.x development
-- `main` — stable release line
-- `1.x` — critical 1.9.x fixes and security backports only
+Stage explicit paths — `git add <path> …`. Never `git add .` or `git add -A`.
 
-Do not implement normal feature work directly against `main`.
+The tree accumulates zero-byte files with names like `$env`, `` b)` `` or
+`'Current`, left by shell quoting accidents rather than by intent. They are
+invisible in a summary and permanent once committed. Staging by path cannot pick
+them up.
 
-Do not run release scripts, create release tags, change release versions,
-or modify release metadata unless the task explicitly requires release work.
+Read `git status --porcelain --untracked-files=all` before committing and remove
+such files by name. Do not run `git clean -f`: it deletes new source files that
+have not been staged yet along with the junk.
 
-## Java Baseline
+## Verification
 
-Production code must remain compatible with Java 17.
+Run the smallest relevant tests while working:
 
-`maven.compiler.release` in `core/pom.xml` enforces this, so a Java 21+ API
-fails the build rather than reaching a user. The list below is what to watch for
-while writing and reviewing, not the only line of defence:
+```
+./mvnw -B -ntp verify -pl :graph-compose-core
+```
 
-- `List.getFirst()`
-- `List.getLast()`
-- `List.reversed()`
-- `Thread.threadId()`
-- record deconstruction patterns
-- Java 21+ pattern-switch constructs
+Before reporting the work complete:
 
-The build may run on newer JDKs, but Java 17 is the compatibility baseline.
+```
+./mvnw -B -ntp clean verify
+```
 
-## Architecture
+`CONTRIBUTING.md` lists the guard suites and the documentation guards in the
+`qa` module, including the install a standalone `-f qa/pom.xml` run needs first.
 
-The supported authoring pipeline is:
+Do not weaken, delete or bypass an existing regression test to make a change
+pass, unless the behaviour it pins deliberately changed.
 
-`GraphCompose.document(...)`
-→ `DocumentSession`
-→ `DocumentDsl`
-→ semantic `DocumentNode` tree
-→ `LayoutCompiler`
-→ deterministic layout/pagination
-→ backend rendering
+**Never report that a test passed unless it was executed and observed to pass.**
+Report any command that could not be run, and why.
 
-Keep these responsibilities separated.
+### Two results that mislead rather than fail
 
-### Canonical public surface
+Both of these return success while telling you the opposite of the truth.
 
-Application-facing features belong primarily under:
+**A standalone examples run resolves from `~/.m2`.** The full reactor builds
+`examples` from source, but `cd examples && ../mvnw compile exec:java …` does
+not — it resolves `graph-compose-*` from the local repository, exactly as a
+standalone `-f qa/pom.xml` run does. After changing a render backend, install
+first:
 
-- `com.demcha.compose.document.api`
-- `com.demcha.compose.document.dsl`
-- `com.demcha.compose.document.node`
-- `com.demcha.compose.document.style`
-- `com.demcha.compose.document.table`
-- `com.demcha.compose.document.image`
-- `com.demcha.compose.document.output`
-- `com.demcha.compose.document.snapshot`
-
-New public authoring features should normally enter through the canonical
-`document.*` surface.
-
-### Internal engine
-
-`com.demcha.compose.engine.*` is internal infrastructure.
-
-Do not expose engine internals as the normal application API.
-
-Before adding a new engine primitive, determine whether it should instead be:
-
-1. a semantic `DocumentNode`,
-2. a DSL builder operation,
-3. a `NodeDefinition`,
-4. backend-specific rendering logic.
-
-Do not create a second authoring model beside the canonical document surface.
-
-## Module Boundaries
-
-GraphCompose is intentionally multi-module.
-
-Important modules:
-
-- `core` — renderer-neutral engine and canonical authoring API
-- `render-pdf` — PDFBox backend
-- `render-pptx` — PowerPoint backend
-- `render-docx` — semantic DOCX exporter
-- `templates` — built-in document templates
-- `testing` — reusable consumer testing support
-- `wrapper` — compatibility `graph-compose` coordinate
-- `bundle` — batteries-included aggregate
-- `qa` — cross-module validation
-- `benchmarks` — performance benchmarks
-
-Do not move backend implementation concerns into `core`.
-
-### Core must remain backend-neutral
-
-Production code in the canonical authoring surface must not depend on:
-
-- PDFBox
-- Apache POI
-- PPTX/XSLF types
-- DOCX/XWPF types
-- other backend-specific implementation classes
-
-Backend-specific translation belongs in the appropriate renderer module.
-
-### PDF
-
-PDFBox lifecycle, content streams, PDF-specific rendering, annotations,
-and PDF-specific conversions belong in `render-pdf`.
-
-### PPTX
-
-PPTX rendering belongs in `render-pptx`.
-
-The fixed-layout PPTX backend consumes the resolved layout graph.
-Do not create a separate layout algorithm merely for PPTX.
-
-When changing PPTX capabilities, update the backend capability matrix.
-
-### DOCX
-
-DOCX is a semantic exporter and does not consume the fixed-layout graph.
-
-Do not attempt to force fixed PDF geometry into the DOCX path unless an
-explicit architectural change has been approved.
-
-## Reuse Before Adding
-
-Before introducing a new:
-
-- class
-- interface
-- utility
-- builder
-- DTO
-- abstraction
-- render handler
-- layout primitive
-- template component
-
-search the repository for an existing equivalent or extension point.
-
-Prefer extending an established abstraction over creating a parallel one.
-
-In particular, inspect:
-
-- similar `DocumentNode` implementations
-- existing DSL builders
-- `NodeDefinition`
-- `BuiltInNodeDefinitions`
-- backend fragment handlers
-- shared template widgets/components
-- existing public value types
-
-Do not duplicate functionality merely because a local implementation is easier.
-
-## Public API Changes
-
-Treat public APIs as compatibility-sensitive.
-
-Prefer additive and backward-compatible changes.
-
-When adding fields to public records or changing constructors,
-preserve compatibility where the established pattern requires it.
-
-Do not:
-
-- rename public packages casually
-- move public classes casually
-- introduce compatibility aliases without architectural justification
-- leak internal implementation types into public method signatures
-
-Check `docs/api-stability.md` before modifying public API contracts.
-
-## DSL and Node Rules
-
-DSL builders belong in:
-
-`com.demcha.compose.document.dsl`
-
-DSL implementation helpers belong in:
-
-`com.demcha.compose.document.dsl.internal`
-
-Semantic nodes belong in:
-
-`com.demcha.compose.document.node`
-
-Nodes describe intent, not renderer mechanics.
-
-Layout behaviour for a node should normally be implemented through
-`NodeDefinition` and registered through the established registry mechanism.
-
-## Templates
-
-Templates must compose through the canonical `DocumentDsl`.
-
-Do not import PDFBox or POI implementation classes into template code.
-
-Reuse the shared template architecture:
-
-- `templates.core`
-- shared `BrandTheme`
-- shared widgets
-- shared identity/text components
-
-Visible design values should come from theme tokens where the template system
-already provides them.
-
-Do not create family-specific copies of generic reusable widgets.
-
-## Determinism
-
-Layout output must remain deterministic.
-
-Pay special attention when modifying:
-
-- measurement
-- pagination
-- text shaping
-- RTL/BiDi handling
-- table layout
-- fragment ordering
-- transforms
-- clipping
-- fonts
-- backend dispatch
-
-Do not depend on unordered iteration where it can affect output geometry
-or rendering order.
-
-## Rendering Rules
-
-Layout determines geometry.
-Renderers draw resolved geometry.
-
-Do not move layout decisions into renderer handlers merely to fix one backend.
-
-An unsupported backend capability should fail or use the documented fallback
-mechanism rather than silently producing incorrect output.
-
-Renderer handlers must respect backend-owned resource and graphics-state
-lifecycles.
-
-## Testing
-
-During implementation, run the smallest relevant tests first.
-
-Core iteration:
-
-`./mvnw -B -ntp verify -pl :graph-compose-core`
-
-Before considering repository work complete, run:
-
-`./mvnw -B -ntp clean verify`
-
-For architecture-sensitive core changes, also run the repository guard suite
-documented in `CONTRIBUTING.md`.
-
-For documentation code snippets, run the documentation guards from the
-`qa` module as described in `CONTRIBUTING.md`.
-
-For changes affecting:
-
-- geometry
-- pagination
-- ordering
-
-prefer layout snapshot tests.
-
-For changes affecting visual PDF output, add or update the appropriate
-visual regression/render smoke coverage.
-
-For performance-sensitive changes, follow
-`docs/operations/benchmarks.md`.
-
-Do not weaken, delete, or bypass an existing regression test merely to make a
-change pass unless the expected behaviour itself intentionally changed.
-
-### Running the examples after a render change
-
-The full reactor builds `examples` from source, but a standalone invocation does
-not: `cd examples && ../mvnw compile exec:java -Dexec.mainClass=...` resolves its
-`graph-compose-*` dependencies from `~/.m2`, the same way a standalone
-`-f qa/pom.xml` run does. So after changing a render backend, install first:
-
-`./mvnw -B -ntp -DskipTests install`
+```
+./mvnw -B -ntp -DskipTests install
+```
 
 Without it the examples regenerate through the artifacts you last installed, and
 the output looks unchanged because the change was never in it.
 
-### Example output is not byte-comparable
+**Example output is not byte-comparable.** Rendering the same example twice
+produces different bytes — the writers embed timestamps. Comparing a fresh
+render against the committed preview under `assets/readme/` therefore reports a
+difference for every example, including ones the change cannot reach. To decide
+whether a render change owes regenerated previews, establish the changed code
+path's trigger condition and find the examples that meet it; the
+visual-regression baselines in `qa` are the independent check.
 
-Regenerating an example twice in a row produces different bytes — the writers
-embed timestamps. Comparing a fresh render against the committed preview under
-`assets/readme/` therefore reports a difference for every example, including
-ones your change cannot reach, so a byte comparison answers no question worth
-asking.
+## Before finishing
 
-To decide whether a render change owes regenerated previews, establish the
-changed code path's trigger condition and search the examples for documents that
-meet it. The visual-regression baselines in the `qa` module are the independent
-check.
-
-## Working Tree Hygiene
-
-Stage explicit paths — `git add <path> …`. Never `git add .` or `git add -A`.
-
-The working tree accumulates zero-byte files with names like `$env`, `b)` or
-`'Current`, left behind by shell quoting accidents rather than by anyone's
-intent. They are invisible in a summary and permanent once committed. `git add`
-by path cannot pick them up.
-
-Before committing, read `git status --porcelain --untracked-files=all` and
-remove such files by name. Do not run `git clean -f`: it also deletes new source
-files that have not been staged yet.
-
-## Documentation
-
-When changing public behaviour, update affected documentation in the same change.
-
-Keep these synchronized when relevant:
-
-- README examples
-- architecture documentation
-- package map
-- extension guide
-- capability matrix
-- runnable examples
-- screenshots
-- migration documentation
-
-Examples must use the current canonical public API.
-
-Do not document an API that does not compile.
-
-Prose that describes how the engine works is checked by guards in
-`core/src/test/java/com/demcha/documentation/`. A description that has stopped
-being true fails the build there, so correct the sentence rather than the guard.
-
-## Code Quality
-
-Follow existing Java naming and formatting conventions.
-
-Prefer:
-
-- small focused changes
-- explicit names
-- immutable values where appropriate
-- existing abstractions
-- single-purpose classes
-- clear module ownership
-
-Avoid:
-
-- unrelated refactoring
-- speculative abstractions
-- duplicated helpers
-- hidden coupling
-- backend leakage
-- unnecessary dependencies
-- clever code that makes layout behaviour harder to reason about
-
-Keep refactoring separate from behavioural changes when practical.
-
-## Dependencies
-
-Do not add a dependency until checking whether the repository already provides
-the required functionality.
-
-New runtime dependencies require particular care because `graph-compose-core`
-is intentionally lean.
-
-Do not add PDFBox, POI, or other backend libraries to `core`.
-
-## POM and Versioning Rules
-
-The repository root `pom.xml` is a reactor aggregator, not the published engine.
-
-`core/pom.xml` owns `graph-compose-core`.
-
-Do not convert the root aggregator into a shared Maven parent without an
-explicit architectural decision.
-
-Engine modules follow the repository's lockstep release model.
-Fonts and emoji have their own version lines.
-
-Do not manually change a subset of lockstep module versions.
-
-## Before Finishing
-
-Before reporting completion:
-
-1. inspect the final diff;
-2. verify no unrelated files changed;
-3. confirm module boundaries were preserved;
-4. confirm public API compatibility was considered;
-5. run the relevant focused tests;
-6. run `./mvnw -B -ntp clean verify` when feasible;
-7. report any test or validation command that could not be run.
-
-Never claim a test passed unless it was actually executed successfully.
+1. Read the final diff, and confirm nothing unrelated changed.
+2. Confirm the documentation the change touches was updated with it — a
+   capability matrix row, an example, a package map entry.
+3. Run the focused tests, then the full reactor when feasible.
+4. State what was run, and what was not.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,440 @@
+# AGENTS.md
+
+## Purpose
+
+This file defines the operating rules for coding agents working on GraphCompose.
+
+GraphCompose is a modular Java document layout engine.
+Changes must preserve its architecture, module boundaries, public API stability,
+deterministic layout behaviour, and backend independence.
+
+Do not treat this repository as a generic Java application.
+
+## Read Before Editing
+
+Before making non-trivial changes, read the relevant repository documentation:
+
+- `CONTRIBUTING.md`
+- `docs/architecture/overview.md`
+- `docs/architecture/package-map.md`
+- `docs/contributing/extension-guide.md`
+
+Also read when relevant:
+
+- `docs/architecture/backend-capability-matrix.md`
+  for PDF, PPTX, or DOCX capability changes
+- `docs/api-stability.md`
+  for public API changes
+- `docs/adr/`
+  for architectural decisions
+- `docs/operations/benchmarks.md`
+  for layout/render/performance changes
+- `docs/contributing/release-process.md`
+  for release-related work
+
+Do not duplicate or replace these documents in code comments.
+Treat them as the repository source of truth.
+
+## Development Branches
+
+Normal feature and bug-fix work targets `develop`.
+
+- `develop` — active 2.x development
+- `main` — stable release line
+- `1.x` — critical 1.9.x fixes and security backports only
+
+Do not implement normal feature work directly against `main`.
+
+Do not run release scripts, create release tags, change release versions,
+or modify release metadata unless the task explicitly requires release work.
+
+## Java Baseline
+
+Production code must remain compatible with Java 17.
+
+`maven.compiler.release` in `core/pom.xml` enforces this, so a Java 21+ API
+fails the build rather than reaching a user. The list below is what to watch for
+while writing and reviewing, not the only line of defence:
+
+- `List.getFirst()`
+- `List.getLast()`
+- `List.reversed()`
+- `Thread.threadId()`
+- record deconstruction patterns
+- Java 21+ pattern-switch constructs
+
+The build may run on newer JDKs, but Java 17 is the compatibility baseline.
+
+## Architecture
+
+The supported authoring pipeline is:
+
+`GraphCompose.document(...)`
+→ `DocumentSession`
+→ `DocumentDsl`
+→ semantic `DocumentNode` tree
+→ `LayoutCompiler`
+→ deterministic layout/pagination
+→ backend rendering
+
+Keep these responsibilities separated.
+
+### Canonical public surface
+
+Application-facing features belong primarily under:
+
+- `com.demcha.compose.document.api`
+- `com.demcha.compose.document.dsl`
+- `com.demcha.compose.document.node`
+- `com.demcha.compose.document.style`
+- `com.demcha.compose.document.table`
+- `com.demcha.compose.document.image`
+- `com.demcha.compose.document.output`
+- `com.demcha.compose.document.snapshot`
+
+New public authoring features should normally enter through the canonical
+`document.*` surface.
+
+### Internal engine
+
+`com.demcha.compose.engine.*` is internal infrastructure.
+
+Do not expose engine internals as the normal application API.
+
+Before adding a new engine primitive, determine whether it should instead be:
+
+1. a semantic `DocumentNode`,
+2. a DSL builder operation,
+3. a `NodeDefinition`,
+4. backend-specific rendering logic.
+
+Do not create a second authoring model beside the canonical document surface.
+
+## Module Boundaries
+
+GraphCompose is intentionally multi-module.
+
+Important modules:
+
+- `core` — renderer-neutral engine and canonical authoring API
+- `render-pdf` — PDFBox backend
+- `render-pptx` — PowerPoint backend
+- `render-docx` — semantic DOCX exporter
+- `templates` — built-in document templates
+- `testing` — reusable consumer testing support
+- `wrapper` — compatibility `graph-compose` coordinate
+- `bundle` — batteries-included aggregate
+- `qa` — cross-module validation
+- `benchmarks` — performance benchmarks
+
+Do not move backend implementation concerns into `core`.
+
+### Core must remain backend-neutral
+
+Production code in the canonical authoring surface must not depend on:
+
+- PDFBox
+- Apache POI
+- PPTX/XSLF types
+- DOCX/XWPF types
+- other backend-specific implementation classes
+
+Backend-specific translation belongs in the appropriate renderer module.
+
+### PDF
+
+PDFBox lifecycle, content streams, PDF-specific rendering, annotations,
+and PDF-specific conversions belong in `render-pdf`.
+
+### PPTX
+
+PPTX rendering belongs in `render-pptx`.
+
+The fixed-layout PPTX backend consumes the resolved layout graph.
+Do not create a separate layout algorithm merely for PPTX.
+
+When changing PPTX capabilities, update the backend capability matrix.
+
+### DOCX
+
+DOCX is a semantic exporter and does not consume the fixed-layout graph.
+
+Do not attempt to force fixed PDF geometry into the DOCX path unless an
+explicit architectural change has been approved.
+
+## Reuse Before Adding
+
+Before introducing a new:
+
+- class
+- interface
+- utility
+- builder
+- DTO
+- abstraction
+- render handler
+- layout primitive
+- template component
+
+search the repository for an existing equivalent or extension point.
+
+Prefer extending an established abstraction over creating a parallel one.
+
+In particular, inspect:
+
+- similar `DocumentNode` implementations
+- existing DSL builders
+- `NodeDefinition`
+- `BuiltInNodeDefinitions`
+- backend fragment handlers
+- shared template widgets/components
+- existing public value types
+
+Do not duplicate functionality merely because a local implementation is easier.
+
+## Public API Changes
+
+Treat public APIs as compatibility-sensitive.
+
+Prefer additive and backward-compatible changes.
+
+When adding fields to public records or changing constructors,
+preserve compatibility where the established pattern requires it.
+
+Do not:
+
+- rename public packages casually
+- move public classes casually
+- introduce compatibility aliases without architectural justification
+- leak internal implementation types into public method signatures
+
+Check `docs/api-stability.md` before modifying public API contracts.
+
+## DSL and Node Rules
+
+DSL builders belong in:
+
+`com.demcha.compose.document.dsl`
+
+DSL implementation helpers belong in:
+
+`com.demcha.compose.document.dsl.internal`
+
+Semantic nodes belong in:
+
+`com.demcha.compose.document.node`
+
+Nodes describe intent, not renderer mechanics.
+
+Layout behaviour for a node should normally be implemented through
+`NodeDefinition` and registered through the established registry mechanism.
+
+## Templates
+
+Templates must compose through the canonical `DocumentDsl`.
+
+Do not import PDFBox or POI implementation classes into template code.
+
+Reuse the shared template architecture:
+
+- `templates.core`
+- shared `BrandTheme`
+- shared widgets
+- shared identity/text components
+
+Visible design values should come from theme tokens where the template system
+already provides them.
+
+Do not create family-specific copies of generic reusable widgets.
+
+## Determinism
+
+Layout output must remain deterministic.
+
+Pay special attention when modifying:
+
+- measurement
+- pagination
+- text shaping
+- RTL/BiDi handling
+- table layout
+- fragment ordering
+- transforms
+- clipping
+- fonts
+- backend dispatch
+
+Do not depend on unordered iteration where it can affect output geometry
+or rendering order.
+
+## Rendering Rules
+
+Layout determines geometry.
+Renderers draw resolved geometry.
+
+Do not move layout decisions into renderer handlers merely to fix one backend.
+
+An unsupported backend capability should fail or use the documented fallback
+mechanism rather than silently producing incorrect output.
+
+Renderer handlers must respect backend-owned resource and graphics-state
+lifecycles.
+
+## Testing
+
+During implementation, run the smallest relevant tests first.
+
+Core iteration:
+
+`./mvnw -B -ntp verify -pl :graph-compose-core`
+
+Before considering repository work complete, run:
+
+`./mvnw -B -ntp clean verify`
+
+For architecture-sensitive core changes, also run the repository guard suite
+documented in `CONTRIBUTING.md`.
+
+For documentation code snippets, run the documentation guards from the
+`qa` module as described in `CONTRIBUTING.md`.
+
+For changes affecting:
+
+- geometry
+- pagination
+- ordering
+
+prefer layout snapshot tests.
+
+For changes affecting visual PDF output, add or update the appropriate
+visual regression/render smoke coverage.
+
+For performance-sensitive changes, follow
+`docs/operations/benchmarks.md`.
+
+Do not weaken, delete, or bypass an existing regression test merely to make a
+change pass unless the expected behaviour itself intentionally changed.
+
+### Running the examples after a render change
+
+The full reactor builds `examples` from source, but a standalone invocation does
+not: `cd examples && ../mvnw compile exec:java -Dexec.mainClass=...` resolves its
+`graph-compose-*` dependencies from `~/.m2`, the same way a standalone
+`-f qa/pom.xml` run does. So after changing a render backend, install first:
+
+`./mvnw -B -ntp -DskipTests install`
+
+Without it the examples regenerate through the artifacts you last installed, and
+the output looks unchanged because the change was never in it.
+
+### Example output is not byte-comparable
+
+Regenerating an example twice in a row produces different bytes — the writers
+embed timestamps. Comparing a fresh render against the committed preview under
+`assets/readme/` therefore reports a difference for every example, including
+ones your change cannot reach, so a byte comparison answers no question worth
+asking.
+
+To decide whether a render change owes regenerated previews, establish the
+changed code path's trigger condition and search the examples for documents that
+meet it. The visual-regression baselines in the `qa` module are the independent
+check.
+
+## Working Tree Hygiene
+
+Stage explicit paths — `git add <path> …`. Never `git add .` or `git add -A`.
+
+The working tree accumulates zero-byte files with names like `$env`, `b)` or
+`'Current`, left behind by shell quoting accidents rather than by anyone's
+intent. They are invisible in a summary and permanent once committed. `git add`
+by path cannot pick them up.
+
+Before committing, read `git status --porcelain --untracked-files=all` and
+remove such files by name. Do not run `git clean -f`: it also deletes new source
+files that have not been staged yet.
+
+## Documentation
+
+When changing public behaviour, update affected documentation in the same change.
+
+Keep these synchronized when relevant:
+
+- README examples
+- architecture documentation
+- package map
+- extension guide
+- capability matrix
+- runnable examples
+- screenshots
+- migration documentation
+
+Examples must use the current canonical public API.
+
+Do not document an API that does not compile.
+
+Prose that describes how the engine works is checked by guards in
+`core/src/test/java/com/demcha/documentation/`. A description that has stopped
+being true fails the build there, so correct the sentence rather than the guard.
+
+## Code Quality
+
+Follow existing Java naming and formatting conventions.
+
+Prefer:
+
+- small focused changes
+- explicit names
+- immutable values where appropriate
+- existing abstractions
+- single-purpose classes
+- clear module ownership
+
+Avoid:
+
+- unrelated refactoring
+- speculative abstractions
+- duplicated helpers
+- hidden coupling
+- backend leakage
+- unnecessary dependencies
+- clever code that makes layout behaviour harder to reason about
+
+Keep refactoring separate from behavioural changes when practical.
+
+## Dependencies
+
+Do not add a dependency until checking whether the repository already provides
+the required functionality.
+
+New runtime dependencies require particular care because `graph-compose-core`
+is intentionally lean.
+
+Do not add PDFBox, POI, or other backend libraries to `core`.
+
+## POM and Versioning Rules
+
+The repository root `pom.xml` is a reactor aggregator, not the published engine.
+
+`core/pom.xml` owns `graph-compose-core`.
+
+Do not convert the root aggregator into a shared Maven parent without an
+explicit architectural decision.
+
+Engine modules follow the repository's lockstep release model.
+Fonts and emoji have their own version lines.
+
+Do not manually change a subset of lockstep module versions.
+
+## Before Finishing
+
+Before reporting completion:
+
+1. inspect the final diff;
+2. verify no unrelated files changed;
+3. confirm module boundaries were preserved;
+4. confirm public API compatibility was considered;
+5. run the relevant focused tests;
+6. run `./mvnw -B -ntp clean verify` when feasible;
+7. report any test or validation command that could not be run.
+
+Never claim a test passed unless it was actually executed successfully.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,9 +1,0 @@
-# CLAUDE.md
-
-The operating rules for coding agents in this repository live in
-[AGENTS.md](AGENTS.md). Read that file.
-
-This one exists because agent tools disagree about where to look — Claude Code
-reads `CLAUDE.md`, several others read `AGENTS.md` — and a second copy of the
-rules would be a second thing to keep true. There is one set of rules, in
-`AGENTS.md`, and this is a pointer to it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# CLAUDE.md
+
+The operating rules for coding agents in this repository live in
+[AGENTS.md](AGENTS.md). Read that file.
+
+This one exists because agent tools disagree about where to look — Claude Code
+reads `CLAUDE.md`, several others read `AGENTS.md` — and a second copy of the
+rules would be a second thing to keep true. There is one set of rules, in
+`AGENTS.md`, and this is a pointer to it.

--- a/core/src/test/java/com/demcha/documentation/AgentsGuideGuardTest.java
+++ b/core/src/test/java/com/demcha/documentation/AgentsGuideGuardTest.java
@@ -1,0 +1,148 @@
+package com.demcha.documentation;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Holds {@code AGENTS.md} to naming things that exist.
+ *
+ * <p>The file is a map: read these documents, work in these packages, these are the
+ * modules. A map is only worth having while it is true, and this one is read by
+ * automation that will follow a dead path without noticing — the failure is not a
+ * confused contributor but a change made in the wrong place, confidently.</p>
+ *
+ * <p>Nothing here judges the advice. It checks that every document it sends a reader
+ * to opens, every package it points at exists, and every module it names is built —
+ * the claims that rot on their own when the repository moves underneath them, which
+ * is how a contributing guide once went on routing new code into two packages the 2.0
+ * split had already emptied.</p>
+ */
+class AgentsGuideGuardTest {
+
+    private static final Path PROJECT_ROOT = RepoRoot.get();
+
+    private static String agentsGuide() throws IOException {
+        return Files.readString(PROJECT_ROOT.resolve("AGENTS.md"));
+    }
+
+    @Test
+    void everyDocumentItSendsAReaderToExists() throws IOException {
+        // Backticked paths under docs/, plus the root-level guides. A path that has
+        // moved leaves the instruction "read this first" pointing at nothing.
+        Matcher referenced = Pattern.compile("`((?:docs/|CONTRIBUTING\\.md|README\\.md)[^`]*)`")
+                .matcher(agentsGuide());
+
+        Set<String> missing = new TreeSet<>();
+        Set<String> checked = new TreeSet<>();
+        while (referenced.find()) {
+            String path = referenced.group(1).replaceAll("/$", "");
+            checked.add(path);
+            if (!Files.exists(PROJECT_ROOT.resolve(path))) {
+                missing.add(path);
+            }
+        }
+
+        assertThat(checked)
+                .describedAs("AGENTS.md must keep pointing readers at the repository's own "
+                        + "documentation — finding none suggests the reading list was "
+                        + "dropped or its formatting changed under this guard")
+                .isNotEmpty();
+        assertThat(missing)
+                .describedAs("AGENTS.md sends a reader to documents that are not there")
+                .isEmpty();
+    }
+
+    @Test
+    void everyPackageItPointsAtExists() throws IOException {
+        // The canonical surface is listed by coordinate. An emptied or renamed package
+        // read as current is how code lands somewhere nothing loads it from.
+        Matcher referenced = Pattern.compile("`(com\\.demcha\\.compose\\.[a-z0-9.]+)`")
+                .matcher(agentsGuide());
+
+        Set<String> missing = new TreeSet<>();
+        Set<String> checked = new TreeSet<>();
+        while (referenced.find()) {
+            String coordinate = referenced.group(1);
+            if (coordinate.endsWith(".")) {
+                continue;
+            }
+            checked.add(coordinate);
+            String relative = coordinate.replace('.', '/');
+            boolean found = SOURCE_ROOTS.stream()
+                    .anyMatch(root -> Files.isDirectory(PROJECT_ROOT.resolve(root).resolve(relative)));
+            if (!found) {
+                missing.add(coordinate);
+            }
+        }
+
+        assertThat(checked).describedAs("AGENTS.md must name the packages it routes work into")
+                .isNotEmpty();
+        assertThat(missing)
+                .describedAs("AGENTS.md points at packages that exist in no source tree")
+                .isEmpty();
+    }
+
+    private static final List<String> SOURCE_ROOTS = List.of(
+            "core/src/main/java", "render-pdf/src/main/java", "render-pptx/src/main/java",
+            "render-docx/src/main/java", "templates/src/main/java", "testing/src/main/java");
+
+    @Test
+    void everyModuleItNamesIsBuilt() throws IOException {
+        // Read from the module list rather than from every backtick in the file: the
+        // section names the modules as a set, and a module dropped from the reactor
+        // should fail here rather than mislead someone about where code belongs.
+        String guide = agentsGuide();
+        int start = guide.indexOf("Important modules:");
+        assertThat(start).describedAs("AGENTS.md must carry its module list").isNotNegative();
+        String section = guide.substring(start, guide.indexOf("\n## ", start));
+
+        Matcher named = Pattern.compile("(?m)^- `([a-z-]+)` —").matcher(section);
+        Set<String> missing = new TreeSet<>();
+        Set<String> checked = new TreeSet<>();
+        while (named.find()) {
+            String module = named.group(1);
+            checked.add(module);
+            if (!Files.exists(PROJECT_ROOT.resolve(module).resolve("pom.xml"))) {
+                missing.add(module);
+            }
+        }
+
+        assertThat(checked).describedAs("the module list must name modules").isNotEmpty();
+        assertThat(missing)
+                .describedAs("AGENTS.md names modules with no pom.xml — either they were "
+                        + "removed or renamed, and the list still sends work to them")
+                .isEmpty();
+    }
+
+    @Test
+    void theClaudePointerLeadsToTheOneSetOfRules() throws IOException {
+        // Claude Code reads CLAUDE.md and several other tools read AGENTS.md. The
+        // pointer is what keeps that from becoming two divergent rule sets, so it has
+        // to stay a pointer: a CLAUDE.md that grew its own instructions is the
+        // duplication it exists to prevent.
+        Path pointer = PROJECT_ROOT.resolve("CLAUDE.md");
+        assertThat(pointer)
+                .describedAs("CLAUDE.md must exist, or Claude Code reads no rules at all")
+                .exists();
+
+        String text = Files.readString(pointer);
+        assertThat(text)
+                .describedAs("CLAUDE.md must point at AGENTS.md")
+                .contains("AGENTS.md");
+        assertThat(text.lines().count())
+                .describedAs("CLAUDE.md is a pointer, not a second rule set — it has grown "
+                        + "to %d lines, which is long enough to have started disagreeing "
+                        + "with AGENTS.md", text.lines().count())
+                .isLessThan(20L);
+    }
+}

--- a/core/src/test/java/com/demcha/documentation/AgentsGuideGuardTest.java
+++ b/core/src/test/java/com/demcha/documentation/AgentsGuideGuardTest.java
@@ -24,7 +24,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  * describing a removed engine stayed green here for a full release line.</p>
  *
  * <p>Neither case is a judgement about the advice. What is checked is that the file
- * still points somewhere real, and still declines to answer questions it has delegated.</p>
+ * still points somewhere real, that the gate it prescribes is a command, and that it has
+ * not started restating package coordinates again — the one restatement recognisable on
+ * sight, and the one the first draft of this file actually made.</p>
  */
 class AgentsGuideGuardTest {
 
@@ -78,7 +80,7 @@ class AgentsGuideGuardTest {
     }
 
     @Test
-    void itDoesNotAnswerWhatItDelegates() throws IOException {
+    void itDoesNotRestateThePackageCoordinatesItLinksTo() throws IOException {
         // The failure this guards is the one that made the first draft of this file a
         // second copy of the documentation: restating the package roots and the module
         // inventory, both owned by docs/architecture/package-map.md. Existence checks

--- a/core/src/test/java/com/demcha/documentation/AgentsGuideGuardTest.java
+++ b/core/src/test/java/com/demcha/documentation/AgentsGuideGuardTest.java
@@ -123,26 +123,4 @@ class AgentsGuideGuardTest {
                         + "removed or renamed, and the list still sends work to them")
                 .isEmpty();
     }
-
-    @Test
-    void theClaudePointerLeadsToTheOneSetOfRules() throws IOException {
-        // Claude Code reads CLAUDE.md and several other tools read AGENTS.md. The
-        // pointer is what keeps that from becoming two divergent rule sets, so it has
-        // to stay a pointer: a CLAUDE.md that grew its own instructions is the
-        // duplication it exists to prevent.
-        Path pointer = PROJECT_ROOT.resolve("CLAUDE.md");
-        assertThat(pointer)
-                .describedAs("CLAUDE.md must exist, or Claude Code reads no rules at all")
-                .exists();
-
-        String text = Files.readString(pointer);
-        assertThat(text)
-                .describedAs("CLAUDE.md must point at AGENTS.md")
-                .contains("AGENTS.md");
-        assertThat(text.lines().count())
-                .describedAs("CLAUDE.md is a pointer, not a second rule set — it has grown "
-                        + "to %d lines, which is long enough to have started disagreeing "
-                        + "with AGENTS.md", text.lines().count())
-                .isLessThan(20L);
-    }
 }

--- a/core/src/test/java/com/demcha/documentation/AgentsGuideGuardTest.java
+++ b/core/src/test/java/com/demcha/documentation/AgentsGuideGuardTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.regex.Matcher;
@@ -14,18 +13,18 @@ import java.util.regex.Pattern;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Holds {@code AGENTS.md} to naming things that exist.
+ * Holds {@code AGENTS.md} to being a set of pointers rather than a second copy of them.
  *
- * <p>The file is a map: read these documents, work in these packages, these are the
- * modules. A map is only worth having while it is true, and this one is read by
- * automation that will follow a dead path without noticing — the failure is not a
- * confused contributor but a change made in the wrong place, confidently.</p>
+ * <p>The file's whole job is to send a reader to the documents that own a subject and
+ * to add only what none of them says. Both halves fail quietly. A link that has moved
+ * leaves "read this first" pointing at nothing, and it is read by automation that
+ * follows a dead path confidently. And a paragraph copied out of a document it links —
+ * the package roots, the module inventory — goes stale the day that document changes,
+ * with nothing to notice: existence checks pass either way, which is how prose
+ * describing a removed engine stayed green here for a full release line.</p>
  *
- * <p>Nothing here judges the advice. It checks that every document it sends a reader
- * to opens, every package it points at exists, and every module it names is built —
- * the claims that rot on their own when the repository moves underneath them, which
- * is how a contributing guide once went on routing new code into two packages the 2.0
- * split had already emptied.</p>
+ * <p>Neither case is a judgement about the advice. What is checked is that the file
+ * still points somewhere real, and still declines to answer questions it has delegated.</p>
  */
 class AgentsGuideGuardTest {
 
@@ -36,16 +35,17 @@ class AgentsGuideGuardTest {
     }
 
     @Test
-    void everyDocumentItSendsAReaderToExists() throws IOException {
-        // Backticked paths under docs/, plus the root-level guides. A path that has
-        // moved leaves the instruction "read this first" pointing at nothing.
-        Matcher referenced = Pattern.compile("`((?:docs/|CONTRIBUTING\\.md|README\\.md)[^`]*)`")
-                .matcher(agentsGuide());
+    void everyPathItSendsAReaderToExists() throws IOException {
+        Matcher links = Pattern.compile("\\[[^\\]]+\\]\\(([^)]+)\\)").matcher(agentsGuide());
 
         Set<String> missing = new TreeSet<>();
         Set<String> checked = new TreeSet<>();
-        while (referenced.find()) {
-            String path = referenced.group(1).replaceAll("/$", "");
+        while (links.find()) {
+            String target = links.group(1);
+            if (target.startsWith("http") || target.startsWith("#")) {
+                continue;
+            }
+            String path = target.replaceAll("[#?].*$", "").replaceAll("/$", "");
             checked.add(path);
             if (!Files.exists(PROJECT_ROOT.resolve(path))) {
                 missing.add(path);
@@ -53,74 +53,50 @@ class AgentsGuideGuardTest {
         }
 
         assertThat(checked)
-                .describedAs("AGENTS.md must keep pointing readers at the repository's own "
-                        + "documentation — finding none suggests the reading list was "
-                        + "dropped or its formatting changed under this guard")
+                .describedAs("AGENTS.md is a reading list before it is anything else — "
+                        + "finding no links suggests the list was dropped, or its formatting "
+                        + "changed out from under this guard")
                 .isNotEmpty();
         assertThat(missing)
-                .describedAs("AGENTS.md sends a reader to documents that are not there")
+                .describedAs("AGENTS.md links documents that are not there, so it tells an "
+                        + "agent to read something it cannot open")
                 .isEmpty();
     }
 
     @Test
-    void everyPackageItPointsAtExists() throws IOException {
-        // The canonical surface is listed by coordinate. An emptied or renamed package
-        // read as current is how code lands somewhere nothing loads it from.
-        Matcher referenced = Pattern.compile("`(com\\.demcha\\.compose\\.[a-z0-9.]+)`")
-                .matcher(agentsGuide());
-
-        Set<String> missing = new TreeSet<>();
-        Set<String> checked = new TreeSet<>();
-        while (referenced.find()) {
-            String coordinate = referenced.group(1);
-            if (coordinate.endsWith(".")) {
-                continue;
-            }
-            checked.add(coordinate);
-            String relative = coordinate.replace('.', '/');
-            boolean found = SOURCE_ROOTS.stream()
-                    .anyMatch(root -> Files.isDirectory(PROJECT_ROOT.resolve(root).resolve(relative)));
-            if (!found) {
-                missing.add(coordinate);
-            }
-        }
-
-        assertThat(checked).describedAs("AGENTS.md must name the packages it routes work into")
-                .isNotEmpty();
-        assertThat(missing)
-                .describedAs("AGENTS.md points at packages that exist in no source tree")
-                .isEmpty();
+    void theBuildCommandsItPrescribesCanBeRun() throws IOException {
+        // The file tells an agent what to run before reporting work complete. A wrapper
+        // that has moved turns that instruction into a failure the agent will read as a
+        // broken repository rather than as a stale document.
+        assertThat(agentsGuide())
+                .describedAs("AGENTS.md must prescribe the reactor gate, or 'verify before "
+                        + "finishing' has no command behind it")
+                .contains("./mvnw -B -ntp clean verify");
+        assertThat(PROJECT_ROOT.resolve("mvnw"))
+                .describedAs("AGENTS.md prescribes ./mvnw, which is not in the repository root")
+                .exists();
     }
 
-    private static final List<String> SOURCE_ROOTS = List.of(
-            "core/src/main/java", "render-pdf/src/main/java", "render-pptx/src/main/java",
-            "render-docx/src/main/java", "templates/src/main/java", "testing/src/main/java");
-
     @Test
-    void everyModuleItNamesIsBuilt() throws IOException {
-        // Read from the module list rather than from every backtick in the file: the
-        // section names the modules as a set, and a module dropped from the reactor
-        // should fail here rather than mislead someone about where code belongs.
+    void itDoesNotAnswerWhatItDelegates() throws IOException {
+        // The failure this guards is the one that made the first draft of this file a
+        // second copy of the documentation: restating the package roots and the module
+        // inventory, both owned by docs/architecture/package-map.md. Existence checks
+        // cannot see that going stale — the packages still exist, they have simply
+        // stopped being the ones the guide names. Linking is the only version of this
+        // that stays true on its own.
         String guide = agentsGuide();
-        int start = guide.indexOf("Important modules:");
-        assertThat(start).describedAs("AGENTS.md must carry its module list").isNotNegative();
-        String section = guide.substring(start, guide.indexOf("\n## ", start));
 
-        Matcher named = Pattern.compile("(?m)^- `([a-z-]+)` —").matcher(section);
-        Set<String> missing = new TreeSet<>();
-        Set<String> checked = new TreeSet<>();
-        while (named.find()) {
-            String module = named.group(1);
-            checked.add(module);
-            if (!Files.exists(PROJECT_ROOT.resolve(module).resolve("pom.xml"))) {
-                missing.add(module);
-            }
+        Matcher coordinates = Pattern.compile("com\\.demcha\\.compose\\.[a-z0-9.]+").matcher(guide);
+        Set<String> restated = new TreeSet<>();
+        while (coordinates.find()) {
+            restated.add(coordinates.group());
         }
 
-        assertThat(checked).describedAs("the module list must name modules").isNotEmpty();
-        assertThat(missing)
-                .describedAs("AGENTS.md names modules with no pom.xml — either they were "
-                        + "removed or renamed, and the list still sends work to them")
+        assertThat(restated)
+                .describedAs("AGENTS.md names package coordinates, which docs/architecture/"
+                        + "package-map.md owns. A copy here goes stale the day that document "
+                        + "moves a package, and nothing fails: link to it instead")
                 .isEmpty();
     }
 }


### PR DESCRIPTION
## Why

An agent cloning this repository is told nothing about it. `CONTRIBUTING.md` and the architecture docs carry the lanes, the pipeline and the testing expectations, but the operating rules — what not to touch, which results lie — lived in whatever local configuration a maintainer happened to have. Nothing in the tree.

Three build properties are worse than undocumented, because each returns success while reporting the opposite of the truth:

- **A standalone examples run resolves from `~/.m2`.** The reactor builds `examples` from source; `cd examples && ../mvnw compile exec:java …` does not — exactly as `CONTRIBUTING.md:37` already warns for `qa`. Skip the install after a render change and the examples regenerate through the artifacts you last installed, so the output looks unchanged because the change was never in it.
- **Example output is not byte-comparable.** The writers embed timestamps, so a fresh render differs from its committed preview for *every* example, including ones the change cannot reach. Verifying by `cmp` concludes the opposite of the truth.
- **The tree collects zero-byte files** named by shell quoting accidents (`$env`, `` b)` ``, `'Current`). `git add .` commits them; `git clean -f` removes new sources along with them.

## What's here

**`AGENTS.md`**, 118 lines. It links `CONTRIBUTING.md` and the architecture docs and answers only what none of them does: release work is not a side effect of a feature branch, staging is by path, the two misleading results above, and "never report a test passed unless it was executed".

An earlier revision of this branch was 440 lines and restated branch policy, the Java baseline, the pipeline, package ownership, module responsibilities, the API tiers and the POM rules — while opening by calling those documents the source of truth. That is a second copy that goes stale the day the original moves, and this repository has already lost a full release line to exactly that: prose describing an engine it no longer has, green under every guard. Determinism was checked too and delegated, since `overview.md` and `package-map.md` each cover it.

**`AgentsGuideGuardTest`**, three cases, holding only what it can see:

| Case | Red when |
|---|---|
| `everyPathItSendsAReaderToExists` | a linked document has moved |
| `theBuildCommandsItPrescribesCanBeRun` | the reactor gate is dropped from the file, or `mvnw` is not at the root |
| `itDoesNotRestateThePackageCoordinatesItLinksTo` | a `com.demcha.compose.*` coordinate reappears |

The third guards the regression above: existence checks cannot see a restatement go stale, because the packages still exist — they have simply stopped being the ones the guide names.

**`.gitignore`** — `/AGENTS.md` was ignored, listed among scratch files (`rectangle.pdf`, `Test.pdf`), from when it was one. Removed, or none of this could ship. `/CLAUDE.md` added: a file named for one tool is configuration belonging to whoever runs that tool, and committing one would oblige this repository to carry a copy of these rules per vendor — the duplication `AGENTS.md` exists to avoid.

**`.github/workflows/ci.yml`** — the guard joins the `Architecture and Documentation Guards` list, which was not running it.

## Verification

`./mvnw -B -ntp clean verify` over the full reactor — `BUILD SUCCESS`. The 9-guard fail-fast list runs 50 tests green.

Both commands the file prescribes were run before it prescribed them: `./mvnw -B -ntp verify -pl :graph-compose-core` and the bare `./mvnw -B -ntp clean verify`. Every document it links was checked to open.

Each guard case was checked against its own breakage — a moved link, a dropped gate command, a package coordinate added back: 2 of 3 red in every case.

## Scope

These are the maintainer's existing practices, not new policy, and nothing here changes how the build works.

Two things were deliberately left out. A commit-attribution rule from an earlier draft governs the maintainer's own commits on their own machine and is not project policy — `CONTRIBUTING.md` has no DCO, sign-off or co-authorship requirement — so it does not belong in a file addressed to contributors. And `PackageMapGuardTest`'s reactor-module logic was not reused: the module inventory it would have checked is precisely the restatement this branch removed, and a stronger check on a paragraph that should not exist is still a paragraph that should not exist.
