### PR TITLE
feat(templates): give a proposal block the paragraph that opens it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ follow semantic versioning; release dates are ISO 8601.
 
 ### Public API
 
+- **A proposal block carries the paragraph that opens it.** `ProposalScope`,
+  `ProposalGoals` and `ProposalGlance` each set a heading and a list, and every one-page
+  sales proposal measured for the header spine also sets a paragraph between the two —
+  five of the seven set two of them, once over the solution and once over the reasons to
+  choose the issuer. The header survey missed it, so it arrives here rather than inside
+  the first preset that needs it. All three records gain `intro`, a plain string blank
+  when absent, and each keeps its previous constructor explicitly, so existing calls
+  compile and link unchanged and every block built through them opens straight into its
+  list as before.
+
 - **A proposal carries the header a one-page sales proposal has.** The proposal model was
   shaped for a two-page consulting document: a running header naming three things by role,
   and a title of exactly three lines. A one-page sales proposal opens differently — an

--- a/knowledge/api/templates.json
+++ b/knowledge/api/templates.json
@@ -23,9 +23,9 @@
   ],
   "counts": {
     "types": 226,
-    "methods": 1269,
+    "methods": 1275,
     "constants": 174,
-    "generated": 683
+    "generated": 686
   },
   "packages": [
     {
@@ -16692,6 +16692,28 @@
                 {
                   "type": "List<ProposalGlance.Fact>",
                   "name": null
+                },
+                {
+                  "type": "String",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "constructor",
+              "name": "ProposalGlance",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "String",
+                  "name": "heading"
+                },
+                {
+                  "type": "List<ProposalGlance.Fact>",
+                  "name": "facts"
                 }
               ]
             },
@@ -16711,6 +16733,15 @@
               "origin": "generated",
               "typeParameters": null,
               "returns": "List<ProposalGlance.Fact>",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "intro",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
               "params": []
             }
           ]
@@ -16816,6 +16847,32 @@
                 {
                   "type": "List<ProposalGoals.Goal>",
                   "name": null
+                },
+                {
+                  "type": "String",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "constructor",
+              "name": "ProposalGoals",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "String",
+                  "name": "heading"
+                },
+                {
+                  "type": "String",
+                  "name": "icon"
+                },
+                {
+                  "type": "List<ProposalGoals.Goal>",
+                  "name": "items"
                 }
               ]
             },
@@ -16844,6 +16901,15 @@
               "origin": "generated",
               "typeParameters": null,
               "returns": "List<ProposalGoals.Goal>",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "intro",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
               "params": []
             }
           ]
@@ -17895,6 +17961,32 @@
                 {
                   "type": "List<ProposalScope.Item>",
                   "name": null
+                },
+                {
+                  "type": "String",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "constructor",
+              "name": "ProposalScope",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "String",
+                  "name": "heading"
+                },
+                {
+                  "type": "String",
+                  "name": "icon"
+                },
+                {
+                  "type": "List<ProposalScope.Item>",
+                  "name": "items"
                 }
               ]
             },
@@ -17923,6 +18015,15 @@
               "origin": "generated",
               "typeParameters": null,
               "returns": "List<ProposalScope.Item>",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "intro",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
               "params": []
             }
           ]

--- a/knowledge/api/templates.md
+++ b/knowledge/api/templates.md
@@ -28,7 +28,7 @@ note: "Generated from the pinned artifact's class files. Authoritative closed se
 
 **GraphCompose version:** 2.4.0-SNAPSHOT
 
-Types: 226 · methods: 1269 · constants: 174 · compiler-generated members: 683
+Types: 226 · methods: 1275 · constants: 174 · compiler-generated members: 686
 
 ## com.demcha.compose.document.templates.api
 
@@ -1393,9 +1393,11 @@ Types: 226 · methods: 1269 · constants: 174 · compiler-generated members: 683
 - `String confidentiality()`
 
 ### ProposalGlance (record)
-- `new ProposalGlance(String, List<ProposalGlance.Fact>)`
+- `new ProposalGlance(String, List<ProposalGlance.Fact>, String)`
+- `new ProposalGlance(String heading, List<ProposalGlance.Fact> facts)`
 - `String heading()`
 - `List<ProposalGlance.Fact> facts()`
+- `String intro()`
 
 ### ProposalGlance.Fact (record)
 - `new Fact(String, String, String, String)`
@@ -1405,10 +1407,12 @@ Types: 226 · methods: 1269 · constants: 174 · compiler-generated members: 683
 - `String note()`
 
 ### ProposalGoals (record)
-- `new ProposalGoals(String, String, List<ProposalGoals.Goal>)`
+- `new ProposalGoals(String, String, List<ProposalGoals.Goal>, String)`
+- `new ProposalGoals(String heading, String icon, List<ProposalGoals.Goal> items)`
 - `String heading()`
 - `String icon()`
 - `List<ProposalGoals.Goal> items()`
+- `String intro()`
 
 ### ProposalGoals.Goal (record)
 - `new Goal(String, String)`
@@ -1506,10 +1510,12 @@ Types: 226 · methods: 1269 · constants: 174 · compiler-generated members: 683
 - `List<String> addressLines()`
 
 ### ProposalScope (record)
-- `new ProposalScope(String, String, List<ProposalScope.Item>)`
+- `new ProposalScope(String, String, List<ProposalScope.Item>, String)`
+- `new ProposalScope(String heading, String icon, List<ProposalScope.Item> items)`
 - `String heading()`
 - `String icon()`
 - `List<ProposalScope.Item> items()`
+- `String intro()`
 
 ### ProposalScope.Item (record)
 - `new Item(String, String, String)`

--- a/qa/src/test/java/com/demcha/compose/document/templates/data/proposal/ProposalHeaderSpineTest.java
+++ b/qa/src/test/java/com/demcha/compose/document/templates/data/proposal/ProposalHeaderSpineTest.java
@@ -150,6 +150,36 @@ class ProposalHeaderSpineTest {
         assertThat(new ProposalFooter(null, null, null, null).isPresent()).isFalse();
     }
 
+    // -- the paragraph that opens a block --------------------------------
+
+    @Test
+    void aBlockCarriesTheParagraphThatOpensItAboveTheItems() {
+        // Every one of the seven sets one, and five of them set two — once over
+        // the solution and once over the reasons to choose the issuer.
+        ProposalScope scope = new ProposalScope("PROJECT OVERVIEW", "",
+                List.of(new ProposalScope.Item("01", "Multi-currency accounts",
+                        "Hold, send, receive in 30+ currencies")),
+                "This proposal outlines a tailored solution.");
+        assertThat(scope.intro()).isEqualTo("This proposal outlines a tailored solution.");
+        assertThat(scope.items()).hasSize(1);
+
+        ProposalGlance glance = new ProposalGlance("ABOUT",
+                List.of(new ProposalGlance.Fact("globe", "Global", "Scale", "")),
+                "Modern financial infrastructure for forward-thinking companies.");
+        assertThat(glance.intro()).contains("Modern financial infrastructure");
+
+        ProposalGoals goals = new ProposalGoals("WHY US", "",
+                List.of(new ProposalGoals.Goal("", "Fast")), "Because it is faster.");
+        assertThat(goals.intro()).isEqualTo("Because it is faster.");
+    }
+
+    @Test
+    void theConstructorsThatPredateTheOpeningParagraphLeaveItBlank() {
+        assertThat(new ProposalScope("PROJECT OVERVIEW", "", List.of()).intro()).isEmpty();
+        assertThat(new ProposalGoals("WHY US", "", List.of()).intro()).isEmpty();
+        assertThat(new ProposalGlance("ABOUT", List.of()).intro()).isEmpty();
+    }
+
     // -- the aggregate ---------------------------------------------------
 
     @Test

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/proposal/ProposalGlance.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/proposal/ProposalGlance.java
@@ -8,8 +8,12 @@ import java.util.Objects;
  *
  * @param heading the card heading
  * @param facts   the fact rows, in order
+ * @param intro   the paragraph that opens the block, above its items; every
+ *                one-page sales proposal measured for this sets one, most of
+ *                them twice, and a block that opens straight into its list
+ *                leaves it blank
  */
-public record ProposalGlance(String heading, List<Fact> facts) {
+public record ProposalGlance(String heading, List<Fact> facts, String intro) {
 
     /**
      * Normalizes optional fields and freezes the fact list.
@@ -17,6 +21,18 @@ public record ProposalGlance(String heading, List<Fact> facts) {
     public ProposalGlance {
         heading = Objects.requireNonNullElse(heading, "");
         facts = List.copyOf(Objects.requireNonNullElse(facts, List.of()));
+        intro = Objects.requireNonNullElse(intro, "");
+    }
+
+    /**
+     * Backward-compatible constructor for callers that predate the opening
+     * paragraph.
+     *
+     * @param heading the block's heading
+     * @param facts   the facts the block sets
+     */
+    public ProposalGlance(String heading, List<Fact> facts) {
+        this(heading, facts, "");
     }
 
     /**

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/proposal/ProposalGoals.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/proposal/ProposalGoals.java
@@ -10,8 +10,13 @@ import java.util.Objects;
  * @param heading the section heading
  * @param icon    the icon token of the section badge
  * @param items   the goal cells, in order
+ * @param intro   the paragraph that opens the block, above its items; every
+ *                one-page sales proposal measured for this sets one, most of
+ *                them twice, and a block that opens straight into its list
+ *                leaves it blank
  */
-public record ProposalGoals(String heading, String icon, List<Goal> items) {
+public record ProposalGoals(String heading, String icon, List<Goal> items,
+                            String intro) {
 
     /**
      * Normalizes optional fields and freezes the goal list.
@@ -20,6 +25,19 @@ public record ProposalGoals(String heading, String icon, List<Goal> items) {
         heading = Objects.requireNonNullElse(heading, "");
         icon = Objects.requireNonNullElse(icon, "");
         items = List.copyOf(Objects.requireNonNullElse(items, List.of()));
+        intro = Objects.requireNonNullElse(intro, "");
+    }
+
+    /**
+     * Backward-compatible constructor for callers that predate the opening
+     * paragraph.
+     *
+     * @param heading the block's heading
+     * @param icon    the mark the heading opens with
+     * @param items   the block's items
+     */
+    public ProposalGoals(String heading, String icon, List<Goal> items) {
+        this(heading, icon, items, "");
     }
 
     /**

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/proposal/ProposalScope.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/proposal/ProposalScope.java
@@ -13,8 +13,13 @@ import java.util.Objects;
  * @param heading the section heading
  * @param icon    the icon token of the section badge
  * @param items   the numbered scope rows, in order
+ * @param intro   the paragraph that opens the block, above its items; every
+ *                one-page sales proposal measured for this sets one, most of
+ *                them twice, and a block that opens straight into its list
+ *                leaves it blank
  */
-public record ProposalScope(String heading, String icon, List<Item> items) {
+public record ProposalScope(String heading, String icon, List<Item> items,
+                            String intro) {
 
     /**
      * Normalizes optional fields and freezes the item list.
@@ -23,6 +28,19 @@ public record ProposalScope(String heading, String icon, List<Item> items) {
         heading = Objects.requireNonNullElse(heading, "");
         icon = Objects.requireNonNullElse(icon, "");
         items = List.copyOf(Objects.requireNonNullElse(items, List.of()));
+        intro = Objects.requireNonNullElse(intro, "");
+    }
+
+    /**
+     * Backward-compatible constructor for callers that predate the opening
+     * paragraph.
+     *
+     * @param heading the block's heading
+     * @param icon    the mark the heading opens with
+     * @param items   the block's items
+     */
+    public ProposalScope(String heading, String icon, List<Item> items) {
+        this(heading, icon, items, "");
     }
 
     /**


### PR DESCRIPTION
## Why

`ProposalScope`, `ProposalGoals` and `ProposalGlance` each set a heading and a list. Every
one-page sales proposal measured for the header spine ([#652](https://github.com/DemchaAV/GraphCompose/pull/652)) also sets a paragraph between
the two:

| bundle | blocks with `heading + paragraph + items` |
|---|---|
| revolut | `projectOverview`, `about` |
| google-cloud | `why` |
| aws-cloud | `solution`, `whyAws` |
| microsoft-cloud | `solution`, `about` |
| salesforce | `why` |
| shopify | `solution`, `whyShopify` |
| stripe | `solutionOverview`, `whyCard` |

**7 of 7**, and five of them twice.

The header survey counted five shared things and there are six. This is the sixth. It
arrives on its own rather than inside the first preset that needs it, for the same reason
the other five did: a field added per preset as it turns up leaves the model a patchwork
of near-duplicates.

## What

All three records gain `intro` — a plain string, blank when absent. Each keeps its
previous constructor explicitly, so existing calls compile and link unchanged and every
block built through them opens straight into its list as before.

## Tests

Two cases added to `ProposalHeaderSpineTest`: all three blocks carry the paragraph they
are given, and the constructors that predate it leave it blank. 17/17.

Javadoc gate clean. Full reactor gate (`core, render-pdf, render-docx, render-pptx,
templates, testing, qa, coverage`) — BUILD SUCCESS.