### PR TITLE
feat(templates): let an invoice line carry where it was delivered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ follow semantic versioning; release dates are ISO 8601.
 
 ### Public API
 
+- **An invoice line carries where it was delivered.** A design that bills the same
+  service in more than one place — the same instance type in two datacentres, the same
+  plan in two jurisdictions — prints where beside what, as its own column next to the
+  service. `InvoiceServiceLines.Line` had nowhere to put it: `servicePeriod` is the
+  neighbouring column on such a sheet, so folding the two together collapses two columns
+  the design draws apart, and `vatRate` is a tax rate that happens to be free. `Line` now
+  carries `region` and `Columns` its caption, both plain strings blank when absent, and a
+  design with one location per invoice leaves them alone. All three constructors that
+  predate it — the ones before the per-line tax rate, the mark, and the region — are kept
+  explicitly, so existing calls compile and link unchanged and every line built through
+  them still prints no region.
+
 - **A supplier carries the legal line it prints under its name.** A footer band that
   identifies the issuer often has to carry more than a name and an address: a
   parent-company or regulator disclosure — "X is a subsidiary of Y" — is a statement the

--- a/knowledge/api/templates.json
+++ b/knowledge/api/templates.json
@@ -23,9 +23,9 @@
   ],
   "counts": {
     "types": 218,
-    "methods": 1224,
+    "methods": 1228,
     "constants": 166,
-    "generated": 647
+    "generated": 649
   },
   "packages": [
     {
@@ -13963,6 +13963,48 @@
                 {
                   "type": "String",
                   "name": null
+                },
+                {
+                  "type": "String",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "constructor",
+              "name": "Columns",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "String",
+                  "name": "index"
+                },
+                {
+                  "type": "String",
+                  "name": "description"
+                },
+                {
+                  "type": "String",
+                  "name": "servicePeriod"
+                },
+                {
+                  "type": "String",
+                  "name": "quantity"
+                },
+                {
+                  "type": "String",
+                  "name": "unitPrice"
+                },
+                {
+                  "type": "String",
+                  "name": "amount"
+                },
+                {
+                  "type": "String",
+                  "name": "vat"
                 }
               ]
             },
@@ -14062,6 +14104,15 @@
               "typeParameters": null,
               "returns": "String",
               "params": []
+            },
+            {
+              "kind": "method",
+              "name": "region",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
             }
           ]
         },
@@ -14121,6 +14172,60 @@
                 {
                   "type": "String",
                   "name": null
+                },
+                {
+                  "type": "String",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "constructor",
+              "name": "Line",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "int",
+                  "name": "lineNumber"
+                },
+                {
+                  "type": "String",
+                  "name": "title"
+                },
+                {
+                  "type": "String",
+                  "name": "description"
+                },
+                {
+                  "type": "String",
+                  "name": "servicePeriod"
+                },
+                {
+                  "type": "BigDecimal",
+                  "name": "quantity"
+                },
+                {
+                  "type": "String",
+                  "name": "unit"
+                },
+                {
+                  "type": "BigDecimal",
+                  "name": "unitPrice"
+                },
+                {
+                  "type": "BigDecimal",
+                  "name": "amount"
+                },
+                {
+                  "type": "String",
+                  "name": "vatRate"
+                },
+                {
+                  "type": "String",
+                  "name": "icon"
                 }
               ]
             },
@@ -14296,6 +14401,15 @@
             {
               "kind": "method",
               "name": "icon",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "region",
               "static": false,
               "origin": "generated",
               "typeParameters": null,

--- a/knowledge/api/templates.md
+++ b/knowledge/api/templates.md
@@ -28,7 +28,7 @@ note: "Generated from the pinned artifact's class files. Authoritative closed se
 
 **GraphCompose version:** 2.4.0-SNAPSHOT
 
-Types: 218 · methods: 1224 · constants: 166 · compiler-generated members: 647
+Types: 218 · methods: 1228 · constants: 166 · compiler-generated members: 649
 
 ## com.demcha.compose.document.templates.api
 
@@ -1175,7 +1175,8 @@ Types: 218 · methods: 1224 · constants: 166 · compiler-generated members: 647
 - `List<InvoiceServiceLines.Line> lines()`
 
 ### InvoiceServiceLines.Columns (record)
-- `new Columns(String, String, String, String, String, String, String)`
+- `new Columns(String, String, String, String, String, String, String, String)`
+- `new Columns(String index, String description, String servicePeriod, String quantity, String unitPrice, String amount, String vat)`
 - `new Columns(String index, String description, String servicePeriod, String quantity, String unitPrice, String amount)`
 - `String index()`
 - `String description()`
@@ -1184,9 +1185,11 @@ Types: 218 · methods: 1224 · constants: 166 · compiler-generated members: 647
 - `String unitPrice()`
 - `String amount()`
 - `String vat()`
+- `String region()`
 
 ### InvoiceServiceLines.Line (record)
-- `new Line(int, String, String, String, BigDecimal, String, BigDecimal, BigDecimal, String, String)`
+- `new Line(int, String, String, String, BigDecimal, String, BigDecimal, BigDecimal, String, String, String)`
+- `new Line(int lineNumber, String title, String description, String servicePeriod, BigDecimal quantity, String unit, BigDecimal unitPrice, BigDecimal amount, String vatRate, String icon)`
 - `new Line(int lineNumber, String title, String description, String servicePeriod, BigDecimal quantity, String unit, BigDecimal unitPrice, BigDecimal amount, String vatRate)`
 - `new Line(int lineNumber, String title, String description, String servicePeriod, BigDecimal quantity, String unit, BigDecimal unitPrice, BigDecimal amount)`
 - `int lineNumber()`
@@ -1199,6 +1202,7 @@ Types: 218 · methods: 1224 · constants: 166 · compiler-generated members: 647
 - `BigDecimal amount()`
 - `String vatRate()`
 - `String icon()`
+- `String region()`
 
 ### InvoiceSummaryBlock (record)
 - `new InvoiceSummaryBlock(String, String, String)`

--- a/qa/src/test/java/com/demcha/compose/document/templates/data/invoice/StructuredInvoiceCompatibilityTest.java
+++ b/qa/src/test/java/com/demcha/compose/document/templates/data/invoice/StructuredInvoiceCompatibilityTest.java
@@ -123,6 +123,42 @@ class StructuredInvoiceCompatibilityTest {
     }
 
     @Test
+    void theColumnsConstructorThatPredatesTheRegionColumnLeavesItBlank() {
+        InvoiceServiceLines.Columns columns = new InvoiceServiceLines.Columns(
+                "#", "DESCRIPTION", "PERIOD", "QTY", "UNIT PRICE", "AMOUNT", "VAT");
+        assertThat(columns.region()).isEmpty();
+        assertThat(columns.vat()).isEqualTo("VAT");
+    }
+
+    @Test
+    void theLineConstructorThatPredatesTheRegionLeavesItBlank() {
+        InvoiceServiceLines.Line line = new InvoiceServiceLines.Line(
+                1, "Compute", "On-demand", "May 2026", BigDecimal.ONE, "Hrs",
+                BigDecimal.ONE, BigDecimal.ONE, "20%", "compute");
+        assertThat(line.region()).isEmpty();
+        assertThat(line.icon()).isEqualTo("compute");
+    }
+
+    @Test
+    void aLineCarriesTheRegionItIsGiven() {
+        InvoiceServiceLines.Line line = new InvoiceServiceLines.Line(
+                1, "Compute", "On-demand", "May 2026", BigDecimal.ONE, "Hrs",
+                BigDecimal.ONE, BigDecimal.ONE, "20%", "compute", "eu-west1");
+        assertThat(line.region()).isEqualTo("eu-west1");
+    }
+
+    @Test
+    void aNullRegionNormalizesToBlankLikeTheFieldsBesideIt() {
+        InvoiceServiceLines.Line line = new InvoiceServiceLines.Line(
+                1, "Compute", "On-demand", "May 2026", BigDecimal.ONE, "Hrs",
+                BigDecimal.ONE, BigDecimal.ONE, "20%", "compute", null);
+        assertThat(line.region()).isEmpty();
+        assertThat(new InvoiceServiceLines.Columns(
+                "#", "DESCRIPTION", "PERIOD", "QTY", "UNIT PRICE", "AMOUNT", "VAT", null)
+                .region()).isEmpty();
+    }
+
+    @Test
     void theRecipientConstructorThatPredatesTheRegistrationLeavesItBlank() {
         InvoiceRecipient recipient = new InvoiceRecipient("BILL TO", "Northwind Ltd.", "",
                 List.of("42 Bridgewater Street"), "Email", "ap@example.test");

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/invoice/InvoiceServiceLines.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/invoice/InvoiceServiceLines.java
@@ -42,6 +42,10 @@ public record InvoiceServiceLines(Columns columns, List<Line> lines) {
      * @param vat           label of the tax-rate column, for the
      *                      jurisdictions that print the rate per line;
      *                      blank leaves the column out
+     * @param region        label of the region column, for the designs that
+     *                      bill the same service in more than one location
+     *                      and print where beside what; blank leaves the
+     *                      column out
      */
     public record Columns(
             String index,
@@ -50,7 +54,8 @@ public record InvoiceServiceLines(Columns columns, List<Line> lines) {
             String quantity,
             String unitPrice,
             String amount,
-            String vat) {
+            String vat,
+            String region) {
 
         /**
          * Normalizes optional labels to empty strings.
@@ -63,6 +68,24 @@ public record InvoiceServiceLines(Columns columns, List<Line> lines) {
             unitPrice = Objects.requireNonNullElse(unitPrice, "");
             amount = Objects.requireNonNullElse(amount, "");
             vat = Objects.requireNonNullElse(vat, "");
+            region = Objects.requireNonNullElse(region, "");
+        }
+
+        /**
+         * Backward-compatible constructor for callers that predate the region
+         * column.
+         *
+         * @param index         label of the line-number column
+         * @param description   label of the description column
+         * @param servicePeriod label of the service-period column
+         * @param quantity      label of the quantity column
+         * @param unitPrice     label of the unit-price column
+         * @param amount        label of the amount column
+         * @param vat           label of the tax-rate column
+         */
+        public Columns(String index, String description, String servicePeriod,
+                       String quantity, String unitPrice, String amount, String vat) {
+            this(index, description, servicePeriod, quantity, unitPrice, amount, vat, "");
         }
 
         /**
@@ -104,6 +127,9 @@ public record InvoiceServiceLines(Columns columns, List<Line> lines) {
      *                      means something only to the preset that packages
      *                      it, and a preset that draws no marks ignores it.
      *                      Blank when absent
+     * @param region        where this line was delivered, for the designs that
+     *                      bill the same service in more than one location and
+     *                      print where beside what; blank when absent
      */
     public record Line(
             int lineNumber,
@@ -115,7 +141,8 @@ public record InvoiceServiceLines(Columns columns, List<Line> lines) {
             BigDecimal unitPrice,
             BigDecimal amount,
             String vatRate,
-            String icon) {
+            String icon,
+            String region) {
 
         /**
          * Normalizes optional fields.
@@ -130,6 +157,28 @@ public record InvoiceServiceLines(Columns columns, List<Line> lines) {
             amount = Objects.requireNonNullElse(amount, BigDecimal.ZERO);
             vatRate = Objects.requireNonNullElse(vatRate, "");
             icon = Objects.requireNonNullElse(icon, "");
+            region = Objects.requireNonNullElse(region, "");
+        }
+
+        /**
+         * Backward-compatible constructor for callers that predate the region.
+         *
+         * @param lineNumber    the printed line number
+         * @param title         the service title
+         * @param description   the description under the title
+         * @param servicePeriod the period this line covers
+         * @param quantity      how much was delivered
+         * @param unit          what the quantity counts
+         * @param unitPrice     the price per unit
+         * @param amount        the line total
+         * @param vatRate       the tax rate printed for this line
+         * @param icon          the mark a preset draws for this line
+         */
+        public Line(int lineNumber, String title, String description, String servicePeriod,
+                    BigDecimal quantity, String unit, BigDecimal unitPrice,
+                    BigDecimal amount, String vatRate, String icon) {
+            this(lineNumber, title, description, servicePeriod, quantity, unit,
+                    unitPrice, amount, vatRate, icon, "");
         }
 
         /**
@@ -149,7 +198,7 @@ public record InvoiceServiceLines(Columns columns, List<Line> lines) {
                     BigDecimal quantity, String unit, BigDecimal unitPrice,
                     BigDecimal amount, String vatRate) {
             this(lineNumber, title, description, servicePeriod, quantity, unit,
-                    unitPrice, amount, vatRate, "");
+                    unitPrice, amount, vatRate, "", "");
         }
 
         /**
@@ -169,7 +218,7 @@ public record InvoiceServiceLines(Columns columns, List<Line> lines) {
                     BigDecimal quantity, String unit, BigDecimal unitPrice,
                     BigDecimal amount) {
             this(lineNumber, title, description, servicePeriod, quantity, unit,
-                    unitPrice, amount, "", "");
+                    unitPrice, amount, "", "", "");
         }
     }
 }


### PR DESCRIPTION
## Why

A design that bills the same service in more than one place — the same instance type in
two datacentres, the same plan in two jurisdictions — prints *where* beside *what*, as
its own column next to the service.

`InvoiceServiceLines.Line` had nowhere to put it. `servicePeriod` is the neighbouring
column on exactly such a sheet, so folding the two together collapses two columns the
design draws apart; `vatRate` is a tax rate that happens to be unused.

This is the enabler for the next promoted invoice preset, whose table has six columns
including a region.

## What

`Line` carries `region` and `Columns` carries its caption — both plain strings, blank
when absent. A design with one location per invoice leaves them alone, and a blank
caption leaves the column out the same way `vat` already does.

All three constructors that predate it (before the per-line tax rate, before the mark,
before the region) are kept explicitly, so existing calls compile and link unchanged and
every line built through them still prints no region.

The templates API surface is regenerated in the same commit.

## Tests

Four cases added to `StructuredInvoiceCompatibilityTest`: the older `Columns` constructor
leaves the caption blank, the older `Line` constructor leaves the region blank, a line
carries the region it is given, and `null` normalizes to blank on both records. 21/21.

Full reactor gate (`core, render-pdf, render-docx, render-pptx, templates, testing, qa,
coverage`) — BUILD SUCCESS.