### PR TITLE
feat(templates): give a proposal the header a one-page sales proposal has

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ follow semantic versioning; release dates are ISO 8601.
 
 ### Public API
 
+- **A proposal carries the header a one-page sales proposal has.** The proposal model was
+  shaped for a two-page consulting document: a running header naming three things by role,
+  and a title of exactly three lines. A one-page sales proposal opens differently — an
+  addressed organisation with its own address block, a named person at it with a role and
+  two channels, a row of marked tiles whose captions are the document's own, a headline
+  broken across however many lines the design breaks it across, and a foot carrying the
+  legal entity rather than only a name. None of that had a home, and each of the seven
+  designs measured for this needs the same five things, which is why they arrive together
+  rather than one per preset: five separate additions to a published record would leave
+  the model a patchwork of near-duplicates.
+  <br><br>
+  `ProposalRecipient`, `ProposalAttention` and `ProposalFooter` are new;
+  `StructuredProposalData` carries them as `recipient`, `attention` and `footer`, and its
+  twelve-argument constructor is kept explicitly so existing calls compile and link
+  unchanged. `ProposalTitleLines` gains `eyebrow`, `lines` and `standfirst`, with `lines`
+  the canonical reading and `lead`/`second`/`third` its first three — one statement kept
+  consistent by construction rather than by the caller, so a preset written against the
+  three reads the same title a four-line document states. The list form is a factory,
+  `ProposalTitleLines.of`, because a second three-argument constructor taking
+  `(String, List, List)` is ambiguous for a caller passing nulls.
+  `ProposalMetaLine` gains `entries`, and those do <em>not</em> derive from the trio in
+  either direction: turning three roles into tiles would mean inventing their captions,
+  and reading roles back out of arbitrary tiles would mean guessing which is which. A
+  preset draws the one its design has.
+
 - **An invoice line carries where it was delivered.** A design that bills the same
   service in more than one place — the same instance type in two datacentres, the same
   plan in two jurisdictions — prints where beside what, as its own column next to the

--- a/knowledge/api/templates.json
+++ b/knowledge/api/templates.json
@@ -22,10 +22,10 @@
     "graph-compose-testing:sources"
   ],
   "counts": {
-    "types": 222,
-    "methods": 1232,
+    "types": 226,
+    "methods": 1269,
     "constants": 174,
-    "generated": 657
+    "generated": 683
   },
   "packages": [
     {
@@ -15240,6 +15240,101 @@
           ]
         },
         {
+          "name": "ProposalAttention",
+          "binaryName": "com.demcha.compose.document.templates.data.proposal.ProposalAttention",
+          "kind": "record",
+          "modifiers": [
+            "final"
+          ],
+          "artifact": "graph-compose-templates",
+          "members": [
+            {
+              "kind": "constructor",
+              "name": "ProposalAttention",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "String",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "isPresent",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "boolean",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "label",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "name",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "role",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "email",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "phone",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            }
+          ]
+        },
+        {
           "name": "ProposalBrand",
           "binaryName": "com.demcha.compose.document.templates.data.proposal.ProposalBrand",
           "kind": "record",
@@ -16492,6 +16587,88 @@
           ]
         },
         {
+          "name": "ProposalFooter",
+          "binaryName": "com.demcha.compose.document.templates.data.proposal.ProposalFooter",
+          "kind": "record",
+          "modifiers": [
+            "final"
+          ],
+          "artifact": "graph-compose-templates",
+          "members": [
+            {
+              "kind": "constructor",
+              "name": "ProposalFooter",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "List<String>",
+                  "name": null
+                },
+                {
+                  "type": "List<String>",
+                  "name": null
+                },
+                {
+                  "type": "String",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "isPresent",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "boolean",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "name",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "addressLines",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "List<String>",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "contacts",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "List<String>",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "confidentiality",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            }
+          ]
+        },
+        {
           "name": "ProposalGlance",
           "binaryName": "com.demcha.compose.document.templates.data.proposal.ProposalGlance",
           "kind": "record",
@@ -16950,6 +17127,46 @@
                 {
                   "type": "String",
                   "name": null
+                },
+                {
+                  "type": "List<ProposalMetaLine.Entry>",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "constructor",
+              "name": "ProposalMetaLine",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "String",
+                  "name": "preparedFor"
+                },
+                {
+                  "type": "String",
+                  "name": "preparedBy"
+                },
+                {
+                  "type": "String",
+                  "name": "date"
+                }
+              ]
+            },
+            {
+              "kind": "constructor",
+              "name": "ProposalMetaLine",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "List<ProposalMetaLine.Entry>",
+                  "name": "entries"
                 }
               ]
             },
@@ -16974,6 +17191,75 @@
             {
               "kind": "method",
               "name": "date",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "entries",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "List<ProposalMetaLine.Entry>",
+              "params": []
+            }
+          ]
+        },
+        {
+          "name": "ProposalMetaLine.Entry",
+          "binaryName": "com.demcha.compose.document.templates.data.proposal.ProposalMetaLine$Entry",
+          "kind": "record",
+          "modifiers": [
+            "final"
+          ],
+          "artifact": "graph-compose-templates",
+          "members": [
+            {
+              "kind": "constructor",
+              "name": "Entry",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "String",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "icon",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "label",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "value",
               "static": false,
               "origin": "generated",
               "typeParameters": null,
@@ -17513,6 +17799,75 @@
           ]
         },
         {
+          "name": "ProposalRecipient",
+          "binaryName": "com.demcha.compose.document.templates.data.proposal.ProposalRecipient",
+          "kind": "record",
+          "modifiers": [
+            "final"
+          ],
+          "artifact": "graph-compose-templates",
+          "members": [
+            {
+              "kind": "constructor",
+              "name": "ProposalRecipient",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "List<String>",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "isPresent",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "boolean",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "label",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "name",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "addressLines",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "List<String>",
+              "params": []
+            }
+          ]
+        },
+        {
           "name": "ProposalScope",
           "binaryName": "com.demcha.compose.document.templates.data.proposal.ProposalScope",
           "kind": "record",
@@ -18043,6 +18398,62 @@
                 {
                   "type": "String",
                   "name": null
+                },
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "List<String>",
+                  "name": null
+                },
+                {
+                  "type": "List<String>",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "constructor",
+              "name": "ProposalTitleLines",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "String",
+                  "name": "lead"
+                },
+                {
+                  "type": "String",
+                  "name": "second"
+                },
+                {
+                  "type": "String",
+                  "name": "third"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "of",
+              "static": true,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "ProposalTitleLines",
+              "params": [
+                {
+                  "type": "String",
+                  "name": "eyebrow"
+                },
+                {
+                  "type": "List<String>",
+                  "name": "lines"
+                },
+                {
+                  "type": "List<String>",
+                  "name": "standfirst"
                 }
               ]
             },
@@ -18071,6 +18482,33 @@
               "origin": "generated",
               "typeParameters": null,
               "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "eyebrow",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "lines",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "List<String>",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "standfirst",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "List<String>",
               "params": []
             }
           ]
@@ -18139,6 +18577,76 @@
                 {
                   "type": "ProposalAcceptance",
                   "name": null
+                },
+                {
+                  "type": "ProposalRecipient",
+                  "name": null
+                },
+                {
+                  "type": "ProposalAttention",
+                  "name": null
+                },
+                {
+                  "type": "ProposalFooter",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "constructor",
+              "name": "StructuredProposalData",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "ProposalBrand",
+                  "name": "brand"
+                },
+                {
+                  "type": "ProposalTitleLines",
+                  "name": "title"
+                },
+                {
+                  "type": "ProposalMetaLine",
+                  "name": "meta"
+                },
+                {
+                  "type": "ProposalSummaryBlock",
+                  "name": "executiveSummary"
+                },
+                {
+                  "type": "ProposalGlance",
+                  "name": "glance"
+                },
+                {
+                  "type": "ProposalGoals",
+                  "name": "goals"
+                },
+                {
+                  "type": "ProposalScope",
+                  "name": "scope"
+                },
+                {
+                  "type": "ProposalDeliverables",
+                  "name": "deliverables"
+                },
+                {
+                  "type": "ProposalPhaseGrid",
+                  "name": "timeline"
+                },
+                {
+                  "type": "ProposalInvestment",
+                  "name": "investment"
+                },
+                {
+                  "type": "ProposalTermsBlock",
+                  "name": "terms"
+                },
+                {
+                  "type": "ProposalAcceptance",
+                  "name": "acceptance"
                 }
               ]
             },
@@ -18257,6 +18765,33 @@
               "origin": "generated",
               "typeParameters": null,
               "returns": "ProposalAcceptance",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "recipient",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "ProposalRecipient",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "attention",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "ProposalAttention",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "footer",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "ProposalFooter",
               "params": []
             }
           ]
@@ -18435,6 +18970,48 @@
                 {
                   "type": "ProposalAcceptance",
                   "name": "acceptance"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "recipient",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "StructuredProposalData.Builder",
+              "params": [
+                {
+                  "type": "ProposalRecipient",
+                  "name": "recipient"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "attention",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "StructuredProposalData.Builder",
+              "params": [
+                {
+                  "type": "ProposalAttention",
+                  "name": "attention"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "footer",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "StructuredProposalData.Builder",
+              "params": [
+                {
+                  "type": "ProposalFooter",
+                  "name": "footer"
                 }
               ]
             },

--- a/knowledge/api/templates.md
+++ b/knowledge/api/templates.md
@@ -28,7 +28,7 @@ note: "Generated from the pinned artifact's class files. Authoritative closed se
 
 **GraphCompose version:** 2.4.0-SNAPSHOT
 
-Types: 222 · methods: 1232 · constants: 174 · compiler-generated members: 657
+Types: 226 · methods: 1269 · constants: 174 · compiler-generated members: 683
 
 ## com.demcha.compose.document.templates.api
 
@@ -1278,6 +1278,15 @@ Types: 222 · methods: 1232 · constants: 174 · compiler-generated members: 657
 - `String statement()`
 - `List<String> fields()`
 
+### ProposalAttention (record)
+- `new ProposalAttention(String, String, String, String, String)`
+- `boolean isPresent()`
+- `String label()`
+- `String name()`
+- `String role()`
+- `String email()`
+- `String phone()`
+
 ### ProposalBrand (record)
 - `new ProposalBrand(String, String, String, String, String, String)`
 - `String monogram()`
@@ -1375,6 +1384,14 @@ Types: 222 · methods: 1232 · constants: 174 · compiler-generated members: 657
 - `ProposalDocumentSpec.Builder footerNote(String footerNote)`
 - `ProposalDocumentSpec build()`
 
+### ProposalFooter (record)
+- `new ProposalFooter(String, List<String>, List<String>, String)`
+- `boolean isPresent()`
+- `String name()`
+- `List<String> addressLines()`
+- `List<String> contacts()`
+- `String confidentiality()`
+
 ### ProposalGlance (record)
 - `new ProposalGlance(String, List<ProposalGlance.Fact>)`
 - `String heading()`
@@ -1418,10 +1435,19 @@ Types: 222 · methods: 1232 · constants: 174 · compiler-generated members: 657
 - `ProposalInvestment.Role role()`
 
 ### ProposalMetaLine (record)
-- `new ProposalMetaLine(String, String, String)`
+- `new ProposalMetaLine(String, String, String, List<ProposalMetaLine.Entry>)`
+- `new ProposalMetaLine(String preparedFor, String preparedBy, String date)`
+- `new ProposalMetaLine(List<ProposalMetaLine.Entry> entries)`
 - `String preparedFor()`
 - `String preparedBy()`
 - `String date()`
+- `List<ProposalMetaLine.Entry> entries()`
+
+### ProposalMetaLine.Entry (record)
+- `new Entry(String, String, String)`
+- `String icon()`
+- `String label()`
+- `String value()`
 
 ### ProposalParty (record)
 - `new ProposalParty(String, List<String>, String, String, String)`
@@ -1471,6 +1497,13 @@ Types: 222 · methods: 1232 · constants: 174 · compiler-generated members: 657
 - `ProposalPricingRow.Builder amount(String amount)`
 - `ProposalPricingRow.Builder emphasized(boolean emphasized)`
 - `ProposalPricingRow build()`
+
+### ProposalRecipient (record)
+- `new ProposalRecipient(String, String, List<String>)`
+- `boolean isPresent()`
+- `String label()`
+- `String name()`
+- `List<String> addressLines()`
 
 ### ProposalScope (record)
 - `new ProposalScope(String, String, List<ProposalScope.Item>)`
@@ -1523,13 +1556,19 @@ Types: 222 · methods: 1232 · constants: 174 · compiler-generated members: 657
 - `ProposalTimelineItem build()`
 
 ### ProposalTitleLines (record)
-- `new ProposalTitleLines(String, String, String)`
+- `new ProposalTitleLines(String, String, String, String, List<String>, List<String>)`
+- `new ProposalTitleLines(String lead, String second, String third)`
+- `ProposalTitleLines of(String eyebrow, List<String> lines, List<String> standfirst)`
 - `String lead()`
 - `String second()`
 - `String third()`
+- `String eyebrow()`
+- `List<String> lines()`
+- `List<String> standfirst()`
 
 ### StructuredProposalData (record)
-- `new StructuredProposalData(ProposalBrand, ProposalTitleLines, ProposalMetaLine, ProposalSummaryBlock, ProposalGlance, ProposalGoals, ProposalScope, ProposalDeliverables, ProposalPhaseGrid, ProposalInvestment, ProposalTermsBlock, ProposalAcceptance)`
+- `new StructuredProposalData(ProposalBrand, ProposalTitleLines, ProposalMetaLine, ProposalSummaryBlock, ProposalGlance, ProposalGoals, ProposalScope, ProposalDeliverables, ProposalPhaseGrid, ProposalInvestment, ProposalTermsBlock, ProposalAcceptance, ProposalRecipient, ProposalAttention, ProposalFooter)`
+- `new StructuredProposalData(ProposalBrand brand, ProposalTitleLines title, ProposalMetaLine meta, ProposalSummaryBlock executiveSummary, ProposalGlance glance, ProposalGoals goals, ProposalScope scope, ProposalDeliverables deliverables, ProposalPhaseGrid timeline, ProposalInvestment investment, ProposalTermsBlock terms, ProposalAcceptance acceptance)`
 - `StructuredProposalData.Builder builder()`
 - `ProposalBrand brand()`
 - `ProposalTitleLines title()`
@@ -1543,6 +1582,9 @@ Types: 222 · methods: 1232 · constants: 174 · compiler-generated members: 657
 - `ProposalInvestment investment()`
 - `ProposalTermsBlock terms()`
 - `ProposalAcceptance acceptance()`
+- `ProposalRecipient recipient()`
+- `ProposalAttention attention()`
+- `ProposalFooter footer()`
 
 ### StructuredProposalData.Builder (class)
 - `StructuredProposalData.Builder brand(ProposalBrand brand)`
@@ -1557,6 +1599,9 @@ Types: 222 · methods: 1232 · constants: 174 · compiler-generated members: 657
 - `StructuredProposalData.Builder investment(ProposalInvestment investment)`
 - `StructuredProposalData.Builder terms(ProposalTermsBlock terms)`
 - `StructuredProposalData.Builder acceptance(ProposalAcceptance acceptance)`
+- `StructuredProposalData.Builder recipient(ProposalRecipient recipient)`
+- `StructuredProposalData.Builder attention(ProposalAttention attention)`
+- `StructuredProposalData.Builder footer(ProposalFooter footer)`
 - `StructuredProposalData build()`
 
 ### StructuredProposalDocumentSpec (record)

--- a/qa/src/test/java/com/demcha/compose/document/templates/data/proposal/ProposalHeaderSpineTest.java
+++ b/qa/src/test/java/com/demcha/compose/document/templates/data/proposal/ProposalHeaderSpineTest.java
@@ -1,0 +1,165 @@
+package com.demcha.compose.document.templates.data.proposal;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The header spine the one-page sales proposals share.
+ *
+ * <p>Each case is one of the seven designs the spine was measured against, so a
+ * field that stops carrying what a design states fails here rather than in that
+ * design's own render.</p>
+ */
+class ProposalHeaderSpineTest {
+
+    // -- the addressed block --------------------------------------------
+
+    @Test
+    void aRecipientCarriesTheCaptionTheNameAndTheAddressSeparately() {
+        ProposalRecipient recipient = new ProposalRecipient("PREPARED FOR", "Bright Future Ltd.",
+                List.of("45 King Street", "Manchester, M2 4WU", "United Kingdom"));
+        assertThat(recipient.label()).isEqualTo("PREPARED FOR");
+        assertThat(recipient.name()).isEqualTo("Bright Future Ltd.");
+        assertThat(recipient.addressLines()).hasSize(3);
+        assertThat(recipient.isPresent()).isTrue();
+    }
+
+    @Test
+    void aRecipientThatNamesNothingIsNotPresent() {
+        assertThat(new ProposalRecipient(null, null, null).isPresent()).isFalse();
+        assertThat(new ProposalRecipient("PREPARED FOR", "", List.of()).isPresent()).isFalse();
+    }
+
+    // -- the attention line ---------------------------------------------
+
+    @Test
+    void anAttentionLineCarriesTheRoleAndBothChannels() {
+        ProposalAttention attention = new ProposalAttention("ATTN", "A. Mitchell", "Founder",
+                "a@brightfuture.example", "+44 7700 900123");
+        assertThat(attention.role()).isEqualTo("Founder");
+        assertThat(attention.email()).isEqualTo("a@brightfuture.example");
+        assertThat(attention.phone()).isEqualTo("+44 7700 900123");
+        assertThat(attention.isPresent()).isTrue();
+    }
+
+    @Test
+    void aDesignThatFoldsTheNameIntoItsCaptionStillReads() {
+        // One of the seven prints "Attn: A. Mitchell" as the caption and gives
+        // the name no line of its own, which is why the caption is the design's
+        // own string rather than a fixed word.
+        ProposalAttention attention = new ProposalAttention("Attn: A. Mitchell", "", "Founder",
+                "a@brightfuture.example", "+44 7700 900123");
+        assertThat(attention.label()).contains("A. Mitchell");
+        assertThat(attention.name()).isEmpty();
+        assertThat(attention.isPresent()).isTrue();
+    }
+
+    // -- the header tiles -----------------------------------------------
+
+    @Test
+    void theTilesAreAListBecauseEveryOneOfTheDesignsSetsFour() {
+        ProposalMetaLine meta = new ProposalMetaLine(List.of(
+                new ProposalMetaLine.Entry("date", "DATE", "27 May 2026"),
+                new ProposalMetaLine.Entry("id", "PROPOSAL ID", "REV-2026-0527-01"),
+                new ProposalMetaLine.Entry("valid", "VALID UNTIL", "26 June 2026"),
+                new ProposalMetaLine.Entry("by", "PREPARED BY", "The Business Team")));
+        assertThat(meta.entries()).hasSize(4);
+        assertThat(meta.entries().get(1).label()).isEqualTo("PROPOSAL ID");
+        // The running-header trio is a different statement, and stays empty.
+        assertThat(meta.preparedFor()).isEmpty();
+    }
+
+    @Test
+    void theRunningHeaderTrioIsUntouchedByTheTiles() {
+        ProposalMetaLine meta = new ProposalMetaLine("Bright Future Ltd.", "The Team", "27 May");
+        assertThat(meta.preparedFor()).isEqualTo("Bright Future Ltd.");
+        assertThat(meta.entries()).isEmpty();
+    }
+
+    // -- the title -------------------------------------------------------
+
+    @Test
+    void aTitleOfFourLinesKeepsAllFourAndStillReadsAsThree() {
+        ProposalTitleLines title = ProposalTitleLines.of("", List.of(
+                "Proposal for", "Financial Infrastructure",
+                "& Embedded Finance", "Partnership"), List.of("Empowering your business."));
+        assertThat(title.lines()).hasSize(4);
+        // The three named lines are the first three of the list, so a preset
+        // written against them reads the same title.
+        assertThat(title.lead()).isEqualTo("Proposal for");
+        assertThat(title.second()).isEqualTo("Financial Infrastructure");
+        assertThat(title.third()).isEqualTo("& Embedded Finance");
+        assertThat(title.standfirst()).containsExactly("Empowering your business.");
+    }
+
+    @Test
+    void aTitleStatedAsThreeLinesReadsBackAsAListOfThree() {
+        ProposalTitleLines title = new ProposalTitleLines("Proposal for", "Cloud Services", "");
+        // The blank third line is not a line of the title.
+        assertThat(title.lines()).containsExactly("Proposal for", "Cloud Services");
+        assertThat(title.eyebrow()).isEmpty();
+    }
+
+    @Test
+    void aTitleCarriesTheEyebrowSomeDesignsSetAboveIt() {
+        ProposalTitleLines title = ProposalTitleLines.of("Proposal for",
+                List.of("Payments", "& Financial Infrastructure"), List.of());
+        assertThat(title.eyebrow()).isEqualTo("Proposal for");
+        assertThat(title.lead()).isEqualTo("Payments");
+    }
+
+    // -- the foot --------------------------------------------------------
+
+    @Test
+    void aFooterCarriesTheEntityTheAddressTheChannelsAndTheNotice() {
+        ProposalFooter footer = new ProposalFooter("Northwind UK Limited",
+                List.of("110 Bishopsgate, London EC2N 4AY, United Kingdom"),
+                List.of("www.northwind.example", "+44 800 092 1223"),
+                "This proposal is confidential and valid for 30 days.");
+        assertThat(footer.name()).isEqualTo("Northwind UK Limited");
+        assertThat(footer.contacts()).hasSize(2);
+        assertThat(footer.confidentiality()).contains("confidential");
+        assertThat(footer.isPresent()).isTrue();
+    }
+
+    @Test
+    void aFootThatCarriesOnlyANoticeIsStillPresent() {
+        // One of the seven states nothing else in its foot.
+        ProposalFooter footer = new ProposalFooter(null, null, null,
+                "This proposal is confidential and valid for 30 days.");
+        assertThat(footer.name()).isEmpty();
+        assertThat(footer.isPresent()).isTrue();
+    }
+
+    @Test
+    void aFootThatStatesNothingIsNotPresent() {
+        assertThat(new ProposalFooter(null, null, null, null).isPresent()).isFalse();
+    }
+
+    // -- the aggregate ---------------------------------------------------
+
+    @Test
+    void theConstructorThatPredatesTheSpineLeavesItEmptyRatherThanNull() {
+        StructuredProposalData data = new StructuredProposalData(
+                null, null, null, null, null, null, null, null, null, null, null, null);
+        assertThat(data.recipient().isPresent()).isFalse();
+        assertThat(data.attention().isPresent()).isFalse();
+        assertThat(data.footer().isPresent()).isFalse();
+    }
+
+    @Test
+    void theBuilderCarriesTheSpineThrough() {
+        StructuredProposalData data = StructuredProposalData.builder()
+                .recipient(new ProposalRecipient("PREPARED FOR", "Bright Future Ltd.",
+                        List.of("45 King Street")))
+                .attention(new ProposalAttention("ATTN", "A. Mitchell", "Founder", "", ""))
+                .footer(new ProposalFooter("Northwind UK Limited", List.of(), List.of(), ""))
+                .build();
+        assertThat(data.recipient().name()).isEqualTo("Bright Future Ltd.");
+        assertThat(data.attention().role()).isEqualTo("Founder");
+        assertThat(data.footer().name()).isEqualTo("Northwind UK Limited");
+    }
+}

--- a/qa/src/test/java/com/demcha/compose/document/templates/data/proposal/ProposalHeaderSpineTest.java
+++ b/qa/src/test/java/com/demcha/compose/document/templates/data/proposal/ProposalHeaderSpineTest.java
@@ -104,6 +104,17 @@ class ProposalHeaderSpineTest {
     }
 
     @Test
+    void statingBothATrioAndAListReadsTheTitleFromTheList() {
+        // Only the canonical constructor allows both, and it resolves rather
+        // than throws: the list is the one that can hold a title of any length,
+        // so reading the three back from it loses nothing the caller stated.
+        ProposalTitleLines title = new ProposalTitleLines("discarded", "also discarded", "",
+                "", List.of("Proposal for", "Cloud Services", "& Support"), List.of());
+        assertThat(title.lines()).containsExactly("Proposal for", "Cloud Services", "& Support");
+        assertThat(title.lead()).isEqualTo("Proposal for");
+    }
+
+    @Test
     void aTitleCarriesTheEyebrowSomeDesignsSetAboveIt() {
         ProposalTitleLines title = ProposalTitleLines.of("Proposal for",
                 List.of("Payments", "& Financial Infrastructure"), List.of());

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/proposal/ProposalAttention.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/proposal/ProposalAttention.java
@@ -1,0 +1,44 @@
+package com.demcha.compose.document.templates.data.proposal;
+
+import java.util.Objects;
+
+/**
+ * The person at the recipient a proposal is addressed to.
+ *
+ * <p>A sales proposal names a company and then a person inside it, with the
+ * person's role and the two ways to reach them. Designs differ in how much of
+ * that they set apart — some print the name in the caption, some give the role,
+ * the address and the number their own lines — so each is carried separately and
+ * a preset draws the ones its design has.</p>
+ *
+ * @param label the caption above the block, as the sheet prints it (e.g.
+ *              {@code "ATTN"}); some designs fold the name into it, which is why
+ *              this is the design's own string rather than a fixed word
+ * @param name  the person addressed; blank when the label already names them
+ * @param role  their role at the recipient; blank when the design omits it
+ * @param email their address, as the sheet prints it; blank when absent
+ * @param phone their number, as the sheet prints it; blank when absent
+ */
+public record ProposalAttention(String label, String name, String role,
+                                String email, String phone) {
+
+    /**
+     * Normalizes optional fields.
+     */
+    public ProposalAttention {
+        label = Objects.requireNonNullElse(label, "");
+        name = Objects.requireNonNullElse(name, "");
+        role = Objects.requireNonNullElse(role, "");
+        email = Objects.requireNonNullElse(email, "");
+        phone = Objects.requireNonNullElse(phone, "");
+    }
+
+    /**
+     * Whether there is anything to draw.
+     *
+     * @return {@code true} when the block names a person or a way to reach them
+     */
+    public boolean isPresent() {
+        return !name.isBlank() || !role.isBlank() || !email.isBlank() || !phone.isBlank();
+    }
+}

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/proposal/ProposalFooter.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/proposal/ProposalFooter.java
@@ -1,0 +1,44 @@
+package com.demcha.compose.document.templates.data.proposal;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The issuer's own identity, as the foot of a proposal states it.
+ *
+ * <p>Distinct from {@link ProposalBrand#footerName()}, which is one name: a
+ * sales proposal's foot carries the legal entity, its registered address, the
+ * channels a reader can follow, and — where the jurisdiction or the deal asks
+ * for it — a confidentiality line. A design that prints only the name leaves the
+ * rest blank.</p>
+ *
+ * @param name            the legal entity the proposal is issued by
+ * @param addressLines    its registered address, in the order it is printed
+ * @param contacts        the channels the foot lists, as the sheet prints them —
+ *                        a site, a number, an address — in order
+ * @param confidentiality the confidentiality or validity line, when the design
+ *                        carries one; blank otherwise
+ */
+public record ProposalFooter(String name, List<String> addressLines,
+                             List<String> contacts, String confidentiality) {
+
+    /**
+     * Normalizes optional fields.
+     */
+    public ProposalFooter {
+        name = Objects.requireNonNullElse(name, "");
+        addressLines = List.copyOf(Objects.requireNonNullElse(addressLines, List.of()));
+        contacts = List.copyOf(Objects.requireNonNullElse(contacts, List.of()));
+        confidentiality = Objects.requireNonNullElse(confidentiality, "");
+    }
+
+    /**
+     * Whether there is anything to draw.
+     *
+     * @return {@code true} when the foot states any of its four parts
+     */
+    public boolean isPresent() {
+        return !name.isBlank() || !addressLines.isEmpty()
+                || !contacts.isEmpty() || !confidentiality.isBlank();
+    }
+}

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/proposal/ProposalMetaLine.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/proposal/ProposalMetaLine.java
@@ -1,23 +1,80 @@
 package com.demcha.compose.document.templates.data.proposal;
 
+import java.util.List;
 import java.util.Objects;
 
 /**
- * The prepared-for / prepared-by / date line under a structured proposal's
- * title.
+ * A proposal's header facts.
  *
- * @param preparedFor the client the proposal is prepared for
- * @param preparedBy  the sender the proposal is prepared by
- * @param date        the proposal date text
+ * <p>Two designs' worth of shape, and they are not the same statement. A running
+ * header names three things by role — who it is for, who prepared it, when — and
+ * {@link #preparedFor()}, {@link #preparedBy()} and {@link #date()} carry those.
+ * A sales proposal instead sets a row of marked tiles whose captions are the
+ * document's own — a proposal number, a date, a validity, a team — and
+ * {@link #entries()} carries those.</p>
+ *
+ * <p>Neither derives from the other: turning three roles into tiles would mean
+ * inventing their captions, and reading roles back out of arbitrary tiles would
+ * mean guessing which is which. A preset draws the one its design has, and a
+ * document states the one it is written for.</p>
+ *
+ * @param preparedFor who the proposal is for, as a running header states it
+ * @param preparedBy  who prepared it
+ * @param date        when it was prepared
+ * @param entries     the marked tiles a sales proposal sets instead; empty when
+ *                    the design has none
  */
-public record ProposalMetaLine(String preparedFor, String preparedBy, String date) {
+public record ProposalMetaLine(String preparedFor, String preparedBy, String date,
+                               List<Entry> entries) {
 
     /**
-     * Normalizes optional fields to empty strings.
+     * Normalizes optional fields.
      */
     public ProposalMetaLine {
         preparedFor = Objects.requireNonNullElse(preparedFor, "");
         preparedBy = Objects.requireNonNullElse(preparedBy, "");
         date = Objects.requireNonNullElse(date, "");
+        entries = List.copyOf(Objects.requireNonNullElse(entries, List.of()));
+    }
+
+    /**
+     * Backward-compatible constructor for callers that predate the tiles.
+     *
+     * @param preparedFor who the proposal is for
+     * @param preparedBy  who prepared it
+     * @param date        when it was prepared
+     */
+    public ProposalMetaLine(String preparedFor, String preparedBy, String date) {
+        this(preparedFor, preparedBy, date, List.of());
+    }
+
+    /**
+     * The tiles alone, for a design that sets no running header.
+     *
+     * @param entries the marked tiles, in order
+     */
+    public ProposalMetaLine(List<Entry> entries) {
+        this("", "", "", entries);
+    }
+
+    /**
+     * One marked tile.
+     *
+     * @param icon  the mark the tile opens with; the token means something only
+     *              to the preset that packages it, and a preset that draws no
+     *              marks ignores it. Blank when absent
+     * @param label the caption, as the sheet prints it
+     * @param value the fact itself
+     */
+    public record Entry(String icon, String label, String value) {
+
+        /**
+         * Normalizes optional fields.
+         */
+        public Entry {
+            icon = Objects.requireNonNullElse(icon, "");
+            label = Objects.requireNonNullElse(label, "");
+            value = Objects.requireNonNullElse(value, "");
+        }
     }
 }

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/proposal/ProposalRecipient.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/proposal/ProposalRecipient.java
@@ -1,0 +1,39 @@
+package com.demcha.compose.document.templates.data.proposal;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The organisation a proposal is addressed to.
+ *
+ * <p>Distinct from {@link ProposalMetaLine#preparedFor()}, which is one line of
+ * a header strip: this is the addressed block a sales proposal opens with — a
+ * caption, the company, and its address — and a design that prints it needs all
+ * three separately rather than as one string.</p>
+ *
+ * @param label        the caption above the block, as the sheet prints it
+ *                     (e.g. {@code "PREPARED FOR"}); blank when the design draws
+ *                     the block without one
+ * @param name         the addressed organisation
+ * @param addressLines the address, in the order it is printed
+ */
+public record ProposalRecipient(String label, String name, List<String> addressLines) {
+
+    /**
+     * Normalizes optional fields.
+     */
+    public ProposalRecipient {
+        label = Objects.requireNonNullElse(label, "");
+        name = Objects.requireNonNullElse(name, "");
+        addressLines = List.copyOf(Objects.requireNonNullElse(addressLines, List.of()));
+    }
+
+    /**
+     * Whether there is anything to draw.
+     *
+     * @return {@code true} when the block names an organisation or an address
+     */
+    public boolean isPresent() {
+        return !name.isBlank() || !addressLines.isEmpty();
+    }
+}

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/proposal/ProposalTitleLines.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/proposal/ProposalTitleLines.java
@@ -1,27 +1,95 @@
 package com.demcha.compose.document.templates.data.proposal;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
 
 /**
- * The display title of a structured proposal, as up to three authored lines.
+ * A proposal's title, as the sheet sets it.
  *
- * <p>The lines are separate fields rather than one string with newlines
- * because presets are expected to set the lead line apart from the other
- * two typographically — the split carries the emphasis and is part of the
- * content, not of the layout.</p>
+ * <p>Designs break a title across a different number of lines — two, three or
+ * four — and some set a short phrase above it and a standfirst under it. The
+ * lines are therefore a list, and {@link #lead()}, {@link #second()} and
+ * {@link #third()} are the first three of that list: one statement, two ways of
+ * reading it, kept consistent by construction rather than by the caller.</p>
  *
- * @param lead   the first title line
- * @param second the second title line
- * @param third  the third title line
+ * <p>A title breaks where the design breaks it. The lines are the document's,
+ * not a paragraph the engine wraps, because where a headline turns is a
+ * typographic decision and not a consequence of the column it happens to sit
+ * in.</p>
+ *
+ * @param lead       the first line, or blank when the title has none
+ * @param second     the second line, or blank
+ * @param third      the third line, or blank
+ * @param eyebrow    the short phrase some designs set above the title (e.g.
+ *                   {@code "Proposal for"}); blank when the title carries it
+ *                   inside its own first line instead
+ * @param lines      every line of the title, in order — the canonical reading
+ * @param standfirst the paragraph under the title, one entry per printed line;
+ *                   empty when the design sets none
  */
-public record ProposalTitleLines(String lead, String second, String third) {
+public record ProposalTitleLines(String lead, String second, String third,
+                                 String eyebrow, List<String> lines,
+                                 List<String> standfirst) {
 
     /**
-     * Normalizes optional lines to empty strings.
+     * Normalizes optional fields and keeps the list and the first three lines
+     * saying the same thing.
+     *
+     * <p>Given lines, the three are its first three. Given only the three, the
+     * lines are those of them that are set. Neither can contradict the other,
+     * because only one of them is ever the input.</p>
      */
     public ProposalTitleLines {
-        lead = Objects.requireNonNullElse(lead, "");
-        second = Objects.requireNonNullElse(second, "");
-        third = Objects.requireNonNullElse(third, "");
+        eyebrow = Objects.requireNonNullElse(eyebrow, "");
+        standfirst = List.copyOf(Objects.requireNonNullElse(standfirst, List.of()));
+        List<String> stated = Objects.requireNonNullElse(lines, List.of());
+        if (stated.isEmpty()) {
+            lead = Objects.requireNonNullElse(lead, "");
+            second = Objects.requireNonNullElse(second, "");
+            third = Objects.requireNonNullElse(third, "");
+            List<String> derived = new ArrayList<>();
+            for (String line : List.of(lead, second, third)) {
+                if (!line.isBlank()) {
+                    derived.add(line);
+                }
+            }
+            lines = List.copyOf(derived);
+        } else {
+            lines = List.copyOf(stated);
+            lead = lines.size() > 0 ? lines.get(0) : "";
+            second = lines.size() > 1 ? lines.get(1) : "";
+            third = lines.size() > 2 ? lines.get(2) : "";
+        }
+    }
+
+    /**
+     * A title of up to three lines.
+     *
+     * @param lead   the first line
+     * @param second the second line
+     * @param third  the third line
+     */
+    public ProposalTitleLines(String lead, String second, String third) {
+        this(lead, second, third, "", List.of(), List.of());
+    }
+
+    /**
+     * A title of any number of lines, with the phrase above it and the paragraph
+     * under it.
+     *
+     * <p>A factory rather than a second three-argument constructor: one taking
+     * {@code (String, List, List)} beside one taking three strings is ambiguous
+     * for a caller passing nulls, and a title is not the place to make someone
+     * cast an argument to find out which they meant.</p>
+     *
+     * @param eyebrow    the phrase above the title, or blank
+     * @param lines      every line of the title, in order
+     * @param standfirst the paragraph under it, one entry per printed line
+     * @return the title
+     */
+    public static ProposalTitleLines of(String eyebrow, List<String> lines,
+                                        List<String> standfirst) {
+        return new ProposalTitleLines("", "", "", eyebrow, lines, standfirst);
     }
 }

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/proposal/ProposalTitleLines.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/proposal/ProposalTitleLines.java
@@ -36,9 +36,12 @@ public record ProposalTitleLines(String lead, String second, String third,
      * Normalizes optional fields and keeps the list and the first three lines
      * saying the same thing.
      *
-     * <p>Given lines, the three are its first three. Given only the three, the
-     * lines are those of them that are set. Neither can contradict the other,
-     * because only one of them is ever the input.</p>
+     * <p>Given lines, the three are read from it. Given no lines, the lines are
+     * those of the three that are set. Given both — which only the canonical
+     * constructor allows, and which neither convenience form can produce — the
+     * list wins and the three are read from it, because the list is the one that
+     * can hold a title of any length and reading it back is the only resolution
+     * that loses nothing the caller stated.</p>
      */
     public ProposalTitleLines {
         eyebrow = Objects.requireNonNullElse(eyebrow, "");

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/proposal/StructuredProposalData.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/proposal/StructuredProposalData.java
@@ -30,6 +30,13 @@ package com.demcha.compose.document.templates.data.proposal;
  * @param investment       the priced block
  * @param terms            the bulleted terms block
  * @param acceptance       the signing card
+ * @param recipient        the addressed organisation, for the designs that open
+ *                         with one; blank when the design names it in its header
+ *                         line instead
+ * @param attention        the person at the recipient the proposal is addressed
+ *                         to; blank when the design addresses no one
+ * @param footer           the issuer's own identity as the foot states it;
+ *                         blank when the design's foot carries only a name
  */
 public record StructuredProposalData(
         ProposalBrand brand,
@@ -43,7 +50,10 @@ public record StructuredProposalData(
         ProposalPhaseGrid timeline,
         ProposalInvestment investment,
         ProposalTermsBlock terms,
-        ProposalAcceptance acceptance) {
+        ProposalAcceptance acceptance,
+        ProposalRecipient recipient,
+        ProposalAttention attention,
+        ProposalFooter footer) {
 
     /**
      * Normalizes absent components to their empty forms.
@@ -73,6 +83,40 @@ public record StructuredProposalData(
                 ? new ProposalTermsBlock(null, null, null) : terms;
         acceptance = acceptance == null
                 ? new ProposalAcceptance(null, null, null, null) : acceptance;
+        recipient = recipient == null
+                ? new ProposalRecipient(null, null, null) : recipient;
+        attention = attention == null
+                ? new ProposalAttention(null, null, null, null, null) : attention;
+        footer = footer == null
+                ? new ProposalFooter(null, null, null, null) : footer;
+    }
+
+    /**
+     * Backward-compatible constructor for callers that predate the addressed
+     * block, the attention line and the foot's own identity.
+     *
+     * @param brand            the issuing brand
+     * @param title            the proposal's title
+     * @param meta             the header facts
+     * @param executiveSummary the summary block
+     * @param glance           the at-a-glance facts
+     * @param goals            the goals block
+     * @param scope            the scope block
+     * @param deliverables     the deliverables block
+     * @param timeline         the phase grid
+     * @param investment       the investment table
+     * @param terms            the terms block
+     * @param acceptance       the signing card
+     */
+    public StructuredProposalData(ProposalBrand brand, ProposalTitleLines title,
+                                  ProposalMetaLine meta,
+                                  ProposalSummaryBlock executiveSummary,
+                                  ProposalGlance glance, ProposalGoals goals,
+                                  ProposalScope scope, ProposalDeliverables deliverables,
+                                  ProposalPhaseGrid timeline, ProposalInvestment investment,
+                                  ProposalTermsBlock terms, ProposalAcceptance acceptance) {
+        this(brand, title, meta, executiveSummary, glance, goals, scope, deliverables,
+                timeline, investment, terms, acceptance, null, null, null);
     }
 
     /**
@@ -100,6 +144,9 @@ public record StructuredProposalData(
         private ProposalInvestment investment;
         private ProposalTermsBlock terms;
         private ProposalAcceptance acceptance;
+        private ProposalRecipient recipient;
+        private ProposalAttention attention;
+        private ProposalFooter footer;
 
         private Builder() {
         }
@@ -237,6 +284,39 @@ public record StructuredProposalData(
         }
 
         /**
+         * Sets the addressed organisation.
+         *
+         * @param recipient the addressed organisation
+         * @return this builder
+         */
+        public Builder recipient(ProposalRecipient recipient) {
+            this.recipient = recipient;
+            return this;
+        }
+
+        /**
+         * Sets the person at the recipient the proposal is addressed to.
+         *
+         * @param attention the addressed person
+         * @return this builder
+         */
+        public Builder attention(ProposalAttention attention) {
+            this.attention = attention;
+            return this;
+        }
+
+        /**
+         * Sets the issuer's own identity, as the foot states it.
+         *
+         * @param footer the issuer's identity
+         * @return this builder
+         */
+        public Builder footer(ProposalFooter footer) {
+            this.footer = footer;
+            return this;
+        }
+
+        /**
          * Builds the normalized structured proposal data.
          *
          * @return structured proposal data
@@ -244,7 +324,7 @@ public record StructuredProposalData(
         public StructuredProposalData build() {
             return new StructuredProposalData(brand, title, meta, executiveSummary,
                     glance, goals, scope, deliverables, timeline, investment,
-                    terms, acceptance);
+                    terms, acceptance, recipient, attention, footer);
         }
     }
 }


### PR DESCRIPTION
## Why

The proposal model was shaped for a two-page consulting document: a running header naming
three things by role, and a title of exactly three lines. The seven proposal bundles left
in the promotion queue are one-page **sales** proposals, and they open differently.

I surveyed all seven before touching anything. Their data shapes agree:

| what the design states | all seven | model today |
|---|---|---|
| addressed organisation: caption + name + address lines | ✅ 7/7 | one string (`meta.preparedFor`) |
| addressed person: caption + name + role + email + phone | ✅ 7/7 | — |
| header tiles: **a list of four** `{icon, label, value}` | ✅ 7/7 | a fixed trio by role |
| headline: 2–4 lines, sometimes an eyebrow, plus a standfirst | ✅ 7/7 | exactly three lines |
| foot: legal entity + address + channels (+ a notice) | 6/7 | `brand.footerName` |

Five separate additions to a published record — one per preset as I met it — would leave
the model a patchwork of near-duplicates. They arrive together instead.

## What

**New:** `ProposalRecipient`, `ProposalAttention`, `ProposalFooter`.
`StructuredProposalData` carries them as `recipient`, `attention` and `footer`, with its
twelve-argument constructor kept explicitly so existing calls compile and link unchanged,
and three builder methods.

**`ProposalTitleLines`** gains `eyebrow`, `lines` and `standfirst`. `lines` is the
canonical reading and `lead`/`second`/`third` are its first three — one statement kept
consistent by the compact constructor rather than by the caller, so a preset written
against the three reads the same title a four-line document states. The list form is a
factory, `ProposalTitleLines.of`, because a second three-argument constructor taking
`(String, List, List)` beside one taking three strings is ambiguous for a caller passing
nulls; that ambiguity showed up as a compile error the first time and is fixed at the API
rather than at the call site.

**`ProposalMetaLine`** gains `entries`. These deliberately do **not** derive from the trio
in either direction: turning three roles into tiles would mean inventing their captions,
and reading roles back out of arbitrary tiles would mean guessing which is which. A preset
draws the one its design has, and the Javadoc says so.

No preset changes here. This is the enabler the seven ports will stand on.

## Tests

`ProposalHeaderSpineTest` — 14 cases, each written from one of the seven designs the
spine was measured against, including the two outliers: the design that folds the
addressed person's name into its caption and gives the name no line of its own, and the
one whose foot carries only a confidentiality line. Also covers the four-line title
reading back as three, a three-line title reading back as a list without its blank, and
the pre-spine constructor leaving the new fields empty rather than null. 14/14.

Full reactor gate (`core, render-pdf, render-docx, render-pptx, templates, testing, qa,
coverage`) — BUILD SUCCESS.