### PR TITLE
fix(release): move the release-status prose with the version it belongs to

### DIFF
--- a/.github/workflows/release-script-check.yml
+++ b/.github/workflows/release-script-check.yml
@@ -201,6 +201,61 @@ jobs:
           if (Test-ReadmeLatestStable '0.0.0-nonexistent') { throw "Test-ReadmeLatestStable matched a bogus version" }
           Write-Host "Test-ReadmeLatestStable: README names v$cur (bogus rejected)."
 
+      - name: Unit-check the README release-status promotion
+        shell: pwsh
+        run: |
+          # The block is two halves, and what moves between them is the sentence, not
+          # only the version. Lifted by AST like the roadmap check below, so the code
+          # under test is the code that ships.
+          $path = (Resolve-Path scripts/cut-release.ps1).Path
+          $ast = [System.Management.Automation.Language.Parser]::ParseFile($path, [ref]$null, [ref]$null)
+          $want = @('Update-ReadmeReleaseStatus', 'Move-ReleaseStatusProse', 'Get-NextSnapshotVersion')
+          $found = $ast.FindAll({
+              param($n)
+              $n -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $want -contains $n.Name
+            }, $true)
+          $missing = $want | Where-Object { $_ -notin ($found | ForEach-Object { $_.Name }) }
+          if ($missing) { throw "cut-release.ps1 no longer defines: $($missing -join ', ')" }
+          Invoke-Expression (($found | ForEach-Object { $_.Extent.Text }) -join "`n")
+          function Note($m) { Write-Host "    $m" }
+          $DryRun = $false
+
+          function New-Readme($stableProse, $devProse) {
+            $file = Join-Path ([IO.Path]::GetTempPath()) ("readme-" + [guid]::NewGuid().ToString() + ".md")
+            Set-Content -Path $file -NoNewline -Value (@(
+              '> **Release status** &mdash;',
+              "> 🟢 **Latest stable**: [v1.2.3](https://github.com/DemchaAV/GraphCompose/releases/tag/v1.2.3) &mdash; $stableProse",
+              "> &nbsp;·&nbsp; 🟡 **In development**: v1.3.0 on ``develop`` &mdash; $devProse"
+            ) -join "`n")
+            return $file
+          }
+
+          # 1. A staged story is the release's own: it moves up, and the lower half is
+          #    left with the pointer. Leaving it behind would publish the new version
+          #    under the previous line's headline.
+          $readme = New-Readme 'the **previous** release: what 1.2 was about.' 'the **staged** release: what 1.3 is about.'
+          Update-ReadmeReleaseStatus $readme '1.3.0'
+          $after = Get-Content $readme -Raw
+          if ($after -notmatch '\*\*Latest stable\*\*:\s*\[v1\.3\.0\]\(\S+/releases/tag/v1\.3\.0\) &mdash; the \*\*staged\*\* release') {
+            throw "the staged story did not move onto the latest-stable half:`n$after"
+          }
+          if ($after -match 'the \*\*previous\*\* release') { throw "the superseded headline survived the promotion:`n$after" }
+          if ($after -notmatch '\*\*In development\*\*: v1\.3\.1 on `develop` &mdash; see \[CHANGELOG\.md\]') {
+            throw "the lower half was not opened on the next patch with the changelog pointer:`n$after"
+          }
+
+          # 2. Nothing staged — a patch on the same line has no new story, and its
+          #    headline is the one already sitting above. Promoting the pointer would
+          #    leave the release advertised by nothing.
+          $readme = New-Readme 'the **line** release: what 1.3 was about.' 'see [CHANGELOG.md](./CHANGELOG.md).'
+          Update-ReadmeReleaseStatus $readme '1.3.1'
+          $after = Get-Content $readme -Raw
+          if ($after -notmatch '\*\*Latest stable\*\*:\s*\[v1\.3\.1\].*the \*\*line\*\* release') {
+            throw "a patch cut lost the headline of the line it belongs to:`n$after"
+          }
+
+          Write-Host "release-status: a staged story is promoted, a patch keeps its line's headline."
+
       - name: Unit-check the roadmap promotion (refusals and the real rewrite)
         shell: pwsh
         run: |

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
 
 > **Release status** &mdash;
 > 🟢 **Latest stable**: [v2.1.1](https://github.com/DemchaAV/GraphCompose/releases/tag/v2.1.1) &mdash; the **PowerPoint** release: `graph-compose-render-pptx` turns the same resolved layout into an editable deck &mdash; one page per slide, geometry-identical to the PDF, text and panels as native shapes. Ships as `@Beta`. **[What each backend supports &darr;](docs/architecture/backend-capability-matrix.md)**
-> &nbsp;·&nbsp; 🟡 **In development**: v2.2.0 on `develop` &mdash; the **right-to-left** line: Hebrew and Arabic lay out, shape, join and mirror through PDF, PowerPoint and Word &mdash; in paragraphs and in table cells &mdash; with the fonts to render them. See [CHANGELOG.md](./CHANGELOG.md).
+> &nbsp;·&nbsp; 🟡 **In development**: v2.2.0 on `develop` &mdash; the **right-to-left** release: Hebrew and Arabic lay out, shape, join and mirror through PDF, PowerPoint and Word &mdash; in paragraphs and in table cells &mdash; with the fonts to render them. See [CHANGELOG.md](./CHANGELOG.md).
 
 <p align="center">
   <a href="https://demchaav.github.io/GraphCompose/"><b>Live Showcase</b></a>

--- a/scripts/cut-release.ps1
+++ b/scripts/cut-release.ps1
@@ -512,6 +512,36 @@ function Update-RoadmapCurrentStable($roadmapPath, $newVersion) {
     Note "ROADMAP.md 'Current stable' -> $newVersion"
 }
 
+function Move-ReleaseStatusProse($content) {
+    # Promotes the 'In development' sentence onto the 'Latest stable' half and leaves the
+    # lower half with the line that says where the detail lives.
+    #
+    # Only when there is a sentence to promote. After a cut the lower half carries the
+    # bare CHANGELOG pointer, and the next patch on the same line has no new story — its
+    # headline is the one the line opened with, which is already sitting above. Promoting
+    # the pointer would delete that headline and leave the release advertised by nothing.
+    $stableLine = [regex]'(?m)^(?<head>>\s*🟢\s*\*\*Latest stable\*\*:\s*\[v[\w\.\-]+\]\([^)]*\)\s*&mdash;\s*)(?<prose>.+)$'
+    $devLine = [regex]'(?m)^(?<head>>.*?🟡\s*\*\*In development\*\*:\s*v[\w\.\-]+\s+on\s+`develop`\s*&mdash;\s*)(?<prose>.+)$'
+
+    $stableMatch = $stableLine.Match($content)
+    $devMatch = $devLine.Match($content)
+    if (-not $stableMatch.Success -or -not $devMatch.Success) {
+        # Nothing recognisable to move. The version tokens are rewritten by the caller
+        # either way, and Assert-ReleaseMetadata refuses a block it cannot read.
+        return $content
+    }
+
+    $promoted = $devMatch.Groups['prose'].Value.Trim()
+    if ($promoted -match '^(?i)see \[CHANGELOG') {
+        Note "README release-status: nothing staged under 'In development' — prose left as it is"
+        return $content
+    }
+
+    $content = $content.Replace($devMatch.Value,
+        $devMatch.Groups['head'].Value + 'see [CHANGELOG.md](./CHANGELOG.md).')
+    return $content.Replace($stableMatch.Value, $stableMatch.Groups['head'].Value + $promoted)
+}
+
 function Update-ReadmeReleaseStatus($readmePath, $newVersion) {
     # The README 'Release status' blockquote carries two halves:
     #
@@ -524,7 +554,12 @@ function Update-ReadmeReleaseStatus($readmePath, $newVersion) {
     # link that 404s. The script owns the block now — Step 1 promotes the in-development
     # half to latest-stable and opens the next patch line — so `develop` stays truthful
     # between releases and the release commit still carries the right text to `main`.
-    # Only the version tokens are rewritten; the maintainer's prose is left alone.
+    #
+    # The prose moves with the version, because the sentence belongs to the release
+    # rather than to the half it sits in: the story a maintainer writes under 'In
+    # development' is the story of the version being cut, and leaving it behind would
+    # publish the new version under the previous line's headline while advertising the
+    # work that just shipped as still to come.
     if (-not (Test-Path $readmePath)) {
         Note "skip (no file): $readmePath"
         return
@@ -537,7 +572,8 @@ function Update-ReadmeReleaseStatus($readmePath, $newVersion) {
     $stableUrl = [regex]'(?<=/releases/tag/v)[\w\.\-]+(?=\))'
     $inDev = [regex]'(?<=\*\*In development\*\*:\s*v)[\w\.\-]+'
 
-    $updated = $stable.Replace($content, $newVersion, 1)
+    $updated = Move-ReleaseStatusProse $content
+    $updated = $stable.Replace($updated, $newVersion, 1)
     $updated = $stableUrl.Replace($updated, $newVersion, 1)
     if ($nextVersion) {
         $updated = $inDev.Replace($updated, $nextVersion, 1)


### PR DESCRIPTION
## Why

The cut owns the README release-status block and rewrites the version tokens in it. It does
not move the sentence beside them. Run against this tree, the 2.2.0 cut would have written:

> 🟢 **Latest stable**: [v2.2.0](…) — the **PowerPoint** release: `graph-compose-render-pptx` turns the same resolved layout into an editable deck …
> &nbsp;·&nbsp; 🟡 **In development**: v2.2.1 on `develop` — the **right-to-left** release: Hebrew and Arabic lay out, shape, join and mirror …

2.2.0 published under 2.1's headline, with the work that shipped in it advertised as still to
come — and carried to `main`, which is the README GitHub renders. The block is the first thing
on the page.

Not fixable by hand ahead of the cut: `VersionConsistencyGuardTest.readmeReleaseStatusNamesAPublishedVersion`
requires `Latest stable` to name a released version, and rightly — its tag page 404s until the
tag exists.

## What changed

`Move-ReleaseStatusProse` runs before the version tokens are rewritten. The story a maintainer
writes under `In development` moves onto the `Latest stable` half, and the lower half opens on
the next patch with the pointer to the changelog — the shape the block already has on `main`
after a cut.

Only when there is a story to move. After a cut the lower half carries that pointer, and a
patch on the same line has no new one: its headline is the one the line opened with, already
sitting above. Promoting the pointer would leave the release advertised by nothing, so a block
with nothing staged keeps its prose and says so in the log.

The 2.2 sentence now reads "release" rather than "line", because it is about to become the
heading of one.

## Tests

A step in the release-script check, against the shipped functions lifted by AST — the pattern
the roadmap promotion already uses:

- a staged story is promoted onto `Latest stable` with the version and its tag link, the
  superseded headline is gone, and the lower half opens on the next patch with the changelog
  pointer;
- a cut with nothing staged keeps the headline of the line it belongs to.

Both run locally against the working tree. Also green: the three existing dry-run scenarios
(full cut at `2.1.99`, `-PostReleaseOnly`, and the crossing cut refused at `2.3.0`), and
`VersionConsistencyGuardTest`, `DocumentationCoverageTest`, `CanonicalSurfaceGuardTest`,
`ReleaseAssetStepGuardTest`.