### PR TITLE
feat(templates): let a billed party print its own registration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ follow semantic versioning; release dates are ISO 8601.
 
 ### Public API
 
+- **A billed party carries a printed registration.** A supplier could already state a
+  tax registration through `InvoiceContactBlock.taxRegistrationLabel` /
+  `taxRegistrationNumber`, and the party being billed could not — but most B2B invoices
+  print the customer's VAT or tax number too, under its address. `subline` was the only
+  spare field and it is contractually the attention line that sits *above* the address,
+  so a registration put there renders in the wrong place. `InvoiceRecipient` now carries
+  `registrationLabel` and `registrationNumber`, mirroring the pair the supplier block
+  already has, with `hasRegistration()` for the presets that draw the row only when
+  there is a number to draw. Both are plain strings, blank when absent, and the
+  six-argument constructor is kept explicitly, so existing calls compile and link
+  unchanged and every recipient built through them still prints no registration.
+
 - **An invoice line carries a mark.** A design that opens each service line with a
   glyph — a card for a billing line, a shield for fraud screening, a globe for a hosted
   service — had nowhere to say which one, and deriving it from the description would

--- a/qa/src/test/java/com/demcha/compose/document/templates/data/invoice/StructuredInvoiceCompatibilityTest.java
+++ b/qa/src/test/java/com/demcha/compose/document/templates/data/invoice/StructuredInvoiceCompatibilityTest.java
@@ -96,6 +96,33 @@ class StructuredInvoiceCompatibilityTest {
     }
 
     @Test
+    void theRecipientConstructorThatPredatesTheRegistrationLeavesItBlank() {
+        InvoiceRecipient recipient = new InvoiceRecipient("BILL TO", "Northwind Ltd.", "",
+                List.of("42 Bridgewater Street"), "Email", "ap@example.test");
+        assertThat(recipient.registrationLabel()).isEmpty();
+        assertThat(recipient.registrationNumber()).isEmpty();
+        assertThat(recipient.hasRegistration()).isFalse();
+    }
+
+    @Test
+    void aRecipientCarriesTheRegistrationItIsGiven() {
+        InvoiceRecipient recipient = new InvoiceRecipient("BILL TO", "Northwind Ltd.", "",
+                List.of("42 Bridgewater Street"), "", "", "VAT Number", "GB 987 6543 21");
+        assertThat(recipient.registrationLabel()).isEqualTo("VAT Number");
+        assertThat(recipient.registrationNumber()).isEqualTo("GB 987 6543 21");
+        assertThat(recipient.hasRegistration()).isTrue();
+    }
+
+    @Test
+    void aRecipientWithALabelAndNoNumberPrintsNothing() {
+        // The number is what makes the row worth drawing; a label on its own is
+        // a heading over an absence.
+        InvoiceRecipient recipient = new InvoiceRecipient("BILL TO", "Northwind Ltd.", "",
+                List.of(), "", "", "VAT Number", null);
+        assertThat(recipient.hasRegistration()).isFalse();
+    }
+
+    @Test
     void theDataConstructorThatPredatesShipToLeavesItEmptyRatherThanNull() {
         // The record normalizes an absent block to its empty form, so preset
         // code reads it without a null check — the promise the whole model

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/invoice/InvoiceRecipient.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/invoice/InvoiceRecipient.java
@@ -19,6 +19,11 @@ import java.util.Objects;
  * @param addressLines the address lines, in order
  * @param emailLabel   the label printed before the email address
  * @param email        the recipient's email address
+ * @param registrationLabel  the label a printed registration is named by
+ *                           (e.g. {@code "VAT Number"}); blank when absent
+ * @param registrationNumber the registration itself, printed under the
+ *                           address rather than under the name; blank when
+ *                           absent
  */
 public record InvoiceRecipient(
         String heading,
@@ -26,7 +31,9 @@ public record InvoiceRecipient(
         String subline,
         List<String> addressLines,
         String emailLabel,
-        String email) {
+        String email,
+        String registrationLabel,
+        String registrationNumber) {
 
     /**
      * Normalizes optional fields and freezes the address lines.
@@ -38,5 +45,32 @@ public record InvoiceRecipient(
         addressLines = List.copyOf(Objects.requireNonNullElse(addressLines, List.of()));
         emailLabel = Objects.requireNonNullElse(emailLabel, "");
         email = Objects.requireNonNullElse(email, "");
+        registrationLabel = Objects.requireNonNullElse(registrationLabel, "");
+        registrationNumber = Objects.requireNonNullElse(registrationNumber, "");
+    }
+
+    /**
+     * Backward-compatible constructor for callers that predate the printed
+     * registration. The recipient simply carries none.
+     *
+     * @param heading      the block heading
+     * @param name         the recipient's name
+     * @param subline      the attention line under the name
+     * @param addressLines the address lines, in order
+     * @param emailLabel   the label printed before the email address
+     * @param email        the recipient's email address
+     */
+    public InvoiceRecipient(String heading, String name, String subline,
+                            List<String> addressLines, String emailLabel, String email) {
+        this(heading, name, subline, addressLines, emailLabel, email, "", "");
+    }
+
+    /**
+     * Whether this recipient prints a registration under its address.
+     *
+     * @return {@code true} when the number is set
+     */
+    public boolean hasRegistration() {
+        return !registrationNumber.isBlank();
     }
 }


### PR DESCRIPTION
## Why

The next invoice bundle in the promotion queue prints the billed party's VAT number
under its address, beside a label. The supplier block can already say that —
`InvoiceContactBlock.taxRegistrationLabel` / `taxRegistrationNumber` — and
`InvoiceRecipient` cannot.

`subline` was the only spare field, and it is contractually *the attention line that
sits above the address* — a department, a contact, a cost centre. A registration put
there renders in the wrong place, above the address instead of below it.

## What

`InvoiceRecipient` carries `registrationLabel` and `registrationNumber`, mirroring the
pair the supplier block already has, plus `hasRegistration()` for the presets that draw
the row only when there is a number to draw — a label on its own is a heading over an
absence.

Both are plain strings, blank when absent. The six-argument constructor is kept
explicitly.

## Tests

- `StructuredInvoiceCompatibilityTest` gains three cases: the constructor that predates
  the registration leaves both fields blank and reports no registration, a recipient
  carries what it is given, and a label with no number still reports none. 14 cases green.
- Full reactor gate green:
  `./mvnw -B -ntp clean verify -pl :graph-compose-core,:graph-compose-render-pdf,:graph-compose-render-docx,:graph-compose-render-pptx,:graph-compose-templates,:graph-compose-testing,:graph-compose-qa,:graph-compose-coverage -am`
- No preset draws the row yet, so no baseline moves.