### PR TITLE
feat(templates): model a staff rota, and retire the roster model nothing rendered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,50 @@ follow semantic versioning; release dates are ISO 8601.
   the model whose shape it renders. Every component normalizes `null` to its empty
   form and freezes its collections, matching the family's existing records.
 
+- **A rota document model, replacing `data.schedule`.** The library already shipped a
+  weekly-roster model — `templates.data.schedule`, public since the templates module was
+  extracted — and nothing ever rendered it, because it is not shaped like a rota is
+  drawn: its people are ordered by a token and grouped nowhere, so there are no staff
+  bands; an assignment cannot say that one half of a split day is drawn more quietly
+  than the other; a day heading is one string, which a design that raises the ordinal's
+  suffix cannot split; and a category carries three `java.awt.Color`s, which puts the
+  rendering decision in the document and stops two presets drawing the same rota in two
+  palettes. `templates.data.rota` is the replacement — `StructuredRotaData` (venue,
+  week, day columns, legend, staff bands, footer) wrapped by
+  `StructuredRotaDocumentSpec`, with `RotaVenue` / `RotaWeek` / `RotaDay` /
+  `RotaCovers` / `RotaLegend` / `RotaGroup` / `RotaStaff` / `RotaShift` / `RotaFooter`
+  and the `ShiftStatus` / `ShiftEmphasis` enumerations.
+  <br><br>
+  **The grid is the document's, not the preset's.** `days()` is the columns and every
+  `RotaStaff.days()` runs in that same order, so a cell is found by position and a rota
+  of five days is as ordinary as one of seven — the span is a label the document
+  carries, not a shape the model imposes. A person's day is a *list* of entries rather
+  than one, which makes the two shapes a rota actually has — a blank cell and a split
+  shift — ordinary rather than special cases a preset has to invent a representation
+  for. `RotaStaff.day(int)` answers with nothing for a day the rota does not reach, so a
+  short row is a short row and not a broken document.
+  <br><br>
+  **What a cell means is separate from what it prints.** `ShiftStatus` is the meaning a
+  preset colours by; the text is the word a particular site uses for it, so a rota
+  printing `A/L` and one printing `HOL` colour alike, and a legend entry pairs the two.
+  `ShiftEmphasis` says how loudly an entry is drawn — the day someone is off is what a
+  reader scans for, the hours they work is what they read once they have found the
+  person. There is deliberately no `marked(text, status)` factory that picks the
+  emphasis: a design that halves a day draws the halves differently, sometimes quiet
+  second and sometimes not, so `RotaShift.strong(...)` and `RotaShift.soft(...)` make
+  the caller say which. Every component normalizes `null` to its empty form and freezes
+  its collections, the inner day lists included, matching the family's existing records.
+
+### Deprecated
+
+- **`templates.data.schedule` — every type.** `WeeklyScheduleData`,
+  `WeeklyScheduleDocumentSpec`, `ScheduleDay`, `ScheduleCategory`, `SchedulePerson`,
+  `ScheduleAssignment`, `ScheduleSlot` and `ScheduleMetricRow` are deprecated since
+  2.4.0 in favour of `templates.data.rota`, each naming its replacement. They still
+  ship and still compile; nothing in the library ever rendered them, so no output moves.
+  `docs/templates/which-template-system.md` now points a caller at the rota model
+  instead.
+
 ### Templates
 
 - **The invoice presets set their page number in their own face.** A header or footer

--- a/docs/templates/which-template-system.md
+++ b/docs/templates/which-template-system.md
@@ -88,7 +88,7 @@ migration is the theme + data-record swap:
 |---|---|
 | `InvoiceTemplateV1` / `InvoiceTemplateV2` | `templates.invoice.presets.ModernInvoice` — `create()` or `create(BrandTheme)`, data record `InvoiceDocumentSpec`. |
 | `ProposalTemplateV1` / `ProposalTemplateV2` | `templates.proposal.presets.ModernProposal` — same shape, data record `ProposalDocumentSpec`. |
-| `WeeklyScheduleTemplateV1` | No 2.0 template yet. The `templates.data.schedule` records still ship; author the rendering on the canonical DSL. |
+| `WeeklyScheduleTemplateV1` | No template yet. Model the rota on `templates.data.rota` (`StructuredRotaDocumentSpec`) and author the rendering on the canonical DSL. The `templates.data.schedule` records still ship but are **deprecated since 2.4.0**: they hold their colours in the data, know nothing of staff bands, and nothing ever rendered them. |
 
 ### Legacy PDF API → canonical DSL
 

--- a/knowledge/api/templates.json
+++ b/knowledge/api/templates.json
@@ -22,10 +22,10 @@
     "graph-compose-testing:sources"
   ],
   "counts": {
-    "types": 227,
-    "methods": 1276,
-    "constants": 177,
-    "generated": 689
+    "types": 242,
+    "methods": 1344,
+    "constants": 188,
+    "generated": 747
   },
   "packages": [
     {
@@ -19171,6 +19171,1111 @@
               "origin": "generated",
               "typeParameters": null,
               "returns": "StructuredProposalData",
+              "params": []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "com.demcha.compose.document.templates.data.rota",
+      "types": [
+        {
+          "name": "RotaCovers",
+          "binaryName": "com.demcha.compose.document.templates.data.rota.RotaCovers",
+          "kind": "record",
+          "modifiers": [
+            "final"
+          ],
+          "artifact": "graph-compose-templates",
+          "members": [
+            {
+              "kind": "constructor",
+              "name": "RotaCovers",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "String",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "isPresent",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "boolean",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "lunch",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "dinner",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            }
+          ]
+        },
+        {
+          "name": "RotaDay",
+          "binaryName": "com.demcha.compose.document.templates.data.rota.RotaDay",
+          "kind": "record",
+          "modifiers": [
+            "final"
+          ],
+          "artifact": "graph-compose-templates",
+          "members": [
+            {
+              "kind": "constructor",
+              "name": "RotaDay",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "RotaCovers",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "constructor",
+              "name": "RotaDay",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "String",
+                  "name": "name"
+                },
+                {
+                  "type": "String",
+                  "name": "ordinal"
+                },
+                {
+                  "type": "String",
+                  "name": "ordinalSuffix"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "name",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "ordinal",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "ordinalSuffix",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "note",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "covers",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "RotaCovers",
+              "params": []
+            }
+          ]
+        },
+        {
+          "name": "RotaFooter",
+          "binaryName": "com.demcha.compose.document.templates.data.rota.RotaFooter",
+          "kind": "record",
+          "modifiers": [
+            "final"
+          ],
+          "artifact": "graph-compose-templates",
+          "members": [
+            {
+              "kind": "constructor",
+              "name": "RotaFooter",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "String",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "isPresent",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "boolean",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "note",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            }
+          ]
+        },
+        {
+          "name": "RotaGroup",
+          "binaryName": "com.demcha.compose.document.templates.data.rota.RotaGroup",
+          "kind": "record",
+          "modifiers": [
+            "final"
+          ],
+          "artifact": "graph-compose-templates",
+          "members": [
+            {
+              "kind": "constructor",
+              "name": "RotaGroup",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "List<RotaStaff>",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "constructor",
+              "name": "RotaGroup",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "String",
+                  "name": "label"
+                },
+                {
+                  "type": "List<RotaStaff>",
+                  "name": "staff"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "label",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "icon",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "staff",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "List<RotaStaff>",
+              "params": []
+            }
+          ]
+        },
+        {
+          "name": "RotaLegend",
+          "binaryName": "com.demcha.compose.document.templates.data.rota.RotaLegend",
+          "kind": "record",
+          "modifiers": [
+            "final"
+          ],
+          "artifact": "graph-compose-templates",
+          "members": [
+            {
+              "kind": "constructor",
+              "name": "RotaLegend",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "List<RotaLegend.Entry>",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "constructor",
+              "name": "RotaLegend",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "String",
+                  "name": "label"
+                },
+                {
+                  "type": "List<RotaLegend.Entry>",
+                  "name": "entries"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "isPresent",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "boolean",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "label",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "coversLabel",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "coversLunchLabel",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "coversDinnerLabel",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "entries",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "List<RotaLegend.Entry>",
+              "params": []
+            }
+          ]
+        },
+        {
+          "name": "RotaLegend.Entry",
+          "binaryName": "com.demcha.compose.document.templates.data.rota.RotaLegend$Entry",
+          "kind": "record",
+          "modifiers": [
+            "final"
+          ],
+          "artifact": "graph-compose-templates",
+          "members": [
+            {
+              "kind": "constructor",
+              "name": "Entry",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "ShiftStatus",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "label",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "status",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "ShiftStatus",
+              "params": []
+            }
+          ]
+        },
+        {
+          "name": "RotaShift",
+          "binaryName": "com.demcha.compose.document.templates.data.rota.RotaShift",
+          "kind": "record",
+          "modifiers": [
+            "final"
+          ],
+          "artifact": "graph-compose-templates",
+          "members": [
+            {
+              "kind": "constructor",
+              "name": "RotaShift",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "ShiftStatus",
+                  "name": null
+                },
+                {
+                  "type": "ShiftEmphasis",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "hours",
+              "static": true,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "RotaShift",
+              "params": [
+                {
+                  "type": "String",
+                  "name": "text"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "strong",
+              "static": true,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "RotaShift",
+              "params": [
+                {
+                  "type": "String",
+                  "name": "text"
+                },
+                {
+                  "type": "ShiftStatus",
+                  "name": "status"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "soft",
+              "static": true,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "RotaShift",
+              "params": [
+                {
+                  "type": "String",
+                  "name": "text"
+                },
+                {
+                  "type": "ShiftStatus",
+                  "name": "status"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "text",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "status",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "ShiftStatus",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "emphasis",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "ShiftEmphasis",
+              "params": []
+            }
+          ]
+        },
+        {
+          "name": "RotaStaff",
+          "binaryName": "com.demcha.compose.document.templates.data.rota.RotaStaff",
+          "kind": "record",
+          "modifiers": [
+            "final"
+          ],
+          "artifact": "graph-compose-templates",
+          "members": [
+            {
+              "kind": "constructor",
+              "name": "RotaStaff",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "List<List<RotaShift>>",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "day",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "List<RotaShift>",
+              "params": [
+                {
+                  "type": "int",
+                  "name": "index"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "name",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "days",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "List<List<RotaShift>>",
+              "params": []
+            }
+          ]
+        },
+        {
+          "name": "RotaVenue",
+          "binaryName": "com.demcha.compose.document.templates.data.rota.RotaVenue",
+          "kind": "record",
+          "modifiers": [
+            "final"
+          ],
+          "artifact": "graph-compose-templates",
+          "members": [
+            {
+              "kind": "constructor",
+              "name": "RotaVenue",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "String",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "isPresent",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "boolean",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "wordmark",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "wordmarkSub",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "footerName",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            }
+          ]
+        },
+        {
+          "name": "RotaWeek",
+          "binaryName": "com.demcha.compose.document.templates.data.rota.RotaWeek",
+          "kind": "record",
+          "modifiers": [
+            "final"
+          ],
+          "artifact": "graph-compose-templates",
+          "members": [
+            {
+              "kind": "constructor",
+              "name": "RotaWeek",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "String",
+                  "name": null
+                },
+                {
+                  "type": "String",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "isPresent",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "boolean",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "title",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "rangeLabel",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "String",
+              "params": []
+            }
+          ]
+        },
+        {
+          "name": "ShiftEmphasis",
+          "binaryName": "com.demcha.compose.document.templates.data.rota.ShiftEmphasis",
+          "kind": "enum",
+          "modifiers": [
+            "final"
+          ],
+          "artifact": "graph-compose-templates",
+          "members": [
+            {
+              "kind": "constant",
+              "name": "STRONG",
+              "static": true,
+              "origin": "generated",
+              "type": "ShiftEmphasis"
+            },
+            {
+              "kind": "constant",
+              "name": "SOFT",
+              "static": true,
+              "origin": "generated",
+              "type": "ShiftEmphasis"
+            },
+            {
+              "kind": "constant",
+              "name": "PLAIN",
+              "static": true,
+              "origin": "generated",
+              "type": "ShiftEmphasis"
+            }
+          ]
+        },
+        {
+          "name": "ShiftStatus",
+          "binaryName": "com.demcha.compose.document.templates.data.rota.ShiftStatus",
+          "kind": "enum",
+          "modifiers": [
+            "final"
+          ],
+          "artifact": "graph-compose-templates",
+          "members": [
+            {
+              "kind": "constant",
+              "name": "NONE",
+              "static": true,
+              "origin": "generated",
+              "type": "ShiftStatus"
+            },
+            {
+              "kind": "constant",
+              "name": "REQUEST",
+              "static": true,
+              "origin": "generated",
+              "type": "ShiftStatus"
+            },
+            {
+              "kind": "constant",
+              "name": "OFF",
+              "static": true,
+              "origin": "generated",
+              "type": "ShiftStatus"
+            },
+            {
+              "kind": "constant",
+              "name": "HOLIDAY",
+              "static": true,
+              "origin": "generated",
+              "type": "ShiftStatus"
+            },
+            {
+              "kind": "constant",
+              "name": "STOCK",
+              "static": true,
+              "origin": "generated",
+              "type": "ShiftStatus"
+            },
+            {
+              "kind": "constant",
+              "name": "STANDBY",
+              "static": true,
+              "origin": "generated",
+              "type": "ShiftStatus"
+            },
+            {
+              "kind": "constant",
+              "name": "TRAINING",
+              "static": true,
+              "origin": "generated",
+              "type": "ShiftStatus"
+            },
+            {
+              "kind": "constant",
+              "name": "SUPPORT",
+              "static": true,
+              "origin": "generated",
+              "type": "ShiftStatus"
+            }
+          ]
+        },
+        {
+          "name": "StructuredRotaData",
+          "binaryName": "com.demcha.compose.document.templates.data.rota.StructuredRotaData",
+          "kind": "record",
+          "modifiers": [
+            "final"
+          ],
+          "artifact": "graph-compose-templates",
+          "members": [
+            {
+              "kind": "constructor",
+              "name": "StructuredRotaData",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "RotaVenue",
+                  "name": null
+                },
+                {
+                  "type": "RotaWeek",
+                  "name": null
+                },
+                {
+                  "type": "List<RotaDay>",
+                  "name": null
+                },
+                {
+                  "type": "RotaLegend",
+                  "name": null
+                },
+                {
+                  "type": "List<RotaGroup>",
+                  "name": null
+                },
+                {
+                  "type": "RotaFooter",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "builder",
+              "static": true,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "StructuredRotaData.Builder",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "venue",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "RotaVenue",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "week",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "RotaWeek",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "days",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "List<RotaDay>",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "legend",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "RotaLegend",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "groups",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "List<RotaGroup>",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "footer",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "RotaFooter",
+              "params": []
+            }
+          ]
+        },
+        {
+          "name": "StructuredRotaData.Builder",
+          "binaryName": "com.demcha.compose.document.templates.data.rota.StructuredRotaData$Builder",
+          "kind": "class",
+          "modifiers": [
+            "final"
+          ],
+          "artifact": "graph-compose-templates",
+          "members": [
+            {
+              "kind": "method",
+              "name": "venue",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "StructuredRotaData.Builder",
+              "params": [
+                {
+                  "type": "RotaVenue",
+                  "name": "venue"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "week",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "StructuredRotaData.Builder",
+              "params": [
+                {
+                  "type": "RotaWeek",
+                  "name": "week"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "days",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "StructuredRotaData.Builder",
+              "params": [
+                {
+                  "type": "List<RotaDay>",
+                  "name": "days"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "legend",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "StructuredRotaData.Builder",
+              "params": [
+                {
+                  "type": "RotaLegend",
+                  "name": "legend"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "groups",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "StructuredRotaData.Builder",
+              "params": [
+                {
+                  "type": "List<RotaGroup>",
+                  "name": "groups"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "footer",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "StructuredRotaData.Builder",
+              "params": [
+                {
+                  "type": "RotaFooter",
+                  "name": "footer"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "build",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "StructuredRotaData",
+              "params": []
+            }
+          ]
+        },
+        {
+          "name": "StructuredRotaDocumentSpec",
+          "binaryName": "com.demcha.compose.document.templates.data.rota.StructuredRotaDocumentSpec",
+          "kind": "record",
+          "modifiers": [
+            "final"
+          ],
+          "artifact": "graph-compose-templates",
+          "members": [
+            {
+              "kind": "constructor",
+              "name": "StructuredRotaDocumentSpec",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "StructuredRotaData",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "from",
+              "static": true,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "StructuredRotaDocumentSpec",
+              "params": [
+                {
+                  "type": "StructuredRotaData",
+                  "name": "rota"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "rota",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "StructuredRotaData",
               "params": []
             }
           ]

--- a/knowledge/api/templates.md
+++ b/knowledge/api/templates.md
@@ -28,7 +28,7 @@ note: "Generated from the pinned artifact's class files. Authoritative closed se
 
 **GraphCompose version:** 2.4.0-SNAPSHOT
 
-Types: 227 · methods: 1276 · constants: 177 · compiler-generated members: 689
+Types: 242 · methods: 1344 · constants: 188 · compiler-generated members: 747
 
 ## com.demcha.compose.document.templates.api
 
@@ -1614,6 +1614,108 @@ Types: 227 · methods: 1276 · constants: 177 · compiler-generated members: 689
 - `new StructuredProposalDocumentSpec(StructuredProposalData)`
 - `StructuredProposalDocumentSpec from(StructuredProposalData proposal)`
 - `StructuredProposalData proposal()`
+
+## com.demcha.compose.document.templates.data.rota
+
+### RotaCovers (record)
+- `new RotaCovers(String, String)`
+- `boolean isPresent()`
+- `String lunch()`
+- `String dinner()`
+
+### RotaDay (record)
+- `new RotaDay(String, String, String, String, RotaCovers)`
+- `new RotaDay(String name, String ordinal, String ordinalSuffix)`
+- `String name()`
+- `String ordinal()`
+- `String ordinalSuffix()`
+- `String note()`
+- `RotaCovers covers()`
+
+### RotaFooter (record)
+- `new RotaFooter(String)`
+- `boolean isPresent()`
+- `String note()`
+
+### RotaGroup (record)
+- `new RotaGroup(String, String, List<RotaStaff>)`
+- `new RotaGroup(String label, List<RotaStaff> staff)`
+- `String label()`
+- `String icon()`
+- `List<RotaStaff> staff()`
+
+### RotaLegend (record)
+- `new RotaLegend(String, String, String, String, List<RotaLegend.Entry>)`
+- `new RotaLegend(String label, List<RotaLegend.Entry> entries)`
+- `boolean isPresent()`
+- `String label()`
+- `String coversLabel()`
+- `String coversLunchLabel()`
+- `String coversDinnerLabel()`
+- `List<RotaLegend.Entry> entries()`
+
+### RotaLegend.Entry (record)
+- `new Entry(String, ShiftStatus)`
+- `String label()`
+- `ShiftStatus status()`
+
+### RotaShift (record)
+- `new RotaShift(String, ShiftStatus, ShiftEmphasis)`
+- `RotaShift hours(String text)`
+- `RotaShift strong(String text, ShiftStatus status)`
+- `RotaShift soft(String text, ShiftStatus status)`
+- `String text()`
+- `ShiftStatus status()`
+- `ShiftEmphasis emphasis()`
+
+### RotaStaff (record)
+- `new RotaStaff(String, List<List<RotaShift>>)`
+- `List<RotaShift> day(int index)`
+- `String name()`
+- `List<List<RotaShift>> days()`
+
+### RotaVenue (record)
+- `new RotaVenue(String, String, String)`
+- `boolean isPresent()`
+- `String wordmark()`
+- `String wordmarkSub()`
+- `String footerName()`
+
+### RotaWeek (record)
+- `new RotaWeek(String, String)`
+- `boolean isPresent()`
+- `String title()`
+- `String rangeLabel()`
+
+### ShiftEmphasis (enum)
+- constants: `STRONG`, `SOFT`, `PLAIN`
+
+### ShiftStatus (enum)
+- constants: `NONE`, `REQUEST`, `OFF`, `HOLIDAY`, `STOCK`, `STANDBY`, `TRAINING`, `SUPPORT`
+
+### StructuredRotaData (record)
+- `new StructuredRotaData(RotaVenue, RotaWeek, List<RotaDay>, RotaLegend, List<RotaGroup>, RotaFooter)`
+- `StructuredRotaData.Builder builder()`
+- `RotaVenue venue()`
+- `RotaWeek week()`
+- `List<RotaDay> days()`
+- `RotaLegend legend()`
+- `List<RotaGroup> groups()`
+- `RotaFooter footer()`
+
+### StructuredRotaData.Builder (class)
+- `StructuredRotaData.Builder venue(RotaVenue venue)`
+- `StructuredRotaData.Builder week(RotaWeek week)`
+- `StructuredRotaData.Builder days(List<RotaDay> days)`
+- `StructuredRotaData.Builder legend(RotaLegend legend)`
+- `StructuredRotaData.Builder groups(List<RotaGroup> groups)`
+- `StructuredRotaData.Builder footer(RotaFooter footer)`
+- `StructuredRotaData build()`
+
+### StructuredRotaDocumentSpec (record)
+- `new StructuredRotaDocumentSpec(StructuredRotaData)`
+- `StructuredRotaDocumentSpec from(StructuredRotaData rota)`
+- `StructuredRotaData rota()`
 
 ## com.demcha.compose.document.templates.data.schedule
 

--- a/qa/src/test/java/com/demcha/compose/document/templates/data/rota/StructuredRotaDataTest.java
+++ b/qa/src/test/java/com/demcha/compose/document/templates/data/rota/StructuredRotaDataTest.java
@@ -1,0 +1,244 @@
+package com.demcha.compose.document.templates.data.rota;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Pins the rota model's two contracts: a partial document composes without null
+ * checks in preset code, and nothing a caller keeps a reference to can change
+ * the document afterwards.
+ */
+class StructuredRotaDataTest {
+
+    @Test
+    void anEmptyRotaHasEveryComponentRatherThanNulls() {
+        // A preset reads six components and drawing guards on each of them is
+        // six chances to forget one. The model is what makes that unnecessary.
+        StructuredRotaData rota = StructuredRotaData.builder().build();
+        assertThat(rota.venue()).isNotNull();
+        assertThat(rota.week()).isNotNull();
+        assertThat(rota.days()).isEmpty();
+        assertThat(rota.legend()).isNotNull();
+        assertThat(rota.groups()).isEmpty();
+        assertThat(rota.footer()).isNotNull();
+        assertThat(rota.venue().isPresent()).isFalse();
+        assertThat(rota.week().isPresent()).isFalse();
+        assertThat(rota.legend().isPresent()).isFalse();
+        assertThat(rota.footer().isPresent()).isFalse();
+        assertThat(StructuredRotaDocumentSpec.from(null).rota()).isNotNull();
+    }
+
+    @Test
+    void everyBuilderSetterReachesTheDocumentItBuilds() {
+        // Without this, a setter that dropped its argument passes the suite:
+        // the empty-rota test above asserts only the absent half of each block.
+        RotaVenue venue = new RotaVenue("HARBOUR", "Quayside", "Harbour Quayside");
+        RotaWeek week = new RotaWeek("WEEKLY ROTA", "31 Aug - 6 Sep");
+        RotaLegend legend = new RotaLegend("STATUS", "COVERS", "L", "D",
+                List.of(new RotaLegend.Entry("OFF", ShiftStatus.OFF)));
+        RotaFooter footer = new RotaFooter("Swaps to the duty manager by Thursday.");
+        RotaDay day = new RotaDay("MONDAY", "31", "ST", "Pianist 18:30",
+                new RotaCovers("104", "50"));
+        RotaGroup group = new RotaGroup("BAR", "glass",
+                List.of(new RotaStaff("Priya", List.of(List.of(RotaShift.hours("09:00-17:00"))))));
+
+        StructuredRotaData rota = StructuredRotaData.builder()
+                .venue(venue).week(week).days(List.of(day))
+                .legend(legend).groups(List.of(group)).footer(footer)
+                .build();
+
+        assertThat(rota.venue()).isEqualTo(venue);
+        assertThat(rota.week()).isEqualTo(week);
+        assertThat(rota.days()).containsExactly(day);
+        assertThat(rota.legend()).isEqualTo(legend);
+        assertThat(rota.groups()).containsExactly(group);
+        assertThat(rota.footer()).isEqualTo(footer);
+        assertThat(StructuredRotaDocumentSpec.from(rota).rota()).isEqualTo(rota);
+    }
+
+    @Test
+    void aStatedBlockReportsItselfPresent() {
+        // The other half of every isPresent(): all three would pass the empty
+        // case if they simply always answered false.
+        assertThat(new RotaVenue("HARBOUR", "", "").isPresent()).isTrue();
+        assertThat(new RotaVenue("", "Quayside", "").isPresent()).isTrue();
+        assertThat(new RotaVenue("", "", "Harbour Quayside").isPresent()).isTrue();
+        assertThat(new RotaWeek("WEEKLY ROTA", "").isPresent()).isTrue();
+        assertThat(new RotaWeek("", "31 Aug - 6 Sep").isPresent()).isTrue();
+        assertThat(new RotaFooter("Swaps to the duty manager.").isPresent()).isTrue();
+        assertThat(new RotaLegend("STATUS", List.of()).isPresent()).isTrue();
+        assertThat(new RotaLegend("", List.of(
+                new RotaLegend.Entry("OFF", ShiftStatus.OFF))).isPresent()).isTrue();
+    }
+
+    @Test
+    void aDayCarriesItsNoteAndItsCovers() {
+        RotaDay day = new RotaDay("MONDAY", "31", "ST", "Pianist 18:30",
+                new RotaCovers("104", "50"));
+        assertThat(day.note()).isEqualTo("Pianist 18:30");
+        assertThat(day.covers().lunch()).isEqualTo("104");
+        assertThat(day.covers().dinner()).isEqualTo("50");
+    }
+
+    @Test
+    void theCoversRowCarriesItsOwnLabels() {
+        // The covers row is a label and two marks, and all three are the
+        // document's words rather than the preset's.
+        RotaLegend legend = new RotaLegend("STATUS LEGEND", "COVERS", "L", "D", List.of());
+        assertThat(legend.coversLabel()).isEqualTo("COVERS");
+        assertThat(legend.coversLunchLabel()).isEqualTo("L");
+        assertThat(legend.coversDinnerLabel()).isEqualTo("D");
+    }
+
+    @Test
+    void aDayIsAListSoAnEmptyDayAndASplitDayAreBothOrdinary() {
+        // The reason days() is a list of lists: a blank cell and a split shift
+        // are the two shapes a rota actually has, and neither is an exception.
+        RotaStaff staff = new RotaStaff("Priya", List.of(
+                List.of(),
+                List.of(RotaShift.hours("09:00-18:00")),
+                List.of(RotaShift.hours("12:00-16:00"),
+                        new RotaShift("16:00-22:00", ShiftStatus.NONE, ShiftEmphasis.SOFT))));
+        assertThat(staff.day(0)).isEmpty();
+        assertThat(staff.day(1)).hasSize(1);
+        assertThat(staff.day(2)).hasSize(2);
+    }
+
+    @Test
+    void askingForADayTheRotaDoesNotReachIsNotAnError() {
+        // A preset walks the rota's own day columns, and a person listed with
+        // fewer days than the sheet has is a short row, not a broken document.
+        RotaStaff staff = new RotaStaff("Priya", List.of(List.of(RotaShift.hours("09:00-17:00"))));
+        assertThat(staff.day(6)).isEmpty();
+        assertThat(staff.day(-1)).isEmpty();
+    }
+
+    @Test
+    void theInnerDayListsAreFrozenAndNotOnlyTheOuterOne() {
+        // A frozen outer list of mutable days is not a frozen rota: the cell a
+        // preset reads twice has to be the cell the caller handed over.
+        List<RotaShift> monday = new ArrayList<>(List.of(RotaShift.hours("09:00-17:00")));
+        List<List<RotaShift>> days = new ArrayList<>(List.of(monday));
+        RotaStaff staff = new RotaStaff("Priya", days);
+
+        monday.add(RotaShift.strong("OFF", ShiftStatus.OFF));
+        days.add(List.of());
+
+        assertThat(staff.days()).hasSize(1);
+        assertThat(staff.day(0)).hasSize(1);
+        assertThatThrownBy(() -> staff.day(0).add(RotaShift.hours("18:00-23:00")))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void aShiftSaysWhatItMeansSeparatelyFromWhatItPrints() {
+        // Two sites print different words for the same thing; a preset colours
+        // by the meaning, so both colour alike.
+        RotaShift annualLeave = RotaShift.strong("A/L", ShiftStatus.HOLIDAY);
+        RotaShift holiday = RotaShift.strong("HOL", ShiftStatus.HOLIDAY);
+        assertThat(annualLeave.status()).isEqualTo(holiday.status());
+        assertThat(annualLeave.text()).isNotEqualTo(holiday.text());
+        assertThat(annualLeave.emphasis()).isEqualTo(ShiftEmphasis.STRONG);
+    }
+
+    @Test
+    void anEntryStatesItsOwnEmphasisBecauseNoFactoryCanGuessIt() {
+        // A split day is drawn loud then quiet, and sometimes the other way,
+        // and sometimes loud twice — so there is no marked(text, status) that
+        // picks for the caller. Both halves are named.
+        assertThat(RotaShift.strong("09:00-16:00", ShiftStatus.STOCK).emphasis())
+                .isEqualTo(ShiftEmphasis.STRONG);
+        assertThat(RotaShift.soft("16:00-22:00", ShiftStatus.STOCK).emphasis())
+                .isEqualTo(ShiftEmphasis.SOFT);
+        assertThat(RotaShift.soft("16:00-22:00", ShiftStatus.STOCK).status())
+                .isEqualTo(ShiftStatus.STOCK);
+    }
+
+    @Test
+    void aShiftThatStatesNothingIsPlainAndUnmarked() {
+        RotaShift shift = new RotaShift(null, null, null);
+        assertThat(shift.text()).isEmpty();
+        assertThat(shift.status()).isEqualTo(ShiftStatus.NONE);
+        assertThat(shift.emphasis()).isEqualTo(ShiftEmphasis.PLAIN);
+        assertThat(RotaShift.hours("09:00-17:00").emphasis()).isEqualTo(ShiftEmphasis.PLAIN);
+    }
+
+    @Test
+    void aBandStatesItsOwnMarkOrNone() {
+        assertThat(new RotaGroup("MANAGEMENT", List.of()).icon()).isEmpty();
+        assertThat(new RotaGroup("BAR", "glass", List.of()).icon()).isEqualTo("glass");
+    }
+
+    @Test
+    void aDaysDateIsThreeFieldsSoASuffixCanBeSetApart() {
+        // A design that raises the suffix cannot split a string that arrived
+        // joined, so the day never joins them itself.
+        RotaDay day = new RotaDay("MONDAY", "31", "ST");
+        assertThat(day.name()).isEqualTo("MONDAY");
+        assertThat(day.ordinal()).isEqualTo("31");
+        assertThat(day.ordinalSuffix()).isEqualTo("ST");
+        assertThat(day.note()).isEmpty();
+        assertThat(day.covers().isPresent()).isFalse();
+    }
+
+    @Test
+    void coversAreTwoCountsBecauseOneStringLosesWhichIsWhich() {
+        RotaCovers covers = new RotaCovers("104", "50");
+        assertThat(covers.isPresent()).isTrue();
+        assertThat(covers.lunch()).isEqualTo("104");
+        assertThat(covers.dinner()).isEqualTo("50");
+        assertThat(new RotaCovers(null, null).isPresent()).isFalse();
+    }
+
+    @Test
+    void aLegendEntryPairsThePrintedWordWithTheStatusItStandsFor() {
+        RotaLegend legend = new RotaLegend("STATUS", List.of(
+                new RotaLegend.Entry("A/L", ShiftStatus.HOLIDAY),
+                new RotaLegend.Entry("OFF", ShiftStatus.OFF)));
+        assertThat(legend.isPresent()).isTrue();
+        assertThat(legend.coversLabel()).isEmpty();
+        assertThat(legend.entries()).extracting(RotaLegend.Entry::status)
+                .containsExactly(ShiftStatus.HOLIDAY, ShiftStatus.OFF);
+        assertThat(new RotaLegend.Entry("?", null).status()).isEqualTo(ShiftStatus.NONE);
+    }
+
+    @Test
+    void theBuildersListsAreCopiedRatherThanKept() {
+        List<RotaDay> days = new ArrayList<>(List.of(new RotaDay("MONDAY", "31", "st")));
+        List<RotaGroup> groups = new ArrayList<>(List.of(new RotaGroup("BAR", List.of())));
+        StructuredRotaData rota = StructuredRotaData.builder()
+                .days(days)
+                .groups(groups)
+                .build();
+
+        days.add(new RotaDay("TUESDAY", "1", "st"));
+        groups.add(new RotaGroup("KITCHEN", List.of()));
+
+        assertThat(rota.days()).hasSize(1);
+        assertThat(rota.groups()).hasSize(1);
+        assertThatThrownBy(() -> rota.days().add(new RotaDay("TUESDAY", "1", "ST")))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> rota.groups().add(new RotaGroup("KITCHEN", List.of())))
+                .isInstanceOf(UnsupportedOperationException.class);
+    }
+
+    @Test
+    void staffAndTheirGroupsAreReadInTheOrderTheyArePrinted() {
+        StructuredRotaData rota = StructuredRotaData.builder()
+                .groups(List.of(
+                        new RotaGroup("MANAGEMENT", List.of(new RotaStaff("Priya", List.of()))),
+                        new RotaGroup("BAR", "glass", List.of(
+                                new RotaStaff("Tomas", List.of()),
+                                new RotaStaff("Lena", List.of())))))
+                .build();
+        assertThat(rota.groups()).extracting(RotaGroup::label)
+                .containsExactly("MANAGEMENT", "BAR");
+        assertThat(rota.groups().get(1).staff()).extracting(RotaStaff::name)
+                .containsExactly("Tomas", "Lena");
+    }
+}

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/package-info.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/package-info.java
@@ -3,6 +3,7 @@
  * {@code document.templates} layer.
  *
  * <p>Concrete public data types live in child packages such as
- * {@code data.invoice}, {@code data.proposal}, and {@code data.schedule}.</p>
+ * {@code data.invoice}, {@code data.proposal}, and {@code data.rota}.
+ * {@code data.schedule} is deprecated in favour of {@code data.rota}.</p>
  */
 package com.demcha.compose.document.templates.data;

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/rota/RotaCovers.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/rota/RotaCovers.java
@@ -1,0 +1,34 @@
+package com.demcha.compose.document.templates.data.rota;
+
+import java.util.Objects;
+
+/**
+ * How many people a day is expecting, split across the two services.
+ *
+ * <p>Two fields and not one string. The counts arrive from the booking system
+ * as a pair, and a rota that prints {@code "104 / 50"} leaves the reader to know
+ * from somewhere else which half is which. Split, the preset can label them.</p>
+ *
+ * @param lunch  the earlier service's count, as printed
+ * @param dinner the later service's count, as printed
+ * @since 2.4.0
+ */
+public record RotaCovers(String lunch, String dinner) {
+
+    /**
+     * Normalizes optional fields.
+     */
+    public RotaCovers {
+        lunch = Objects.requireNonNullElse(lunch, "");
+        dinner = Objects.requireNonNullElse(dinner, "");
+    }
+
+    /**
+     * Whether the day states either count.
+     *
+     * @return {@code true} when there is anything to print
+     */
+    public boolean isPresent() {
+        return !lunch.isBlank() || !dinner.isBlank();
+    }
+}

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/rota/RotaDay.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/rota/RotaDay.java
@@ -1,0 +1,48 @@
+package com.demcha.compose.document.templates.data.rota;
+
+import java.util.Objects;
+
+/**
+ * One day of the rota: its heading, whatever is happening on it, and how busy
+ * it is expected to be.
+ *
+ * <p>The date is three fields rather than one because a heading sets them
+ * differently: {@code MONDAY} large, {@code 31} beside it, and {@code ST}
+ * smaller and raised. A preset that wants them joined can join them; one that
+ * wants the suffix raised cannot split a string that arrived joined.</p>
+ *
+ * @param name          the weekday, as printed
+ * @param ordinal       the day of the month, as printed
+ * @param ordinalSuffix the ordinal's tail, cased as the sheet prints it —
+ *                      {@code ST}, {@code nd} — which a design may set apart;
+ *                      blank when it does not
+ * @param note          what else is happening that day; blank when nothing is
+ * @param covers        the day's expected covers; never {@code null}
+ * @since 2.4.0
+ */
+public record RotaDay(String name, String ordinal, String ordinalSuffix, String note,
+                      RotaCovers covers) {
+
+    /**
+     * Normalizes optional fields.
+     */
+    public RotaDay {
+        name = Objects.requireNonNullElse(name, "");
+        ordinal = Objects.requireNonNullElse(ordinal, "");
+        ordinalSuffix = Objects.requireNonNullElse(ordinalSuffix, "");
+        note = Objects.requireNonNullElse(note, "");
+        covers = covers == null ? new RotaCovers("", "") : covers;
+    }
+
+    /**
+     * A day with a heading and nothing else stated.
+     *
+     * @param name          the weekday
+     * @param ordinal       the day of the month
+     * @param ordinalSuffix the ordinal's tail
+     */
+    public RotaDay(String name, String ordinal, String ordinalSuffix) {
+        this(name, ordinal, ordinalSuffix, "", null);
+    }
+
+}

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/rota/RotaFooter.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/rota/RotaFooter.java
@@ -1,0 +1,29 @@
+package com.demcha.compose.document.templates.data.rota;
+
+import java.util.Objects;
+
+/**
+ * The standing note the rota closes with — the line about swaps, or notice, or
+ * who to tell.
+ *
+ * @param note the note, as printed; blank when the rota closes with none
+ * @since 2.4.0
+ */
+public record RotaFooter(String note) {
+
+    /**
+     * Normalizes optional fields.
+     */
+    public RotaFooter {
+        note = Objects.requireNonNullElse(note, "");
+    }
+
+    /**
+     * Whether there is anything to draw.
+     *
+     * @return {@code true} when the foot states a note
+     */
+    public boolean isPresent() {
+        return !note.isBlank();
+    }
+}

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/rota/RotaGroup.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/rota/RotaGroup.java
@@ -1,0 +1,35 @@
+package com.demcha.compose.document.templates.data.rota;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A band of the rota: the people who do one kind of job, under the name of it.
+ *
+ * @param label the band's name, as the rota prints it
+ * @param icon  the mark the band opens with, from the preset's own vocabulary;
+ *              blank for a band that opens with none
+ * @param staff the people in it, in the order they are listed
+ * @since 2.4.0
+ */
+public record RotaGroup(String label, String icon, List<RotaStaff> staff) {
+
+    /**
+     * Normalizes optional fields and freezes the staff list.
+     */
+    public RotaGroup {
+        label = Objects.requireNonNullElse(label, "");
+        icon = Objects.requireNonNullElse(icon, "");
+        staff = List.copyOf(Objects.requireNonNullElse(staff, List.of()));
+    }
+
+    /**
+     * A band that opens with no mark.
+     *
+     * @param label the band's name
+     * @param staff the people in it
+     */
+    public RotaGroup(String label, List<RotaStaff> staff) {
+        this(label, "", staff);
+    }
+}

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/rota/RotaLegend.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/rota/RotaLegend.java
@@ -1,0 +1,73 @@
+package com.demcha.compose.document.templates.data.rota;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * The strip that tells a reader what the colours mean, and the labels on the
+ * covers row beneath it.
+ *
+ * <p>The words are the document's and the colours are the preset's: an entry
+ * pairs the word a site uses with the {@link ShiftStatus} it stands for, so a
+ * rota that prints {@code A/L} and one that prints {@code HOL} both colour the
+ * same.</p>
+ *
+ * @param label             the strip's own label; blank for a strip that
+ *                          carries none
+ * @param coversLabel       the label on the covers row
+ * @param coversLunchLabel  the mark on the earlier service's count
+ * @param coversDinnerLabel the mark on the later service's count
+ * @param entries           the statuses the rota documents, in order
+ * @since 2.4.0
+ */
+public record RotaLegend(String label, String coversLabel, String coversLunchLabel,
+                         String coversDinnerLabel, List<Entry> entries) {
+
+    /**
+     * Normalizes optional fields and freezes the entry list.
+     */
+    public RotaLegend {
+        label = Objects.requireNonNullElse(label, "");
+        coversLabel = Objects.requireNonNullElse(coversLabel, "");
+        coversLunchLabel = Objects.requireNonNullElse(coversLunchLabel, "");
+        coversDinnerLabel = Objects.requireNonNullElse(coversDinnerLabel, "");
+        entries = List.copyOf(Objects.requireNonNullElse(entries, List.of()));
+    }
+
+    /**
+     * A legend with entries and no covers row.
+     *
+     * @param label   the strip's label
+     * @param entries the statuses it documents
+     */
+    public RotaLegend(String label, List<Entry> entries) {
+        this(label, "", "", "", entries);
+    }
+
+    /**
+     * Whether there is anything to draw.
+     *
+     * @return {@code true} when the legend states a label or any entry
+     */
+    public boolean isPresent() {
+        return !label.isBlank() || !entries.isEmpty();
+    }
+
+    /**
+     * One swatch: the word a site prints, and the status whose colour it shows.
+     *
+     * @param label  the word, as printed
+     * @param status the status it stands for; {@code null} normalizes to
+     *               {@link ShiftStatus#NONE}
+     */
+    public record Entry(String label, ShiftStatus status) {
+
+        /**
+         * Normalizes optional fields.
+         */
+        public Entry {
+            label = Objects.requireNonNullElse(label, "");
+            status = Objects.requireNonNullElse(status, ShiftStatus.NONE);
+        }
+    }
+}

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/rota/RotaShift.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/rota/RotaShift.java
@@ -1,0 +1,69 @@
+package com.demcha.compose.document.templates.data.rota;
+
+import java.util.Objects;
+
+/**
+ * One entry in one cell of a rota: what it says, what it means, and how loudly
+ * it says it.
+ *
+ * <p>The text is what the reader sees — a span of hours where the day is
+ * worked, or the word for the status where it is not. Text and status are kept
+ * apart because they answer different questions: two sites may print
+ * {@code "A/L"} and {@code "HOL"} for the same {@link ShiftStatus#HOLIDAY}, and
+ * a preset that colours by status keeps working for both.</p>
+ *
+ * @param text     what the cell prints
+ * @param status   what the entry means; {@code null} normalizes to
+ *                 {@link ShiftStatus#NONE}
+ * @param emphasis how much of a mark it makes; {@code null} normalizes to
+ *                 {@link ShiftEmphasis#PLAIN}
+ * @since 2.4.0
+ */
+public record RotaShift(String text, ShiftStatus status, ShiftEmphasis emphasis) {
+
+    /**
+     * Normalizes optional fields.
+     */
+    public RotaShift {
+        text = Objects.requireNonNullElse(text, "");
+        status = Objects.requireNonNullElse(status, ShiftStatus.NONE);
+        emphasis = Objects.requireNonNullElse(emphasis, ShiftEmphasis.PLAIN);
+    }
+
+    /**
+     * A worked span of hours, printed as it stands and marked in no way.
+     *
+     * @param text the hours as the rota prints them
+     * @return the shift
+     */
+    public static RotaShift hours(String text) {
+        return new RotaShift(text, ShiftStatus.NONE, ShiftEmphasis.PLAIN);
+    }
+
+    /**
+     * An entry that carries a status, drawn as loudly as the preset draws one.
+     *
+     * @param text   what the cell prints
+     * @param status what the entry means
+     * @return the shift
+     */
+    public static RotaShift strong(String text, ShiftStatus status) {
+        return new RotaShift(text, status, ShiftEmphasis.STRONG);
+    }
+
+    /**
+     * The same entry, drawn quietly.
+     *
+     * <p>There is no single {@code marked(text, status)} factory that picks the
+     * emphasis for you: a design that halves a day draws the two halves
+     * differently, and a factory that chose {@link ShiftEmphasis#STRONG} for
+     * both would be wrong in a way only a pixel diff catches.</p>
+     *
+     * @param text   what the cell prints
+     * @param status what the entry means
+     * @return the shift
+     */
+    public static RotaShift soft(String text, ShiftStatus status) {
+        return new RotaShift(text, status, ShiftEmphasis.SOFT);
+    }
+}

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/rota/RotaStaff.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/rota/RotaStaff.java
@@ -1,0 +1,45 @@
+package com.demcha.compose.document.templates.data.rota;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * One person, and what they are down for on each day of the rota.
+ *
+ * <p>{@code days} is a list of days, and each day is a list of what that person
+ * does on it — which is not the same as one shift each. A day with nothing in it
+ * is a legal blank cell rather than a hole in the data, and a day with two
+ * entries is a split shift. Modelling a day as a single shift would make the
+ * split the exception a preset has to invent a representation for.</p>
+ *
+ * @param name the person, as the rota prints them
+ * @param days one list of entries per day, in the order the rota's days run
+ * @since 2.4.0
+ */
+public record RotaStaff(String name, List<List<RotaShift>> days) {
+
+    /**
+     * Normalizes optional fields and freezes the day lists, including the inner
+     * ones — a frozen outer list of mutable days is not a frozen rota.
+     */
+    public RotaStaff {
+        name = Objects.requireNonNullElse(name, "");
+        List<List<RotaShift>> stated = Objects.requireNonNullElse(days, List.of());
+        List<List<RotaShift>> copied = new ArrayList<>(stated.size());
+        for (List<RotaShift> day : stated) {
+            copied.add(List.copyOf(Objects.requireNonNullElse(day, List.of())));
+        }
+        days = List.copyOf(copied);
+    }
+
+    /**
+     * What this person is down for on one day.
+     *
+     * @param index the day's position in the rota's own day list
+     * @return the entries, or nothing when the rota does not reach that day
+     */
+    public List<RotaShift> day(int index) {
+        return index >= 0 && index < days.size() ? days.get(index) : List.of();
+    }
+}

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/rota/RotaVenue.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/rota/RotaVenue.java
@@ -1,0 +1,33 @@
+package com.demcha.compose.document.templates.data.rota;
+
+import java.util.Objects;
+
+/**
+ * Who the rota is for: the mark it opens with and the name it signs off with.
+ *
+ * @param wordmark    the name as the lockup sets it
+ * @param wordmarkSub the line under it — a site, a branch, a department; blank
+ *                    when the lockup is one line
+ * @param footerName  the name the foot repeats; blank when the foot names none
+ * @since 2.4.0
+ */
+public record RotaVenue(String wordmark, String wordmarkSub, String footerName) {
+
+    /**
+     * Normalizes optional fields.
+     */
+    public RotaVenue {
+        wordmark = Objects.requireNonNullElse(wordmark, "");
+        wordmarkSub = Objects.requireNonNullElse(wordmarkSub, "");
+        footerName = Objects.requireNonNullElse(footerName, "");
+    }
+
+    /**
+     * Whether there is anything to draw.
+     *
+     * @return {@code true} when the venue states any of its three parts
+     */
+    public boolean isPresent() {
+        return !wordmark.isBlank() || !wordmarkSub.isBlank() || !footerName.isBlank();
+    }
+}

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/rota/RotaWeek.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/rota/RotaWeek.java
@@ -1,0 +1,30 @@
+package com.demcha.compose.document.templates.data.rota;
+
+import java.util.Objects;
+
+/**
+ * Which week the rota covers.
+ *
+ * @param title       the sheet's own title; blank when the design carries none
+ * @param rangeLabel  the span the week runs, as printed
+ * @since 2.4.0
+ */
+public record RotaWeek(String title, String rangeLabel) {
+
+    /**
+     * Normalizes optional fields.
+     */
+    public RotaWeek {
+        title = Objects.requireNonNullElse(title, "");
+        rangeLabel = Objects.requireNonNullElse(rangeLabel, "");
+    }
+
+    /**
+     * Whether there is anything to draw.
+     *
+     * @return {@code true} when the week states a title or a range
+     */
+    public boolean isPresent() {
+        return !title.isBlank() || !rangeLabel.isBlank();
+    }
+}

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/rota/ShiftEmphasis.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/rota/ShiftEmphasis.java
@@ -1,0 +1,27 @@
+package com.demcha.compose.document.templates.data.rota;
+
+/**
+ * How much of a mark a shift makes on the cell it sits in.
+ *
+ * <p>A rota is read across a row at a glance, so not every entry can shout. The
+ * document says which ones should: the day someone is off is the thing a reader
+ * scans for, the hours they work are the thing they read once they have found
+ * the person.</p>
+ *
+ * @since 2.4.0
+ */
+public enum ShiftEmphasis {
+
+    /** The loudest form the preset has — a solid mark in the status's colour. */
+    STRONG,
+
+    /**
+     * A quieter form of the same mark. Which entry gets it is the document's
+     * decision and not its position: a split day is often loud then quiet, but
+     * the reverse happens too, and so does loud twice.
+     */
+    SOFT,
+
+    /** No mark at all: the text alone, on the cell. */
+    PLAIN
+}

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/rota/ShiftStatus.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/rota/ShiftStatus.java
@@ -1,0 +1,39 @@
+package com.demcha.compose.document.templates.data.rota;
+
+/**
+ * What a cell on a rota says about the shift in it.
+ *
+ * <p>A status is a meaning, not a colour: the document says a day is holiday
+ * and the preset decides what holiday looks like. That is why the statuses are
+ * an enumeration rather than the colour strings a spreadsheet would carry — two
+ * presets can render the same rota in two palettes, and a status a preset does
+ * not style still says what it means to a reader of the legend.</p>
+ *
+ * @since 2.4.0
+ */
+public enum ShiftStatus {
+
+    /** A worked shift, printed as the hours themselves and carrying no status. */
+    NONE,
+
+    /** Time the person has asked for and which is not yet granted. */
+    REQUEST,
+
+    /** A day not worked. */
+    OFF,
+
+    /** Booked leave. */
+    HOLIDAY,
+
+    /** A shift spent on stock rather than on the floor. */
+    STOCK,
+
+    /** On call: not rostered, but reachable. */
+    STANDBY,
+
+    /** A shift spent training or being trained. */
+    TRAINING,
+
+    /** Covering another team or another site. */
+    SUPPORT
+}

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/rota/StructuredRotaData.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/rota/StructuredRotaData.java
@@ -1,0 +1,147 @@
+package com.demcha.compose.document.templates.data.rota;
+
+import java.util.List;
+
+/**
+ * Display-oriented input for a staff rota: who works when, over one span of
+ * days.
+ *
+ * <p>The shape is a grid the document owns rather than one the preset infers.
+ * {@link #days()} is the columns — the sheet's days, in order — and every
+ * {@link RotaStaff#days()} runs in that same order, so a cell is found by
+ * position and a rota of five days is as ordinary as one of seven. Nothing here
+ * says a week.</p>
+ *
+ * <p>Every component normalizes {@code null} to its empty form and freezes its
+ * collections, so a partial rota composes without null checks in preset code.
+ * The section records construct positionally; this builder is where a document
+ * is assembled.</p>
+ *
+ * @param venue  who the rota is for
+ * @param week   which span it covers
+ * @param days   the day columns, in the order they are printed
+ * @param legend what the marks mean, and the labels on the covers row
+ * @param groups the bands of staff, in the order they are printed
+ * @param footer the standing note the sheet closes with
+ * @since 2.4.0
+ */
+public record StructuredRotaData(
+        RotaVenue venue,
+        RotaWeek week,
+        List<RotaDay> days,
+        RotaLegend legend,
+        List<RotaGroup> groups,
+        RotaFooter footer) {
+
+    /**
+     * Normalizes absent components to their empty forms and freezes the lists.
+     */
+    public StructuredRotaData {
+        venue = venue == null ? new RotaVenue(null, null, null) : venue;
+        week = week == null ? new RotaWeek(null, null) : week;
+        days = List.copyOf(days == null ? List.<RotaDay>of() : days);
+        legend = legend == null ? new RotaLegend(null, null, null, null, null) : legend;
+        groups = List.copyOf(groups == null ? List.<RotaGroup>of() : groups);
+        footer = footer == null ? new RotaFooter(null) : footer;
+    }
+
+    /**
+     * Starts a fluent rota data builder.
+     *
+     * @return rota data builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Fluent builder for complete rota content.
+     */
+    public static final class Builder {
+
+        private RotaVenue venue;
+        private RotaWeek week;
+        private List<RotaDay> days = List.of();
+        private RotaLegend legend;
+        private List<RotaGroup> groups = List.of();
+        private RotaFooter footer;
+
+        private Builder() {
+        }
+
+        /**
+         * Sets who the rota is for.
+         *
+         * @param venue the venue block
+         * @return this builder
+         */
+        public Builder venue(RotaVenue venue) {
+            this.venue = venue;
+            return this;
+        }
+
+        /**
+         * Sets which span the rota covers.
+         *
+         * @param week the week block
+         * @return this builder
+         */
+        public Builder week(RotaWeek week) {
+            this.week = week;
+            return this;
+        }
+
+        /**
+         * Sets the day columns.
+         *
+         * @param days the days, in the order they are printed
+         * @return this builder
+         */
+        public Builder days(List<RotaDay> days) {
+            this.days = days;
+            return this;
+        }
+
+        /**
+         * Sets what the marks mean.
+         *
+         * @param legend the legend block
+         * @return this builder
+         */
+        public Builder legend(RotaLegend legend) {
+            this.legend = legend;
+            return this;
+        }
+
+        /**
+         * Sets the bands of staff.
+         *
+         * @param groups the bands, in the order they are printed
+         * @return this builder
+         */
+        public Builder groups(List<RotaGroup> groups) {
+            this.groups = groups;
+            return this;
+        }
+
+        /**
+         * Sets the standing note the sheet closes with.
+         *
+         * @param footer the footer block
+         * @return this builder
+         */
+        public Builder footer(RotaFooter footer) {
+            this.footer = footer;
+            return this;
+        }
+
+        /**
+         * Builds normalized rota data.
+         *
+         * @return rota data
+         */
+        public StructuredRotaData build() {
+            return new StructuredRotaData(venue, week, days, legend, groups, footer);
+        }
+    }
+}

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/rota/StructuredRotaDocumentSpec.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/rota/StructuredRotaDocumentSpec.java
@@ -1,0 +1,32 @@
+package com.demcha.compose.document.templates.data.rota;
+
+/**
+ * Public compose-first input for rota templates.
+ *
+ * <p><b>Authoring role:</b> the document-level object rota presets are
+ * parameterised on, the way structured invoice presets are parameterised on
+ * {@code StructuredInvoiceDocumentSpec}.</p>
+ *
+ * @param rota normalized rota content
+ * @since 2.4.0
+ */
+public record StructuredRotaDocumentSpec(StructuredRotaData rota) {
+
+    /**
+     * Creates a normalized rota document spec.
+     */
+    public StructuredRotaDocumentSpec {
+        rota = rota == null ? StructuredRotaData.builder().build() : rota;
+    }
+
+    /**
+     * Wraps existing rota data in the document-level spec expected by rota
+     * templates.
+     *
+     * @param rota rota data
+     * @return document spec
+     */
+    public static StructuredRotaDocumentSpec from(StructuredRotaData rota) {
+        return new StructuredRotaDocumentSpec(rota);
+    }
+}

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/rota/package-info.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/rota/package-info.java
@@ -1,0 +1,27 @@
+/**
+ * Shared, render-neutral rota document specs and supporting data records,
+ * consumed by the layered {@code rota.presets} presets.
+ *
+ * <p>A rota is a grid the document owns rather than one a preset infers:
+ * {@link com.demcha.compose.document.templates.data.rota.StructuredRotaData#days()}
+ * is the columns and every
+ * {@link com.demcha.compose.document.templates.data.rota.RotaStaff#days()}
+ * runs in that same order, so a cell is found by position. A day holds a list
+ * of entries rather than one, which makes an empty day and a split day ordinary
+ * rather than special cases.</p>
+ *
+ * <p>This package supersedes {@code templates.data.schedule}, which modelled
+ * the same document and which nothing ever rendered. The three differences are
+ * the reasons: staff belong to bands rather than being ordered by a token,
+ * an entry states how loudly it is drawn, and colour stays out of the document
+ * — a schedule category carried three {@link java.awt.Color}s, which stops two
+ * presets drawing the same rota in two palettes.</p>
+ *
+ * <p>What a cell means and what it prints are separate:
+ * {@link com.demcha.compose.document.templates.data.rota.ShiftStatus} is the
+ * meaning a preset colours by, and the text is the word a particular site uses
+ * for it. Two rotas that print {@code A/L} and {@code HOL} colour alike.</p>
+ *
+ * @since 2.4.0
+ */
+package com.demcha.compose.document.templates.data.rota;

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/schedule/ScheduleAssignment.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/schedule/ScheduleAssignment.java
@@ -13,7 +13,13 @@ import java.util.Objects;
  * @param categoryId category identifier
  * @param slots      shift/time slots
  * @param note       optional assignment note
+ *
+ * @deprecated superseded by
+ *             {@link com.demcha.compose.document.templates.data.rota.RotaShift},
+ *             which a person's own day list holds directly rather than an
+ *             assignment referring to both by identifier.
  */
+@Deprecated(since = "2.4.0")
 public record ScheduleAssignment(
         String personId,
         String dayId,

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/schedule/ScheduleCategory.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/schedule/ScheduleCategory.java
@@ -11,7 +11,14 @@ import java.util.Objects;
  * @param fillColor   category fill color
  * @param textColor   category text color
  * @param borderColor category border color
+ *
+ * @deprecated superseded by
+ *             {@link com.demcha.compose.document.templates.data.rota.ShiftStatus}
+ *             and a legend entry that names it. A category here carries three
+ *             colours, which is a rendering decision living in the data layer:
+ *             two presets cannot draw the same rota in two palettes.
  */
+@Deprecated(since = "2.4.0")
 public record ScheduleCategory(
         String id,
         String label,

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/schedule/ScheduleDay.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/schedule/ScheduleDay.java
@@ -9,7 +9,14 @@ import java.util.Objects;
  * @param label            display day label
  * @param headerNote       optional header note
  * @param headerCategoryId optional category shown in the header
+ *
+ * @deprecated superseded by
+ *             {@link com.demcha.compose.document.templates.data.rota.RotaDay},
+ *             which keeps the weekday, the ordinal and its tail apart so a
+ *             design can set the suffix apart, and carries the day's expected
+ *             covers.
  */
+@Deprecated(since = "2.4.0")
 public record ScheduleDay(
         String id,
         String label,

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/schedule/ScheduleMetricRow.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/schedule/ScheduleMetricRow.java
@@ -10,7 +10,13 @@ import java.util.Objects;
  *
  * @param label     metric label
  * @param dayValues values aligned to days in display order
+ *
+ * @deprecated superseded by
+ *             {@link com.demcha.compose.document.templates.data.rota.RotaCovers},
+ *             which the day itself carries rather than a parallel row whose
+ *             values are aligned to the days by position alone.
  */
+@Deprecated(since = "2.4.0")
 public record ScheduleMetricRow(
         String label,
         List<String> dayValues

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/schedule/SchedulePerson.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/schedule/SchedulePerson.java
@@ -8,7 +8,13 @@ import java.util.Objects;
  * @param id          stable person identifier
  * @param displayName display name
  * @param sortOrder   ordering token for roster display
+ *
+ * @deprecated superseded by
+ *             {@link com.demcha.compose.document.templates.data.rota.RotaStaff},
+ *             which holds its own days and sits inside the band it belongs to
+ *             rather than being ordered by a token and grouped nowhere.
  */
+@Deprecated(since = "2.4.0")
 public record SchedulePerson(
         String id,
         String displayName,

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/schedule/ScheduleSlot.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/schedule/ScheduleSlot.java
@@ -7,7 +7,13 @@ import java.util.Objects;
  *
  * @param start start time/label
  * @param end   end time/label
+ *
+ * @deprecated superseded by
+ *             {@link com.demcha.compose.document.templates.data.rota.RotaShift},
+ *             whose text is whatever the cell prints — a span of hours, or the
+ *             word for a day not worked, which a start/end pair cannot carry.
  */
+@Deprecated(since = "2.4.0")
 public record ScheduleSlot(
         String start,
         String end

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/schedule/WeeklyScheduleData.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/schedule/WeeklyScheduleData.java
@@ -18,7 +18,14 @@ import java.util.function.Consumer;
  * @param people        people rows in the schedule matrix
  * @param assignments   person/day assignments
  * @param footerNotes   footer notes rendered after the matrix
+ *
+ * @deprecated superseded by
+ *             {@link com.demcha.compose.document.templates.data.rota.StructuredRotaData},
+ *             which carries the staff bands and the per-entry emphasis a rota is
+ *             actually drawn with, and leaves colour to the preset rather than
+ *             holding it in the document. No preset ever rendered this model.
  */
+@Deprecated(since = "2.4.0")
 public record WeeklyScheduleData(
         String title,
         String weekLabel,

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/schedule/WeeklyScheduleDocumentSpec.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/schedule/WeeklyScheduleDocumentSpec.java
@@ -13,7 +13,13 @@ import java.util.function.Consumer;
  *
  * @param schedule normalized weekly schedule content rendered by templates
  * @author Artem Demchyshyn
+ *
+ * @deprecated superseded by
+ *             {@link com.demcha.compose.document.templates.data.rota.StructuredRotaDocumentSpec},
+ *             which is the spec rota presets are parameterised on. No preset
+ *             ever consumed this one.
  */
+@Deprecated(since = "2.4.0")
 public record WeeklyScheduleDocumentSpec(WeeklyScheduleData schedule) {
 
     /**

--- a/templates/src/main/java/com/demcha/compose/document/templates/data/schedule/package-info.java
+++ b/templates/src/main/java/com/demcha/compose/document/templates/data/schedule/package-info.java
@@ -1,4 +1,17 @@
 /**
- * Weekly schedule document specs and supporting data records for canonical templates.
+ * Weekly schedule document specs and supporting data records for canonical
+ * templates.
+ *
+ * <p><strong>Superseded.</strong> Every type here is deprecated in favour of
+ * {@link com.demcha.compose.document.templates.data.rota}, which models the
+ * same document — who works when, over a span of days — and models it as the
+ * sheet is actually drawn: staff in bands, an entry that states how loudly it
+ * is drawn, and a day heading whose suffix a design can set apart. It also
+ * keeps colour out of the document, which this package does not: a category
+ * here carries three {@link java.awt.Color}s, so two presets cannot draw the
+ * same schedule in two palettes. Nothing in the library ever rendered these
+ * records.</p>
+ *
+ * @see com.demcha.compose.document.templates.data.rota
  */
 package com.demcha.compose.document.templates.data.schedule;


### PR DESCRIPTION
## Why

The next template to promote is a staff rota — a landscape sheet of who works
when — and the library has no model for one. It turned out it did:
`templates.data.schedule` has been public since the templates module was
extracted, and **nothing has ever rendered it**. Looking at why, the model is not
shaped like a rota is drawn:

- its people are ordered by a token and grouped nowhere, so there are no staff
  bands — and a rota sheet is built on them;
- an assignment cannot say that one half of a split day is drawn more quietly
  than the other;
- a day heading is one string, which a design that raises the ordinal's suffix
  cannot split;
- a category carries three `java.awt.Color`s, which puts a rendering decision in
  the document and stops two presets drawing the same rota in two palettes — the
  module's own rule is that `data/` holds content, not styling.

So this replaces it rather than adding a rival beside it.

## What

`templates.data.rota` — `StructuredRotaData` (venue, week, day columns, legend,
staff bands, footer) wrapped by `StructuredRotaDocumentSpec`, with `RotaVenue`,
`RotaWeek`, `RotaDay`, `RotaCovers`, `RotaLegend`, `RotaGroup`, `RotaStaff`,
`RotaShift`, `RotaFooter` and the `ShiftStatus` / `ShiftEmphasis` enumerations.
No preset in this change; the preset that ports the design follows.

**The grid belongs to the document.** `days()` is the columns and every
`RotaStaff.days()` runs in that same order, so a cell is found by position and a
rota of five days is as ordinary as one of seven — the span is a label the
document carries, not a shape the model imposes. A person's day is a *list* of
entries rather than one, which makes the two shapes a rota actually has — a blank
cell and a split shift — ordinary rather than special cases a preset has to
invent a representation for. `RotaStaff.day(int)` answers with nothing for a day
the rota does not reach, so a short row is a short row.

**What a cell means is separate from what it prints.** `ShiftStatus` is the
meaning a preset colours by; the text is the word a particular site uses for it,
so a rota printing `A/L` and one printing `HOL` colour alike, and a legend entry
pairs the two. There is deliberately **no** `marked(text, status)` factory that
picks the emphasis — a design that halves a day draws the halves differently,
sometimes quiet second and sometimes not, so `RotaShift.strong(...)` and
`RotaShift.soft(...)` make the caller say which. A factory that chose for them
would be wrong in a way only a pixel diff catches.

**Deprecation.** Every type in `templates.data.schedule` is `@Deprecated(since =
"2.4.0")` and names its replacement in Javadoc. They still ship and still
compile; since nothing rendered them, no output moves.
`docs/templates/which-template-system.md` pointed callers at them and now points
at the rota model.

## Tests

Seventeen, in `StructuredRotaDataTest`:

- the empty document — every component present rather than null, every
  `isPresent()` false;
- **every builder setter reaching what it builds**, and the true half of every
  `isPresent()` — without these a setter that dropped its argument, or an
  `isPresent()` that always answered false, would pass;
- the deep freeze: the caller's own lists are mutated *after* the build,
  including the inner day lists, and the document does not move; the built lists
  refuse `add`;
- a blank day, a split day, a row shorter than the sheet, and a negative index;
- meaning held apart from text, and both emphasis factories asserted.

Reactor gate green (1251 tests); javadoc gate green; API surface regenerated in
the same change.
