### PR TITLE
feat(templates): let a supplier carry the legal line it prints under its name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ follow semantic versioning; release dates are ISO 8601.
 
 ### Public API
 
+- **A supplier carries the legal line it prints under its name.** A footer band that
+  identifies the issuer often has to carry more than a name and an address: a
+  parent-company or regulator disclosure — "X is a subsidiary of Y" — is a statement the
+  jurisdiction requires on the sheet, and deriving it from the fields beside it is not
+  possible because it is prose, not a number. Composed from `legalName` alone, that line
+  simply went missing. `InvoiceContactBlock` now carries `legalFootnote`, a plain string
+  blank when absent, like the fields beside it; a preset with no footer band ignores it.
+  Both constructors that predate it — the one before the second registration and the one
+  before the footnote — are kept explicitly, so existing calls compile and link unchanged
+  and every block built through them still prints no disclosure.
+
 - **A billed party carries a printed registration.** A supplier could already state a
   tax registration through `InvoiceContactBlock.taxRegistrationLabel` /
   `taxRegistrationNumber`, and the party being billed could not — but most B2B invoices

--- a/knowledge/api/templates.json
+++ b/knowledge/api/templates.json
@@ -23,9 +23,9 @@
   ],
   "counts": {
     "types": 217,
-    "methods": 1221,
+    "methods": 1223,
     "constants": 164,
-    "generated": 644
+    "generated": 645
   },
   "packages": [
     {
@@ -11738,6 +11738,56 @@
                 {
                   "type": "String",
                   "name": null
+                },
+                {
+                  "type": "String",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "constructor",
+              "name": "InvoiceContactBlock",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "String",
+                  "name": "legalName"
+                },
+                {
+                  "type": "List<String>",
+                  "name": "addressLines"
+                },
+                {
+                  "type": "String",
+                  "name": "phone"
+                },
+                {
+                  "type": "String",
+                  "name": "email"
+                },
+                {
+                  "type": "String",
+                  "name": "website"
+                },
+                {
+                  "type": "String",
+                  "name": "registrationLabel"
+                },
+                {
+                  "type": "String",
+                  "name": "registrationNumber"
+                },
+                {
+                  "type": "String",
+                  "name": "taxRegistrationLabel"
+                },
+                {
+                  "type": "String",
+                  "name": "taxRegistrationNumber"
                 }
               ]
             },
@@ -11854,6 +11904,15 @@
             {
               "kind": "method",
               "name": "taxRegistrationNumber",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "legalFootnote",
               "static": false,
               "origin": "generated",
               "typeParameters": null,

--- a/knowledge/api/templates.md
+++ b/knowledge/api/templates.md
@@ -28,7 +28,7 @@ note: "Generated from the pinned artifact's class files. Authoritative closed se
 
 **GraphCompose version:** 2.4.0-SNAPSHOT
 
-Types: 217 · methods: 1221 · constants: 164 · compiler-generated members: 644
+Types: 217 · methods: 1223 · constants: 164 · compiler-generated members: 645
 
 ## com.demcha.compose.document.templates.api
 
@@ -995,7 +995,8 @@ Types: 217 · methods: 1221 · constants: 164 · compiler-generated members: 644
 - `String monogramBottom()`
 
 ### InvoiceContactBlock (record)
-- `new InvoiceContactBlock(String, List<String>, String, String, String, String, String, String, String)`
+- `new InvoiceContactBlock(String, List<String>, String, String, String, String, String, String, String, String)`
+- `new InvoiceContactBlock(String legalName, List<String> addressLines, String phone, String email, String website, String registrationLabel, String registrationNumber, String taxRegistrationLabel, String taxRegistrationNumber)`
 - `new InvoiceContactBlock(String legalName, List<String> addressLines, String phone, String email, String website, String registrationLabel, String registrationNumber)`
 - `String legalName()`
 - `List<String> addressLines()`
@@ -1006,6 +1007,7 @@ Types: 217 · methods: 1221 · constants: 164 · compiler-generated members: 644
 - `String registrationNumber()`
 - `String taxRegistrationLabel()`
 - `String taxRegistrationNumber()`
+- `String legalFootnote()`
 
 ### InvoiceData (record)
 - `new InvoiceData(String, String, String, String, String, String, InvoiceParty, InvoiceParty, List<InvoiceLineItem>, List<InvoiceSummaryRow>, List<String>, List<String>, String)`

--- a/qa/src/test/java/com/demcha/compose/document/templates/data/invoice/StructuredInvoiceCompatibilityTest.java
+++ b/qa/src/test/java/com/demcha/compose/document/templates/data/invoice/StructuredInvoiceCompatibilityTest.java
@@ -41,6 +41,33 @@ class StructuredInvoiceCompatibilityTest {
     }
 
     @Test
+    void theContactConstructorThatPredatesTheLegalFootnoteLeavesItBlank() {
+        InvoiceContactBlock supplier = new InvoiceContactBlock(
+                "Luma Ltd", List.of("14 Gower Street"), "+44", "a@b.c", "b.c",
+                "Company No.", "12578934", "VAT No.", "GB123");
+        assertThat(supplier.legalFootnote()).isEmpty();
+        assertThat(supplier.taxRegistrationNumber()).isEqualTo("GB123");
+    }
+
+    @Test
+    void aContactCarriesTheLegalFootnoteItIsGiven() {
+        InvoiceContactBlock supplier = new InvoiceContactBlock(
+                "Luma Ltd", List.of("14 Gower Street"), "+44", "a@b.c", "b.c",
+                "Company No.", "12578934", "VAT No.", "GB123",
+                "Luma Ltd is a subsidiary of Luma Group plc.");
+        assertThat(supplier.legalFootnote())
+                .isEqualTo("Luma Ltd is a subsidiary of Luma Group plc.");
+    }
+
+    @Test
+    void aNullLegalFootnoteNormalizesToBlankLikeTheFieldsBesideIt() {
+        InvoiceContactBlock supplier = new InvoiceContactBlock(
+                "Luma Ltd", List.of("14 Gower Street"), "+44", "a@b.c", "b.c",
+                "Company No.", "12578934", "VAT No.", "GB123", null);
+        assertThat(supplier.legalFootnote()).isEmpty();
+    }
+
+    @Test
     void thePaymentConstructorThatPredatesTheAccountHolderLeavesItBlank() {
         InvoicePaymentBlock payment = new InvoicePaymentBlock(
                 "PAYMENT", List.of(new InvoicePaymentBlock.Field("BANK", "Starling")),

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/invoice/InvoiceContactBlock.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/invoice/InvoiceContactBlock.java
@@ -24,6 +24,10 @@ import java.util.Objects;
  *                              jurisdiction requires beside the first
  *                              (e.g. {@code "VAT No."}); blank when absent
  * @param taxRegistrationNumber that second number itself; blank when absent
+ * @param legalFootnote      a legal disclosure the sheet prints beside the
+ *                           name — a parent-company or regulator statement
+ *                           such as {@code "… is a subsidiary of …"}; blank
+ *                           when the jurisdiction requires none
  */
 public record InvoiceContactBlock(
         String legalName,
@@ -34,7 +38,8 @@ public record InvoiceContactBlock(
         String registrationLabel,
         String registrationNumber,
         String taxRegistrationLabel,
-        String taxRegistrationNumber) {
+        String taxRegistrationNumber,
+        String legalFootnote) {
 
     /**
      * Normalizes optional fields and freezes the address lines.
@@ -49,6 +54,29 @@ public record InvoiceContactBlock(
         registrationNumber = Objects.requireNonNullElse(registrationNumber, "");
         taxRegistrationLabel = Objects.requireNonNullElse(taxRegistrationLabel, "");
         taxRegistrationNumber = Objects.requireNonNullElse(taxRegistrationNumber, "");
+        legalFootnote = Objects.requireNonNullElse(legalFootnote, "");
+    }
+
+    /**
+     * Backward-compatible constructor for callers that predate the legal
+     * footnote.
+     *
+     * @param legalName             the registered business name
+     * @param addressLines          the address lines, in order
+     * @param phone                 the phone channel
+     * @param email                 the email channel
+     * @param website               the website channel
+     * @param registrationLabel     the label of the registration number
+     * @param registrationNumber    the registration number itself
+     * @param taxRegistrationLabel  the label of the second registration
+     * @param taxRegistrationNumber that second number itself
+     */
+    public InvoiceContactBlock(String legalName, List<String> addressLines, String phone,
+                               String email, String website, String registrationLabel,
+                               String registrationNumber, String taxRegistrationLabel,
+                               String taxRegistrationNumber) {
+        this(legalName, addressLines, phone, email, website, registrationLabel,
+                registrationNumber, taxRegistrationLabel, taxRegistrationNumber, "");
     }
 
     /**
@@ -67,6 +95,6 @@ public record InvoiceContactBlock(
                                String email, String website, String registrationLabel,
                                String registrationNumber) {
         this(legalName, addressLines, phone, email, website,
-                registrationLabel, registrationNumber, "", "");
+                registrationLabel, registrationNumber, "", "", "");
     }
 }


### PR DESCRIPTION
## Why

A footer band that identifies the issuer often has to carry more than a name and an
address. A parent-company or regulator disclosure — "X is a subsidiary of Y" — is a
statement the jurisdiction requires on the sheet, and it cannot be derived from the
fields beside it because it is prose, not a number. Composed from `legalName` alone,
that line simply goes missing.

This is the enabler for the next promoted invoice preset, whose design carries exactly
such a line in its dark footer band.

## What

`InvoiceContactBlock` carries `legalFootnote` — a plain string, blank when absent, like
the fields beside it. A preset with no footer band ignores it.

Both constructors that predate it are kept explicitly, so existing calls compile and
link unchanged and every block built through them still prints no disclosure.

The templates API surface is regenerated in the same commit.

## Tests

Three cases added to `StructuredInvoiceCompatibilityTest`: the older constructor leaves
the footnote blank, a block carries the footnote it is given, and `null` normalizes to
blank like its neighbours. 17/17 green.

Full reactor gate (`core, render-pdf, render-docx, render-pptx, templates, testing, qa,
coverage`) — BUILD SUCCESS.