### PR TITLE
chore(deps): move the train and the consumer smokes onto one set of versions

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,3 +1,3 @@
 wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.12/apache-maven-3.9.12-bin.zip
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip

--- a/benchmarks/pom.xml
+++ b/benchmarks/pom.xml
@@ -25,9 +25,9 @@
         <maven.compiler.release>17</maven.compiler.release>
 
         <jmh.version>1.37</jmh.version>
-        <junit.bom.version>6.1.2</junit.bom.version>
+        <junit.bom.version>6.1.3</junit.bom.version>
         <assertj.version>3.27.7</assertj.version>
-        <logback.version>1.6.1</logback.version>
+        <logback.version>1.6.2</logback.version>
 
         <openhtmltopdf.version>1.0.10</openhtmltopdf.version>
         <itext.version>9.7.1</itext.version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -47,13 +47,13 @@
 
         <!-- Runtime / library dependencies -->
         <flexmark.version>0.64.8</flexmark.version>
-        <logback.version>1.6.1</logback.version>
+        <logback.version>1.6.2</logback.version>
         <lombok.version>1.18.46</lombok.version>
         <slf4j.version>2.0.18</slf4j.version>
 
         <!-- Test dependencies -->
         <assertj.version>3.27.7</assertj.version>
-        <junit.bom.version>6.1.2</junit.bom.version>
+        <junit.bom.version>6.1.3</junit.bom.version>
         <mockito.version>5.23.0</mockito.version>
         <byteBuddy.version>1.18.11</byteBuddy.version>
         <archunit.version>1.5.0</archunit.version>

--- a/core/src/test/java/com/demcha/documentation/VersionConsistencyGuardTest.java
+++ b/core/src/test/java/com/demcha/documentation/VersionConsistencyGuardTest.java
@@ -1038,6 +1038,82 @@ class VersionConsistencyGuardTest {
         return false;
     }
 
+    /**
+     * Every consumer-smoke default names the release a user can actually resolve.
+     *
+     * <p>The harness verifies the published artefacts, and each of its entry points writes
+     * down which version to verify when the caller names none: the two runner scripts, the
+     * workflow input, and the {@code <gc.version>} each consumer pom falls back to. The
+     * runners always pass one, so the poms' copy decides nothing on a normal run — which is
+     * how it sat two releases behind the rest without a single run going red, until
+     * Dependabot opened a pull request to move it.</p>
+     *
+     * <p>Read out of the files rather than compared against a constant here, and held to
+     * {@link #acceptableTargets()} — the same published-release rule the install snippets
+     * follow. A default naming a version nobody can download would have the gate verify a
+     * release that does not exist; one naming an older release has it report green for the
+     * release before, which is the failure a release gate must not have.</p>
+     */
+    @Test
+    void everyConsumerSmokeDefaultNamesThePublishedRelease() throws Exception {
+        Set<String> targets = acceptableTargets();
+        Map<String, String> defaults = new LinkedHashMap<>();
+
+        defaults.put("scripts/release-smoke/run.sh",
+                declaredVersion("scripts/release-smoke/run.sh",
+                        "(?m)^GC_VERSION=\"([\\w.\\-]+)\""));
+        defaults.put("scripts/release-smoke/run.ps1",
+                declaredVersion("scripts/release-smoke/run.ps1",
+                        "\\[string]\\$Version = '([\\w.\\-]+)'"));
+        defaults.put(".github/workflows/release-smoke.yml",
+                declaredVersion(".github/workflows/release-smoke.yml",
+                        "(?m)^\\s+default: '([\\w.\\-]+)'"));
+
+        List<Path> consumers = consumerProjects();
+        assertThat(consumers)
+                .describedAs("no consumer-smoke project under scripts/release-smoke: the harness "
+                        + "this guards would be verifying nothing")
+                .isNotEmpty();
+        for (Path pom : consumers) {
+            String relative = PROJECT_ROOT.relativize(pom).toString().replace('\\', '/');
+            defaults.put(relative,
+                    declaredVersion(relative, "<gc\\.version>([\\w.\\-]+)</gc\\.version>"));
+        }
+
+        assertThat(defaults)
+                .describedAs("each consumer-smoke default must name the published release %s: a "
+                        + "run that accepts the prefilled value would otherwise verify a version "
+                        + "nobody can resolve, or the release before this one", targets)
+                .allSatisfy((where, version) -> assertThat(version)
+                        .describedAs("%s", where)
+                        .isIn(targets));
+    }
+
+    /** The consumer projects, found rather than listed: one arrives per published coordinate. */
+    private static List<Path> consumerProjects() throws IOException {
+        Path root = PROJECT_ROOT.resolve("scripts/release-smoke");
+        if (!Files.isDirectory(root)) {
+            return List.of();
+        }
+        try (Stream<Path> entries = Files.list(root)) {
+            return entries.map(entry -> entry.resolve("pom.xml"))
+                    .filter(Files::isRegularFile)
+                    .sorted()
+                    .toList();
+        }
+    }
+
+    /** The one version a file declares, or a failure naming the file that stopped declaring it. */
+    private static String declaredVersion(String relativePath, String pattern) throws IOException {
+        Matcher declared = Pattern.compile(pattern)
+                .matcher(Files.readString(PROJECT_ROOT.resolve(relativePath)));
+        assertThat(declared.find())
+                .describedAs("%s no longer declares a smoke version matching %s — the release step "
+                        + "that moves it would silently skip the file", relativePath, pattern)
+                .isTrue();
+        return declared.group(1);
+    }
+
     private static Element directChild(Element parent, String name) {
         NodeList children = parent.getChildNodes();
         for (int i = 0; i < children.getLength(); i++) {

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -18,7 +18,7 @@
 
     <properties>
         <graphcompose.version>${project.version}</graphcompose.version>
-        <logback.version>1.6.1</logback.version>
+        <logback.version>1.6.2</logback.version>
         <maven.compiler.release>17</maven.compiler.release>
 
         <!--
@@ -45,7 +45,7 @@
         -->
         <graphcompose.examples.renderDate>2026-01-15</graphcompose.examples.renderDate>
 
-        <junit.bom.version>6.1.2</junit.bom.version>
+        <junit.bom.version>6.1.3</junit.bom.version>
         <assertj.version>3.27.7</assertj.version>
     </properties>
 

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -38,10 +38,10 @@
         <maven.surefire.plugin.version>3.5.6</maven.surefire.plugin.version>
 
         <jackson.bom.version>2.22.1</jackson.bom.version>
-        <junit.bom.version>6.1.2</junit.bom.version>
+        <junit.bom.version>6.1.3</junit.bom.version>
         <assertj.version>3.27.7</assertj.version>
         <mockito.version>5.23.0</mockito.version>
-        <logback.version>1.6.1</logback.version>
+        <logback.version>1.6.2</logback.version>
         <pdfbox.version>3.0.8</pdfbox.version>
         <javafx.version>21.0.12</javafx.version>
         <!-- ArchUnit for the cross-module boundary guards below. Roughly in step

--- a/render-docx/pom.xml
+++ b/render-docx/pom.xml
@@ -58,9 +58,9 @@
         <maven.compiler.release>17</maven.compiler.release>
 
         <poi.version>5.5.1</poi.version>
-        <junit.bom.version>6.1.2</junit.bom.version>
+        <junit.bom.version>6.1.3</junit.bom.version>
         <assertj.version>3.27.7</assertj.version>
-        <logback.version>1.6.1</logback.version>
+        <logback.version>1.6.2</logback.version>
         <graphcompose.fonts.version>1.1.0</graphcompose.fonts.version>
         <graphcompose.emoji.version>1.0.0</graphcompose.emoji.version>
 

--- a/render-pdf/pom.xml
+++ b/render-pdf/pom.xml
@@ -67,10 +67,10 @@
         <pdfbox.version>3.0.8</pdfbox.version>
         <zxing.version>3.5.4</zxing.version>
         <slf4j.version>2.0.18</slf4j.version>
-        <junit.bom.version>6.1.2</junit.bom.version>
+        <junit.bom.version>6.1.3</junit.bom.version>
         <assertj.version>3.27.7</assertj.version>
         <mockito.version>5.23.0</mockito.version>
-        <logback.version>1.6.1</logback.version>
+        <logback.version>1.6.2</logback.version>
         <graphcompose.fonts.version>1.1.0</graphcompose.fonts.version>
         <graphcompose.emoji.version>1.0.0</graphcompose.emoji.version>
 

--- a/render-pptx/pom.xml
+++ b/render-pptx/pom.xml
@@ -61,9 +61,9 @@
         <!-- Keep in lockstep with render-pdf/pom.xml: a drift would mix fontbox
              and pdfbox versions at runtime (the direct fontbox wins mediation). -->
         <pdfbox.version>3.0.8</pdfbox.version>
-        <junit.bom.version>6.1.2</junit.bom.version>
+        <junit.bom.version>6.1.3</junit.bom.version>
         <assertj.version>3.27.7</assertj.version>
-        <logback.version>1.6.1</logback.version>
+        <logback.version>1.6.2</logback.version>
         <graphcompose.fonts.version>1.1.0</graphcompose.fonts.version>
 
         <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>

--- a/scripts/cut-release.ps1
+++ b/scripts/cut-release.ps1
@@ -776,6 +776,16 @@ function Update-ReleaseSmokeDefaultVersion($repoRoot, $newVersion) {
     # re-verifies the PREVIOUS release and reports green — the one failure mode a
     # release gate must not have. Each pattern is anchored to its own construct so
     # a bump cannot smear across unrelated version strings in the same file.
+    #
+    # The consumer projects carry that default a second time, in the <gc.version>
+    # each pom falls back to when the runner passes none. Every runner does pass one,
+    # so the fallback decides nothing on a normal run — which is why it sat two
+    # releases behind until Dependabot opened a PR to move it. It is still a published
+    # version written down in the repository, so it moves with the release.
+    #
+    # Found rather than listed: the projects are one per published coordinate
+    # combination, so the set grows when a coordinate does, and a list here would be a
+    # second place to remember that.
     $targets = @(
         @{ Path = 'scripts/release-smoke/run.sh';        Pattern = '(?<=^GC_VERSION=")[\w\.\-]+(?=")';               Label = 'run.sh default' },
         @{ Path = 'scripts/release-smoke/run.sh';        Pattern = '(?<=tests gc\.version=)[\w\.\-]+';                Label = 'run.sh usage' },
@@ -784,6 +794,19 @@ function Update-ReleaseSmokeDefaultVersion($repoRoot, $newVersion) {
         @{ Path = '.github/workflows/release-smoke.yml'; Pattern = "(?<=^\s{8}default: ')[\w\.\-]+(?=')";             Label = 'workflow input default' },
         @{ Path = 'scripts/release-smoke/README.md';     Pattern = '(?<=defaults to the current published release \(`)[\w\.\-]+(?=`\))'; Label = 'README prose' }
     )
+
+    $consumerRoot = Join-Path $repoRoot 'scripts/release-smoke'
+    if (Test-Path $consumerRoot) {
+        foreach ($project in Get-ChildItem $consumerRoot -Directory | Sort-Object Name) {
+            if (Test-Path (Join-Path $project.FullName 'pom.xml')) {
+                $targets += @{
+                    Path    = "scripts/release-smoke/$($project.Name)/pom.xml"
+                    Pattern = '(?<=<gc\.version>)[\w\.\-]+(?=</gc\.version>)'
+                    Label   = "$($project.Name) fallback"
+                }
+            }
+        }
+    }
 
     foreach ($target in $targets) {
         $path = Join-Path $repoRoot $target.Path

--- a/scripts/release-smoke/s1-graph-compose/pom.xml
+++ b/scripts/release-smoke/s1-graph-compose/pom.xml
@@ -13,10 +13,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
-        <gc.version>2.0.0</gc.version>
-        <junit.version>5.11.4</junit.version>
+        <gc.version>2.2.0</gc.version>
+        <junit.version>6.1.3</junit.version>
         <assertj.version>3.27.7</assertj.version>
-        <surefire.version>3.5.2</surefire.version>
+        <surefire.version>3.5.6</surefire.version>
     </properties>
 
     <dependencies>

--- a/scripts/release-smoke/s2-core-only/pom.xml
+++ b/scripts/release-smoke/s2-core-only/pom.xml
@@ -13,11 +13,11 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
-        <gc.version>2.0.0</gc.version>
-        <junit.version>5.11.4</junit.version>
+        <gc.version>2.2.0</gc.version>
+        <junit.version>6.1.3</junit.version>
         <assertj.version>3.27.7</assertj.version>
-        <surefire.version>3.5.2</surefire.version>
-        <enforcer.version>3.5.0</enforcer.version>
+        <surefire.version>3.5.6</surefire.version>
+        <enforcer.version>3.6.3</enforcer.version>
     </properties>
 
     <dependencies>

--- a/scripts/release-smoke/s3-core-render-pdf/pom.xml
+++ b/scripts/release-smoke/s3-core-render-pdf/pom.xml
@@ -13,10 +13,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
-        <gc.version>2.0.0</gc.version>
-        <junit.version>5.11.4</junit.version>
+        <gc.version>2.2.0</gc.version>
+        <junit.version>6.1.3</junit.version>
         <assertj.version>3.27.7</assertj.version>
-        <surefire.version>3.5.2</surefire.version>
+        <surefire.version>3.5.6</surefire.version>
     </properties>
 
     <dependencies>

--- a/scripts/release-smoke/s4-templates/pom.xml
+++ b/scripts/release-smoke/s4-templates/pom.xml
@@ -14,10 +14,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
-        <gc.version>2.0.0</gc.version>
-        <junit.version>5.11.4</junit.version>
+        <gc.version>2.2.0</gc.version>
+        <junit.version>6.1.3</junit.version>
         <assertj.version>3.27.7</assertj.version>
-        <surefire.version>3.5.2</surefire.version>
+        <surefire.version>3.5.6</surefire.version>
     </properties>
 
     <dependencies>

--- a/scripts/release-smoke/s5-testing/pom.xml
+++ b/scripts/release-smoke/s5-testing/pom.xml
@@ -14,10 +14,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
-        <gc.version>2.0.0</gc.version>
-        <junit.version>5.11.4</junit.version>
+        <gc.version>2.2.0</gc.version>
+        <junit.version>6.1.3</junit.version>
         <assertj.version>3.27.7</assertj.version>
-        <surefire.version>3.5.2</surefire.version>
+        <surefire.version>3.5.6</surefire.version>
     </properties>
 
     <dependencies>

--- a/scripts/release-smoke/s6-bundle/pom.xml
+++ b/scripts/release-smoke/s6-bundle/pom.xml
@@ -14,10 +14,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
-        <gc.version>2.0.0</gc.version>
-        <junit.version>5.11.4</junit.version>
+        <gc.version>2.2.0</gc.version>
+        <junit.version>6.1.3</junit.version>
         <assertj.version>3.27.7</assertj.version>
-        <surefire.version>3.5.2</surefire.version>
+        <surefire.version>3.5.6</surefire.version>
     </properties>
 
     <dependencies>

--- a/scripts/release-smoke/s7-core-render-pptx/pom.xml
+++ b/scripts/release-smoke/s7-core-render-pptx/pom.xml
@@ -14,10 +14,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
-        <gc.version>2.0.0</gc.version>
-        <junit.version>5.11.4</junit.version>
+        <gc.version>2.2.0</gc.version>
+        <junit.version>6.1.3</junit.version>
         <assertj.version>3.27.7</assertj.version>
-        <surefire.version>3.5.2</surefire.version>
+        <surefire.version>3.5.6</surefire.version>
     </properties>
 
     <dependencies>

--- a/scripts/release-smoke/s8-core-render-docx/pom.xml
+++ b/scripts/release-smoke/s8-core-render-docx/pom.xml
@@ -13,10 +13,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.release>17</maven.compiler.release>
-        <gc.version>2.0.0</gc.version>
-        <junit.version>5.11.4</junit.version>
+        <gc.version>2.2.0</gc.version>
+        <junit.version>6.1.3</junit.version>
         <assertj.version>3.27.7</assertj.version>
-        <surefire.version>3.5.2</surefire.version>
+        <surefire.version>3.5.6</surefire.version>
     </properties>
 
     <dependencies>

--- a/templates/pom.xml
+++ b/templates/pom.xml
@@ -56,9 +56,9 @@
         <maven.compiler.release>17</maven.compiler.release>
 
         <lombok.version>1.18.46</lombok.version>
-        <junit.bom.version>6.1.2</junit.bom.version>
+        <junit.bom.version>6.1.3</junit.bom.version>
         <assertj.version>3.27.7</assertj.version>
-        <logback.version>1.6.1</logback.version>
+        <logback.version>1.6.2</logback.version>
 
         <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
         <maven.jar.plugin.version>3.5.1</maven.jar.plugin.version>

--- a/testing/pom.xml
+++ b/testing/pom.xml
@@ -59,9 +59,9 @@
 
         <pdfbox.version>3.0.8</pdfbox.version>
         <jackson.bom.version>2.22.1</jackson.bom.version>
-        <junit.bom.version>6.1.2</junit.bom.version>
+        <junit.bom.version>6.1.3</junit.bom.version>
         <assertj.version>3.27.7</assertj.version>
-        <logback.version>1.6.1</logback.version>
+        <logback.version>1.6.2</logback.version>
 
         <maven.compiler.plugin.version>3.15.0</maven.compiler.plugin.version>
         <maven.jar.plugin.version>3.5.1</maven.jar.plugin.version>


### PR DESCRIPTION
Replaces #565, #566, #567, #568, #569, #570, #571, #572 and #573.

## Why

The release push made Dependabot rescan, and it opened nine pull requests. Eight are the
same bump — `junit-jupiter` 5.11.4 → 6.1.3 in each consumer-smoke project, one per manifest
because the group covers minor and patch and this is a major. The ninth carries everything
else. Taken together they are one change.

One of them was already stale when it opened. It proposed `<gc.version>` 2.0.0 → **2.1.1**
in the consumer poms, and 2.2.0 has been on Central since the cut.

## What changed

**The train** — `junit-bom` 6.1.2 → 6.1.3 and `logback-classic` 1.6.1 → 1.6.2 wherever they
are pinned (core, qa, templates, testing, render-pdf/docx/pptx, examples, benchmarks), and
the Maven wrapper to 3.9.16.

**The consumer projects** — `junit-jupiter` 5.11.4 → 6.1.3, `surefire` 3.5.2 → 3.5.6, and
`enforcer` 3.5.0 → 3.6.3 in s2. They were two majors behind the JUnit the rest of the
repository runs.

**Their `<gc.version>` → 2.2.0**, not 2.1.1. That property is the version each project
verifies when the runner names none. The release step moves the same default in `run.sh`,
`run.ps1`, the workflow input and the README — and never reached the poms. Every runner does
pass a version, so the fallback decides nothing on a normal run, which is how it stayed two
releases behind without a single run going red.

**So the release step finds the consumer projects rather than listing them.** They arrive one
per published coordinate combination, so the set grows when a coordinate does, and a list in
the script would be a second place to remember that.

**And a guard holds the default in one place.** `VersionConsistencyGuardTest` now reads all
eleven — the two runners, the workflow input, and each pom's `<gc.version>` — and holds them
to `acceptableTargets()`, the published-release rule the install snippets already follow.

`mvnw.cmd` is left alone: the offered change rewrote the whole file for its line endings,
while what the wrapper upgrade needs is the `distributionUrl`.

## Tests

**The consumer harness, which is what a JUnit major actually risks** —
`bash scripts/release-smoke/run.sh` → **8 of 8 BUILD SUCCESS**, exit 0. Each project builds
in an isolated local repository with the cache evicted, so the coordinates were resolved from
Central rather than from anything this machine had lying around.

**`./mvnw -B -ntp clean verify`** → **BUILD SUCCESS**, no failures.

**The new guard was driven from the files in three broken states**, each red, and green on
the tree as it stands: one pom left on the previous release, a runner naming a version nobody
published, and a pom that stops declaring the property at all — that last one names the file
rather than silently skipping it.

**The release step's discovery** was dry-run against a copy of the tree: it finds all eight
consumer poms and moves each fallback with the release.