### PR TITLE
fix(api): size the inline chip from the paragraph it sits in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ follow semantic versioning; release dates are ISO 8601.
 
 ## v2.3.0 — Planned
 
+### Public API
+
+- **A chip is sized like the text around it.** `ParagraphBuilder.inlineChip(text, fg, bg)`
+  built its glyph style from scratch — `DocumentTextStyle.builder().color(fg)` — so the
+  badge came out at the 14 pt Helvetica default whatever the paragraph said. In a 9 pt
+  footer the words rendered at 9 pt and the chip between them rendered half again as
+  large, which reads as a rendering fault rather than a choice.
+
+  The colour-only overload now derives its style from the paragraph's `textStyle` and
+  replaces only the colour:
+
+  ```java
+  paragraph.textStyle(DocumentTextStyle.builder().size(9).build())
+          .inlineText("Build ")
+          .inlineChip(" Paid ", GREEN_INK, GREEN_FILL);   // a 9 pt chip
+  ```
+
+  That is how the rest of the builder already behaves. `inlineText`, `inlineLink` and
+  `inlineLinkTo` pass a `null` run style, which the layout resolves to the paragraph's,
+  and `inlineHighlight` documents that fallback on its `textStyle` parameter. The chip
+  sugar was the one call that opted out of it.
+
+  **This moves rendered output** wherever a chip sits in a paragraph that is not at the
+  default style: the glyphs — and with them the chip's measured width — now follow the
+  paragraph. The paragraph style is read at the point of the call, so `textStyle(...)`
+  has to come before the chip.
+
+- **`inlineStyledChip(text, textStyle, bg)`** styles a chip that is meant to differ from
+  its paragraph: an explicit glyph style on a custom fill, keeping the default chip
+  radius and padding, which previously meant restating both through `inlineHighlight`.
+  It carries its own name rather than overloading `inlineChip` on the second parameter,
+  which would have made a literal `inlineChip(text, null, bg)` ambiguous and stopped it
+  compiling.
+
+  `RichText.chip(...)` is unchanged and still draws at the default size: a rich-text
+  builder is assembled without a paragraph to read. Its documentation now says so, and
+  points at `highlight(...)` for an explicitly sized chip.
+
 ### Templates
 
 - **Monogram Sidebar draws the employer.** Its experience entries rendered the position,

--- a/core/src/main/java/com/demcha/compose/document/dsl/ParagraphBuilder.java
+++ b/core/src/main/java/com/demcha/compose/document/dsl/ParagraphBuilder.java
@@ -372,16 +372,38 @@ public final class ParagraphBuilder {
      * Adds a coloured chip: {@code text} in {@code fg} on a {@code bg} fill, with
      * the default code radius and padding.
      *
+     * <p>The glyphs take the paragraph's {@linkplain #textStyle(DocumentTextStyle)
+     * text style} — family, size and decoration — with only the colour replaced by
+     * {@code fg}, so a chip in a 9 pt paragraph is a 9 pt chip. The paragraph style is
+     * read when this method is called, so set it before the chip; to size a chip
+     * independently of the paragraph, pass the style explicitly with
+     * {@link #inlineStyledChip(String, DocumentTextStyle, DocumentColor)}.</p>
+     *
      * @param text the text
-     * @param fg   the text colour
+     * @param fg   the text colour; {@code null} leaves the glyphs black
      * @param bg   the chip fill colour; must not be {@code null}
      * @return this builder
      * @since 1.9.0
      */
     public ParagraphBuilder inlineChip(String text, DocumentColor fg, DocumentColor bg) {
+        return inlineStyledChip(text, this.textStyle.withColor(fg), bg);
+    }
+
+    /**
+     * Adds a chip with an explicit glyph style on a {@code bg} fill, keeping the
+     * default code radius and padding — the escape hatch from
+     * {@link #inlineChip(String, DocumentColor, DocumentColor)} for a chip that is
+     * meant to differ from the paragraph around it.
+     *
+     * @param text      the text
+     * @param textStyle the glyph style; falls back to the paragraph style when {@code null}
+     * @param bg        the chip fill colour; must not be {@code null}
+     * @return this builder
+     * @since 2.3.0
+     */
+    public ParagraphBuilder inlineStyledChip(String text, DocumentTextStyle textStyle, DocumentColor bg) {
         Objects.requireNonNull(bg, "bg");
-        this.inlineRuns.add(new InlineHighlightRun(text == null ? "" : text,
-                DocumentTextStyle.builder().color(fg).build(),
+        this.inlineRuns.add(new InlineHighlightRun(text == null ? "" : text, textStyle,
                 new InlineBackground(bg, CodeChip.BACKGROUND.cornerRadius(), CodeChip.BACKGROUND.padding())));
         this.text = "";
         return this;

--- a/core/src/main/java/com/demcha/compose/document/dsl/RichText.java
+++ b/core/src/main/java/com/demcha/compose/document/dsl/RichText.java
@@ -282,6 +282,13 @@ public final class RichText {
      * Appends a coloured chip: {@code text} in {@code fg} on a {@code bg} fill,
      * with the default code radius and padding.
      *
+     * <p>A rich-text builder is assembled without a paragraph, so — unlike
+     * {@link ParagraphBuilder#inlineChip(String, DocumentColor, DocumentColor)},
+     * which reads the paragraph it is called on — these glyphs are drawn at the
+     * default family and size. In a paragraph styled to another size, reach for
+     * {@link #highlight(String, DocumentTextStyle, DocumentColor, double, DocumentInsets)}
+     * with an explicit style instead.</p>
+     *
      * @param text the text
      * @param fg   the text colour
      * @param bg   the chip fill colour; must not be {@code null}

--- a/core/src/test/java/com/demcha/compose/document/dsl/InlineHighlightRunTest.java
+++ b/core/src/test/java/com/demcha/compose/document/dsl/InlineHighlightRunTest.java
@@ -3,6 +3,7 @@ package com.demcha.compose.document.dsl;
 import com.demcha.compose.document.node.InlineHighlightRun;
 import com.demcha.compose.document.style.DocumentColor;
 import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.document.style.DocumentTextDecoration;
 import com.demcha.compose.document.style.DocumentTextStyle;
 import com.demcha.compose.document.style.InlineBackground;
 import com.demcha.compose.font.FontName;
@@ -81,6 +82,60 @@ class InlineHighlightRunTest {
                 "x", DocumentTextStyle.DEFAULT, DocumentColor.GRAY, 4.0, padding,
                 new com.demcha.compose.document.node.DocumentLinkOptions("https://example.com")));
         assertThat(linked.linkTarget()).isNotNull();
+    }
+
+    @Test
+    void paragraphChipInheritsTheParagraphStyleAndOverridesOnlyTheColour() {
+        DocumentTextStyle paragraphStyle = DocumentTextStyle.builder()
+                .fontName(FontName.TIMES_ROMAN)
+                .size(9)
+                .decoration(DocumentTextDecoration.BOLD)
+                .build();
+        InlineHighlightRun run = onlyHighlight(new ParagraphBuilder()
+                .textStyle(paragraphStyle)
+                .inlineChip(" Paid ", DocumentColor.rgb(0, 100, 0), DocumentColor.rgb(220, 255, 220)));
+
+        // Everything but the colour is the paragraph's, compared as a whole so a
+        // component added to DocumentTextStyle later is covered too. Normalized to
+        // one shared colour because DocumentColor compares by identity.
+        assertThat(run.textStyle().withColor(DocumentColor.BLACK))
+                .isEqualTo(paragraphStyle.withColor(DocumentColor.BLACK));
+        assertThat(run.textStyle().size()).isEqualTo(9.0, within(1e-9));
+        assertThat(run.textStyle().fontName()).isEqualTo(FontName.TIMES_ROMAN);
+        assertThat(run.textStyle().decoration()).isEqualTo(DocumentTextDecoration.BOLD);
+        assertThat(run.textStyle().color().color()).isEqualTo(new Color(0, 100, 0));
+        // The fill and the chip geometry are the caller's, not the paragraph's.
+        assertThat(run.background().fill().color()).isEqualTo(new Color(220, 255, 220));
+        assertThat(run.background().cornerRadius()).isEqualTo(3.0);
+    }
+
+    @Test
+    void paragraphChipWithAnExplicitStyleIgnoresTheParagraph() {
+        DocumentTextStyle chipStyle = DocumentTextStyle.builder().size(20).build();
+        InlineHighlightRun run = onlyHighlight(new ParagraphBuilder()
+                .textStyle(DocumentTextStyle.builder().size(9).build())
+                .inlineStyledChip("BIG", chipStyle, DocumentColor.GRAY));
+        assertThat(run.textStyle().size()).isEqualTo(20.0, within(1e-9));
+    }
+
+    @Test
+    void paragraphChipReadsTheStyleThatWasSetWhenItWasCalled() {
+        // The documented ordering caveat, pinned: the chip snapshots the paragraph
+        // style at the call, so a textStyle(...) that lands afterwards does not
+        // reach it. Change this test deliberately if the resolution ever moves to
+        // build() -- do not let it drift silently.
+        InlineHighlightRun run = onlyHighlight(new ParagraphBuilder()
+                .inlineChip("x", DocumentColor.rgb(0, 100, 0), DocumentColor.GRAY)
+                .textStyle(DocumentTextStyle.builder().size(9).build()));
+        assertThat(run.textStyle().size()).isEqualTo(DocumentTextStyle.DEFAULT.size(), within(1e-9));
+    }
+
+    private static InlineHighlightRun onlyHighlight(ParagraphBuilder paragraph) {
+        return paragraph.build().inlineRuns().stream()
+                .filter(InlineHighlightRun.class::isInstance)
+                .map(InlineHighlightRun.class::cast)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no InlineHighlightRun in the paragraph"));
     }
 
     private static InlineHighlightRun onlyHighlight(RichText rich) {

--- a/qa/src/test/java/com/demcha/compose/document/dsl/InlineHighlightRenderTest.java
+++ b/qa/src/test/java/com/demcha/compose/document/dsl/InlineHighlightRenderTest.java
@@ -19,6 +19,7 @@ import org.apache.pdfbox.rendering.PDFRenderer;
 import org.apache.pdfbox.text.PDFTextStripper;
 import org.junit.jupiter.api.Test;
 
+import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.util.List;
 import java.util.function.Consumer;
@@ -320,6 +321,43 @@ class InlineHighlightRenderTest {
             String rendered = new PDFTextStripper().getText(document).replaceAll("\\s+", " ").trim();
             assertThat(rendered).isEqualTo("Tags: alpha beta gamma delta epsilon end");
         }
+    }
+
+    @Test
+    void chipFollowsTheParagraphSizeInsteadOfTheDefault() throws Exception {
+        // A chip is glyphs on a fill, so it has to be sized like the glyphs around
+        // it: in a 9 pt paragraph the badge measures 9 pt, not the 14 pt default.
+        DocumentTextStyle small = DocumentTextStyle.builder().size(9).build();
+        List<ParagraphTextSpan> spans = textSpans(p -> p
+                .textStyle(small)
+                .inlineText("Build ")
+                .inlineChip(" Paid ", DocumentColor.rgb(22, 101, 52), FILL));
+
+        ParagraphTextSpan plain = spans.stream().filter(s -> s.background() == null).findFirst().orElseThrow();
+        ParagraphTextSpan chip = spans.stream().filter(s -> s.background() != null).findFirst().orElseThrow();
+        assertThat(plain.textStyle().size()).isEqualTo(9.0, within(1e-9));
+        assertThat(chip.textStyle().size())
+                .as("the chip is drawn at the paragraph size, not the 14 pt default")
+                .isEqualTo(9.0, within(1e-9));
+        assertThat(chip.textStyle().color()).isEqualTo(new Color(22, 101, 52));
+
+        // Measured, not just declared: the same chip in a default-styled paragraph
+        // is wider, because its glyphs really are bigger.
+        List<ParagraphTextSpan> defaultSized = textSpans(p -> p
+                .inlineChip(" Paid ", DocumentColor.rgb(22, 101, 52), FILL));
+        double wide = defaultSized.stream().filter(s -> s.background() != null).findFirst().orElseThrow().width();
+        assertThat(chip.width()).as("a 9 pt chip measures narrower than a 14 pt one").isLessThan(wide);
+    }
+
+    @Test
+    void explicitlyStyledChipKeepsItsOwnSize() throws Exception {
+        List<ParagraphTextSpan> spans = textSpans(p -> p
+                .textStyle(DocumentTextStyle.builder().size(9).build())
+                .inlineStyledChip("BIG", DocumentTextStyle.builder().size(18).build(), FILL));
+        ParagraphTextSpan chip = spans.stream().filter(s -> s.background() != null).findFirst().orElseThrow();
+        assertThat(chip.textStyle().size())
+                .as("an explicit chip style overrides the paragraph, both ways")
+                .isEqualTo(18.0, within(1e-9));
     }
 
     @Test


### PR DESCRIPTION
> Stacked on #606 (`chore/open-2.3.0`), which opens the minor this behaviour change
> has to ship in. Retarget to `develop` once that merges.

## Why

`ParagraphBuilder.inlineChip(text, fg, bg)` built its glyph style from scratch:

```java
new InlineHighlightRun(text, DocumentTextStyle.builder().color(fg).build(), ...)
```

`DocumentTextStyle` has no notion of an unset component — every field carries a default —
so that value is not "the paragraph's style plus a colour", it is `HELVETICA`, `14`,
`DEFAULT`, `fg`. The layout's fallback is binary (`ParagraphWrapping.java:687`): a `null`
run style resolves to the paragraph's, a non-null one replaces it whole. The chip always
handed over a non-null one, so it always rendered at 14 pt.

In a paragraph styled at 9 pt the surrounding words come out at 9 pt and the badge
between them half again as large — it reads as a rendering fault, not a design choice.

Every other inline run in the builder already inherits: `inlineText`, `inlineLink` and
`inlineLinkTo` pass `null` and let the layout resolve it, and `inlineHighlight`
documents that fallback on its `textStyle` parameter. The chip sugar was the one call
that opted out.

## What changed

`inlineChip(text, fg, bg)` now derives its run style from the paragraph's `textStyle`
and replaces only the colour — `this.textStyle.withColor(fg)`. Family, size and
decoration follow the paragraph; `fg == null` still means black, as before.

The style is read **at the call**, so `textStyle(...)` has to come first. Deferring
resolution to `build()` would remove that ordering dependency, but `InlineRun` is a
`sealed` interface — a deferred marker means widening `permits` and touching every
exhaustive `instanceof` chain in the engine, which is out of proportion to a caveat one
Javadoc sentence can state. The caveat is pinned by a test so it cannot drift silently.

`inlineStyledChip(text, textStyle, bg)` is the escape hatch for a chip meant to differ
from its paragraph: an explicit glyph style on a custom fill, keeping the default chip
radius and padding. That combination was previously unreachable — `inlineHighlight`
demands explicit radius and padding, and the defaults live in package-private
`CodeChip`. It carries its own name rather than overloading `inlineChip` on the second
parameter: an overload would have made `inlineChip(text, null, bg)` ambiguous and
stopped it compiling, which the Stable tier does not permit
(`docs/api-stability.md` § 2). Verified with `javac` both ways.

`RichText.chip(...)` is unchanged and still draws at the default size — a rich-text
builder is assembled with no paragraph to read, so inheriting there needs the same
deferred machinery. Its Javadoc now says so and points at `highlight(...)`. That
asymmetry is deliberate and worth a follow-up, not a silent gap.

### Impact on committed renders

None in this repository. `inlineChip` has exactly one set of callers outside the builder
— `qa/.../InlineHighlightRenderTest` — and they use default-styled paragraphs, where
`DEFAULT.withColor(fg)` equals the old `builder().color(fg).build()`. No preset, example
or showcase calls it; the `RichText.chip` badge in `InlineHighlightExample` goes through
the unchanged path. All four visual-parity suites are green against the committed
baselines, unmodified: cover letter 15, CV 16, invoice 1, proposal 1.

Downstream, this does move rendered output wherever a chip sits in a non-default-styled
paragraph — which is why it is filed under a minor rather than the patch that was open.

## Verification

```
./mvnw -B -ntp clean verify -pl :graph-compose-core,:graph-compose-render-pdf,:graph-compose-render-docx,:graph-compose-render-pptx,:graph-compose-templates,:graph-compose-testing,:graph-compose-qa,:graph-compose-coverage -am
./mvnw -B -ntp javadoc:javadoc
```

Both `BUILD SUCCESS`.

Five new tests. Three model pins in `InlineHighlightRunTest` (9): the run style is the
paragraph's with only the colour replaced — asserted as a whole record, colour-normalized,
so a component added to `DocumentTextStyle` later is covered; an explicit style overrides
the paragraph; and the call-time ordering caveat. Two end-to-end pins in
`InlineHighlightRenderTest` (22): the resolved span size is 9 pt, not 14, and the same
chip measures narrower than in a default-styled paragraph — measured, not merely
declared — plus the explicit-style path.

Both inheritance pins were confirmed red against the previous implementation before the
fix was restored: `InlineHighlightRunTest` failed on the style comparison,
`InlineHighlightRenderTest.chipFollowsTheParagraphSizeInsteadOfTheDefault` on the 14-vs-9
size.
