### PR TITLE
docs(bench): escape the ampersand that fails the benchmarks javadoc build

### DIFF
--- a/benchmarks/src/main/java/com/demcha/compose/ComparativeBenchmark.java
+++ b/benchmarks/src/main/java/com/demcha/compose/ComparativeBenchmark.java
@@ -33,7 +33,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Fair Comparative Benchmark (CPU & RAM)
+ * Fair Comparative Benchmark (CPU &amp; RAM)
  * Compares GraphCompose canonical semantic composition, iText, and JasperReports by isolating the compilation phase
  * and enforcing layout calculations.
  */


### PR DESCRIPTION
## Why

`ComparativeBenchmark`'s class Javadoc carries a raw `&` ("CPU & RAM"), which `javadoc` rejects as a bad HTML entity — so a full-reactor `./mvnw -B -ntp javadoc:javadoc` fails on the benchmarks module. Nothing ever went red for it because the CI javadoc gate excludes benchmarks; the break only surfaces when someone runs the gate across the whole reactor locally.

## What changed

- `benchmarks/src/main/java/com/demcha/compose/ComparativeBenchmark.java` — `&` → `&amp;` in the class Javadoc. A sweep of the module's Javadoc found no other raw `&` / `<` / `>`; the remaining doclint output is missing-comment warnings, which don't fail the build.

## Verification

`./mvnw -B -ntp javadoc:javadoc -pl :graph-compose-benchmarks -am` → **BUILD SUCCESS** (exit 0, zero `error:` lines). No runtime code touched.

**Lane:** docs — one Javadoc literal in the benchmarks module.
