### PR TITLE
chore(api): graduate the SVG surface from beta to stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ follow semantic versioning; release dates are ISO 8601.
 
 ## v2.2.1 — Planned
 
+### Public API
+
+- **The SVG surface graduates from `@Beta` to Stable.** `SvgPath`, `SvgIcon`,
+  `PathBuilder.svg(svgPath)`, both `addSvgIcon(...)` flow adders,
+  `ShapeContainerBuilder.path(w, h, svgPath)`, and the gradient paints the
+  reader emits (`DocumentPaint.LinearAxis` / `RadialCircle`) drop the
+  annotation and join the Stable tier — additive-only changes in minors from
+  here on. The surface shipped in 1.8.0 marked `@Beta` "while it hardens
+  against real-world exporter output"; that hardening is done — the stroke,
+  colour and unit work, per-element error context, the clip-path support
+  added in 1.9.0, and the opacity-family + warning pass in this release —
+  and the API shape itself has not moved since 1.9.0, four minors of real
+  use. The annotation drop also closes an inconsistency: `inlineSvgIcon` /
+  `RichText.svgIcon` and the emoji pipeline were built on `@Beta` `SvgIcon`
+  without carrying the marker themselves; now no SVG entry point does. No
+  binary or source change for callers — the remaining `@Beta` carriers are
+  the `NodeDefinition` Extension SPI seam and the PPTX backend, exactly as
+  [docs/api-stability.md](docs/api-stability.md) lists them.
+
 ### Fixed
 
 - **The SVG reader honours the opacity family.** `opacity`, `fill-opacity` and

--- a/core/src/main/java/com/demcha/compose/document/dsl/AbstractFlowBuilder.java
+++ b/core/src/main/java/com/demcha/compose/document/dsl/AbstractFlowBuilder.java
@@ -626,7 +626,6 @@ public abstract class AbstractFlowBuilder<T extends AbstractFlowBuilder<T, N>, N
      * @return this builder
      * @since 1.8.0
      */
-    @com.demcha.compose.document.api.Beta
     public T addSvgIcon(com.demcha.compose.document.svg.SvgIcon icon, double width) {
         Objects.requireNonNull(icon, "icon");
         return add(icon.node(width));
@@ -643,7 +642,6 @@ public abstract class AbstractFlowBuilder<T extends AbstractFlowBuilder<T, N>, N
      * @return this builder
      * @since 1.8.0
      */
-    @com.demcha.compose.document.api.Beta
     public T addSvgIcon(com.demcha.compose.document.svg.SvgIcon icon, double width,
                         com.demcha.compose.document.node.HorizontalAlign align) {
         Objects.requireNonNull(icon, "icon");

--- a/core/src/main/java/com/demcha/compose/document/dsl/PathBuilder.java
+++ b/core/src/main/java/com/demcha/compose/document/dsl/PathBuilder.java
@@ -1,6 +1,5 @@
 package com.demcha.compose.document.dsl;
 
-import com.demcha.compose.document.api.Beta;
 import com.demcha.compose.document.node.PathNode;
 import com.demcha.compose.document.style.DocumentColor;
 import com.demcha.compose.document.style.DocumentDashPattern;
@@ -171,7 +170,6 @@ public final class PathBuilder {
      * @return this builder
      * @since 1.8.0
      */
-    @Beta
     public PathBuilder svg(SvgPath svgPath) {
         Objects.requireNonNull(svgPath, "svgPath");
         segments.addAll(svgPath.segments());

--- a/core/src/main/java/com/demcha/compose/document/dsl/ShapeContainerBuilder.java
+++ b/core/src/main/java/com/demcha/compose/document/dsl/ShapeContainerBuilder.java
@@ -225,7 +225,6 @@ public final class ShapeContainerBuilder implements Transformable<ShapeContainer
      * @return this builder
      * @since 1.8.0
      */
-    @com.demcha.compose.document.api.Beta
     public ShapeContainerBuilder path(double width, double height,
                                       com.demcha.compose.document.svg.SvgPath svgPath) {
         Objects.requireNonNull(svgPath, "svgPath");

--- a/core/src/main/java/com/demcha/compose/document/style/DocumentPaint.java
+++ b/core/src/main/java/com/demcha/compose/document/style/DocumentPaint.java
@@ -1,6 +1,5 @@
 package com.demcha.compose.document.style;
 
-import com.demcha.compose.document.api.Beta;
 
 import java.util.List;
 import java.util.Objects;
@@ -134,9 +133,6 @@ public sealed interface DocumentPaint
      * exact: colour runs from the first stop at {@code (x0, y0)} to the last
      * stop at {@code (x1, y1)} and clamps beyond (pad spread).
      *
-     * <p>Marked {@link Beta} — emitted by the beta SVG gradient reader; the
-     * endpoint normalization contract may shift while that reader hardens.</p>
-     *
      * @param stops ordered colour stops, offsets in [0,1]; at least two
      * @param x0    axis start x, normalized to the box width
      * @param y0    axis start y, normalized to the box height
@@ -144,7 +140,6 @@ public sealed interface DocumentPaint
      * @param y1    axis end y, normalized to the box height
      * @since 1.8.0
      */
-    @Beta
     record LinearAxis(List<Stop> stops, double x0, double y0, double x1, double y1)
             implements DocumentPaint {
         /**
@@ -179,16 +174,12 @@ public sealed interface DocumentPaint
      * a circle when the box preserves the source's aspect ratio (the SVG
      * icon frame contract). Colour clamps beyond the last stop (pad spread).
      *
-     * <p>Marked {@link Beta} — emitted by the beta SVG gradient reader; the
-     * centre/radius normalization contract may shift while that reader hardens.</p>
-     *
      * @param stops ordered colour stops, offsets in [0,1]; at least two
      * @param cx    centre x, normalized to the box width
      * @param cy    centre y, normalized to the box height
      * @param r     radius as a fraction of the box width; positive
      * @since 1.8.0
      */
-    @Beta
     record RadialCircle(List<Stop> stops, double cx, double cy, double r)
             implements DocumentPaint {
         /**

--- a/core/src/main/java/com/demcha/compose/document/svg/SvgIcon.java
+++ b/core/src/main/java/com/demcha/compose/document/svg/SvgIcon.java
@@ -1,6 +1,5 @@
 package com.demcha.compose.document.svg;
 
-import com.demcha.compose.document.api.Beta;
 import com.demcha.compose.document.node.LayerStackNode;
 import com.demcha.compose.document.node.PathNode;
 import com.demcha.compose.document.style.DocumentColor;
@@ -69,13 +68,9 @@ import java.util.Objects;
  * card.center(logo.node(48));         // node form for layer anchors
  * }</pre>
  *
- * <p><b>Beta:</b> the SVG surface is new in 1.8.0 and marked {@link Beta}
- * while it hardens against real-world exporter output.</p>
- *
  * @author Artem Demchyshyn
  * @since 1.8.0
  */
-@Beta
 public final class SvgIcon {
 
     private final List<Layer> layers;

--- a/core/src/main/java/com/demcha/compose/document/svg/SvgPath.java
+++ b/core/src/main/java/com/demcha/compose/document/svg/SvgPath.java
@@ -1,6 +1,5 @@
 package com.demcha.compose.document.svg;
 
-import com.demcha.compose.document.api.Beta;
 import com.demcha.compose.document.style.DocumentPathSegment;
 
 import java.util.ArrayList;
@@ -34,14 +33,9 @@ import java.util.List;
  *         .fillColor(crimson));
  * }</pre>
  *
- * <p><b>Beta:</b> the SVG surface is new in 1.8.0 and marked {@link Beta}
- * while it hardens against real-world files — the API may still adjust in a
- * minor release based on feedback.</p>
- *
  * @author Artem Demchyshyn
  * @since 1.8.0
  */
-@Beta
 public final class SvgPath {
 
     private static final double EPS = 1e-9;

--- a/core/src/main/java/com/demcha/compose/document/svg/package-info.java
+++ b/core/src/main/java/com/demcha/compose/document/svg/package-info.java
@@ -8,9 +8,6 @@
  * {@code PathBuilder.svg(...)} / {@code PathNode}. Curves render as native
  * PDF operators; nothing is tessellated.</p>
  *
- * <p><b>Beta:</b> the whole package is marked beta for the 1.8 cycle while
- * it hardens against real-world exporter output.</p>
- *
  * @since 1.8.0
  */
 package com.demcha.compose.document.svg;

--- a/core/src/test/java/com/demcha/compose/document/svg/SvgPathTest.java
+++ b/core/src/test/java/com/demcha/compose/document/svg/SvgPathTest.java
@@ -205,7 +205,7 @@ class SvgPathTest {
         // Regression: an operand-less Z/z followed by a non-command token used
         // to spin forever (the close op consumes no characters, so the scanner
         // never advanced), appending a close op per iteration until OOM. A
-        // single malformed/hostile 'd' string would DoS the @Beta reader.
+        // single malformed/hostile 'd' string would DoS the reader.
         // Each call must fail fast; the assertTimeout pins that it cannot hang.
         Assertions.assertTimeoutPreemptively(
                 Duration.ofSeconds(2), () -> {


### PR DESCRIPTION
## Why

The SVG surface has carried `@Beta` since 1.8.0 with an explicit exit condition — "while the surface hardens against real-world exporter output". That condition is met: the stroke/colour/unit hardening landed through 1.8.x (#180, #184–#186, #193), clip-path support in 1.9.0, and the opacity family plus the approximation warnings in #596 — while the API *shape* itself has not moved since 1.9.0, four minors of real use (the 2.0 line only relocated the files). The stability policy in [docs/api-stability.md](docs/api-stability.md) says an Experimental surface graduates "typically by the next minor release", and its own registry of current `@Beta` carriers already lists only `NodeDefinition` and the PPTX backend — the code disagreed with the policy doc. The marker was also internally inconsistent: `inlineSvgIcon` / `RichText.svgIcon` and the emoji pipeline were built on `@Beta` `SvgIcon` without carrying the annotation themselves.

## What changed

- **Eight annotation sites dropped**: `SvgIcon`, `SvgPath` (class-level), `PathBuilder.svg(svgPath)`, both `AbstractFlowBuilder.addSvgIcon(...)` overloads and `ShapeContainerBuilder.path(w, h, svgPath)` (these three used the fully-qualified `@com.demcha.compose.document.api.Beta` form — a plain-text `@Beta` grep misses them), and `DocumentPaint.LinearAxis` / `RadialCircle`. The paints graduate together with the reader that emits them: `SvgIcon.Layer` exposes `DocumentPaint` publicly, so a beta paint under a stable icon would re-create the same inconsistency this PR closes.
- **The four "Beta:" Javadoc paragraphs removed** (`SvgIcon`, `SvgPath`, `document.svg` package-info, and the "may shift while that reader hardens" caveats on both paint records) — the surrounding docs already state the supported subset, the out-of-scope list, and each normalization contract, which is the stable promise. One stale test comment ("would DoS the @Beta reader") updated alongside.
- **CHANGELOG `### Public API` entry** under v2.2.1 — Planned calls the transition out explicitly, as the policy requires, and names the two remaining `@Beta` carriers (`NodeDefinition` Extension SPI, PPTX backend), which now match `docs/api-stability.md` exactly — no doc edit needed there.
- No behaviour, signature, or binary change — annotation and Javadoc only. `BetaAnnotationDocumentationTest` pins the annotation's shape, not its carriers, so no test changes.

## Verification

Full reactor gate `./mvnw -B -ntp clean verify -pl :graph-compose-core,…,:graph-compose-coverage -am` → **BUILD SUCCESS** (exit 0, unpiped), and the Javadoc gate `./mvnw -B -ntp javadoc:javadoc` → **BUILD SUCCESS** — the removed `{@link Beta}` references leave no dangling links. japicmp stays green: annotation removal is not a binary-compatibility event, and the plugin carries no `@Beta` exclusion that could have been load-bearing.

**Lane:** canonical (`document.svg`, `document.dsl`, `document.style`) — annotation/docs only.

Follow-up to #596 (the hardening pass this graduation was gated on).

