### PR TITLE
chore(api): mark the PDF backend's engine packages @Internal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,25 @@ follow semantic versioning; release dates are ISO 8601.
   `TimelineMinimal`, which splits its own columns. `docs/templates/v2-layered/using-templates.md`
   carries the same table under *Picking a preset*. The caps themselves are unchanged.
 
+- **The PDF backend's engine packages carry the `@Internal` marker the policy already
+  promised.** `docs/api-stability.md` has always put the whole
+  `com.demcha.compose.engine` tree in the Internal tier — removable in any release, no
+  deprecation window — and names `engine.render.pdf.*` as the part of it that ships from
+  `graph-compose-render-pdf`. The annotation itself had stayed behind in the engine
+  artifact, so nothing in the published `graph-compose-render-pdf` Javadoc said so.
+  `engine.render.pdf` and `engine.render.pdf.helpers` now carry the marker at the package
+  level, the way `document.layout` does, and `PdfFont`, `GlyphFallbackLogger`,
+  `PdfHeaderFooterRenderer` and `PdfWatermarkRenderer` carry it on the type as well —
+  Javadoc renders a package annotation on the package page and nowhere else, so the
+  package marker alone leaves each class page reading as a plain public class.
+
+  `InternalEnginePackageMarkerTest` enforces the package half module-locally, in
+  `graph-compose-render-pdf` and `graph-compose-render-pptx`. A guard in the engine
+  cannot: it only sees the engine's own classpath. It reads its package list from the
+  source tree rather than a fixed probe set, so a newly added engine package fails the
+  build until it is marked. Annotation and documentation only; no signature or behaviour
+  changed.
+
 
 ## v2.2.2 — 2026-08-27
 

--- a/docs/adr/0003-api-stability-and-internal-marker.md
+++ b/docs/adr/0003-api-stability-and-internal-marker.md
@@ -77,6 +77,24 @@ right next to `DocumentSession`, so it is discoverable.
   and the source-level Javadoc contract (the phrase
   *"may change in any release without notice"* and the link to the
   issue tracker).
+- The Internal tier does not stop at the engine artifact: the 2.0 module
+  split moved `com.demcha.compose.engine.render.pdf` and its `helpers`
+  sub-package into `graph-compose-render-pdf`, and both carry `@Internal`
+  at the package level. Package annotations do not nest, so the parent
+  marker does not cover `helpers` — each package declares its own.
+- The four public types in those packages (`PdfFont`, `GlyphFallbackLogger`,
+  `PdfHeaderFooterRenderer`, `PdfWatermarkRenderer`) also carry an explicit
+  `@Internal`, for the same reason the `BuiltInNodeDefinitions` payload
+  records do: Javadoc renders a package annotation on the package-summary
+  page and nowhere else, so a package marker on its own leaves every class
+  page reading as an unqualified public class.
+- `InternalEnginePackageMarkerTest` enforces that, module-locally, in
+  [`graph-compose-render-pdf`](../../render-pdf/src/test/java/com/demcha/documentation/InternalEnginePackageMarkerTest.java)
+  and [`graph-compose-render-pptx`](../../render-pptx/src/test/java/com/demcha/documentation/InternalEnginePackageMarkerTest.java).
+  A single test in the engine cannot do this job: it only sees the engine's
+  classpath. The guard reads its package list from `src/main/java` instead of
+  a hard-coded probe set, so a *new* engine package is caught rather than only
+  a marker deleted from a known one.
 
 ## Consequences
 

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -289,6 +289,15 @@ Javadoc per element.
   — the architecture guards that fail the build if the package-level
   `@Internal` marker disappears from `document.layout` or the
   annotation's contract drifts from this policy.
+- [`InternalEnginePackageMarkerTest`](../render-pdf/src/test/java/com/demcha/documentation/InternalEnginePackageMarkerTest.java)
+  in `graph-compose-render-pdf` and its
+  [twin](../render-pptx/src/test/java/com/demcha/documentation/InternalEnginePackageMarkerTest.java)
+  in `graph-compose-render-pptx` — the same guard, module-local. The engine's
+  coverage test can only reach classes on the engine's own classpath, so it
+  cannot see `engine.render.pdf.*`; each module that may ship a
+  `com.demcha.compose.engine.*` package enforces the marker in its own build,
+  over a package list read from the source tree so a newly added package fails
+  until it is marked.
 
 ---
 

--- a/render-pdf/src/main/java/com/demcha/compose/engine/render/pdf/GlyphFallbackLogger.java
+++ b/render-pdf/src/main/java/com/demcha/compose/engine/render/pdf/GlyphFallbackLogger.java
@@ -1,5 +1,6 @@
 package com.demcha.compose.engine.render.pdf;
 
+import com.demcha.compose.document.api.Internal;
 import com.demcha.compose.engine.text.TextControlSanitizer;
 import com.demcha.compose.engine.text.bidi.ArabicShaper;
 
@@ -30,6 +31,7 @@ import java.util.concurrent.ConcurrentHashMap;
  *
  * @author Artem Demchyshyn
  */
+@Internal
 public final class GlyphFallbackLogger {
 
     private static final Logger LOG = LoggerFactory.getLogger(

--- a/render-pdf/src/main/java/com/demcha/compose/engine/render/pdf/PdfFont.java
+++ b/render-pdf/src/main/java/com/demcha/compose/engine/render/pdf/PdfFont.java
@@ -1,5 +1,6 @@
 package com.demcha.compose.engine.render.pdf;
 
+import com.demcha.compose.document.api.Internal;
 import com.demcha.compose.engine.components.content.text.TextStyle;
 import com.demcha.compose.engine.components.geometry.ContentSize;
 import com.demcha.compose.engine.font.FontBase;
@@ -16,6 +17,17 @@ import java.awt.geom.GeneralPath;
 import java.awt.geom.Rectangle2D;
 import java.io.IOException;
 
+/**
+ * PDFBox font handle: loading, embedding, width and vertical metrics for one family.
+ *
+ * <p><strong>Internal API</strong>, like the rest of this package &mdash;
+ * {@code docs/api-stability.md} allows it to change in any release. Note the tension
+ * this marker exposes: {@code PdfRenderEnvironment.fonts()} is public on the render
+ * handler SPI, and a handler that draws text has to reach a {@code PdfFont} through it.
+ * Until that seam gets a supported accessor, a third-party handler depends on this type
+ * at its own risk.</p>
+ */
+@Internal
 @Slf4j
 @Accessors(fluent = true)
 public class PdfFont extends FontBase<PDFont> {

--- a/render-pdf/src/main/java/com/demcha/compose/engine/render/pdf/helpers/PdfHeaderFooterRenderer.java
+++ b/render-pdf/src/main/java/com/demcha/compose/engine/render/pdf/helpers/PdfHeaderFooterRenderer.java
@@ -1,5 +1,6 @@
 package com.demcha.compose.engine.render.pdf.helpers;
 
+import com.demcha.compose.document.api.Internal;
 import com.demcha.compose.engine.components.content.header_footer.HeaderFooterConfig;
 import com.demcha.compose.engine.components.content.header_footer.HeaderFooterZone;
 import com.demcha.compose.engine.render.pdf.GlyphFallbackLogger;
@@ -24,6 +25,7 @@ import java.util.List;
  *
  * @author Artem Demchyshyn
  */
+@Internal
 @Slf4j
 public final class PdfHeaderFooterRenderer {
 

--- a/render-pdf/src/main/java/com/demcha/compose/engine/render/pdf/helpers/PdfWatermarkRenderer.java
+++ b/render-pdf/src/main/java/com/demcha/compose/engine/render/pdf/helpers/PdfWatermarkRenderer.java
@@ -1,5 +1,6 @@
 package com.demcha.compose.engine.render.pdf.helpers;
 
+import com.demcha.compose.document.api.Internal;
 import com.demcha.compose.engine.components.content.watermark.WatermarkConfig;
 import com.demcha.compose.engine.components.content.watermark.WatermarkPosition;
 import com.demcha.compose.engine.render.pdf.GlyphFallbackLogger;
@@ -26,6 +27,7 @@ import java.nio.file.Files;
  *
  * @author Artem Demchyshyn
  */
+@Internal
 @Slf4j
 public final class PdfWatermarkRenderer {
 

--- a/render-pdf/src/main/java/com/demcha/compose/engine/render/pdf/helpers/package-info.java
+++ b/render-pdf/src/main/java/com/demcha/compose/engine/render/pdf/helpers/package-info.java
@@ -3,5 +3,14 @@
  * {@code PdfHeaderFooterRenderer} (running headers and footers) and
  * {@code PdfWatermarkRenderer} (page watermarks), applied by
  * {@code com.demcha.compose.document.backend.fixed.pdf.PdfDocumentPostProcessor}.
+ *
+ * <p><strong>Internal API.</strong> Tagged {@link com.demcha.compose.document.api.Internal}
+ * at the package level. Package annotations do not nest &mdash; the marker on the enclosing
+ * {@code com.demcha.compose.engine.render.pdf} package says nothing about this one &mdash; so
+ * this package declares its own. Both renderers repeat it on the type as well: Javadoc puts
+ * a package annotation on this page and nowhere else, so without the type-level marker a
+ * caller reading {@code PdfHeaderFooterRenderer} still sees a plain public class while
+ * {@code docs/api-stability.md} reserves the right to delete it in any release.</p>
  */
+@com.demcha.compose.document.api.Internal
 package com.demcha.compose.engine.render.pdf.helpers;

--- a/render-pdf/src/main/java/com/demcha/compose/engine/render/pdf/package-info.java
+++ b/render-pdf/src/main/java/com/demcha/compose/engine/render/pdf/package-info.java
@@ -22,5 +22,16 @@
  * <p>The 2.0 line removed the legacy entity-based PDF renderer that once sat beside
  * this package; nothing here or in the canonical pipeline replaced it, because the
  * canonical backend had already taken over every path it served.</p>
+ *
+ * <p><strong>Internal API.</strong> Tagged {@link com.demcha.compose.document.api.Internal}
+ * at the package level, like the engine packages that stayed in {@code graph-compose-core}.
+ * {@code docs/api-stability.md} has always put the whole {@code com.demcha.compose.engine}
+ * tree in the Internal tier &mdash; any release, no deprecation window &mdash; and names this
+ * package as the part of it that ships from {@code graph-compose-render-pdf}. Only the
+ * annotation is something a guard test can read, and without it {@code PdfFont} and
+ * {@code GlyphFallbackLogger} look from the outside like a supported surface. Both repeat
+ * the marker on the type, because Javadoc renders a package annotation on this page only
+ * &mdash; never on the class pages the package covers.</p>
  */
+@com.demcha.compose.document.api.Internal
 package com.demcha.compose.engine.render.pdf;

--- a/render-pdf/src/test/java/com/demcha/documentation/InternalEnginePackageMarkerTest.java
+++ b/render-pdf/src/test/java/com/demcha/documentation/InternalEnginePackageMarkerTest.java
@@ -1,0 +1,170 @@
+package com.demcha.documentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+import com.demcha.compose.document.api.Internal;
+
+/**
+ * Module-local twin of the engine's {@code InternalAnnotationCoverageTest}.
+ *
+ * <p>{@code docs/api-stability.md} § 4 puts the whole {@code com.demcha.compose.engine}
+ * tree in the Internal tier and calls out that {@code engine.render.pdf.*} ships from
+ * this module rather than from {@code graph-compose-core}. The engine's own coverage
+ * test can only reach classes on the engine's classpath, so nothing there can see the
+ * packages this module publishes; a package added here without the marker stays
+ * invisible to it. This test closes that half of the boundary.</p>
+ *
+ * <p>Two assertions, because the marker has two jobs. The package-level one is what
+ * policy and the japicmp excludes hang off. The type-level one is what a reader sees:
+ * Javadoc renders a package annotation on the package-summary page and nowhere else, so
+ * a class in a marked package still publishes an unqualified public class page unless it
+ * declares {@code @Internal} itself.</p>
+ *
+ * <p>Both lists are derived from the source tree rather than hard-coded, so a
+ * <em>new</em> {@code com.demcha.compose.engine.*} package or public type fails the
+ * build until it carries the marker.</p>
+ */
+class InternalEnginePackageMarkerTest {
+
+    /** The package prefix {@code docs/api-stability.md} maps to the Internal tier. */
+    private static final String ENGINE_ROOT = "com.demcha.compose.engine";
+
+    /** Surefire runs with the module directory as the working directory. */
+    private static final Path SOURCE_ROOT = Path.of("src/main/java");
+
+    @Test
+    void everyEnginePackageInThisModuleCarriesTheInternalMarker() throws IOException {
+        List<String> mainPackages = packagesUnderMainSources();
+
+        // Without this, a scan that silently found nothing would report zero
+        // unmarked packages below and pass while inspecting nothing at all.
+        assertThat(mainPackages)
+                .describedAs("Found no packages under %s — the engine assertion below would"
+                        + " then pass without inspecting anything", SOURCE_ROOT)
+                .isNotEmpty();
+
+        List<String> unmarked = mainPackages.stream()
+                .filter(InternalEnginePackageMarkerTest::isEnginePackage)
+                .filter(pkg -> !isMarkedInternal(pkg))
+                .toList();
+
+        assertThat(unmarked)
+                .describedAs("docs/api-stability.md puts %s.* in the Internal tier — removable"
+                        + " in any release, with no deprecation window. These packages ship"
+                        + " from this module without the package-level @Internal marker, so"
+                        + " their published Javadoc reads as a supported surface", ENGINE_ROOT)
+                .isEmpty();
+    }
+
+    /** Every package under {@code src/main/java} that holds at least one source file. */
+    private static List<String> packagesUnderMainSources() throws IOException {
+        try (Stream<Path> tree = Files.walk(SOURCE_ROOT)) {
+            return tree.filter(Files::isRegularFile)
+                    .filter(file -> file.getFileName().toString().endsWith(".java"))
+                    .map(InternalEnginePackageMarkerTest::packageOf)
+                    .distinct()
+                    .sorted()
+                    .toList();
+        }
+    }
+
+    @Test
+    void everyPublicTypeInThoseEnginePackagesCarriesItToo() throws IOException {
+        List<String> enginePackages = packagesUnderMainSources().stream()
+                .filter(InternalEnginePackageMarkerTest::isEnginePackage)
+                .toList();
+        List<String> publicTypes = publicTopLevelTypesInEnginePackages();
+
+        // A silently-empty type scan would satisfy the assertion below without reading
+        // a single class; an engine package with no public type in it cannot happen.
+        assertThat(enginePackages.isEmpty() || !publicTypes.isEmpty())
+                .describedAs("Found engine packages %s but no public type in any of them —"
+                        + " the type scan is not reading this module", enginePackages)
+                .isTrue();
+
+        List<String> unmarked = new ArrayList<>();
+        for (String type : publicTypes) {
+            if (loadClass(type).getAnnotation(Internal.class) == null) {
+                unmarked.add(type);
+            }
+        }
+
+        assertThat(unmarked)
+                .describedAs("These public types sit in an Internal-tier package but declare"
+                        + " no @Internal of their own, so their published Javadoc page carries"
+                        + " no marker at all")
+                .isEmpty();
+    }
+
+    /** Top-level public types declared in this module's engine packages. */
+    private static List<String> publicTopLevelTypesInEnginePackages() throws IOException {
+        List<String> types = new ArrayList<>();
+        try (Stream<Path> tree = Files.walk(SOURCE_ROOT)) {
+            for (Path file : tree.filter(Files::isRegularFile).toList()) {
+                String fileName = file.getFileName().toString();
+                if (!fileName.endsWith(".java") || fileName.equals("package-info.java")) {
+                    continue;
+                }
+                String pkg = packageOf(file);
+                if (!isEnginePackage(pkg)) {
+                    continue;
+                }
+                String name = pkg + "." + fileName.substring(0, fileName.length() - ".java".length());
+                if (Modifier.isPublic(loadClass(name).getModifiers())) {
+                    types.add(name);
+                }
+            }
+        }
+        return types;
+    }
+
+    private static Class<?> loadClass(String binaryName) {
+        try {
+            return Class.forName(binaryName, false,
+                    InternalEnginePackageMarkerTest.class.getClassLoader());
+        } catch (ClassNotFoundException e) {
+            throw new AssertionError(
+                    "Source file for " + binaryName + " exists but nothing compiled to it", e);
+        }
+    }
+
+    /** The package a source file under {@link #SOURCE_ROOT} declares, by its location. */
+    private static String packageOf(Path sourceFile) {
+        Path directory = SOURCE_ROOT.relativize(sourceFile.getParent());
+        return directory.toString().replace(directory.getFileSystem().getSeparator(), ".");
+    }
+
+    private static boolean isEnginePackage(String packageName) {
+        return packageName.equals(ENGINE_ROOT) || packageName.startsWith(ENGINE_ROOT + ".");
+    }
+
+    /**
+     * Reads the package-level marker off the compiled {@code package-info} class, which
+     * is where javac stores package annotations. Anything the reflection cannot confirm
+     * counts as unmarked, so the guard fails closed.
+     */
+    private static boolean isMarkedInternal(String packageName) {
+        try {
+            Class<?> packageInfo = Class.forName(
+                    packageName + ".package-info",
+                    false,
+                    InternalEnginePackageMarkerTest.class.getClassLoader());
+            return packageInfo.getAnnotation(Internal.class) != null;
+        } catch (ClassNotFoundException noCompiledPackageInfo) {
+            // javac emits package-info.class only for an annotated package
+            // declaration, so a package carrying prose alone lands here — exactly
+            // the gap this guard exists to catch.
+            return false;
+        }
+    }
+}

--- a/render-pptx/src/test/java/com/demcha/documentation/InternalEnginePackageMarkerTest.java
+++ b/render-pptx/src/test/java/com/demcha/documentation/InternalEnginePackageMarkerTest.java
@@ -1,0 +1,173 @@
+package com.demcha.documentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+
+import com.demcha.compose.document.api.Internal;
+
+/**
+ * Module-local twin of the engine's {@code InternalAnnotationCoverageTest}, and of the
+ * copy in {@code graph-compose-render-pdf}.
+ *
+ * <p>This module ships no {@code com.demcha.compose.engine.*} package today — its whole
+ * public surface is {@code document.backend.fixed.pptx.*}, which is Experimental and
+ * carries {@code @Beta}. The guard is here as a tripwire rather than a description of
+ * today: the PPTX backend is the fixed-layout twin of the PDF one, and the PDF backend
+ * does keep part of itself under {@code engine.render.pdf}, so the day a PPTX sibling
+ * lands the marker has to land with it. The scan it runs is proven live by the
+ * self-check below, so an armed-but-idle guard is not a guard that silently stopped
+ * looking.</p>
+ *
+ * <p>Two assertions, because the marker has two jobs. The package-level one is what
+ * policy and the japicmp excludes hang off. The type-level one is what a reader sees:
+ * Javadoc renders a package annotation on the package-summary page and nowhere else, so
+ * a class in a marked package still publishes an unqualified public class page unless it
+ * declares {@code @Internal} itself.</p>
+ *
+ * <p>Both lists are derived from the source tree rather than hard-coded, so a
+ * <em>new</em> {@code com.demcha.compose.engine.*} package or public type fails the
+ * build until it carries the marker.</p>
+ */
+class InternalEnginePackageMarkerTest {
+
+    /** The package prefix {@code docs/api-stability.md} maps to the Internal tier. */
+    private static final String ENGINE_ROOT = "com.demcha.compose.engine";
+
+    /** Surefire runs with the module directory as the working directory. */
+    private static final Path SOURCE_ROOT = Path.of("src/main/java");
+
+    @Test
+    void everyEnginePackageInThisModuleCarriesTheInternalMarker() throws IOException {
+        List<String> mainPackages = packagesUnderMainSources();
+
+        // Without this, a scan that silently found nothing would report zero
+        // unmarked packages below and pass while inspecting nothing at all.
+        assertThat(mainPackages)
+                .describedAs("Found no packages under %s — the engine assertion below would"
+                        + " then pass without inspecting anything", SOURCE_ROOT)
+                .isNotEmpty();
+
+        List<String> unmarked = mainPackages.stream()
+                .filter(InternalEnginePackageMarkerTest::isEnginePackage)
+                .filter(pkg -> !isMarkedInternal(pkg))
+                .toList();
+
+        assertThat(unmarked)
+                .describedAs("docs/api-stability.md puts %s.* in the Internal tier — removable"
+                        + " in any release, with no deprecation window. These packages ship"
+                        + " from this module without the package-level @Internal marker, so"
+                        + " their published Javadoc reads as a supported surface", ENGINE_ROOT)
+                .isEmpty();
+    }
+
+    /** Every package under {@code src/main/java} that holds at least one source file. */
+    private static List<String> packagesUnderMainSources() throws IOException {
+        try (Stream<Path> tree = Files.walk(SOURCE_ROOT)) {
+            return tree.filter(Files::isRegularFile)
+                    .filter(file -> file.getFileName().toString().endsWith(".java"))
+                    .map(InternalEnginePackageMarkerTest::packageOf)
+                    .distinct()
+                    .sorted()
+                    .toList();
+        }
+    }
+
+    @Test
+    void everyPublicTypeInThoseEnginePackagesCarriesItToo() throws IOException {
+        List<String> enginePackages = packagesUnderMainSources().stream()
+                .filter(InternalEnginePackageMarkerTest::isEnginePackage)
+                .toList();
+        List<String> publicTypes = publicTopLevelTypesInEnginePackages();
+
+        // A silently-empty type scan would satisfy the assertion below without reading
+        // a single class; an engine package with no public type in it cannot happen.
+        assertThat(enginePackages.isEmpty() || !publicTypes.isEmpty())
+                .describedAs("Found engine packages %s but no public type in any of them —"
+                        + " the type scan is not reading this module", enginePackages)
+                .isTrue();
+
+        List<String> unmarked = new ArrayList<>();
+        for (String type : publicTypes) {
+            if (loadClass(type).getAnnotation(Internal.class) == null) {
+                unmarked.add(type);
+            }
+        }
+
+        assertThat(unmarked)
+                .describedAs("These public types sit in an Internal-tier package but declare"
+                        + " no @Internal of their own, so their published Javadoc page carries"
+                        + " no marker at all")
+                .isEmpty();
+    }
+
+    /** Top-level public types declared in this module's engine packages. */
+    private static List<String> publicTopLevelTypesInEnginePackages() throws IOException {
+        List<String> types = new ArrayList<>();
+        try (Stream<Path> tree = Files.walk(SOURCE_ROOT)) {
+            for (Path file : tree.filter(Files::isRegularFile).toList()) {
+                String fileName = file.getFileName().toString();
+                if (!fileName.endsWith(".java") || fileName.equals("package-info.java")) {
+                    continue;
+                }
+                String pkg = packageOf(file);
+                if (!isEnginePackage(pkg)) {
+                    continue;
+                }
+                String name = pkg + "." + fileName.substring(0, fileName.length() - ".java".length());
+                if (Modifier.isPublic(loadClass(name).getModifiers())) {
+                    types.add(name);
+                }
+            }
+        }
+        return types;
+    }
+
+    private static Class<?> loadClass(String binaryName) {
+        try {
+            return Class.forName(binaryName, false,
+                    InternalEnginePackageMarkerTest.class.getClassLoader());
+        } catch (ClassNotFoundException e) {
+            throw new AssertionError(
+                    "Source file for " + binaryName + " exists but nothing compiled to it", e);
+        }
+    }
+
+    /** The package a source file under {@link #SOURCE_ROOT} declares, by its location. */
+    private static String packageOf(Path sourceFile) {
+        Path directory = SOURCE_ROOT.relativize(sourceFile.getParent());
+        return directory.toString().replace(directory.getFileSystem().getSeparator(), ".");
+    }
+
+    private static boolean isEnginePackage(String packageName) {
+        return packageName.equals(ENGINE_ROOT) || packageName.startsWith(ENGINE_ROOT + ".");
+    }
+
+    /**
+     * Reads the package-level marker off the compiled {@code package-info} class, which
+     * is where javac stores package annotations. Anything the reflection cannot confirm
+     * counts as unmarked, so the guard fails closed.
+     */
+    private static boolean isMarkedInternal(String packageName) {
+        try {
+            Class<?> packageInfo = Class.forName(
+                    packageName + ".package-info",
+                    false,
+                    InternalEnginePackageMarkerTest.class.getClassLoader());
+            return packageInfo.getAnnotation(Internal.class) != null;
+        } catch (ClassNotFoundException noCompiledPackageInfo) {
+            // javac emits package-info.class only for an annotated package
+            // declaration, so a package carrying prose alone lands here — exactly
+            // the gap this guard exists to catch.
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
## Why

`docs/api-stability.md` § 4 puts the whole `com.demcha.compose.engine` tree in the **Internal** tier — *"not part of the public contract regardless of the `public` keyword"*, removable in any release with no deprecation window — and explicitly notes that `engine.render.pdf.*` ships in `graph-compose-render-pdf` rather than in the engine artifact.

The annotation never followed it out of core. `render-pdf`'s two `engine.render.pdf*` packages carried a doc comment and nothing else, so the published Javadoc for `PdfFont`, `GlyphFallbackLogger`, `PdfHeaderFooterRenderer` and `PdfWatermarkRenderer` showed four plain public classes while the policy reserved the right to delete them without notice.

Nor could anything catch it: `InternalAnnotationCoverageTest` probes six core classes, and core cannot see a class that ships from `render-pdf`. Its probe list is also hard-coded, so it only ever catches a marker someone *deleted* from a known package — never a new package that arrives unmarked.

## What changed

**The marker, at two levels.** `com.demcha.compose.engine.render.pdf` and its `helpers` sub-package now declare `@Internal` at the package level, matching `document.layout` and `engine.text`. Package annotations do not nest, so the parent's marker would not have covered `helpers` — each declares its own.

The four public types carry it on the type as well. That is not belt-and-braces: I checked the generated HTML, and Javadoc renders a package annotation on the package-summary page and **nowhere else** — `LayoutGraph.html` in core proves it, with zero occurrences of "Internal" despite its package being marked since 1.6.0. The package marker alone would have left the original complaint — a class page reading as unqualified public API — exactly where it was.

**The guard, module-local.** `InternalEnginePackageMarkerTest` asserts both halves, in `render-pdf` and `render-pptx`. A single test in core cannot do this job; it only sees core's classpath. Both lists are read off `src/main/java` rather than hard-coded, so a *newly added* engine package or public type fails the build until it carries the marker. Each test also self-checks that its scan actually found something, so a scan that silently stopped working cannot pass as "nothing unmarked".

`render-pptx` ships no `com.demcha.compose.engine.*` package today — its surface is `document.backend.fixed.pptx.*`, already `@Beta`. Its copy is an armed tripwire rather than a description of today: the PPTX backend is the fixed-layout twin of the PDF one, and the PDF backend does keep part of itself under `engine.render.pdf`.

**Docs.** `docs/api-stability.md` § 6 and ADR-0003's *Coverage* section now name the module-local guards and record why a package marker alone is not enough. `CHANGELOG.md` gets a `v2.2.3` *Documentation* entry.

`PdfFont` also gained the class documentation it never had, including the tension this marker exposes — see below.

## Verification

- **Reactor gate**, root pom, the ten modules CI builds: `BUILD SUCCESS`, **1,983 tests, 0 failures**.
- **Javadoc gate**: `javadoc:javadoc` green for `:graph-compose-core` (the CI form) and for both render modules.
- **Both new assertions verified red by sabotage**, not just green by construction:
  - dropping the `helpers` package marker → `["com.demcha.compose.engine.render.pdf.helpers"]`
  - dropping `PdfWatermarkRenderer`'s type marker → that class reported
  - adding an unmarked `engine.render.pptx` package → the pptx copy fails
- **Rendered output confirmed** in `target/reports/apidocs`: all four class pages now emit `<span class="annotations">@Internal</span>`; before the type-level markers, none did.

No behaviour change — annotations and documentation only, no signature touched.

## One thing this surfaces

`PdfRenderEnvironment.fonts()` is **public** on the render-handler SPI that [ADR-0004](docs/adr/0004-pdf-handler-spi-extension.md) declares public, and the only way to draw text through it is `fonts.getFont(name, PdfFont.class)` — naming a type this PR marks `@Internal`. So a third-party handler cannot render text without touching Internal API.

This is not introduced here: the policy already declared the tier, and the marker is doing what ADR-0003 designed it to do — act as a forcing function. Resolving it (a supported font accessor on the SPI, or an ADR-0004 note sanctioning `PdfFont` for handler implementers) is a public-API design decision, so it stays out of this PR; `PdfFont`'s new Javadoc records the tension in the meantime.

Separately: **21 of core's 23 `com.demcha.compose.engine.*` packages still lack the marker** — only `engine.text` and `engine.text.bidi` have it. Same defect, same fix, but a 21-package Javadoc change deserves its own reviewable pass.
