### PR TITLE
docs(api): name the PDF backend's beta members, and guard the omission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,13 @@ jobs:
         if: matrix.java == '17'
         run: node knowledge/tools/api-surface/extract-api.mjs --from-reactor --check
 
+      # docs/api-stability.md is where a reader asks "what is still moving", and
+      # nothing was checking that it still names what carries @Beta. The test it
+      # cites as its guard examines the annotation type, never what is annotated.
+      - name: Knowledge pack — the stability document names every @Beta
+        if: matrix.java == '17'
+        run: node knowledge/tools/api-surface/check-stability-doc.mjs
+
       - name: Knowledge pack — claim parser fixtures
         if: matrix.java == '17'
         run: node knowledge/tools/claims/test/claims.test.mjs

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -56,6 +56,18 @@ matrix.
 > methods on `DocumentSession` (`toPptxBytes`, `writePptx`, `buildPptx`).
 > Geometry identity with the PDF backend is a design invariant and will not
 > change; the API shape around it may still move in a minor release.
+>
+> Four members of the otherwise-Stable **PDF backend** also carry `@Beta`. The
+> package is not Experimental — these are:
+> `PdfFixedLayoutBackend.renderSections` / `writeSections`, the low-level seam
+> that concatenates several sections into one document, where
+> `MultiSectionDocument` via `GraphCompose.documents()` is the settled entry
+> point most callers want instead; and
+> `PdfFixedLayoutBackend.Builder.deterministic` in both overloads, which pins
+> `CreationDate` / `ModDate` and derives the `/ID` from metadata so a document
+> renders byte-identically across runs. Determinism is off by default, and what
+> reproducible builds depend on is the *behaviour* — it is the shape of the
+> opt-in that may still move.
 
 ### What each tier promises
 

--- a/knowledge/api/backends.json
+++ b/knowledge/api/backends.json
@@ -3978,6 +3978,7 @@
     },
     {
       "name": "com.demcha.compose.document.backend.fixed.pptx",
+      "stability": "beta",
       "types": [
         {
           "name": "PptxCoordinates",
@@ -4589,6 +4590,7 @@
     },
     {
       "name": "com.demcha.compose.document.backend.fixed.pptx.handlers",
+      "stability": "beta",
       "types": [
         {
           "name": "PptxAnchorMarkerRenderHandler",

--- a/knowledge/api/extension-spi.json
+++ b/knowledge/api/extension-spi.json
@@ -300,6 +300,7 @@
     },
     {
       "name": "com.demcha.compose.document.backend.fixed.pptx",
+      "stability": "beta",
       "types": [
         {
           "name": "PptxFragmentRenderHandler",

--- a/knowledge/tools/api-surface/check-stability-doc.mjs
+++ b/knowledge/tools/api-surface/check-stability-doc.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+/**
+ * knowledge/tools/api-surface/check-stability-doc.mjs — does the stability
+ * document still name everything that carries `@Beta`?
+ *
+ *   node knowledge/tools/api-surface/check-stability-doc.mjs
+ *
+ * Exit 0 every originating `@Beta` is named · 1 something is unnamed · 2 usage.
+ *
+ * `docs/api-stability.md` is where a reader goes to ask "what is still moving".
+ * It answers by naming things — the PPTX packages, `NodeDefinition`, the PPTX
+ * convenience methods on `DocumentSession` — and a name that stops being true,
+ * or a marker that never acquires one, is invisible until someone reads both the
+ * document and the code side by side.
+ *
+ * Nothing was checking that. The document cites `BetaAnnotationDocumentationTest`
+ * as its guard, but that test examines the *annotation type* — its retention,
+ * its targets, its own Javadoc. It never looks at what carries the annotation.
+ * So four `@Beta` members of the PDF backend went undocumented while every other
+ * beta surface was enumerated carefully: not neglect, just an unguarded seam.
+ *
+ * **Only originating markers are required.** A type that is beta because its
+ * package is, or a member that is beta because its type is, inherits the status
+ * and is covered by the entry naming its origin — demanding a line for each of
+ * the fifteen PPTX handlers would produce a document nobody finishes reading.
+ * What must be named is every place the marker is actually *written*.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "..", "..", "..");
+const API_DIR = path.join(REPO_ROOT, "knowledge", "api");
+const DOC = path.join(REPO_ROOT, "docs", "api-stability.md");
+
+if (process.argv.length > 2) {
+  process.stdout.write(
+    "usage: node knowledge/tools/api-surface/check-stability-doc.mjs\n\n" +
+      "exit: 0 every originating @Beta is named | 1 something is unnamed | 2 usage\n",
+  );
+  process.exit(process.argv[2] === "--help" || process.argv[2] === "-h" ? 0 : 2);
+}
+
+if (!fs.existsSync(API_DIR)) {
+  process.stderr.write("[stability-doc] no surfaces — run extract-api.mjs --from-reactor first\n");
+  process.exit(1);
+}
+
+const doc = fs.readFileSync(DOC, "utf8");
+
+/**
+ * Everything that *originates* a beta marker.
+ *
+ * A surface document records inherited stability the same way as declared, so
+ * the two are told apart here: a type is an origin when its package is not beta,
+ * and a member is an origin when its type is not.
+ */
+const origins = new Map();
+for (const file of fs.readdirSync(API_DIR).filter((f) => f.endsWith(".json") && f !== "excluded.json")) {
+  const surface = JSON.parse(fs.readFileSync(path.join(API_DIR, file), "utf8"));
+  for (const pkg of surface.packages ?? []) {
+    const packageIsBeta = pkg.stability === "beta";
+    if (packageIsBeta) origins.set(pkg.name, { what: pkg.name, kind: "package" });
+
+    for (const type of pkg.types ?? []) {
+      const typeIsBeta = type.stability === "beta";
+      // A type in a beta package inherits it; only a marker written on the type
+      // itself is an origin.
+      if (typeIsBeta && !packageIsBeta) origins.set(type.name, { what: type.name, kind: "type" });
+      for (const member of type.members ?? []) {
+        if (member.stability === "beta" && !typeIsBeta) {
+          origins.set(`${type.name}.${member.name}`, {
+            what: `${type.name}.${member.name}`,
+            kind: "member",
+          });
+        }
+      }
+    }
+  }
+}
+
+// Named is "the document contains this identifier": the doc writes short forms
+// (`toPptxBytes`, `…pptx.handlers`), so requiring a fully-qualified match would
+// fail on prose that is perfectly clear.
+const shortName = (what) => what.split(".").pop();
+const unnamed = [...origins.values()]
+  .filter((o) => !doc.includes(o.what) && !doc.includes(shortName(o.what)))
+  .sort((a, b) => a.what.localeCompare(b.what));
+
+if (unnamed.length) {
+  process.stderr.write(
+    `[stability-doc] ${unnamed.length} thing(s) carry @Beta and are not named in docs/api-stability.md:\n\n` +
+      unnamed.map((o) => `    ${o.kind.padEnd(8)} ${o.what}\n`).join("") +
+      "\n  A reader asking what is still moving reads that document, so a marker it\n" +
+      "  does not mention is a promise nobody made. Name it, or drop the marker.\n",
+  );
+  process.exit(1);
+}
+
+const counts = [...origins.values()].reduce((acc, o) => ({ ...acc, [o.kind]: (acc[o.kind] ?? 0) + 1 }), {});
+process.stdout.write(
+  `[stability-doc] every originating @Beta is named — ` +
+    `${counts.package ?? 0} package(s), ${counts.type ?? 0} type(s), ${counts.member ?? 0} member(s)\n`,
+);

--- a/knowledge/tools/api-surface/extract-api.mjs
+++ b/knowledge/tools/api-surface/extract-api.mjs
@@ -49,6 +49,7 @@ import { readAnnotations, memberKeyForMember } from "./lib/annotations.mjs";
 import {
   admit,
   stability,
+  BETA,
   memberStability,
   SURFACES,
   inImplementationRoot,
@@ -537,6 +538,7 @@ function buildSurface({ version, artifacts, javap }) {
       name: type.name,
       binaryName: type.binaryName,
       package: type.package,
+      packageStability: type.packageAnnotations.includes(BETA) ? "beta" : "stable",
       kind: type.kind,
       modifiers: type.modifiers,
       artifact: type.artifact,
@@ -645,10 +647,18 @@ function surfaceDocument({ surface, version, types, artifacts }) {
   for (const type of sorted) {
     let bucket = packages[packages.length - 1];
     if (!bucket || bucket.name !== type.package) {
-      bucket = { name: type.package, types: [] };
+      bucket = {
+        name: type.package,
+        // Recorded rather than inferred. A consumer cannot tell a beta *package*
+        // from a package whose one admitted type happens to be beta, and
+        // `document.layout` is exactly that: everything in it is excluded except
+        // `NodeDefinition`, which is beta.
+        ...(type.packageStability === "beta" ? { stability: "beta" } : {}),
+        types: [],
+      };
       packages.push(bucket);
     }
-    const { package: _drop, ...rest } = type;
+    const { package: _drop, packageStability: _drop2, ...rest } = type;
     bucket.types.push(rest);
   }
 


### PR DESCRIPTION
## Why

`docs/api-stability.md` is where a reader goes to ask what is still moving, and it answers by naming things. It names them carefully: both PPTX packages, five PPTX types, `NodeDefinition`, and the three PPTX convenience methods on `DocumentSession`.

It misses four members of the otherwise-Stable PDF backend — `PdfFixedLayoutBackend.renderSections`, `writeSections`, and `Builder.deterministic` in both overloads. A reader consulting that document to decide what is safe to depend on would conclude those four are settled. They are marked `@Beta` in the source.

The omission had nothing keeping it honest. The document cites `BetaAnnotationDocumentationTest` as its guard, but that test examines the annotation *type*: its retention, its `@Documented`, its targets, its own Javadoc. It never looks at what carries the annotation. The careful enumeration everywhere else was careful by hand.

Found by comparing the document against the knowledge pack's beta set — the first time that comparison has been mechanically possible.

## What changed

- **`docs/api-stability.md` names the four**, described rather than listed. `renderSections` / `writeSections` are the low-level seam that concatenates sections into one document, and the entry says most callers want `MultiSectionDocument` via `GraphCompose.documents()` instead. `deterministic` pins `CreationDate` / `ModDate` and derives the `/ID` from metadata for byte-identical output; the entry distinguishes the *behaviour*, which reproducible builds depend on, from the *shape of the opt-in*, which is what may still move.

- **`check-stability-doc.mjs` guards it.** Every place a `@Beta` marker is actually written must be named in the document. Origins only, deliberately: a type that is beta because its package is, or a member because its type is, is covered by the entry naming its origin. Requiring a line per beta symbol would mean listing fifteen PPTX handlers and producing a document nobody finishes reading.

- **The extractor records package-level stability.** The check's first version inferred a beta *package* from "every admitted type is beta", and `document.layout` qualified — everything in it is excluded except `NodeDefinition`, which is beta. That is a false origin. The surface documents now carry `stability` on the package itself, so a consumer reads the fact instead of reconstructing it, and nothing else could have told a beta package from a package holding one beta type.

- **CI runs it** as a sixth knowledge step on JDK 17.

## Verification

Reactor slice `clean verify` → BUILD SUCCESS, 2101 tests across 377 classes, 0 failures.

Knowledge gates: surfaces current, stability doc complete (2 packages, 1 type, 6 members), 27 claims and 6 proofs current, 3 routes hold, classifier fixtures 23, claim fixtures 18.

The guard was verified by removing the entry this PR adds: it names all three missing symbols and exits 1. Restoring the entry returns it to 0.

**Lane:** test — a documentation correction plus the guard that keeps it correct; no engine, canonical API or render output touched.
