### PR TITLE
ci(release): try the cut on a line the roadmap has not staged

### DIFF
--- a/.github/workflows/release-script-check.yml
+++ b/.github/workflows/release-script-check.yml
@@ -58,9 +58,22 @@ jobs:
           # version would leave '## Current stable — 2.1' above '**2.2.0** is the current
           # release'. Both the old guard and the new one pass that, because each asks
           # only whether the version is published. The cut has to refuse it instead.
+          #
+          # The line to try is the one after everything the roadmap names, not the one
+          # after 'Current stable'. Staging the next line is what makes a crossing cut
+          # legal — so once a maintainer prepares it, the version derived from the
+          # current-stable heading alone is a cut the script is right to allow, and this
+          # step fails for the roadmap being ready.
+          $content = Get-Content ROADMAP.md -Raw
+          $named = [regex]::Matches($content, '##\s+(?:Current stable|Upcoming)\s*[—-]\s*(\d+)\.(\d+)')
+          if ($named.Count -eq 0) { throw "ROADMAP.md names no release line to derive an unprepared one from" }
           $line = (Select-String -Path ROADMAP.md -Pattern '##\s+Current stable\s*[—-]\s*(\d+\.\d+)').Matches[0].Groups[1].Value
-          $major, $minor = $line.Split('.')
-          $crossing = "$major.$([int]$minor + 1).0"
+          $highest = $named |
+            ForEach-Object { [pscustomobject]@{ Major = [int]$_.Groups[1].Value; Minor = [int]$_.Groups[2].Value } } |
+            Sort-Object Major, Minor |
+            Select-Object -Last 1
+          $crossing = "$($highest.Major).$($highest.Minor + 1).0"
+          Write-Host "roadmap names up to $($highest.Major).$($highest.Minor); trying a cut at $crossing"
           # The refusal is a `throw`, which terminates the script — so it has to be
           # caught here, not merged with `*>&1`. Redirection captures the message but
           # not the termination, and an uncaught throw fails this step for doing

--- a/.github/workflows/release-script-check.yml
+++ b/.github/workflows/release-script-check.yml
@@ -233,10 +233,15 @@ jobs:
           $DryRun = $false
 
           function New-Roadmap($staged) {
-            # A scratch repoRoot per case, so each starts from the committed roadmap.
+            # A scratch repoRoot per case, so each starts from the committed roadmap —
+            # with whatever it stages taken out. Every case below stages exactly what it
+            # is about, so a section the repository happens to carry would answer for
+            # them: case 1 would find the line prepared and not refuse, and case 4's
+            # promotion would leave that heading behind and trip its own check.
             $dir = Join-Path ([IO.Path]::GetTempPath()) ([guid]::NewGuid())
             New-Item -ItemType Directory -Path $dir | Out-Null
-            $text = Get-Content ROADMAP.md -Raw
+            $text = [regex]::Replace((Get-Content ROADMAP.md -Raw),
+                                     '(?ms)^##\s+Upcoming\s*[—-].*?(?=^##\s|\z)', '')
             if ($staged) {
               $text = $text -replace "## Current stable — $([regex]::Escape($script:line))", "$staged## Current stable — $($script:line)"
             }


### PR DESCRIPTION
## Why

The release-script rehearsal has two halves that read the repository's own ROADMAP, and both
assumed it stages nothing for the line after the current one. Staging that line is a normal
step, and it is what makes a crossing cut legal — so once `## Upcoming — 2.2` landed, both
halves started failing for the roadmap being ready.

The job is red on develop, and on every branch that touches the two paths this workflow
watches. It runs on those paths only, which is why nothing said so for a day.

## What changed

- **The crossing cut is tried on a line nobody has staged.** The version came from the
  `## Current stable` heading plus one minor; it now comes from every line the ROADMAP names
  — `Current stable` and each `Upcoming` — and the cut is tried on the one after the highest.
  That line is unprepared by construction, whatever has been staged since. The step prints
  what it derived, so a future failure says which line it tried.
- **The promotion cases start from a roadmap with nothing staged.** Each of the five stages
  exactly what it is about — nothing, a heading carrying no version, a version off the line,
  a correct section — so a section the file already carries answers for them: the first finds
  the line prepared and gets no refusal, and the fourth promotes while that heading survives
  and trips its own check.

## Tests

Both halves run locally against the working tree's roadmap (`Current stable — 2.1`,
`Upcoming — 2.2`):

- the crossing step derived `2.3.0` and the real script refused it — `ROADMAP.md '## Current
  stable' describes the 2.1 line, but this cut is 2.3.0` — leaving the tree clean, which is
  the step's second assertion;
- the five promotion cases pass: three refusals, the rewrite promoting `Upcoming — 2.2` to
  `Current stable` with 2.1 demoted to `Previously`, and the no-op on re-run;
- the two positive dry-runs still exit 0: the full cut at `2.1.99`, and `-PostReleaseOnly`.

Before the change, the crossing step ran the cut through to completion on clean develop.