### PR TITLE
test(ci): stop the CodeQL scope guard from being emptied by a rewritten deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -589,6 +589,21 @@ follow semantic versioning; release dates are ISO 8601.
 
 ### Tests
 
+- **The CodeQL scope guard can no longer be emptied by rewriting a deploy command.**
+  `CodeQlScopeGuardTest` asks whether every module a release publishes is inside the
+  security scan, and it read the answer's left-hand side out of the publish workflows by
+  matching `-f <module>/pom.xml` on a line mentioning `deploy`. A deploy written any
+  other way — `-pl :graph-compose-fonts`, or the same command wrapped across two lines —
+  simply left that module out of the inventory, and a shorter inventory is an easier
+  comparison rather than a failing one. Verified by mutation: with `publish-fonts.yml`
+  switched to the `-pl` form and `graph-compose-fonts` removed from the scan's module
+  list, the suite stayed green while a module published to Maven Central went unscanned.
+  Two checks now key on the absence of a positive signal instead — a publish workflow
+  that contributes no module to the inventory fails, and `publish.yml`'s deploy steps
+  are held against the `order` line it validates its own resume against, which is a
+  second statement of the train that nothing derives from the first. Both go red under
+  the mutation that used to pass.
+
 - **The sidebar CV samples are held to the width of the column they are drawn in.**
   A contact channel in `ProfessionalSidebar` and `NavySidebar` is one paragraph — the
   mark and the value share a line — so a value wider than the sidebar's text column

--- a/core/src/test/java/com/demcha/documentation/CodeQlScopeGuardTest.java
+++ b/core/src/test/java/com/demcha/documentation/CodeQlScopeGuardTest.java
@@ -98,6 +98,77 @@ class CodeQlScopeGuardTest {
     }
 
     /**
+     * The inventory the second test compares against is itself read out of the publish
+     * workflows, so it can be emptied by editing them — and an emptier inventory is an
+     * easier comparison, not a failing one. Both halves below key on the absence of a
+     * positive signal instead: a publish workflow that deploys nothing, and a train
+     * whose declared modules are not among the steps read from it.
+     *
+     * <p>Writing a deploy as {@code -pl :graph-compose-fonts} rather than
+     * {@code -f fonts/pom.xml} is enough to do it, and nothing about that edit looks
+     * like it touches the scan.</p>
+     */
+    @Test
+    void everyPublishWorkflowContributesToTheInventoryItIsRead() throws IOException {
+        Map<String, List<String>> byWorkflow = PublishedModules.deployedByWorkflow(PROJECT_ROOT);
+
+        assertThat(byWorkflow)
+                .describedAs("no publish workflow was found at all — they were renamed, and the "
+                        + "inventory the deployed-module test compares against is now empty")
+                .isNotEmpty();
+
+        Set<String> silent = new TreeSet<>();
+        byWorkflow.forEach((workflow, modules) -> {
+            if (modules.isEmpty()) {
+                silent.add(workflow);
+            }
+        });
+
+        assertThat(silent)
+                .describedAs("a publish workflow whose deploy steps this guard can no longer "
+                        + "read: whatever it ships is now invisible to the deployed-module test, "
+                        + "which will pass without ever asking about it. Either the workflow "
+                        + "stopped deploying — in which case it should stop being a publish "
+                        + "workflow — or its deploy is written some way other than "
+                        + "`-f <module>/pom.xml`, and this guard has to learn that shape before "
+                        + "the edit lands")
+                .isEmpty();
+    }
+
+    /**
+     * The train {@code publish.yml} declares matches the steps it carries.
+     *
+     * <p>The workflow states its module set twice and neither statement is derived from
+     * the other: the {@code order} the resume input is validated against, and the deploy
+     * steps themselves. A module dropped from the steps — or written in a shape this
+     * guard cannot read — leaves the two disagreeing, which is the signal that the
+     * inventory shrank rather than the train.</p>
+     */
+    @Test
+    void theDeployStepsCoverThePublishTrainTheWorkflowDeclares() throws IOException {
+        List<String> declared = PublishedModules.declaredTrain(PROJECT_ROOT);
+        List<String> steps = PublishedModules.deployedByWorkflow(PROJECT_ROOT)
+                .getOrDefault("publish.yml", List.of());
+
+        assertThat(declared)
+                .describedAs("publish.yml no longer declares its train as `order=\"...\"` — the "
+                        + "resume validation moved, and with it the second, independent statement "
+                        + "of what a release publishes that this guard holds the steps against")
+                .isNotEmpty();
+
+        Set<String> missing = new TreeSet<>(declared);
+        missing.removeAll(steps);
+
+        assertThat(missing)
+                .describedAs("publish.yml names these in its train but this guard finds no deploy "
+                        + "step for them. Either the module stopped shipping and belongs out of "
+                        + "the train, or its step is written some way other than "
+                        + "`-f <module>/pom.xml` — in which case the module is deployed, absent "
+                        + "from the inventory, and therefore never checked against the scan")
+                .isEmpty();
+    }
+
+    /**
      * The {@code -pl} selectors of the {@code mvnw} invocation carrying {@code goal}, or
      * every reactor module when the command carries no {@code -pl} at all — a build
      * without one compiles the whole reactor, which is more coverage, not less.

--- a/core/src/test/java/com/demcha/documentation/PublishedModules.java
+++ b/core/src/test/java/com/demcha/documentation/PublishedModules.java
@@ -33,6 +33,10 @@ final class PublishedModules {
     private static final Pattern DEPLOY_STEP =
             Pattern.compile("-f\\s+([\\w-]+)/pom\\.xml");
 
+    /** The {@code order="core render-pdf ..."} line publish.yml validates its resume against. */
+    private static final Pattern TRAIN_ORDER =
+            Pattern.compile("order=\"([^\"]+)\"");
+
     /**
      * The modules a release actually deploys, read from the publish workflows.
      *
@@ -42,26 +46,72 @@ final class PublishedModules {
      * comparison, which is precisely the shape that keeps it green.</p>
      */
     static List<String> deployed(Path repoRoot) throws IOException {
-        Path workflows = repoRoot.resolve(".github/workflows");
         List<String> deployed = new ArrayList<>();
+        deployedByWorkflow(repoRoot).values().forEach(modules -> modules.forEach(module -> {
+            if (!deployed.contains(module)) {
+                deployed.add(module);
+            }
+        }));
+        return deployed;
+    }
+
+    /**
+     * The modules each publish workflow deploys, keyed by the workflow's file name —
+     * including the workflows that deploy none.
+     *
+     * <p>Attribution is what lets a caller tell "this workflow publishes nothing" from
+     * "this workflow was not read". A flat list cannot: both look like a shorter list,
+     * and a shorter list is exactly what a guard comparing against it wants to see.</p>
+     *
+     * @param repoRoot the repository root
+     * @return every {@code publish*.yml}, mapped to the module directories it deploys
+     * @throws IOException when a workflow cannot be read
+     */
+    static Map<String, List<String>> deployedByWorkflow(Path repoRoot) throws IOException {
+        Path workflows = repoRoot.resolve(".github/workflows");
+        Map<String, List<String>> byWorkflow = new LinkedHashMap<>();
         try (var files = Files.list(workflows)) {
             for (Path workflow : files.sorted().toList()) {
                 String name = workflow.getFileName().toString();
                 if (!name.startsWith("publish") || !name.endsWith(".yml")) {
                     continue;
                 }
+                List<String> modules = new ArrayList<>();
                 for (String line : Files.readAllLines(workflow)) {
                     if (!line.contains("deploy")) {
                         continue;
                     }
                     Matcher module = DEPLOY_STEP.matcher(line);
-                    if (module.find() && !deployed.contains(module.group(1))) {
-                        deployed.add(module.group(1));
+                    if (module.find() && !modules.contains(module.group(1))) {
+                        modules.add(module.group(1));
                     }
                 }
+                byWorkflow.put(name, modules);
             }
         }
-        return deployed;
+        return byWorkflow;
+    }
+
+    /**
+     * The publish train {@code publish.yml} declares for itself, in order.
+     *
+     * <p>The workflow states its module set twice — once as the {@code order} the resume
+     * input is validated against, and once as the deploy steps themselves. Neither is
+     * derived from the other, so holding them together catches the step list drifting
+     * away from the train without anything having to restate it a third time.</p>
+     *
+     * @param repoRoot the repository root
+     * @return the module directories the train names, or an empty list when the
+     *         declaration is absent
+     * @throws IOException when the workflow cannot be read
+     */
+    static List<String> declaredTrain(Path repoRoot) throws IOException {
+        Path workflow = repoRoot.resolve(".github/workflows/publish.yml");
+        if (!Files.isRegularFile(workflow)) {
+            return List.of();
+        }
+        Matcher order = TRAIN_ORDER.matcher(Files.readString(workflow));
+        return order.find() ? List.of(order.group(1).strip().split("\\s+")) : List.of();
     }
 
     /** The module directories the root reactor builds, in declaration order. */


### PR DESCRIPTION
## Why

`CodeQlScopeGuardTest` exists to answer one question: is every module a release publishes
inside the CodeQL scan? Its own Javadoc explains why that matters — the Java extractor
sees whatever the build compiles, so a module absent from the scan's `-pl` list is not
partially covered, it is not scanned at all, and nothing about the result says so.

The left-hand side of that comparison was read out of the publish workflows by matching
`-f <module>/pom.xml` on a line mentioning `deploy`. A deploy written any other way left
the module out of the inventory — and a shorter inventory is an easier comparison, not a
failing one. The guard went green on a scope it had stopped checking.

**Verified by mutation, before the fix:**

| change | expected | actual |
|---|---|---|
| `publish-fonts.yml` deploy rewritten as `-pl :graph-compose-fonts`, and `graph-compose-fonts` removed from the scan's `-pl` list | red | **green — 2/2 passing** |

`graph-compose-fonts` is published to Maven Central and, in that state, unscanned. Only
`fonts` and `emoji` are exposed this way today — they are absent from the CI verify list,
so the deployed-module check is the only thing standing behind them — but the same shape
reaches the whole train through `publish.yml`.

## What

Two checks that key on the absence of a positive signal rather than on a set comparison:

- `everyPublishWorkflowContributesToTheInventoryItIsRead` — a `publish*.yml` that
  contributes no module to the inventory fails. A deploy shape the guard cannot read is
  now reported instead of silently dropped.
- `theDeployStepsCoverThePublishTrainTheWorkflowDeclares` — `publish.yml` states its
  module set twice, as the `order` its resume input is validated against and as the
  deploy steps themselves, and neither is derived from the other. Holding them together
  catches a step lost from that file using the file itself.

`PublishedModules` gains `deployedByWorkflow` and `declaredTrain` for this. Attribution
is the point: a flat list cannot tell "this workflow publishes nothing" from "this
workflow was not read", because both look like a shorter list.

No workflow changed — the scan's scope is correct today (all 8 published source-bearing
modules are named). This is about it staying correct.

## Tests

| mutation | before | after |
|---|---|---|
| fonts deployed via `-pl`, dropped from the scan | green | **red** |
| a train module's deploy step rewritten as `-pl` | green | **red** |
| clean tree | green | green (4/4) |

Also re-ran the guards CI runs alongside it — `CiGuardListGuardTest`,
`CiGateCoverageGuardTest`, `DocumentationLinkGuardTest` — 9/9. No new test class, so
ci.yml's `-Dtest=` list is unchanged.

Full reactor gate (`core, render-pdf, render-docx, render-pptx, templates, testing, qa,
coverage`) — BUILD SUCCESS.