### PR TITLE
docs: stage the 2.2 line so the cut can describe it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,12 @@ follow semantic versioning; release dates are ISO 8601.
   always took — held to that by the layout snapshots and visual baselines, none of which
   moved.
 
-  A paragraph is the unit this applies to. Text inside a **table cell** goes through the
-  table's own layout, which has no direction handling, so the same Hebrew string draws
-  reversed in a cell while drawing correctly in a paragraph — and Arabic in a cell is
-  unjoined. Set such text as a paragraph, or place the table's own content right to left
-  by hand, until the table path carries direction too.
+  A paragraph is the unit this applies to, and a **table cell** gets it by being one:
+  `DocumentTableCell.node(...)` takes a composed paragraph, which carries its direction
+  into the cell like anywhere else. What does not is the plain-string shortcut —
+  `row("...")` and `DocumentTableCell.text(...)` go through the table's own layout, which
+  neither reorders nor shapes, so the same Hebrew string draws reversed there and Arabic
+  draws unjoined. Compose the cell until that path carries direction too.
 
   All three wrap paths carry it: plain text, inline runs (what templates author
   through), and markdown. Each backend does what it must and no more — the PDF backend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -491,6 +491,23 @@ follow semantic versioning; release dates are ISO 8601.
 
 ### Fixed
 
+- **A Word export resolves an image once, and says so when it cannot.** `writeImage`
+  needed the node's data twice over — the bytes it writes, and the intrinsic size it
+  measures the fit against — and fetched it twice, from two places. Resolving is not
+  free: the source cache copies the byte array whole and hashes it, so a large image
+  paid both costs on every export.
+
+  The second fetch was also reading a different thing. The cache keys on the path alone,
+  so once a render had warmed it, a file rewritten underneath gave the export fresh bytes
+  from disk and the previous version's dimensions — a picture embedded at another image's
+  size, with nothing reporting it, because both halves succeeded and simply described
+  different files. The bytes now come from the resolution that sizes the frame.
+
+  One behaviour changes with it: an image whose source cannot be read stops the export.
+  It used to disappear from the document silently — not a decision, but the side effect
+  of a read that swallowed its own exception — and a document that comes back one picture
+  short is the worst of the available answers.
+
 - **DOCX keeps the styling a mixed paragraph asks for.** A `RichText` paragraph exported
   with every run in the paragraph's base style, so a bold segment, an accent-coloured
   segment and plain text all came out identical — a valid `.docx`, no warning, and the

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 > **Release status** &mdash;
 > 🟢 **Latest stable**: [v2.1.1](https://github.com/DemchaAV/GraphCompose/releases/tag/v2.1.1) &mdash; the **PowerPoint** release: `graph-compose-render-pptx` turns the same resolved layout into an editable deck &mdash; one page per slide, geometry-identical to the PDF, text and panels as native shapes. Ships as `@Beta`. **[What each backend supports &darr;](docs/architecture/backend-capability-matrix.md)**
-> &nbsp;·&nbsp; 🟡 **In development**: v2.2.0 on `develop` &mdash; the **right-to-left** line: Hebrew and Arabic lay out, shape, join and mirror through PDF, PowerPoint and Word, with the fonts to render them. See [CHANGELOG.md](./CHANGELOG.md).
+> &nbsp;·&nbsp; 🟡 **In development**: v2.2.0 on `develop` &mdash; the **right-to-left** line: Hebrew and Arabic **paragraphs** lay out, shape, join and mirror through PDF, PowerPoint and Word, with the fonts to render them. See [CHANGELOG.md](./CHANGELOG.md).
 
 <p align="center">
   <a href="https://demchaav.github.io/GraphCompose/"><b>Live Showcase</b></a>
@@ -340,7 +340,7 @@ See [CONTRIBUTING](./CONTRIBUTING.md) for the branch-routing table and the full 
 
 ### Text &amp; internationalization
 
-- Paragraphs support **right-to-left text**: `ParagraphBuilder.direction(RTL)` (or `AUTO`) reorders lines with the Unicode Bidirectional Algorithm, and Arabic is shaped into its joined contextual forms &mdash; Amiri and David Libre ship in `graph-compose-fonts`. Two limits remain: text inside a **table cell** carries no direction (set such text as a paragraph instead), and **Indic reordering** is not performed.
+- Paragraphs support **right-to-left text**: `ParagraphBuilder.direction(RTL)` (or `AUTO`) reorders lines with the Unicode Bidirectional Algorithm, and Arabic is shaped into its joined contextual forms &mdash; Amiri and David Libre ship in `graph-compose-fonts`. Two limits remain: a **table cell written as a plain string** carries no direction &mdash; put a paragraph in the cell with `DocumentTableCell.node(...)` and it does &mdash; and **Indic reordering** is not performed.
 - A glyph the active font does not cover renders as `?` (with a warning logged); load a font that covers the script you need.
 
 ### When to use GraphCompose

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 > **Release status** &mdash;
 > 🟢 **Latest stable**: [v2.1.1](https://github.com/DemchaAV/GraphCompose/releases/tag/v2.1.1) &mdash; the **PowerPoint** release: `graph-compose-render-pptx` turns the same resolved layout into an editable deck &mdash; one page per slide, geometry-identical to the PDF, text and panels as native shapes. Ships as `@Beta`. **[What each backend supports &darr;](docs/architecture/backend-capability-matrix.md)**
-> &nbsp;·&nbsp; 🟡 **In development**: v2.1.2 on `develop` &mdash; see [CHANGELOG.md](./CHANGELOG.md).
+> &nbsp;·&nbsp; 🟡 **In development**: v2.2.0 on `develop` &mdash; the **right-to-left** line: Hebrew and Arabic lay out, shape, join and mirror through PDF, PowerPoint and Word, with the fonts to render them. See [CHANGELOG.md](./CHANGELOG.md).
 
 <p align="center">
   <a href="https://demchaav.github.io/GraphCompose/"><b>Live Showcase</b></a>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,6 +6,24 @@ GraphCompose is solo-maintained. This roadmap is a direction, not a contract. Da
 
 Consolidation ahead of the next patch: the documentation and contributor surfaces are being brought onto the 2.x vocabulary, the CI guards onto what they actually run, and the committed example assets onto a regeneration path. Open engineering threads are tracked in [issues](https://github.com/DemchaAV/GraphCompose/issues) — vector clipping for the PPTX backend, backend-neutral font measurement, and font-face selection are the live ones.
 
+## Upcoming — 2.2
+
+**2.2.0** is the current release. Its headline is **right-to-left text**: a paragraph says
+which way it runs, and Hebrew and Arabic lay out, shape, join and mirror correctly through
+all three backends. The PDF is painted, so the engine resolves the line itself with the
+Unicode Bidirectional Algorithm, shapes Arabic into its joined forms, and writes the file
+so a reader copies out the letters an author typed rather than the shapes they were drawn
+as. Word and PowerPoint have bidirectional engines of their own, so each is handed logical
+text and told what it needs — `w:bidi` and the complex-script twins for Word, a declared
+direction per frame for PowerPoint — with the differences recorded in the
+[backend capability matrix](docs/architecture/backend-capability-matrix.md).
+
+The scripts come with it: Amiri, David Libre, the Noto faces for Georgian and Armenian and
+Gothic A1 for Korean join the bundled catalogue, and a PowerPoint deck now carries the
+bundled family it drew with instead of naming a font the reader may not have.
+
+Full detail in [CHANGELOG.md](CHANGELOG.md) under `v2.2.0`.
+
 ## Current stable — 2.1
 
 **2.1.1** is the current release. Its headline is the one 2.1.0 opened the line with: the **fixed-layout PPTX render backend**, where the same `DocumentSession` that prints a PDF also emits an editable PowerPoint deck — one page per slide, identical geometry by construction, native shapes. It ships as `@Beta` (Experimental) while its API shape settles; the geometry identity with the PDF backend is a design invariant, not subject to change. See the [API stability policy](docs/api-stability.md) and the [backend capability matrix](docs/architecture/backend-capability-matrix.md).

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,9 +8,10 @@ Consolidation ahead of the next patch: the documentation and contributor surface
 
 ## Upcoming — 2.2
 
-**2.2.0** is the current release. Its headline is **right-to-left text**: a paragraph says
-which way it runs, and Hebrew and Arabic lay out, shape, join and mirror correctly through
-all three backends. The PDF is painted, so the engine resolves the line itself with the
+**2.2.0** brings **right-to-left text**: a paragraph says which way it runs, and Hebrew and
+Arabic lay out, shape, join and mirror correctly through all three backends. The paragraph
+is the unit that carries it, including inside a table cell composed as one; a cell written
+as a plain string still has no direction. The PDF is painted, so the engine resolves the line itself with the
 Unicode Bidirectional Algorithm, shapes Arabic into its joined forms, and writes the file
 so a reader copies out the letters an author typed rather than the shapes they were drawn
 as. Word and PowerPoint have bidirectional engines of their own, so each is handed logical


### PR DESCRIPTION
Release prep for 2.2.0. Three gaps a readiness audit of `develop` found, none of them code.

## The cut cannot run without the staged section

`ROADMAP.md` describes the 2.1 line and 2.2.0 crosses into a new one. `Assert-RoadmapReadyForCut` refuses that in Step 0 — the heading and the prose describe the release that shipped, and no rewrite can produce a paragraph about a line nobody has described yet.

Verified both ways with a real dry-run against this branch:

| | |
|---|---|
| before this commit | refused, with the preparation instructions |
| after | `[DRY RUN] ROADMAP.md promote 'Upcoming — 2.2' → 'Current stable', demote 2.1` |

`## Current stable` deliberately still names **2.1.1**, the version on Central — `VersionConsistencyGuardTest` holds it there, and `aPreparedUpcomingSectionNamesTheLineUnderDevelopment` holds the staged section to the line the poms are on. The cut promotes one and demotes the other.

The headline is what the changelog actually contains: right-to-left text through all three backends, and the five bundled script families that render it.

## The README promised a release nobody is building

Line 24 read `In development: v2.1.2` while the poms and the changelog say 2.2.0. The post-release bump writes a patch increment unconditionally; the line was later retargeted, and this half was left behind. The cut would overwrite it, but `develop` has been advertising it in the meantime, and no guard covers this half of the block — `VersionConsistencyGuardTest` checks *Latest stable* against published versions only.

## The image change shipped without a changelog entry

[#555](https://github.com/DemchaAV/GraphCompose/pull/555) merged with no entry, and it carries a behaviour change a reader should meet before upgrading rather than after: **an image whose source cannot be read now stops the export** instead of disappearing from the document. The entry also records the reason the work was worth doing — the bytes and the dimensions were arriving from different places, so a file rewritten between renders produced a picture embedded at another image's size, silently.

## Verification

`./mvnw -B -ntp clean verify` over the full reactor — `BUILD SUCCESS`, 368 green suites.

The 9-guard fail-fast list runs green, including the two that constrain this change: `VersionConsistencyGuardTest` (the roadmap's current-stable section, its heading, and the staged line) and `AgentsGuideGuardTest`.

## Not in this change

The remaining audit findings are not release blockers and are left alone: the open DOCX feature issues ([#527](https://github.com/DemchaAV/GraphCompose/issues/527), [#529](https://github.com/DemchaAV/GraphCompose/issues/529), [#530](https://github.com/DemchaAV/GraphCompose/issues/530)), and `cut-release.ps1` hardcoding `mvnw.cmd`, which makes it unrunnable on Linux and macOS.
