### PR TITLE
feat(knowledge): route the two questions a signature cannot answer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,27 +225,34 @@ jobs:
         with:
           node-version: '20'
 
-      # Every fixture suite the knowledge tools ship, found rather than listed.
-      # Naming them one step each meant a new suite ran only if someone also
-      # remembered to edit this file — and a suite that never runs looks exactly
-      # like a suite that passes.
+      # Every fixture suite the knowledge tools ship, discovered and then held to
+      # a declared list. Neither half is enough on its own: naming them one step
+      # each meant a new suite ran only if someone remembered to edit this file,
+      # and discovery alone meant a suite renamed out of the glob stopped running
+      # with nothing to notice. A suite that never runs looks exactly like one
+      # that passes.
       #
-      # Discovery is recursive, so a suite nested a directory deeper is still
-      # found, and the floor is what keeps the step honest in the other
-      # direction: deleting or moving a suite drops the count and goes red
-      # instead of quietly reducing coverage. Raise the floor in the same commit
-      # that adds a suite.
+      # So the set is compared, not counted. Add, rename or delete a suite and
+      # this step goes red until the list below says so too — which is the point:
+      # the change becomes deliberate instead of silent.
       - name: Knowledge pack — tool fixtures
         if: matrix.java == '17'
         run: |
-          mapfile -t suites < <(find knowledge/tools -type f -name '*.test.mjs' | sort)
-          minimum=4
-          if [ "${#suites[@]}" -lt "$minimum" ]; then
-            echo "found ${#suites[@]} fixture suites under knowledge/tools, expected at least $minimum" >&2
-            printf '  %s\n' "${suites[@]}" >&2
+          expected=$(printf '%s\n' \
+            knowledge/tools/api-surface/test/classifier.test.mjs \
+            knowledge/tools/claims/test/claims.test.mjs \
+            knowledge/tools/routing/test/anchors.test.mjs \
+            knowledge/tools/routing/test/pack-version.test.mjs)
+          found=$(find knowledge/tools -type f -name '*.test.mjs' | sort)
+          if [ "$found" != "$expected" ]; then
+            echo "the fixture suites on disk are not the ones this step declares:" >&2
+            diff <(printf '%s\n' "$expected") <(printf '%s\n' "$found") >&2 || true
             exit 1
           fi
-          for suite in "${suites[@]}"; do
+          # Not piped into `while read`: that runs the loop in a subshell, where
+          # a failing suite could not fail the step. The paths hold no spaces, so
+          # word splitting is safe and `bash -e` aborts on the first non-zero.
+          for suite in $found; do
             echo "--- $suite"
             node "$suite"
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,15 +228,21 @@ jobs:
       # Every fixture suite the knowledge tools ship, found rather than listed.
       # Naming them one step each meant a new suite ran only if someone also
       # remembered to edit this file — and a suite that never runs looks exactly
-      # like a suite that passes. The loop fails on the first non-zero exit and
-      # prints which file it was running.
+      # like a suite that passes.
+      #
+      # Discovery is recursive, so a suite nested a directory deeper is still
+      # found, and the floor is what keeps the step honest in the other
+      # direction: deleting or moving a suite drops the count and goes red
+      # instead of quietly reducing coverage. Raise the floor in the same commit
+      # that adds a suite.
       - name: Knowledge pack — tool fixtures
         if: matrix.java == '17'
         run: |
-          shopt -s nullglob
-          suites=(knowledge/tools/*/test/*.test.mjs)
-          if [ ${#suites[@]} -eq 0 ]; then
-            echo "no fixture suites found under knowledge/tools/*/test/ — the layout moved" >&2
+          mapfile -t suites < <(find knowledge/tools -type f -name '*.test.mjs' | sort)
+          minimum=4
+          if [ "${#suites[@]}" -lt "$minimum" ]; then
+            echo "found ${#suites[@]} fixture suites under knowledge/tools, expected at least $minimum" >&2
+            printf '  %s\n' "${suites[@]}" >&2
             exit 1
           fi
           for suite in "${suites[@]}"; do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,9 +225,24 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Knowledge pack — classification fixtures
+      # Every fixture suite the knowledge tools ship, found rather than listed.
+      # Naming them one step each meant a new suite ran only if someone also
+      # remembered to edit this file — and a suite that never runs looks exactly
+      # like a suite that passes. The loop fails on the first non-zero exit and
+      # prints which file it was running.
+      - name: Knowledge pack — tool fixtures
         if: matrix.java == '17'
-        run: node knowledge/tools/api-surface/test/classifier.test.mjs
+        run: |
+          shopt -s nullglob
+          suites=(knowledge/tools/*/test/*.test.mjs)
+          if [ ${#suites[@]} -eq 0 ]; then
+            echo "no fixture suites found under knowledge/tools/*/test/ — the layout moved" >&2
+            exit 1
+          fi
+          for suite in "${suites[@]}"; do
+            echo "--- $suite"
+            node "$suite"
+          done
 
       # Blocking, and blocking from the first run. A warn-only gate is one
       # nobody reads, which is the failure mode this pack exists to remove: the
@@ -236,10 +251,6 @@ jobs:
       - name: Knowledge pack — API surface is current
         if: matrix.java == '17'
         run: node knowledge/tools/api-surface/extract-api.mjs --from-reactor --check
-
-      - name: Knowledge pack — claim parser fixtures
-        if: matrix.java == '17'
-        run: node knowledge/tools/claims/test/claims.test.mjs
 
       # A claim is a promise a published page makes to a reader. This fails when
       # a page names API that no surface has — which a reader would discover by

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,15 @@ jobs:
           # generated counterpart, so validating them is the check.)
           node knowledge/tools/claims/check-claims.mjs --check
           node knowledge/tools/routing/check-routes.mjs
+          # And the tool fixtures, for the same reason. build-bundle --verify
+          # asserts exit codes only, which cannot see whether the version
+          # comparison inside the shipped bin/query.mjs is right — and that copy
+          # exists precisely because the bundle cannot import the shared module.
+          # Without this, the one thing pinning it never runs at a tag.
+          for suite in $(find knowledge/tools -type f -name '*.test.mjs' | sort); do
+            echo "--- $suite"
+            node "$suite"
+          done
           node knowledge/tools/bundle/build-bundle.mjs --verify
 
       - name: Extract CHANGELOG section for the tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,23 @@ follow semantic versioning; release dates are ISO 8601.
   neither gate; the coverage for this change is the unit test and the two
   previews.
 
+### Documentation
+
+- **A row's width rule, and what `fill()` does when there is no slot.** Two things a
+  signature cannot say now have a page and a proof. A row with no `columns(...)`, no
+  `weights(...)`, no grow spacer and the default `START` arrangement splits its inner
+  width into equal shares — one per child, content playing no part — so a 13pt icon
+  beside a paragraph takes half the row and the text wraps into twice the lines;
+  `columns(auto(), weight(1))` is the form that stays right when the column is resized.
+  And `LineBuilder.horizontal(width)` is points, not a percentage, with nothing clipping
+  the line to the space it was given: a rule that must meet the column edge is `fill()`
+  in a weight column. `LineBuilder.fill()`'s own Javadoc now names the case it used to
+  promise away — a flex row (a grow spacer, or any non-`START` arrangement) sizes every
+  non-grow child to its content, so a filled line answers with the row's whole available
+  width and is then placed past the edge. `docs/recipes/layered-page-design.md` carries
+  both sections, and the recipe's own failure modes are documented with them: a spacer
+  neither shrinks a fixed rule nor gives `fill()` a slot, and a centre- or right-aligned
+  heading claims the whole `auto()` column and leaves the rule zero width.
 
 ## v2.3.0 — 2026-08-31
 

--- a/core/src/main/java/com/demcha/compose/document/dsl/LineBuilder.java
+++ b/core/src/main/java/com/demcha/compose/document/dsl/LineBuilder.java
@@ -273,6 +273,16 @@ public final class LineBuilder implements Transformable<LineBuilder> {
      * or diagonal line it is a no-op, since stretching the end point would change
      * the line's slope.</p>
      *
+     * <p><strong>A flex row has no slot to fill.</strong> When the row carries a
+     * grow spacer or a non-{@code START}
+     * {@link com.demcha.compose.document.node.RowArrangement}, every non-grow
+     * child is sized to its content instead of to a slot — and a filled line
+     * answers with the row's <em>whole</em> available width, which is then placed
+     * after the children before it and runs past the row. Give the line a
+     * {@link RowBuilder#columns(com.demcha.compose.document.style.DocumentRowColumn...)
+     * weight column} rather than a spacer when it must stop at the column edge;
+     * see {@code docs/recipes/layered-page-design.md#a-rule-that-reaches-the-column-edge}.</p>
+     *
      * @return this builder
      * @since 1.9.0
      */

--- a/core/src/test/java/com/demcha/documentation/DocumentationLinkGuardTest.java
+++ b/core/src/test/java/com/demcha/documentation/DocumentationLinkGuardTest.java
@@ -56,8 +56,15 @@ class DocumentationLinkGuardTest {
      */
     private static final Pattern LINK = Pattern.compile("\\[[^]]*]\\(([^)\\s]+)");
 
-    /** An ATX heading, whose text GitHub turns into the anchor. */
-    private static final Pattern HEADING = Pattern.compile("(?m)^#{1,6}\\s+(.+?)\\s*$");
+    /**
+     * An ATX heading, whose text GitHub turns into the anchor.
+     *
+     * <p>The run after the hashes is spaces and tabs, not {@code \s}: {@code \s}
+     * matches a newline, so a lone {@code #} on its own line swallowed the break
+     * and claimed the following line's text as a heading. GitHub renders that
+     * {@code #} as an empty heading and the next line as a paragraph.</p>
+     */
+    private static final Pattern HEADING = Pattern.compile("(?m)^#{1,6}[ \\t]+(.+?)[ \\t]*$");
 
     /** A hand-written anchor: {@code <a name="x">} or {@code <a id="x">}. */
     private static final Pattern EXPLICIT_ANCHOR =
@@ -81,7 +88,26 @@ class DocumentationLinkGuardTest {
     private static final Pattern INLINE_CODE = Pattern.compile("`[^`\\n]*`");
 
     /** Everything GitHub drops from a heading before hyphenating it. */
-    private static final Pattern NOT_IN_ANCHOR = Pattern.compile("[^\\w\\s-]", Pattern.UNICODE_CHARACTER_CLASS);
+    /**
+     * Everything GitHub drops from an anchor.
+     *
+     * <p>Spelled as categories rather than {@code \w} because {@code \w} is not
+     * GitHub's keep-set: under {@link Pattern#UNICODE_CHARACTER_CLASS} its digit
+     * class is decimal-only, so a numeral like {@code ①} was dropped where the
+     * rendered page keeps it. Marks stay in, so a decomposed accent survives.</p>
+     */
+    private static final Pattern NOT_IN_ANCHOR =
+            Pattern.compile("[^\\p{L}\\p{N}\\p{M}_\\s-]", Pattern.UNICODE_CHARACTER_CLASS);
+
+    /**
+     * The whitespace GitHub turns into hyphens — all of it.
+     *
+     * <p>{@code String.replaceAll("\\s", "-")} compiles without flags and is
+     * therefore ASCII-only, so a non-breaking space survived into the anchor as
+     * a literal U+00A0 instead of becoming a hyphen.</p>
+     */
+    private static final Pattern ANCHOR_WHITESPACE =
+            Pattern.compile("\\s", Pattern.UNICODE_CHARACTER_CLASS);
 
     /** A markdown link inside a heading — the anchor uses the text, not the target. */
     private static final Pattern HEADING_LINK = Pattern.compile("\\[([^]]*)]\\([^)]*\\)");
@@ -157,6 +183,87 @@ class DocumentationLinkGuardTest {
     }
 
     /**
+     * A heading reference written in Java: {@code docs/recipes/x.md#some-heading}
+     * inside a Javadoc block.
+     *
+     * <p>The leading boundary keeps this off absolute URLs. Several sources
+     * already link to {@code https://github.com/…/blob/main/docs/…md}; without
+     * the lookbehind the {@code docs/…} tail of such a URL matches, and a
+     * branch-pinned external link would be validated against the current
+     * worktree — which {@link #everyRelativeLinkResolves()} deliberately does not
+     * do for {@code https://} targets. The same guard is spelled as a lookbehind
+     * in {@code knowledge/tools/routing/lib/anchors.mjs}, for the same reason.</p>
+     */
+    private static final Pattern JAVA_DOCS_ANCHOR =
+            Pattern.compile("(?<![\\w./:-])(docs/[\\w./-]+\\.md)#([\\w-]+)");
+
+    /**
+     * Javadoc that points a reader at a section of the documentation points at a
+     * section that exists.
+     *
+     * <p>The markdown half of this guard reads {@code [text](target)} links, which
+     * is every reference a page can make. A Javadoc block cannot write one of
+     * those — it names the path as prose — so a heading rename fixes every
+     * markdown citation and the routing table's copies, and silently leaves the
+     * Javadoc one dangling. That copy has the widest audience of the three: the
+     * knowledge surfaces carry signatures and no prose, so for an API-first
+     * reader the Javadoc <em>is</em> the documentation, and it ships to
+     * javadoc.io and to every IDE tooltip.</p>
+     *
+     * @throws IOException when a source file or page cannot be read
+     */
+    @Test
+    void everyDocsAnchorCitedFromJavaResolves() throws IOException {
+        List<Path> sources = mainJavaSources();
+        // Fail-closed on the scan root rather than on the number of citations:
+        // there may legitimately be none one day, but "the tree moved and this
+        // read nothing" must not look like "every citation resolves".
+        assertThat(sources)
+                .describedAs("no main Java sources found under %s — this guard is reading a tree "
+                        + "that moved, so it is no longer guarding anything", PROJECT_ROOT)
+                .hasSizeGreaterThan(100);
+
+        Map<Path, Set<String>> anchors = new HashMap<>();
+        for (Path page : documentationPages()) {
+            anchors.put(page.toAbsolutePath().normalize(), anchorsOf(page));
+        }
+
+        Map<String, String> broken = new TreeMap<>();
+        for (Path source : sources) {
+            Matcher cited = JAVA_DOCS_ANCHOR.matcher(read(source));
+            while (cited.find()) {
+                String reference = cited.group(1) + "#" + cited.group(2);
+                Path page = PROJECT_ROOT.resolve(cited.group(1)).toAbsolutePath().normalize();
+                if (!Files.exists(page)) {
+                    broken.put(relative(source) + " -> " + reference, "no such page");
+                } else if (!anchors.getOrDefault(page, Set.of()).contains(cited.group(2))) {
+                    broken.put(relative(source) + " -> " + reference,
+                            "no heading in " + relative(page) + " anchors there");
+                }
+            }
+        }
+
+        assertThat(broken)
+                .describedAs("Javadoc naming a documentation section that is not there. Renaming a "
+                        + "heading is invisible to the compiler and to every markdown guard, and "
+                        + "this citation ships to javadoc.io. Fix the citation or restore the "
+                        + "heading")
+                .isEmpty();
+    }
+
+    /** Every module's production Java, which is what gets published as Javadoc. */
+    private static List<Path> mainJavaSources() throws IOException {
+        List<Path> sources = new ArrayList<>();
+        try (Stream<Path> tree = Files.walk(PROJECT_ROOT)) {
+            tree.filter(p -> p.toString().endsWith(".java"))
+                    .filter(p -> p.toAbsolutePath().normalize().toString()
+                            .replace('\\', '/').contains("/src/main/java/"))
+                    .forEach(sources::add);
+        }
+        return sources;
+    }
+
+    /**
      * The anchors GitHub generates for a page.
      *
      * <p>The rule: take the heading text, drop HTML tags, keep a link's text rather
@@ -195,7 +302,35 @@ class DocumentationLinkGuardTest {
         text = HEADING_LINK.matcher(text).replaceAll("$1");
         text = text.replace("`", "").toLowerCase(java.util.Locale.ROOT);
         text = NOT_IN_ANCHOR.matcher(text).replaceAll("");
-        return text.replaceAll("\\s", "-");
+        return ANCHOR_WHITESPACE.matcher(text).replaceAll("-");
+    }
+
+    /**
+     * The same four inputs {@code knowledge/tools/routing/test/anchors.test.mjs}
+     * pins on the JavaScript side.
+     *
+     * <p>GitHub's rule is implemented twice in this repository — here, and in
+     * {@code knowledge/tools/routing/lib/anchors.mjs}, which the routing gate
+     * resolves route citations with. Neither can call the other across the
+     * language boundary, so they are held together by asserting the same table
+     * from both sides: change one and its own fixture goes red. These four are
+     * the inputs on which the two implementations were measured to disagree.</p>
+     */
+    @Test
+    void theAnchorRuleAgreesWithItsJavaScriptTwin() {
+        assertThat(slug("Zebra alternating rows"))
+                .describedAs("a non-breaking space is whitespace, so it hyphenates like any other "
+                        + "instead of surviving into the anchor as a literal U+00A0")
+                .isEqualTo("zebra-alternating-rows");
+        assertThat(slug("Row span"))
+                .describedAs("so does an em space")
+                .isEqualTo("row-span");
+        assertThat(slug("Item ① first"))
+                .describedAs("a circled numeral is a number and survives, as it does on the page")
+                .isEqualTo("item-①-first");
+        assertThat(slug("Café rules"))
+                .describedAs("a decomposed accent is a combining mark and stays with its letter")
+                .isEqualTo("café-rules");
     }
 
     private static String withoutFencedBlocks(String markdown) {

--- a/core/src/test/java/com/demcha/documentation/DocumentationLinkGuardTest.java
+++ b/core/src/test/java/com/demcha/documentation/DocumentationLinkGuardTest.java
@@ -92,14 +92,16 @@ class DocumentationLinkGuardTest {
      *
      * <p>The keep-set was read off GitHub rather than reasoned about, by posting
      * headings to {@code api.github.com/markdown} and reading the ids it
-     * generates: letters of any script, combining marks, decimal digits,
-     * {@code _}, {@code -} and the ASCII space survive, and everything else is
-     * dropped — <em>including every other kind of whitespace</em>. A
-     * non-breaking space, an em space and a tab are all removed rather than
-     * hyphenated, and {@code ①} is removed because it is not a decimal digit,
-     * leaving the spaces that surrounded it.</p>
+     * generates: letters of any script, combining marks, decimal digits, letter
+     * numerals, connector punctuation (which is where {@code _} lives),
+     * {@code -} and the ASCII space survive, and everything else is dropped —
+     * <em>including every other kind of whitespace</em>. A non-breaking space, an
+     * em space and a tab are all removed rather than hyphenated. {@code ①} is
+     * removed because it is a {@code No} numeral, leaving the spaces that
+     * surrounded it, while {@code Ⅰ} is an {@code Nl} numeral and survives.</p>
      */
-    private static final Pattern NOT_IN_ANCHOR = Pattern.compile("[^\\p{L}\\p{M}\\p{Nd}_ -]");
+    private static final Pattern NOT_IN_ANCHOR =
+            Pattern.compile("[^\\p{L}\\p{M}\\p{Nd}\\p{Nl}\\p{Pc} -]");
 
     /** A markdown link inside a heading — the anchor uses the text, not the target. */
     private static final Pattern HEADING_LINK = Pattern.compile("\\[([^]]*)]\\([^)]*\\)");
@@ -187,7 +189,7 @@ class DocumentationLinkGuardTest {
      * in {@code knowledge/tools/routing/lib/anchors.mjs}, for the same reason.</p>
      */
     private static final Pattern JAVA_DOCS_ANCHOR =
-            Pattern.compile("(?<![\\w./:-])(docs/[\\w./-]+\\.md)#([\\p{L}\\p{M}\\p{Nd}_-]+)");
+            Pattern.compile("(?<![\\w./:-])(docs/[\\w./-]+\\.md)#([\\p{L}\\p{M}\\p{Nd}\\p{Nl}\\p{Pc}-]+)");
 
     /**
      * Javadoc that points a reader at a section of the documentation points at a
@@ -228,6 +230,14 @@ class DocumentationLinkGuardTest {
                 Path page = PROJECT_ROOT.resolve(cited.group(1)).toAbsolutePath().normalize();
                 if (!Files.exists(page)) {
                     broken.put(relative(source) + " -> " + reference, "no such page");
+                } else if (!citedAsNamedOnDisk(page, cited.group(1))) {
+                    // Files.exists and Path.equals are case-insensitive on
+                    // Windows, so a mis-cased citation was green on a developer's
+                    // box and failed only on the Linux runner — reported there as
+                    // "no such page", which reads as a missing file rather than
+                    // as the casing it is.
+                    broken.put(relative(source) + " -> " + reference,
+                            "the page on disk is named differently; check the citation's casing");
                 } else if (!anchors.getOrDefault(page, Set.of()).contains(cited.group(2))) {
                     broken.put(relative(source) + " -> " + reference,
                             "no heading in " + relative(page) + " anchors there");
@@ -241,6 +251,29 @@ class DocumentationLinkGuardTest {
                         + "this citation ships to javadoc.io. Fix the citation or restore the "
                         + "heading")
                 .isEmpty();
+    }
+
+    /**
+     * Whether a citation spells the page the way the filesystem does.
+     *
+     * <p>{@link Path#toRealPath} resolves to the on-disk name, which is the only
+     * way to see a casing mismatch on a case-insensitive filesystem. The routing
+     * gate makes the same comparison for its own citations.</p>
+     *
+     * @param page  the resolved page
+     * @param cited the path half of the citation, as written
+     * @return {@code true} when the two agree
+     */
+    private static boolean citedAsNamedOnDisk(Path page, String cited) {
+        try {
+            String onDisk = PROJECT_ROOT.toRealPath().relativize(page.toRealPath()).toString()
+                    .replace('\\', '/');
+            return onDisk.equals(cited);
+        } catch (IOException e) {
+            // Unreadable is not mis-cased; the caller has already established the
+            // file exists, so let the anchor check speak instead.
+            return true;
+        }
     }
 
     /** Every module's production Java, which is what gets published as Javadoc. */
@@ -302,15 +335,19 @@ class DocumentationLinkGuardTest {
     }
 
     /**
-     * The same four inputs {@code knowledge/tools/routing/test/anchors.test.mjs}
-     * pins on the JavaScript side.
+     * The same table {@code knowledge/tools/routing/test/anchors.test.mjs} pins
+     * on the JavaScript side.
      *
      * <p>GitHub's rule is implemented twice in this repository — here, and in
      * {@code knowledge/tools/routing/lib/anchors.mjs}, which the routing gate
      * resolves route citations with. Neither can call the other across the
-     * language boundary, so they are held together by asserting the same table
-     * from both sides: change one and its own fixture goes red. These four are
-     * the inputs on which the two implementations were measured to disagree.</p>
+     * language boundary, so they are held together by asserting the same inputs
+     * from both sides: change one and its own fixture goes red.</p>
+     *
+     * <p>Every expected value was read off GitHub, by posting the heading to
+     * {@code api.github.com/markdown} and taking the id it generated — not
+     * derived from either implementation. Three earlier versions of this rule
+     * were reasoned about instead, and all three were wrong.</p>
      */
     @Test
     void theAnchorRuleAgreesWithItsJavaScriptTwin() {
@@ -338,6 +375,19 @@ class DocumentationLinkGuardTest {
         assertThat(slug("A & B"))
                 .describedAs("a dropped character leaves its spaces behind")
                 .isEqualTo("a--b");
+        assertThat(slug("Chapter Ⅰ here"))
+                .describedAs("a letter numeral is kept, unlike the circled one above")
+                .isEqualTo("chapter-ⅰ-here");
+        assertThat(slug("a‿f b"))
+                .describedAs("connector punctuation is kept — that is where the underscore lives")
+                .isEqualTo("a‿f-b");
+        assertThat(slug("  A"))
+                .describedAs("a non-ASCII space at the edge is dropped, and the ASCII space "
+                        + "beside it still becomes a hyphen — GitHub does not trim it away")
+                .isEqualTo("-a");
+        assertThat(slug("A  "))
+                .describedAs("the same at the trailing edge")
+                .isEqualTo("a-");
         assertThat(slug("Zebra — alternating row fills"))
                 .describedAs("and the case that started all this: a spaced em dash is two spaces, "
                         + "so it is two hyphens")

--- a/core/src/test/java/com/demcha/documentation/DocumentationLinkGuardTest.java
+++ b/core/src/test/java/com/demcha/documentation/DocumentationLinkGuardTest.java
@@ -87,27 +87,19 @@ class DocumentationLinkGuardTest {
      */
     private static final Pattern INLINE_CODE = Pattern.compile("`[^`\\n]*`");
 
-    /** Everything GitHub drops from a heading before hyphenating it. */
     /**
      * Everything GitHub drops from an anchor.
      *
-     * <p>Spelled as categories rather than {@code \w} because {@code \w} is not
-     * GitHub's keep-set: under {@link Pattern#UNICODE_CHARACTER_CLASS} its digit
-     * class is decimal-only, so a numeral like {@code ①} was dropped where the
-     * rendered page keeps it. Marks stay in, so a decomposed accent survives.</p>
+     * <p>The keep-set was read off GitHub rather than reasoned about, by posting
+     * headings to {@code api.github.com/markdown} and reading the ids it
+     * generates: letters of any script, combining marks, decimal digits,
+     * {@code _}, {@code -} and the ASCII space survive, and everything else is
+     * dropped — <em>including every other kind of whitespace</em>. A
+     * non-breaking space, an em space and a tab are all removed rather than
+     * hyphenated, and {@code ①} is removed because it is not a decimal digit,
+     * leaving the spaces that surrounded it.</p>
      */
-    private static final Pattern NOT_IN_ANCHOR =
-            Pattern.compile("[^\\p{L}\\p{N}\\p{M}_\\s-]", Pattern.UNICODE_CHARACTER_CLASS);
-
-    /**
-     * The whitespace GitHub turns into hyphens — all of it.
-     *
-     * <p>{@code String.replaceAll("\\s", "-")} compiles without flags and is
-     * therefore ASCII-only, so a non-breaking space survived into the anchor as
-     * a literal U+00A0 instead of becoming a hyphen.</p>
-     */
-    private static final Pattern ANCHOR_WHITESPACE =
-            Pattern.compile("\\s", Pattern.UNICODE_CHARACTER_CLASS);
+    private static final Pattern NOT_IN_ANCHOR = Pattern.compile("[^\\p{L}\\p{M}\\p{Nd}_ -]");
 
     /** A markdown link inside a heading — the anchor uses the text, not the target. */
     private static final Pattern HEADING_LINK = Pattern.compile("\\[([^]]*)]\\([^)]*\\)");
@@ -195,7 +187,7 @@ class DocumentationLinkGuardTest {
      * in {@code knowledge/tools/routing/lib/anchors.mjs}, for the same reason.</p>
      */
     private static final Pattern JAVA_DOCS_ANCHOR =
-            Pattern.compile("(?<![\\w./:-])(docs/[\\w./-]+\\.md)#([\\w-]+)");
+            Pattern.compile("(?<![\\w./:-])(docs/[\\w./-]+\\.md)#([\\p{L}\\p{M}\\p{Nd}_-]+)");
 
     /**
      * Javadoc that points a reader at a section of the documentation points at a
@@ -267,8 +259,9 @@ class DocumentationLinkGuardTest {
      * The anchors GitHub generates for a page.
      *
      * <p>The rule: take the heading text, drop HTML tags, keep a link's text rather
-     * than its target, lowercase, remove everything that is not a word character,
-     * whitespace or a hyphen, then replace whitespace with hyphens. Leading and
+     * than its target, lowercase, remove everything that is not a letter, a
+     * combining mark, a decimal digit, {@code _}, {@code -} or an ASCII space,
+     * then replace each remaining ASCII space with a hyphen. Leading and
      * trailing hyphens survive — {@code ## 🚀 Start here} anchors as
      * {@code -start-here}, not {@code start-here} — and a repeated heading gets
      * {@code -1}, {@code -2} appended.</p>
@@ -302,7 +295,10 @@ class DocumentationLinkGuardTest {
         text = HEADING_LINK.matcher(text).replaceAll("$1");
         text = text.replace("`", "").toLowerCase(java.util.Locale.ROOT);
         text = NOT_IN_ANCHOR.matcher(text).replaceAll("");
-        return ANCHOR_WHITESPACE.matcher(text).replaceAll("-");
+        // The ASCII space only. Every other kind of whitespace was removed above,
+        // which is what GitHub does — hyphenating them put characters into the
+        // anchor that the rendered page does not have.
+        return text.replace(' ', '-');
     }
 
     /**
@@ -319,17 +315,35 @@ class DocumentationLinkGuardTest {
     @Test
     void theAnchorRuleAgreesWithItsJavaScriptTwin() {
         assertThat(slug("Zebra alternating rows"))
-                .describedAs("a non-breaking space is whitespace, so it hyphenates like any other "
-                        + "instead of surviving into the anchor as a literal U+00A0")
-                .isEqualTo("zebra-alternating-rows");
+                .describedAs("a non-breaking space is dropped, not hyphenated")
+                .isEqualTo("zebraalternating-rows");
         assertThat(slug("Row span"))
-                .describedAs("so does an em space")
-                .isEqualTo("row-span");
+                .describedAs("an em space is dropped too")
+                .isEqualTo("rowspan");
+        assertThat(slug("A\tB"))
+                .describedAs("and a tab — only the ASCII space becomes a hyphen")
+                .isEqualTo("ab");
         assertThat(slug("Item ① first"))
-                .describedAs("a circled numeral is a number and survives, as it does on the page")
-                .isEqualTo("item-①-first");
+                .describedAs("a circled numeral is not a decimal digit, so it goes and its spaces stay")
+                .isEqualTo("item--first");
+        assertThat(slug("Привет мир"))
+                .describedAs("letters of any script survive")
+                .isEqualTo("привет-мир");
+        assertThat(slug("v1.8.0 fonts"))
+                .describedAs("so do digits, while the dots between them go")
+                .isEqualTo("v180-fonts");
+        assertThat(slug("snake_case name"))
+                .describedAs("an underscore survives")
+                .isEqualTo("snake_case-name");
+        assertThat(slug("A & B"))
+                .describedAs("a dropped character leaves its spaces behind")
+                .isEqualTo("a--b");
+        assertThat(slug("Zebra — alternating row fills"))
+                .describedAs("and the case that started all this: a spaced em dash is two spaces, "
+                        + "so it is two hyphens")
+                .isEqualTo("zebra--alternating-row-fills");
         assertThat(slug("Café rules"))
-                .describedAs("a decomposed accent is a combining mark and stays with its letter")
+                .describedAs("a decomposed accent is a combining mark and stays with its letter (GitHub keeps it)")
                 .isEqualTo("café-rules");
     }
 

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -16,7 +16,7 @@ authoring API; public application code should not import
 | [Shape-as-container](recipes/shape-as-container.md) | `addCircle` / `addEllipse` / `addContainer` with `ClipPolicy` (clipped layered children) |
 | [Transforms and z-index](recipes/transforms.md) | `rotate` / `scale` mixin, per-layer `zIndex` for overlays |
 | [Page backgrounds](recipes/page-backgrounds.md) | `pageBackground` / `pageBackgrounds`, `PageBackgroundFill` columns, bands, point-based fills, layering |
-| [Layered page design](recipes/layered-page-design.md) | Page background vs. row vs. layer stack vs. canvas — choosing the layer |
+| [Layered page design](recipes/layered-page-design.md) | Page background vs. row vs. layer stack vs. canvas — choosing the layer; how a row splits its width, icon beside text, a rule that reaches the column edge |
 | [Absolute placement](recipes/absolute-placement.md) | `addCanvas` + `position(x, y)` for pixel-precise certificates and badges |
 | [Tables](recipes/tables.md) | Row span, zebra rows, totals row, repeated header on page break |
 | [Text direction](recipes/text-direction.md) | `TextDirection` — right-to-left paragraphs, `AUTO` resolved from the text, mixed lines, and the bundled Hebrew / Arabic families |

--- a/docs/recipes/layered-page-design.md
+++ b/docs/recipes/layered-page-design.md
@@ -139,10 +139,10 @@ the line and cannot hold a left rail.
 <!-- claim: symbol=LineBuilder.horizontal -->
 <!-- claim: symbol=LineBuilder.fill -->
 <!-- claim: symbol=ParagraphBuilder.align -->
-<!-- claim: behavior=line.horizontal-is-points-and-is-not-clipped proof=test:LineWidthUnitsContractTest -->
+<!-- claim: behavior=line.horizontal-is-points-and-is-not-clipped proof=test:LineWidthUnitsContractTest#horizontalIsPointsAndTheLineIsNotClippedToItsSlot -->
 <!-- claim: behavior=line.fill-spans-its-slot proof=test:LineWidthUnitsContractTest -->
 <!-- claim: behavior=line.fill-overflows-a-flex-row proof=test:LineWidthUnitsContractTest -->
-<!-- claim: behavior=row.an-aligned-paragraph-in-an-auto-column-takes-the-whole-row proof=test:LineWidthUnitsContractTest -->
+<!-- claim: behavior=row.an-aligned-paragraph-in-an-auto-column-takes-the-whole-row proof=test:LineWidthUnitsContractTest#anAlignedHeadingLeavesTheWeightColumnNothingToFill -->
 
 `horizontal(width)` takes **points**. Not a percentage — even though the numbers
 next to it on this page are ratios (`weights(0.34, 0.66)`,

--- a/docs/recipes/layered-page-design.md
+++ b/docs/recipes/layered-page-design.md
@@ -55,6 +55,155 @@ document.pageFlow()
 Often you want **both**: the tint as a page background and the content as a row
 column over it.
 
+### Icon beside text
+
+<!-- claim: capability=layout.icon-beside-text -->
+<!-- claim: symbol=RowBuilder.columns -->
+<!-- claim: symbol=DocumentRowColumn.auto -->
+<!-- claim: symbol=DocumentRowColumn.weight -->
+<!-- claim: symbol=RowBuilder.flexSpacer -->
+<!-- claim: symbol=ParagraphBuilder.inlineSvgIcon -->
+<!-- claim: behavior=row.no-column-spec-splits-the-width-evenly proof=test:RowWidthDistributionContractTest -->
+<!-- claim: behavior=row.a-flex-row-sizes-every-other-child-to-its-content proof=test:RowWidthDistributionContractTest -->
+
+A row with no `columns(...)`, no `weights(...)`, no grow spacer and the default
+`START` arrangement splits its inner width into **equal shares — one per child**.
+Content plays no part. Two children means half each, whether the child is a
+paragraph or a 13pt icon:
+
+<!-- doc-example: id=row-icon-even-split mode=method imports=com.demcha.compose.GraphCompose,com.demcha.compose.document.api.DocumentSession,com.demcha.compose.document.svg.SvgIcon,java.nio.file.Path -->
+```java
+SvgIcon icon = SvgIcon.read(Path.of("check.svg"));
+
+try (DocumentSession document = GraphCompose.document(Path.of("cv.pdf")).create()) {
+    document.pageFlow(page -> page
+            .addRow(row -> row
+                    .spacing(8)
+                    .add(icon.node(13))
+                    .addParagraph(p -> p.text("Delivered 120+ events annually."))));
+}
+```
+
+In a 135.7pt sidebar column that is a 63.85pt slot each. The icon still *draws*
+at 13pt, so nothing looks broken — it simply occupies nearly five times the width
+it needs, and the paragraph pays for it in line count.
+
+Size the icon column instead: `auto()` takes the icon's own width, `weight(1)`
+takes everything left.
+
+<!-- doc-example: id=row-icon-auto-column mode=method imports=com.demcha.compose.GraphCompose,com.demcha.compose.document.api.DocumentSession,com.demcha.compose.document.style.DocumentRowColumn,com.demcha.compose.document.svg.SvgIcon,java.nio.file.Path -->
+```java
+SvgIcon icon = SvgIcon.read(Path.of("check.svg"));
+
+try (DocumentSession document = GraphCompose.document(Path.of("cv.pdf")).create()) {
+    document.pageFlow(page -> page
+            .addRow(row -> row
+                    .spacing(8)
+                    .columns(DocumentRowColumn.auto(), DocumentRowColumn.weight(1))
+                    .add(icon.node(13))
+                    .addParagraph(p -> p.text("Delivered 120+ events annually."))));
+}
+```
+
+Use `fixed(13)` in place of `auto()` when a column of icons must line up down a
+list whatever each one contains. Reach for `weights(...)` only when both children
+are content and you want a *proportion* — a weight is a share of the row, so a
+ratio picked for one column width is wrong at another, and it can hand a
+fixed-size icon a slot narrower than the icon.
+
+A trailing `flexSpacer()` reaches the same widths by a different route, and this
+is worth knowing because it makes two nearly identical rows disagree: a grow
+spacer switches the row to intrinsic sizing, where **every** non-grow child takes
+its natural width and the spacer absorbs the rest. Add one to push a value to the
+right edge and the icon stops taking half the row as a side effect — but no child
+in that row can be given a proportional share any more.
+
+**A non-`START` arrangement does the same thing.** `arrangement(CENTER)`,
+`END`, `SPACE_BETWEEN`, `SPACE_AROUND` and `SPACE_EVENLY` each put the row on the
+identical intrinsic-sizing path with no spacer anywhere, so "no grow spacer" is
+only half the condition for the even split — the other half is that the
+arrangement is `START`. The two triggers are interchangeable, and `columns(...)`
+or `weights(...)` cannot be combined with either: the row rejects that outright
+rather than picking one.
+
+When the icon belongs *in* the sentence rather than beside the block, there is no
+row to distribute: `inlineSvgIcon` puts it in the text run, where it wraps with
+the line and cannot hold a left rail.
+
+### A rule that reaches the column edge
+
+<!-- claim: capability=layout.rule-beside-a-heading -->
+<!-- claim: symbol=RowBuilder.addLine -->
+<!-- claim: symbol=LineBuilder.horizontal -->
+<!-- claim: symbol=LineBuilder.fill -->
+<!-- claim: behavior=line.horizontal-is-points-and-is-not-clipped proof=test:LineWidthUnitsContractTest -->
+<!-- claim: behavior=line.fill-spans-its-slot proof=test:LineWidthUnitsContractTest -->
+<!-- claim: behavior=line.fill-overflows-a-flex-row proof=test:LineWidthUnitsContractTest -->
+<!-- claim: behavior=row.an-aligned-paragraph-in-an-auto-column-takes-the-whole-row proof=test:LineWidthUnitsContractTest -->
+
+`horizontal(width)` takes **points**. Not a percentage — even though the numbers
+next to it on this page are ratios (`weights(0.34, 0.66)`,
+`leftColumn(0.34, ...)`), and a `double` named `width` looks like one:
+
+<!-- doc-example: id=row-rule-fixed-width mode=method imports=com.demcha.compose.GraphCompose,com.demcha.compose.document.api.DocumentSession,com.demcha.compose.document.style.DocumentColor,java.nio.file.Path -->
+```java
+DocumentColor coral = DocumentColor.rgb(0xE2, 0x6D, 0x5A);
+
+try (DocumentSession document = GraphCompose.document(Path.of("cv.pdf")).create()) {
+    document.pageFlow(page -> page
+            .addRow(row -> row
+                    .addParagraph(p -> p.text("CORE COMPETENCIES"))
+                    .addLine(line -> line.horizontal(100).color(coral))));
+}
+```
+
+Nothing clips a line to the space it was given. In a 135.7pt column the even
+split above hands the rule a 67.85pt slot and it is drawn at 100pt anyway —
+32.15pt past the column, across whatever is beside it, with no warning and a
+clean render.
+
+A rule that must *meet* the column edge is `fill()`, which stretches a horizontal
+line to the slot it is placed in. Pair it with a weight column so the slot is the
+leftover width rather than half the row:
+
+<!-- doc-example: id=row-rule-fill mode=method imports=com.demcha.compose.GraphCompose,com.demcha.compose.document.api.DocumentSession,com.demcha.compose.document.style.DocumentColor,com.demcha.compose.document.style.DocumentRowColumn,java.nio.file.Path -->
+```java
+DocumentColor coral = DocumentColor.rgb(0xE2, 0x6D, 0x5A);
+
+try (DocumentSession document = GraphCompose.document(Path.of("cv.pdf")).create()) {
+    document.pageFlow(page -> page
+            .addRow(row -> row
+                    .spacing(6)
+                    .columns(DocumentRowColumn.auto(), DocumentRowColumn.weight(1))
+                    .addParagraph(p -> p.text("CORE COMPETENCIES"))
+                    .addLine(line -> line.fill().color(coral))));
+}
+```
+
+**Leave that heading unaligned.** A right- or centre-aligned paragraph claims the
+full row width; the `auto()` column grants it, because a fixed-and-auto pair that
+fits is not an error; and the weight column is left with nothing. The rule then
+has width zero — it does not overflow and it does not throw, it simply is not
+drawn. If the heading must be aligned, give it a `weight(...)` column instead of
+`auto()`, so its share is decided by the row rather than by the text.
+
+Keep `horizontal(n)` for what it is good at: a fixed-length accent under a title,
+where the length is the design and not a measurement of the column.
+
+Two repairs that look right and are not. A `flexSpacer()` before the rule *moves*
+it without sizing it — in the 135.7pt column above, a 100pt rule still runs past
+the edge, and it stops doing so only when whatever sits beside it is narrow
+enough to leave the spacer some slack, which is a property of that row and not a
+fix. And `fill()` in a **flex row** — one with a grow spacer *or* a non-`START`
+arrangement — overflows further than the fixed rule it replaced: the flex path
+asks every non-grow child for its natural width, a fill line answers with the
+row's whole available width, and it is then placed after the other children.
+
+What `fill()` needs is a weight column, not a spacer, and the row will not let
+you have both: combining `columns(...)` or `weights(...)` with a grow spacer or a
+non-`START` arrangement is rejected outright, with a message naming the two
+strategies. So this is a choice between them rather than something to stack.
+
 ### Overlap: layer stack vs. canvas
 
 A badge centred on a card, sizing to the card, is a **layer stack** — use

--- a/docs/recipes/layered-page-design.md
+++ b/docs/recipes/layered-page-design.md
@@ -61,7 +61,9 @@ column over it.
 <!-- claim: symbol=RowBuilder.columns -->
 <!-- claim: symbol=DocumentRowColumn.auto -->
 <!-- claim: symbol=DocumentRowColumn.weight -->
+<!-- claim: symbol=DocumentRowColumn.fixed -->
 <!-- claim: symbol=RowBuilder.flexSpacer -->
+<!-- claim: symbol=RowBuilder.arrangement -->
 <!-- claim: symbol=ParagraphBuilder.inlineSvgIcon -->
 <!-- claim: behavior=row.no-column-spec-splits-the-width-evenly proof=test:RowWidthDistributionContractTest -->
 <!-- claim: behavior=row.a-flex-row-sizes-every-other-child-to-its-content proof=test:RowWidthDistributionContractTest -->
@@ -136,6 +138,7 @@ the line and cannot hold a left rail.
 <!-- claim: symbol=RowBuilder.addLine -->
 <!-- claim: symbol=LineBuilder.horizontal -->
 <!-- claim: symbol=LineBuilder.fill -->
+<!-- claim: symbol=ParagraphBuilder.align -->
 <!-- claim: behavior=line.horizontal-is-points-and-is-not-clipped proof=test:LineWidthUnitsContractTest -->
 <!-- claim: behavior=line.fill-spans-its-slot proof=test:LineWidthUnitsContractTest -->
 <!-- claim: behavior=line.fill-overflows-a-flex-row proof=test:LineWidthUnitsContractTest -->

--- a/knowledge/claims/index.json
+++ b/knowledge/claims/index.json
@@ -316,7 +316,7 @@
           "page": "docs/recipes/layered-page-design.md",
           "line": 142,
           "heading": "A rule that reaches the column edge",
-          "proof": "test:LineWidthUnitsContractTest"
+          "proof": "test:LineWidthUnitsContractTest#horizontalIsPointsAndTheLineIsNotClippedToItsSlot"
         }
       ],
       "row.a-flex-row-sizes-every-other-child-to-its-content": [
@@ -332,7 +332,7 @@
           "page": "docs/recipes/layered-page-design.md",
           "line": 145,
           "heading": "A rule that reaches the column edge",
-          "proof": "test:LineWidthUnitsContractTest"
+          "proof": "test:LineWidthUnitsContractTest#anAlignedHeadingLeavesTheWeightColumnNothingToFill"
         }
       ],
       "row.auto-column-rejects-right-aligned-text": [

--- a/knowledge/claims/index.json
+++ b/knowledge/claims/index.json
@@ -4,7 +4,7 @@
   "generator": "knowledge/tools/claims/check-claims.mjs",
   "counts": {
     "pagesWithClaims": 2,
-    "symbol": 22,
+    "symbol": 25,
     "capability": 8,
     "behavior": 13
   },
@@ -50,6 +50,15 @@
         {
           "page": "docs/recipes/layered-page-design.md",
           "line": 62,
+          "heading": "Icon beside text",
+          "surface": "authoring",
+          "stability": "stable"
+        }
+      ],
+      "DocumentRowColumn.fixed": [
+        {
+          "page": "docs/recipes/layered-page-design.md",
+          "line": 64,
           "heading": "Icon beside text",
           "surface": "authoring",
           "stability": "stable"
@@ -103,7 +112,7 @@
       "LineBuilder.fill": [
         {
           "page": "docs/recipes/layered-page-design.md",
-          "line": 138,
+          "line": 140,
           "heading": "A rule that reaches the column edge",
           "surface": "authoring",
           "stability": "stable"
@@ -112,7 +121,7 @@
       "LineBuilder.horizontal": [
         {
           "page": "docs/recipes/layered-page-design.md",
-          "line": 137,
+          "line": 139,
           "heading": "A rule that reaches the column edge",
           "surface": "authoring",
           "stability": "stable"
@@ -127,10 +136,19 @@
           "stability": "stable"
         }
       ],
+      "ParagraphBuilder.align": [
+        {
+          "page": "docs/recipes/layered-page-design.md",
+          "line": 141,
+          "heading": "A rule that reaches the column edge",
+          "surface": "authoring",
+          "stability": "stable"
+        }
+      ],
       "ParagraphBuilder.inlineSvgIcon": [
         {
           "page": "docs/recipes/layered-page-design.md",
-          "line": 65,
+          "line": 67,
           "heading": "Icon beside text",
           "surface": "authoring",
           "stability": "stable"
@@ -139,8 +157,17 @@
       "RowBuilder.addLine": [
         {
           "page": "docs/recipes/layered-page-design.md",
-          "line": 136,
+          "line": 138,
           "heading": "A rule that reaches the column edge",
+          "surface": "authoring",
+          "stability": "stable"
+        }
+      ],
+      "RowBuilder.arrangement": [
+        {
+          "page": "docs/recipes/layered-page-design.md",
+          "line": 66,
+          "heading": "Icon beside text",
           "surface": "authoring",
           "stability": "stable"
         }
@@ -157,7 +184,7 @@
       "RowBuilder.flexSpacer": [
         {
           "page": "docs/recipes/layered-page-design.md",
-          "line": 64,
+          "line": 65,
           "heading": "Icon beside text",
           "surface": "authoring",
           "stability": "stable"
@@ -227,7 +254,7 @@
       "layout.rule-beside-a-heading": [
         {
           "page": "docs/recipes/layered-page-design.md",
-          "line": 135,
+          "line": 137,
           "heading": "A rule that reaches the column edge"
         }
       ],
@@ -271,7 +298,7 @@
       "line.fill-overflows-a-flex-row": [
         {
           "page": "docs/recipes/layered-page-design.md",
-          "line": 141,
+          "line": 144,
           "heading": "A rule that reaches the column edge",
           "proof": "test:LineWidthUnitsContractTest"
         }
@@ -279,7 +306,7 @@
       "line.fill-spans-its-slot": [
         {
           "page": "docs/recipes/layered-page-design.md",
-          "line": 140,
+          "line": 143,
           "heading": "A rule that reaches the column edge",
           "proof": "test:LineWidthUnitsContractTest"
         }
@@ -287,7 +314,7 @@
       "line.horizontal-is-points-and-is-not-clipped": [
         {
           "page": "docs/recipes/layered-page-design.md",
-          "line": 139,
+          "line": 142,
           "heading": "A rule that reaches the column edge",
           "proof": "test:LineWidthUnitsContractTest"
         }
@@ -295,7 +322,7 @@
       "row.a-flex-row-sizes-every-other-child-to-its-content": [
         {
           "page": "docs/recipes/layered-page-design.md",
-          "line": 67,
+          "line": 69,
           "heading": "Icon beside text",
           "proof": "test:RowWidthDistributionContractTest"
         }
@@ -303,7 +330,7 @@
       "row.an-aligned-paragraph-in-an-auto-column-takes-the-whole-row": [
         {
           "page": "docs/recipes/layered-page-design.md",
-          "line": 142,
+          "line": 145,
           "heading": "A rule that reaches the column edge",
           "proof": "test:LineWidthUnitsContractTest"
         }
@@ -319,7 +346,7 @@
       "row.no-column-spec-splits-the-width-evenly": [
         {
           "page": "docs/recipes/layered-page-design.md",
-          "line": 66,
+          "line": 68,
           "heading": "Icon beside text",
           "proof": "test:RowWidthDistributionContractTest"
         }

--- a/knowledge/claims/index.json
+++ b/knowledge/claims/index.json
@@ -4,9 +4,9 @@
   "generator": "knowledge/tools/claims/check-claims.mjs",
   "counts": {
     "pagesWithClaims": 2,
-    "symbol": 14,
-    "capability": 6,
-    "behavior": 7
+    "symbol": 22,
+    "capability": 8,
+    "behavior": 13
   },
   "claims": {
     "symbol": {
@@ -42,6 +42,24 @@
           "page": "docs/recipes/layered-page-design.md",
           "line": 12,
           "heading": "The four tools",
+          "surface": "authoring",
+          "stability": "stable"
+        }
+      ],
+      "DocumentRowColumn.auto": [
+        {
+          "page": "docs/recipes/layered-page-design.md",
+          "line": 62,
+          "heading": "Icon beside text",
+          "surface": "authoring",
+          "stability": "stable"
+        }
+      ],
+      "DocumentRowColumn.weight": [
+        {
+          "page": "docs/recipes/layered-page-design.md",
+          "line": 63,
+          "heading": "Icon beside text",
           "surface": "authoring",
           "stability": "stable"
         }
@@ -82,11 +100,65 @@
           "stability": "stable"
         }
       ],
+      "LineBuilder.fill": [
+        {
+          "page": "docs/recipes/layered-page-design.md",
+          "line": 138,
+          "heading": "A rule that reaches the column edge",
+          "surface": "authoring",
+          "stability": "stable"
+        }
+      ],
+      "LineBuilder.horizontal": [
+        {
+          "page": "docs/recipes/layered-page-design.md",
+          "line": 137,
+          "heading": "A rule that reaches the column edge",
+          "surface": "authoring",
+          "stability": "stable"
+        }
+      ],
       "PageBackgroundFill.leftColumn": [
         {
           "page": "docs/recipes/layered-page-design.md",
           "line": 29,
           "heading": "Sidebar: page background vs. row",
+          "surface": "authoring",
+          "stability": "stable"
+        }
+      ],
+      "ParagraphBuilder.inlineSvgIcon": [
+        {
+          "page": "docs/recipes/layered-page-design.md",
+          "line": 65,
+          "heading": "Icon beside text",
+          "surface": "authoring",
+          "stability": "stable"
+        }
+      ],
+      "RowBuilder.addLine": [
+        {
+          "page": "docs/recipes/layered-page-design.md",
+          "line": 136,
+          "heading": "A rule that reaches the column edge",
+          "surface": "authoring",
+          "stability": "stable"
+        }
+      ],
+      "RowBuilder.columns": [
+        {
+          "page": "docs/recipes/layered-page-design.md",
+          "line": 61,
+          "heading": "Icon beside text",
+          "surface": "authoring",
+          "stability": "stable"
+        }
+      ],
+      "RowBuilder.flexSpacer": [
+        {
+          "page": "docs/recipes/layered-page-design.md",
+          "line": 64,
+          "heading": "Icon beside text",
           "surface": "authoring",
           "stability": "stable"
         }
@@ -145,6 +217,20 @@
           "heading": "The four tools"
         }
       ],
+      "layout.icon-beside-text": [
+        {
+          "page": "docs/recipes/layered-page-design.md",
+          "line": 60,
+          "heading": "Icon beside text"
+        }
+      ],
+      "layout.rule-beside-a-heading": [
+        {
+          "page": "docs/recipes/layered-page-design.md",
+          "line": 135,
+          "heading": "A rule that reaches the column edge"
+        }
+      ],
       "layout.two-columns": [
         {
           "page": "docs/recipes/layered-page-design.md",
@@ -182,12 +268,60 @@
       ]
     },
     "behavior": {
+      "line.fill-overflows-a-flex-row": [
+        {
+          "page": "docs/recipes/layered-page-design.md",
+          "line": 141,
+          "heading": "A rule that reaches the column edge",
+          "proof": "test:LineWidthUnitsContractTest"
+        }
+      ],
+      "line.fill-spans-its-slot": [
+        {
+          "page": "docs/recipes/layered-page-design.md",
+          "line": 140,
+          "heading": "A rule that reaches the column edge",
+          "proof": "test:LineWidthUnitsContractTest"
+        }
+      ],
+      "line.horizontal-is-points-and-is-not-clipped": [
+        {
+          "page": "docs/recipes/layered-page-design.md",
+          "line": 139,
+          "heading": "A rule that reaches the column edge",
+          "proof": "test:LineWidthUnitsContractTest"
+        }
+      ],
+      "row.a-flex-row-sizes-every-other-child-to-its-content": [
+        {
+          "page": "docs/recipes/layered-page-design.md",
+          "line": 67,
+          "heading": "Icon beside text",
+          "proof": "test:RowWidthDistributionContractTest"
+        }
+      ],
+      "row.an-aligned-paragraph-in-an-auto-column-takes-the-whole-row": [
+        {
+          "page": "docs/recipes/layered-page-design.md",
+          "line": 142,
+          "heading": "A rule that reaches the column edge",
+          "proof": "test:LineWidthUnitsContractTest"
+        }
+      ],
       "row.auto-column-rejects-right-aligned-text": [
         {
           "page": "docs/recipes/layered-page-design.md",
           "line": 31,
           "heading": "Sidebar: page background vs. row",
           "proof": "test:AutoColumnRightAlignContractTest"
+        }
+      ],
+      "row.no-column-spec-splits-the-width-evenly": [
+        {
+          "page": "docs/recipes/layered-page-design.md",
+          "line": 66,
+          "heading": "Icon beside text",
+          "proof": "test:RowWidthDistributionContractTest"
         }
       ],
       "row.rejects-a-nested-row": [

--- a/knowledge/proofs/index.json
+++ b/knowledge/proofs/index.json
@@ -5,7 +5,7 @@
   "counts": {
     "proofs": 8,
     "claimsHeld": 13,
-    "claimsWithoutProof": 30
+    "claimsWithoutProof": 33
   },
   "proofs": {
     "test:AutoColumnRightAlignContractTest": {
@@ -42,28 +42,28 @@
           "kind": "behavior",
           "value": "line.horizontal-is-points-and-is-not-clipped",
           "page": "docs/recipes/layered-page-design.md",
-          "line": 139,
+          "line": 142,
           "heading": "A rule that reaches the column edge"
         },
         {
           "kind": "behavior",
           "value": "line.fill-spans-its-slot",
           "page": "docs/recipes/layered-page-design.md",
-          "line": 140,
+          "line": 143,
           "heading": "A rule that reaches the column edge"
         },
         {
           "kind": "behavior",
           "value": "line.fill-overflows-a-flex-row",
           "page": "docs/recipes/layered-page-design.md",
-          "line": 141,
+          "line": 144,
           "heading": "A rule that reaches the column edge"
         },
         {
           "kind": "behavior",
           "value": "row.an-aligned-paragraph-in-an-auto-column-takes-the-whole-row",
           "page": "docs/recipes/layered-page-design.md",
-          "line": 142,
+          "line": 145,
           "heading": "A rule that reaches the column edge"
         }
       ]
@@ -89,14 +89,14 @@
           "kind": "behavior",
           "value": "row.no-column-spec-splits-the-width-evenly",
           "page": "docs/recipes/layered-page-design.md",
-          "line": 66,
+          "line": 68,
           "heading": "Icon beside text"
         },
         {
           "kind": "behavior",
           "value": "row.a-flex-row-sizes-every-other-child-to-its-content",
           "page": "docs/recipes/layered-page-design.md",
-          "line": 67,
+          "line": 69,
           "heading": "Icon beside text"
         }
       ]

--- a/knowledge/proofs/index.json
+++ b/knowledge/proofs/index.json
@@ -3,7 +3,7 @@
   "note": "Every proof a documentation claim cites, resolved to where it lives and what it holds up. Generated from the claim markers in docs/; a proof that nothing cites does not appear, and a claim whose proof does not resolve fails the check rather than landing here.",
   "generator": "knowledge/tools/claims/check-claims.mjs",
   "counts": {
-    "proofs": 8,
+    "proofs": 10,
     "claimsHeld": 13,
     "claimsWithoutProof": 33
   },
@@ -34,7 +34,20 @@
         }
       ]
     },
-    "test:LineWidthUnitsContractTest": {
+    "test:LineWidthUnitsContractTest#anAlignedHeadingLeavesTheWeightColumnNothingToFill": {
+      "kind": "test",
+      "path": "qa/src/test/java/com/demcha/compose/document/dsl/LineWidthUnitsContractTest.java",
+      "holds": [
+        {
+          "kind": "behavior",
+          "value": "row.an-aligned-paragraph-in-an-auto-column-takes-the-whole-row",
+          "page": "docs/recipes/layered-page-design.md",
+          "line": 145,
+          "heading": "A rule that reaches the column edge"
+        }
+      ]
+    },
+    "test:LineWidthUnitsContractTest#horizontalIsPointsAndTheLineIsNotClippedToItsSlot": {
       "kind": "test",
       "path": "qa/src/test/java/com/demcha/compose/document/dsl/LineWidthUnitsContractTest.java",
       "holds": [
@@ -44,7 +57,13 @@
           "page": "docs/recipes/layered-page-design.md",
           "line": 142,
           "heading": "A rule that reaches the column edge"
-        },
+        }
+      ]
+    },
+    "test:LineWidthUnitsContractTest": {
+      "kind": "test",
+      "path": "qa/src/test/java/com/demcha/compose/document/dsl/LineWidthUnitsContractTest.java",
+      "holds": [
         {
           "kind": "behavior",
           "value": "line.fill-spans-its-slot",
@@ -57,13 +76,6 @@
           "value": "line.fill-overflows-a-flex-row",
           "page": "docs/recipes/layered-page-design.md",
           "line": 144,
-          "heading": "A rule that reaches the column edge"
-        },
-        {
-          "kind": "behavior",
-          "value": "row.an-aligned-paragraph-in-an-auto-column-takes-the-whole-row",
-          "page": "docs/recipes/layered-page-design.md",
-          "line": 145,
           "heading": "A rule that reaches the column edge"
         }
       ]

--- a/knowledge/proofs/index.json
+++ b/knowledge/proofs/index.json
@@ -3,9 +3,9 @@
   "note": "Every proof a documentation claim cites, resolved to where it lives and what it holds up. Generated from the claim markers in docs/; a proof that nothing cites does not appear, and a claim whose proof does not resolve fails the check rather than landing here.",
   "generator": "knowledge/tools/claims/check-claims.mjs",
   "counts": {
-    "proofs": 6,
-    "claimsHeld": 7,
-    "claimsWithoutProof": 20
+    "proofs": 8,
+    "claimsHeld": 13,
+    "claimsWithoutProof": 30
   },
   "proofs": {
     "test:AutoColumnRightAlignContractTest": {
@@ -34,6 +34,40 @@
         }
       ]
     },
+    "test:LineWidthUnitsContractTest": {
+      "kind": "test",
+      "path": "qa/src/test/java/com/demcha/compose/document/dsl/LineWidthUnitsContractTest.java",
+      "holds": [
+        {
+          "kind": "behavior",
+          "value": "line.horizontal-is-points-and-is-not-clipped",
+          "page": "docs/recipes/layered-page-design.md",
+          "line": 139,
+          "heading": "A rule that reaches the column edge"
+        },
+        {
+          "kind": "behavior",
+          "value": "line.fill-spans-its-slot",
+          "page": "docs/recipes/layered-page-design.md",
+          "line": 140,
+          "heading": "A rule that reaches the column edge"
+        },
+        {
+          "kind": "behavior",
+          "value": "line.fill-overflows-a-flex-row",
+          "page": "docs/recipes/layered-page-design.md",
+          "line": 141,
+          "heading": "A rule that reaches the column edge"
+        },
+        {
+          "kind": "behavior",
+          "value": "row.an-aligned-paragraph-in-an-auto-column-takes-the-whole-row",
+          "page": "docs/recipes/layered-page-design.md",
+          "line": 142,
+          "heading": "A rule that reaches the column edge"
+        }
+      ]
+    },
     "test:RowBuilderTest": {
       "kind": "test",
       "path": "qa/src/test/java/com/demcha/compose/document/dsl/RowBuilderTest.java",
@@ -44,6 +78,26 @@
           "page": "docs/recipes/layered-page-design.md",
           "line": 30,
           "heading": "Sidebar: page background vs. row"
+        }
+      ]
+    },
+    "test:RowWidthDistributionContractTest": {
+      "kind": "test",
+      "path": "qa/src/test/java/com/demcha/compose/document/dsl/RowWidthDistributionContractTest.java",
+      "holds": [
+        {
+          "kind": "behavior",
+          "value": "row.no-column-spec-splits-the-width-evenly",
+          "page": "docs/recipes/layered-page-design.md",
+          "line": 66,
+          "heading": "Icon beside text"
+        },
+        {
+          "kind": "behavior",
+          "value": "row.a-flex-row-sizes-every-other-child-to-its-content",
+          "page": "docs/recipes/layered-page-design.md",
+          "line": 67,
+          "heading": "Icon beside text"
         }
       ]
     },

--- a/knowledge/routing/tasks.json
+++ b/knowledge/routing/tasks.json
@@ -34,7 +34,7 @@
       "surfaces": ["authoring"],
       "docs": ["docs/recipes/layered-page-design.md#sidebar-page-background-vs-row"],
       "verifiedAgainst": "2.2.3-SNAPSHOT",
-      "confirmedBy": "DemchaAV"
+      "confirmedBy": "Artem Demchyshyn"
     },
     {
       "task": "layout.icon-beside-text",
@@ -158,7 +158,7 @@
       "surfaces": ["authoring"],
       "docs": ["docs/recipes/layered-page-design.md#the-four-tools"],
       "verifiedAgainst": "2.2.3-SNAPSHOT",
-      "confirmedBy": "DemchaAV"
+      "confirmedBy": "Artem Demchyshyn"
     },
     {
       "task": "table.header-on-every-page",
@@ -180,7 +180,7 @@
       "surfaces": ["authoring"],
       "docs": ["docs/recipes/tables.md#repeated-header-on-page-break"],
       "verifiedAgainst": "2.2.3-SNAPSHOT",
-      "confirmedBy": "DemchaAV"
+      "confirmedBy": "Artem Demchyshyn"
     }
   ]
 }

--- a/knowledge/routing/tasks.json
+++ b/knowledge/routing/tasks.json
@@ -40,7 +40,7 @@
       "task": "layout.icon-beside-text",
       "intent": "Put a small icon to the left of a line or block of text.",
       "recommended": "row-with-an-auto-and-a-weight-column",
-      "recommendedBecause": "docs/recipes/layered-page-design.md#icon-beside-text states the rule the signatures cannot: a row with no column spec, no grow spacer and the default START arrangement splits its inner width into equal shares, one per child, so a 13pt icon takes half the row. auto() is the icon's own width and weight(1) is everything left, which is the only form that stays right when the column is resized. RowWidthDistributionContractTest measures both, and the icon case on a real SvgIcon node.",
+      "recommendedBecause": "docs/recipes/layered-page-design.md#icon-beside-text states the rule the signatures cannot: a row with no column spec, no grow spacer and the default START arrangement splits its inner width into equal shares, one per child, so a 13pt icon takes half the row. auto() is the icon's own width and weight(1) is everything left, so the icon keeps its own size whatever the column is resized to — unlike weights(...), where the share is fixed and the icon's slot moves with the row. fixed(13) is as stable, and is the alternative when a rail of icons must line up. RowWidthDistributionContractTest measures both, and the icon case on a real SvgIcon node.",
       "alternatives": [
         {
           "id": "row-with-a-fixed-column",

--- a/knowledge/routing/tasks.json
+++ b/knowledge/routing/tasks.json
@@ -37,6 +37,97 @@
       "confirmedBy": "DemchaAV"
     },
     {
+      "task": "layout.icon-beside-text",
+      "intent": "Put a small icon to the left of a line or block of text.",
+      "recommended": "row-with-an-auto-and-a-weight-column",
+      "recommendedBecause": "docs/recipes/layered-page-design.md#icon-beside-text states the rule the signatures cannot: a row with no column spec, no grow spacer and the default START arrangement splits its inner width into equal shares, one per child, so a 13pt icon takes half the row. auto() is the icon's own width and weight(1) is everything left, which is the only form that stays right when the column is resized. RowWidthDistributionContractTest measures both, and the icon case on a real SvgIcon node.",
+      "alternatives": [
+        {
+          "id": "row-with-a-fixed-column",
+          "useWhen": "a column of icons must line up down a list whatever each one contains",
+          "tradeoffs": "pins the rail exactly, but the point size now lives in the column spec as well as in the icon call, so the two can drift apart"
+        },
+        {
+          "id": "row-with-explicit-weights",
+          "useWhen": "both children are content and what you want is a proportion of the row — a 34/66 sidebar",
+          "tradeoffs": "a weight is a share, not a size: the ratio is chosen against one column width and is wrong at another, and it can hand a fixed-size icon a slot narrower than the icon itself"
+        },
+        {
+          "id": "row-with-a-flex-spacer",
+          "useWhen": "the row already needs its children pushed apart — a label left, a value hard right",
+          "tradeoffs": "a grow spacer switches the whole row to intrinsic sizing, which fixes the icon as a side effect but leaves no child able to take a proportional share, and it cannot be combined with columns() or weights() — the row rejects that pairing outright. A non-START arrangement(...) is the same switch by another name, so a row can land on this path without a spacer anywhere in it"
+        },
+        {
+          "id": "inline-svg-icon-in-a-paragraph",
+          "useWhen": "the icon belongs inside the sentence rather than beside the block",
+          "tradeoffs": "there is no row and no width to distribute, but the icon wraps with the text line and cannot hold a fixed left rail for the paragraph to hang off"
+        }
+      ],
+      "constraints": [
+        "row.no-column-spec-splits-the-width-evenly",
+        "row.a-flex-row-sizes-every-other-child-to-its-content"
+      ],
+      "symbols": [
+        "AbstractFlowBuilder.addRow",
+        "RowBuilder.columns",
+        "DocumentRowColumn.auto",
+        "DocumentRowColumn.weight",
+        "DocumentRowColumn.fixed",
+        "RowBuilder.weights",
+        "RowBuilder.flexSpacer",
+        "ParagraphBuilder.inlineSvgIcon"
+      ],
+      "surfaces": ["authoring"],
+      "docs": ["docs/recipes/layered-page-design.md#icon-beside-text"],
+      "verifiedAgainst": "2.4.0-SNAPSHOT",
+      "confirmedBy": null
+    },
+    {
+      "task": "layout.rule-beside-a-heading",
+      "intent": "Draw a rule or divider next to a heading, reaching the edge of the column.",
+      "recommended": "fill-in-a-weight-column",
+      "recommendedBecause": "docs/recipes/layered-page-design.md#a-rule-that-reaches-the-column-edge says what no signature can: horizontal(width) is points, not a percentage, and nothing clips a line to the space it was given. fill() stretches a horizontal line to its slot, and a weight column makes that slot the leftover width instead of half the row. Leave the heading unaligned — a right- or centre-aligned paragraph claims the whole row from the auto() column and the rule collapses to zero width. LineWidthUnitsContractTest measures the overflow, the repair and both ways the repair fails.",
+      "alternatives": [
+        {
+          "id": "fixed-length-rule",
+          "useWhen": "the rule is a fixed-length accent under a title, where the length is the design rather than a measurement of the column",
+          "tradeoffs": "the argument is points and nothing clips it, so a value guessed as a percentage is drawn at that many points straight across whatever is beside it, with no warning and a clean render"
+        },
+        {
+          "id": "fill-without-a-column-spec",
+          "useWhen": "the rule is the last child and the heading beside it is short enough to survive an equal share",
+          "tradeoffs": "the rule does end on the row edge, but the even split still applies to the heading — it gets half the row and wraps, which is the same defect moved one child to the left"
+        },
+        {
+          "id": "weight-column-for-the-heading-too",
+          "useWhen": "the heading has to be centred or right-aligned",
+          "tradeoffs": "the only form that survives an aligned heading, because the row decides the share instead of the text; the cost is that the heading no longer sizes to itself, so a short one leaves a gap before the rule rather than meeting it"
+        }
+      ],
+      "constraints": [
+        "line.horizontal-is-points-and-is-not-clipped",
+        "line.fill-spans-its-slot",
+        "line.fill-overflows-a-flex-row",
+        "row.an-aligned-paragraph-in-an-auto-column-takes-the-whole-row",
+        "row.no-column-spec-splits-the-width-evenly"
+      ],
+      "symbols": [
+        "AbstractFlowBuilder.addRow",
+        "RowBuilder.addLine",
+        "RowBuilder.columns",
+        "RowBuilder.arrangement",
+        "DocumentRowColumn.auto",
+        "DocumentRowColumn.weight",
+        "ParagraphBuilder.align",
+        "LineBuilder.horizontal",
+        "LineBuilder.fill"
+      ],
+      "surfaces": ["authoring"],
+      "docs": ["docs/recipes/layered-page-design.md#a-rule-that-reaches-the-column-edge"],
+      "verifiedAgainst": "2.4.0-SNAPSHOT",
+      "confirmedBy": null
+    },
+    {
       "task": "layout.choose-the-layer",
       "intent": "Decide which of the four placement tools a piece of page design needs.",
       "recommended": "page-flow",

--- a/knowledge/routing/tasks.json
+++ b/knowledge/routing/tasks.json
@@ -80,7 +80,7 @@
       "surfaces": ["authoring"],
       "docs": ["docs/recipes/layered-page-design.md#icon-beside-text"],
       "verifiedAgainst": "2.4.0-SNAPSHOT",
-      "confirmedBy": null
+      "confirmedBy": "Artem Demchyshyn"
     },
     {
       "task": "layout.rule-beside-a-heading",
@@ -125,7 +125,7 @@
       "surfaces": ["authoring"],
       "docs": ["docs/recipes/layered-page-design.md#a-rule-that-reaches-the-column-edge"],
       "verifiedAgainst": "2.4.0-SNAPSHOT",
-      "confirmedBy": null
+      "confirmedBy": "Artem Demchyshyn"
     },
     {
       "task": "layout.choose-the-layer",

--- a/knowledge/tools/README.md
+++ b/knowledge/tools/README.md
@@ -21,18 +21,25 @@ library's to define. That is what moving the generator here fixes.
 | `api-surface/lib/source-names.mjs` | lifts real parameter names out of a sources jar |
 | `api-surface/lib/zip.mjs` | reads a jar without unpacking it |
 | `api-surface/lib/render-markdown.mjs` | renders the Markdown view *from the JSON* |
+| `api-surface/lib/surfaces.mjs` | the admission and stability rules — which types belong to which surface |
+| `api-surface/lib/annotations.mjs` | reads `@Internal` / `@Beta` off a class, package included |
+| `api-surface/lib/tree.mjs` | finds the reactor's modules and the version they build at |
+| `api-surface/lib/provenance.mjs` | records what a run read: commit, timestamp, artifact digests |
 | `api-query/api-query.mjs` | answers a question about the surfaces instead of making you read them |
 | `claims/check-claims.mjs` | holds a page to what it claims, and builds the reverse index |
 | `claims/lib/claims.mjs` | reads the claim markers and resolves a symbol against the surfaces |
 | `routing/check-routes.mjs` | the gate a route must pass: anchors resolve, symbols exist, constraints are proven |
 | `routing/lib/anchors.mjs` | GitHub's heading-to-anchor rule, and the references a prose field makes |
 | `routing/lib/pack-version.mjs` | orders a route's `verifiedAgainst` against the version the surfaces carry |
+| `changeset/changeset.mjs` | what changed between two surfaces, as the set of pages it invalidates |
 | `bundle/build-bundle.mjs` | packs all of it into an archive that answers with no repository around it |
+| `bundle/lib/zip-write.mjs` | writes the archive; hand-rolled, because this directory ships no dependencies |
+| `lib/fixtures.mjs` | the fixture harness every `*.test.mjs` below reports through |
 
-Every `*.test.mjs` under `knowledge/tools/` is a fixture suite, and CI runs them
-by discovery rather than by name — add one and it runs. Raise the floor in
-`.github/workflows/ci.yml` in the same commit, or a suite deleted later will not
-be missed.
+Every `*.test.mjs` under `knowledge/tools/` is a fixture suite. CI discovers them
+and then holds the discovered set against a list it declares, so adding,
+renaming or deleting one goes red until `.github/workflows/ci.yml` says so too —
+a suite that silently stops running looks exactly like a suite that passes.
 
 ## The rules
 

--- a/knowledge/tools/README.md
+++ b/knowledge/tools/README.md
@@ -22,6 +22,17 @@ library's to define. That is what moving the generator here fixes.
 | `api-surface/lib/zip.mjs` | reads a jar without unpacking it |
 | `api-surface/lib/render-markdown.mjs` | renders the Markdown view *from the JSON* |
 | `api-query/api-query.mjs` | answers a question about the surfaces instead of making you read them |
+| `claims/check-claims.mjs` | holds a page to what it claims, and builds the reverse index |
+| `claims/lib/claims.mjs` | reads the claim markers and resolves a symbol against the surfaces |
+| `routing/check-routes.mjs` | the gate a route must pass: anchors resolve, symbols exist, constraints are proven |
+| `routing/lib/anchors.mjs` | GitHub's heading-to-anchor rule, and the references a prose field makes |
+| `routing/lib/pack-version.mjs` | orders a route's `verifiedAgainst` against the version the surfaces carry |
+| `bundle/build-bundle.mjs` | packs all of it into an archive that answers with no repository around it |
+
+Every `*.test.mjs` under `knowledge/tools/` is a fixture suite, and CI runs them
+by discovery rather than by name — add one and it runs. Raise the floor in
+`.github/workflows/ci.yml` in the same commit, or a suite deleted later will not
+be missed.
 
 ## The rules
 

--- a/knowledge/tools/api-query/api-query.mjs
+++ b/knowledge/tools/api-query/api-query.mjs
@@ -145,12 +145,24 @@ function answerTask(id) {
 }
 
 /**
- * Whether the documentation tree a route's `docs:` path is relative to is beside
- * this pack — true in a checkout, false in the published bundle, which carries
- * the routing table but not the pages it points at.
+ * Whether the pages a route hands over are actually beside this pack — true in a
+ * checkout, false in the published bundle, which carries the routing table but
+ * not the documentation tree.
+ *
+ * Every cited page is resolved, rather than probing for a directory called
+ * `docs`. The bundle is normally unpacked *inside* another project, and that
+ * project usually has documentation of its own: keying on the directory name
+ * suppressed the note exactly where it was needed and handed the reader a
+ * GraphCompose path that appeared to resolve against their own tree.
+ *
+ * @param {string[]} refs the route's `docs:` entries
  */
-function docsAreAlongside() {
-  return fs.existsSync(path.join(KNOWLEDGE_ROOT, "..", "docs"));
+function docsArePresent(refs) {
+  return (refs ?? []).every((ref) => {
+    const rel = ref.split("#")[0];
+    if (!rel) return false;
+    return fs.existsSync(path.join(KNOWLEDGE_ROOT, "..", ...rel.split("/")));
+  });
 }
 
 /**
@@ -247,7 +259,7 @@ function renderTask(answer) {
     // names a page that is not in the archive. Saying so beats printing it as
     // though it were openable: a reader with only the bundle would otherwise go
     // looking for a file that was never there.
-    if (!docsAreAlongside()) {
+    if (!docsArePresent(answer.docs)) {
       out.push("        (not in this bundle — that path is relative to the GraphCompose repository)");
     }
   }

--- a/knowledge/tools/api-query/api-query.mjs
+++ b/knowledge/tools/api-query/api-query.mjs
@@ -172,17 +172,27 @@ function docsArePresent(refs) {
  * comparing a route against it is not something {@link versionParts} can do.
  */
 function packVersion() {
+  let files;
   try {
     // Sorted: an inconsistent pack must not answer differently depending on the
     // order the filesystem lists it in.
-    for (const file of fs.readdirSync(API_DIR).sort()) {
-      if (!file.endsWith(".json") || file === "excluded.json") continue;
+    files = fs.readdirSync(API_DIR).sort();
+  } catch {
+    // No surfaces at all is a pack that can still answer routing questions; the
+    // provenance line goes back to naming the route's own version.
+    return null;
+  }
+  for (const file of files) {
+    if (!file.endsWith(".json") || file === "excluded.json") continue;
+    try {
       const doc = JSON.parse(fs.readFileSync(path.join(API_DIR, file), "utf8"));
       if (doc.verifiedAgainst) return doc.verifiedAgainst;
+    } catch {
+      // Per file, not per pack. One unreadable surface used to take the whole
+      // version down with it -- and `authoring.json` sorts first, so the most
+      // likely corruption was also the one that silently removed the staleness
+      // note from every answer while four good surfaces still carried the stamp.
     }
-  } catch {
-    // A pack without readable surfaces still answers routing questions; the
-    // provenance line simply goes back to naming the route's own version.
   }
   return null;
 }
@@ -274,11 +284,20 @@ function renderTask(answer) {
     // Behind by version, not by spelling: at a release tag the surfaces read
     // 2.4.0 while a route signed during the cycle reads 2.4.0-SNAPSHOT, and
     // those are the same line of development.
-    out.push(
-      compareVersions(answer.verifiedAgainst, pack) < 0
-        ? `  checked against: ${answer.verifiedAgainst} (this pack is ${pack} — the route has not been re-read since)`
-        : `  checked against: ${answer.verifiedAgainst}`,
-    );
+    // Every verdict is forwarded, not only "behind". An unorderable version and
+    // one ahead of the surfaces both look like provenance and are not, and
+    // printing them bare made a typo read exactly like a route re-read today.
+    // check-routes fails on both, but it is not what a reader runs.
+    const order = pack === null ? undefined : compareVersions(answer.verifiedAgainst, pack);
+    let note = "";
+    if (order === null) {
+      note = ` (this pack is ${pack} — those two versions cannot be compared)`;
+    } else if (order < 0) {
+      note = ` (this pack is ${pack} — the route has not been re-read since)`;
+    } else if (order > 0) {
+      note = ` (this pack is ${pack} — the route claims a version the surfaces do not have)`;
+    }
+    out.push(`  checked against: ${answer.verifiedAgainst}${note}`);
   }
   if (!answer.confirmedBy) {
     out.push("");

--- a/knowledge/tools/api-query/api-query.mjs
+++ b/knowledge/tools/api-query/api-query.mjs
@@ -138,7 +138,74 @@ function answerTask(id) {
       .filter((t) => t.includes(id) || id.includes(t.split(".").pop()));
     return { found: false, query: { task: id }, didYouMean: near, available: doc.tasks.map((t) => t.task) };
   }
-  return { found: true, query: { task: id }, ...route };
+  // The pack's own version travels with the answer: a route's verifiedAgainst
+  // is only meaningful next to the pack being read from, and check-routes --
+  // which owns the comparison -- is not shipped in the bundle.
+  return { found: true, query: { task: id }, ...route, packVersion: packVersion() };
+}
+
+/**
+ * Whether the documentation tree a route's `docs:` path is relative to is beside
+ * this pack — true in a checkout, false in the published bundle, which carries
+ * the routing table but not the pages it points at.
+ */
+function docsAreAlongside() {
+  return fs.existsSync(path.join(KNOWLEDGE_ROOT, "..", "docs"));
+}
+
+/**
+ * The version the surfaces were extracted from, read without loading them all.
+ *
+ * `targetVersion` is not a fallback: it is a line (`2.4.x`), not a version, and
+ * comparing a route against it is not something {@link versionParts} can do.
+ */
+function packVersion() {
+  try {
+    // Sorted: an inconsistent pack must not answer differently depending on the
+    // order the filesystem lists it in.
+    for (const file of fs.readdirSync(API_DIR).sort()) {
+      if (!file.endsWith(".json") || file === "excluded.json") continue;
+      const doc = JSON.parse(fs.readFileSync(path.join(API_DIR, file), "utf8"));
+      if (doc.verifiedAgainst) return doc.verifiedAgainst;
+    }
+  } catch {
+    // A pack without readable surfaces still answers routing questions; the
+    // provenance line simply goes back to naming the route's own version.
+  }
+  return null;
+}
+
+/*
+ * Version ordering, duplicated on purpose.
+ *
+ * knowledge/tools/routing/lib/pack-version.mjs is the canonical copy, and this
+ * file cannot import it: build-bundle.mjs publishes this one file as
+ * `bin/query.mjs` with nothing beside it, so a relative import would make the
+ * published bundle fail to start. The duplicate is held to the canonical one by
+ * knowledge/tools/routing/test/pack-version.test.mjs, which runs the same table
+ * through both -- because an unwatched copy drifts, and this one already did:
+ * it shipped raw string comparison while the gate compared numeric heads, so at
+ * a release tag the bundle called every route stale and the gate called none.
+ */
+
+/** The numeric head of a version, or null when it cannot be ordered. */
+function versionParts(version) {
+  const head = String(version).trim().split("-")[0];
+  const parts = head.split(".");
+  if (!parts.length || parts.some((p) => !/^\d+$/.test(p))) return null;
+  return parts.map(Number);
+}
+
+/** -1 route behind pack · 0 same line · 1 route ahead · null unorderable. */
+function compareVersions(routeVersion, packVersion) {
+  const a = versionParts(routeVersion);
+  const b = versionParts(packVersion);
+  if (!a || !b) return null;
+  for (let i = 0; i < Math.max(a.length, b.length); i += 1) {
+    const diff = (a[i] ?? 0) - (b[i] ?? 0);
+    if (diff !== 0) return diff < 0 ? -1 : 1;
+  }
+  return 0;
 }
 
 function renderTask(answer) {
@@ -176,6 +243,30 @@ function renderTask(answer) {
   if (answer.docs?.length) {
     out.push("");
     out.push(`  read: ${answer.docs.join("  ")}`);
+    // The bundle ships routing/ and not docs/, so in that copy the path above
+    // names a page that is not in the archive. Saying so beats printing it as
+    // though it were openable: a reader with only the bundle would otherwise go
+    // looking for a file that was never there.
+    if (!docsAreAlongside()) {
+      out.push("        (not in this bundle — that path is relative to the GraphCompose repository)");
+    }
+  }
+  // Provenance, not decoration: two routes read identically otherwise, and a
+  // reader has no way to tell one re-checked against this pack from one last
+  // looked at two minors ago. A bare route version cannot answer that either --
+  // "2.2.3-SNAPSHOT" means nothing without the pack it is being read from --
+  // so the pack's own version is printed beside it whenever the two differ.
+  if (answer.verifiedAgainst) {
+    out.push("");
+    const pack = answer.packVersion;
+    // Behind by version, not by spelling: at a release tag the surfaces read
+    // 2.4.0 while a route signed during the cycle reads 2.4.0-SNAPSHOT, and
+    // those are the same line of development.
+    out.push(
+      compareVersions(answer.verifiedAgainst, pack) < 0
+        ? `  checked against: ${answer.verifiedAgainst} (this pack is ${pack} — the route has not been re-read since)`
+        : `  checked against: ${answer.verifiedAgainst}`,
+    );
   }
   if (!answer.confirmedBy) {
     out.push("");

--- a/knowledge/tools/api-surface/test/classifier.test.mjs
+++ b/knowledge/tools/api-surface/test/classifier.test.mjs
@@ -29,6 +29,8 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
+import { suite } from "../../lib/fixtures.mjs";
+
 import { findJavap } from "../lib/javap.mjs";
 import {
   readAnnotations,
@@ -123,19 +125,7 @@ public interface OpenedSpi {
 
 // --- harness -----------------------------------------------------------------
 
-let failures = 0;
-let passes = 0;
-
-function check(name, actual, expected) {
-  const a = JSON.stringify(actual);
-  const e = JSON.stringify(expected);
-  if (a === e) {
-    passes += 1;
-    return;
-  }
-  failures += 1;
-  process.stdout.write(`  FAIL  ${name}\n        expected ${e}\n        actual   ${a}\n`);
-}
+const { check, done } = suite("classifier.test");
 
 function compileFixtures(outDir) {
   const srcDir = path.join(outDir, "src");
@@ -380,12 +370,7 @@ function run() {
     fs.rmSync(tmp, { recursive: true, force: true });
   }
 
-  process.stdout.write(
-    failures
-      ? `\n[classifier.test] ${failures} failed, ${passes} passed\n`
-      : `[classifier.test] ${passes} passed\n`,
-  );
-  process.exit(failures ? 1 : 0);
+  done();
 }
 
 run();

--- a/knowledge/tools/claims/check-claims.mjs
+++ b/knowledge/tools/claims/check-claims.mjs
@@ -222,14 +222,37 @@ for (const file of docPages()) {
   for (const claim of claims) {
     if (claim.proof) {
       const [scheme, id] = [claim.proof.slice(0, claim.proof.indexOf(":")), claim.proof.slice(claim.proof.indexOf(":") + 1)];
-      if (scheme === "test" && !proofTargets.tests.has(id)) {
-        errors.push({
-          file: claim.file,
-          line: claim.line,
-          heading: claim.heading,
-          message: `proof "${claim.proof}" names no test class — it was renamed or removed, so the claim is unheld.`,
-        });
-        continue;
+      if (scheme === "test") {
+        // `Class`, or `Class#method`. Resolving the class alone catches a class
+        // rename and nothing else: delete the one method that holds a behaviour
+        // and the claim goes on reading as proven, because the file still
+        // exists. Naming the method closes that, and stays optional so no
+        // existing claim has to change to keep working.
+        const [className, method] = id.split("#");
+        const testPath = proofTargets.tests.get(className);
+        if (!testPath) {
+          errors.push({
+            file: claim.file,
+            line: claim.line,
+            heading: claim.heading,
+            message: `proof "${claim.proof}" names no test class — it was renamed or removed, so the claim is unheld.`,
+          });
+          continue;
+        }
+        if (method) {
+          const source = fs.readFileSync(path.join(REPO_ROOT, testPath), "utf8");
+          if (!new RegExp(`\\b${method}\\s*\\(`).test(source)) {
+            errors.push({
+              file: claim.file,
+              line: claim.line,
+              heading: claim.heading,
+              message:
+                `proof "${claim.proof}" names no method "${method}" in ${testPath} — ` +
+                "the assertion that held this claim was renamed or removed.",
+            });
+            continue;
+          }
+        }
       }
       if (scheme === "snippet" && !proofTargets.snippets.has(id)) {
         errors.push({
@@ -331,7 +354,7 @@ for (const claim of allClaims) {
   const id = claim.proof.slice(claim.proof.indexOf(":") + 1);
   const entry = (proofs[claim.proof] ??= {
     kind: scheme,
-    ...(scheme === "test" ? { path: proofTargets.tests.get(id) ?? null } : {}),
+    ...(scheme === "test" ? { path: proofTargets.tests.get(id.split("#")[0]) ?? null } : {}),
     ...(scheme === "snippet" ? { page: proofTargets.snippets.get(id) ?? null } : {}),
     ...(scheme === "probe" || scheme === "render" ? { unresolved: "no registry for this scheme yet" } : {}),
     holds: [],

--- a/knowledge/tools/claims/test/claims.test.mjs
+++ b/knowledge/tools/claims/test/claims.test.mjs
@@ -14,20 +14,9 @@
  */
 
 import { parseClaims, resolveSymbol } from "../lib/claims.mjs";
+import { suite } from "../../lib/fixtures.mjs";
 
-let failures = 0;
-let passes = 0;
-
-function check(name, actual, expected) {
-  const a = JSON.stringify(actual);
-  const e = JSON.stringify(expected);
-  if (a === e) {
-    passes += 1;
-    return;
-  }
-  failures += 1;
-  process.stdout.write(`  FAIL  ${name}\n        expected ${e}\n        actual   ${a}\n`);
-}
+const { check, done } = suite("claims.test");
 
 const parse = (body) => parseClaims(body, "x.md");
 const messages = (body) => parse(body).errors.map((e) => e.message);
@@ -139,7 +128,4 @@ check(
   false,
 );
 
-process.stdout.write(
-  failures ? `\n[claims.test] ${failures} failed, ${passes} passed\n` : `[claims.test] ${passes} passed\n`,
-);
-process.exit(failures ? 1 : 0);
+done();

--- a/knowledge/tools/lib/fixtures.mjs
+++ b/knowledge/tools/lib/fixtures.mjs
@@ -1,0 +1,53 @@
+/**
+ * knowledge/tools/lib/fixtures.mjs — the smallest test harness that says what
+ * failed.
+ *
+ * The knowledge tools ship no dependencies, so their fixture suites are plain
+ * node scripts. Each one had grown its own byte-identical copy of this: four
+ * copies of ten lines, which is four places to improve the reporting and four
+ * chances for one of them to drift into saying something slightly different
+ * about a failure.
+ *
+ * Deliberately tiny. `node --test` exists, but these suites are run one file at
+ * a time by CI and by hand, and their whole value is a diff of expected against
+ * actual — a runner would add ceremony without adding that.
+ */
+
+/**
+ * A suite of checks that reports once, at the end, and sets the exit code.
+ *
+ * @param {string} name shown in the summary line, e.g. `anchors.test`
+ * @returns {{check: (name: string, actual: unknown, expected: unknown) => void, fail: (message: string) => void, done: () => never}}
+ */
+export function suite(name) {
+  let failures = 0;
+  let passes = 0;
+
+  return {
+    /** Compare by value; anything JSON can express is fair game. */
+    check(what, actual, expected) {
+      const a = JSON.stringify(actual);
+      const e = JSON.stringify(expected);
+      if (a === e) {
+        passes += 1;
+        return;
+      }
+      failures += 1;
+      process.stdout.write(`  FAIL  ${what}\n        expected ${e}\n        actual   ${a}\n`);
+    },
+
+    /** A failure with no comparison behind it — a missing file, a bad shape. */
+    fail(message) {
+      failures += 1;
+      process.stdout.write(`  FAIL  ${message}\n`);
+    },
+
+    /** Print the summary and exit; never returns. */
+    done() {
+      process.stdout.write(
+        failures ? `\n[${name}] ${failures} failed, ${passes} passed\n` : `[${name}] ${passes} passed\n`,
+      );
+      process.exit(failures ? 1 : 0);
+    },
+  };
+}

--- a/knowledge/tools/routing/check-routes.mjs
+++ b/knowledge/tools/routing/check-routes.mjs
@@ -23,10 +23,21 @@
  *   5. a recommendation traceable to something in this repository;
  *   6. `verifiedAgainst`.
  *
- * Points 1-4 are checked here. Point 5 is checked as far as a machine can — the
- * `recommendedBecause` must cite a real anchor — but whether the recommendation
- * is *right* is a human's call, which is what `confirmedBy` records. A route with
- * `confirmedBy: null` is served with its status attached rather than silently.
+ * Points 1-4 are checked here. Point 5 is checked as far as a machine can — every
+ * `docs/…#anchor` written inside the `recommendedBecause` prose is resolved the
+ * same way the `docs:` list is, so the gated copy and the prose copy of a
+ * reference cannot drift apart when a heading is renamed — but whether the
+ * recommendation is *right* is a human's call, which is what `confirmedBy`
+ * records. A route with `confirmedBy: null` is served with its status attached
+ * rather than silently.
+ *
+ * Point 6 is presence plus provenance. Age alone is not a failure — a route
+ * checked two minors ago is old, not wrong — so a route genuinely behind the
+ * surfaces is reported in the same status block as an unconfirmed one. Versions
+ * are compared by their numeric head, so `2.4.0` and `2.4.0-SNAPSHOT` are one
+ * line of development and the release tag does not flag the whole file. What
+ * *is* failed is a version that cannot be ordered at all, or one ahead of the
+ * surfaces: both look like provenance and are not.
  *
  * Seeding this from the AI Flow loading map or `.llm-wiki/02-decision-tree/` was
  * considered and refused: the audit that motivated this whole plan found drift in
@@ -40,6 +51,8 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { resolveSymbol } from "../claims/lib/claims.mjs";
+import { anchorsIn, anchorRefsIn } from "./lib/anchors.mjs";
+import { compareVersions, packVersionOf } from "./lib/pack-version.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HERE, "..", "..", "..");
@@ -61,29 +74,33 @@ if (args.some((a) => a === "--help" || a === "-h")) {
 // generated artifact to compare against, so every run is the check.
 if (args.length) process.exit(2);
 
-/** GitHub's heading -> anchor rule, enough of it for our own headings. */
-function anchorOf(heading) {
-  return heading
-    .toLowerCase()
-    .replace(/[^\w\s-]/g, "")
-    .trim()
-    .replace(/\s+/g, "-");
+const anchorCache = new Map();
+
+/** Anchors a page offers, read once per page. */
+function anchorsInFile(file) {
+  let anchors = anchorCache.get(file);
+  if (!anchors) {
+    anchors = anchorsIn(fs.readFileSync(file, "utf8"));
+    anchorCache.set(file, anchors);
+  }
+  return anchors;
 }
 
-function anchorsIn(file) {
-  const out = new Set();
-  for (const line of fs.readFileSync(file, "utf8").split(/\r?\n/)) {
-    const m = line.match(/^#{1,6}\s+(.+?)\s*$/);
-    if (m) out.add(anchorOf(m[1]));
-  }
-  return out;
-}
 
 function loadSurfaces() {
   const types = new Map();
-  for (const file of fs.readdirSync(API_DIR).filter((f) => f.endsWith(".json") && f !== "excluded.json")) {
+  // Sorted, so the pack version is not whichever file the filesystem happened to
+  // yield first: an inconsistent pack would otherwise pass or fail by directory
+  // iteration order, which differs between this machine and the runner.
+  const surfaceDocs = [];
+  const files = fs
+    .readdirSync(API_DIR)
+    .filter((f) => f.endsWith(".json") && f !== "excluded.json")
+    .sort();
+  for (const file of files) {
     const surface = path.basename(file, ".json");
     const doc = JSON.parse(fs.readFileSync(path.join(API_DIR, file), "utf8"));
+    surfaceDocs.push(doc);
     for (const pkg of doc.packages ?? []) {
       for (const type of pkg.types ?? []) {
         types.set(type.name, {
@@ -95,7 +112,7 @@ function loadSurfaces() {
       }
     }
   }
-  return { types };
+  return { types, packVersion: packVersionOf(surfaceDocs) };
 }
 
 const index = loadSurfaces();
@@ -104,7 +121,75 @@ const doc = JSON.parse(fs.readFileSync(TASKS_FILE, "utf8"));
 
 const errors = [];
 const unconfirmed = [];
+const stale = [];
 const fail = (task, message) => errors.push({ task, message });
+
+/**
+ * Resolve one `page.md#anchor`, wherever it was written. One implementation, so
+ * a rule added to the anchor check cannot land in the `docs:` copy and miss the
+ * prose copy — which is the shape of the drift this check exists to catch.
+ */
+function checkAnchorRef(id, ref, where) {
+  const [rel, anchor] = ref.split("#");
+  if (!rel) {
+    fail(id, `${where} "${ref}" — names an anchor but no page`);
+    return;
+  }
+  const file = path.join(REPO_ROOT, ...rel.split("/"));
+  // statSync rather than existsSync: a reference whose path half is a directory
+  // ("docs/recipes#zebra") exists, passes the anchor guard below because it does
+  // carry a fragment, and then dies inside readFileSync with an EISDIR stack
+  // trace naming no route at all.
+  let stat;
+  try {
+    stat = fs.statSync(file);
+  } catch {
+    fail(id, `${where} "${ref}" — no such page`);
+    return;
+  }
+  if (!stat.isFile()) {
+    fail(id, `${where} "${ref}" — that is a directory, not a page`);
+    return;
+  }
+  // existsSync is case-insensitive on Windows and case-sensitive on the runner,
+  // so a mis-cased citation passes here and fails on CI with "no such page",
+  // which reads as a missing file rather than as the casing it is.
+  const onDisk = path.relative(REPO_ROOT, fs.realpathSync.native(file)).split(path.sep).join("/");
+  if (onDisk !== rel) {
+    fail(id, `${where} "${ref}" — the page on disk is "${onDisk}"; the citation's casing does not match`);
+    return;
+  }
+  if (!anchor) {
+    fail(id, `${where} "${ref}" — needs an #anchor; a route hands over one section, not a whole page`);
+    return;
+  }
+  if (!anchorsInFile(file).has(anchor)) {
+    fail(id, `${where} "${ref}" — the page has no heading with that anchor (a heading was renamed)`);
+  }
+}
+
+/**
+ * Every prose field `api-query` prints verbatim. All of it is read by whoever
+ * asks for the route, so an anchor in any of it has to resolve — checking only
+ * `recommendedBecause` would leave a dangling link one field to the left.
+ */
+function servedProse(route) {
+  const fields = [route.intent, route.recommendedBecause];
+  for (const alt of route.alternatives ?? []) {
+    if (typeof alt === "object" && alt) fields.push(alt.useWhen, alt.tradeoffs);
+  }
+  return fields;
+}
+
+// Fail closed. Without a pack version every route's age is unknowable, and a
+// check that quietly skips itself reports exactly what a passing one reports.
+if (!index.packVersion) {
+  fail(
+    "(pack)",
+    "no verifiedAgainst on any surface in knowledge/api — the age of every route is unknowable, " +
+      "so this check cannot run; regenerate the surfaces",
+  );
+}
 
 const seen = new Set();
 for (const route of doc.tasks) {
@@ -116,31 +201,51 @@ for (const route of doc.tasks) {
   if (seen.has(id)) fail(id, "duplicate task id — an intent must resolve to one route");
   seen.add(id);
 
-  // 6 — the version it was checked against.
-  if (!route.verifiedAgainst) fail(id, "no verifiedAgainst: a route with no version is a route nobody can re-check");
+  // 6 — the version it was checked against, and where it sits against the pack.
+  if (!route.verifiedAgainst) {
+    fail(id, "no verifiedAgainst: a route with no version is a route nobody can re-check");
+  } else if (index.packVersion) {
+    // Only when there is something to order against; the pack-level failure
+    // above already names the cause, and repeating it per route buries it.
+    const order = compareVersions(route.verifiedAgainst, index.packVersion);
+    if (order === null) {
+      // A version nobody can order is worse than an old one: it looks checked
+      // and cannot be compared, so it is a failure rather than a note.
+      fail(
+        id,
+        `verifiedAgainst "${route.verifiedAgainst}" is not a version this can order against ` +
+          `the pack's "${index.packVersion}" — a typo reads as provenance`,
+      );
+    } else if (order < 0) {
+      // Not a failure: a route checked two minors ago is old, not wrong. But
+      // served unmarked it carries the authority of one checked today, so it is
+      // reported rather than passed over. Only a genuinely lower version counts
+      // — 2.4.0 and 2.4.0-SNAPSHOT are the same line, so the release tag does
+      // not flag the whole file.
+      stale.push({ task: id, at: route.verifiedAgainst });
+    } else if (order > 0) {
+      fail(
+        id,
+        `verifiedAgainst "${route.verifiedAgainst}" is ahead of the pack's "${index.packVersion}" — ` +
+          "a route cannot have been checked against surfaces that do not exist yet",
+      );
+    }
+  }
 
   // 5 — the recommendation must be traceable, and the citation must be a real anchor.
   if (!route.recommended) fail(id, "no recommended: — a route that does not recommend is a list, not a route");
   if (!route.recommendedBecause) {
     fail(id, "no recommendedBecause: — the recommendation must trace to something in this repository");
   }
+  // Prose is what an agent actually reads when it asks for the route, so every
+  // anchor in it is held to the same check as `docs:` — otherwise renaming a
+  // heading fixes the gated copy and leaves the quoted one dangling.
+  for (const prose of servedProse(route)) {
+    for (const ref of anchorRefsIn(prose)) checkAnchorRef(id, ref, "prose cites");
+  }
 
   // 1 — every docs anchor resolves.
-  for (const ref of route.docs ?? []) {
-    const [rel, anchor] = ref.split("#");
-    const file = path.join(REPO_ROOT, ...rel.split("/"));
-    if (!fs.existsSync(file)) {
-      fail(id, `docs "${ref}" — no such page`);
-      continue;
-    }
-    if (!anchor) {
-      fail(id, `docs "${ref}" — needs an #anchor; a route hands over one section, not a whole page`);
-      continue;
-    }
-    if (!anchorsIn(file).has(anchor)) {
-      fail(id, `docs "${ref}" — the page has no heading with that anchor (a heading was renamed)`);
-    }
-  }
+  for (const ref of route.docs ?? []) checkAnchorRef(id, ref, "docs");
   if (!(route.docs ?? []).length) fail(id, "no docs: — a route must hand over an anchor to open");
 
   // 2 — every symbol exists.
@@ -202,6 +307,13 @@ if (unconfirmed.length) {
     `\n  ${unconfirmed.length} route(s) have no confirmedBy — the mechanical checks pass,\n` +
       "  but whether the recommendation is the RIGHT one is a maintainer's call:\n" +
       unconfirmed.map((t) => `    ${t}\n`).join(""),
+  );
+}
+if (stale.length) {
+  process.stdout.write(
+    `\n  ${stale.length} route(s) were last checked against an older pack than ${index.packVersion} —\n` +
+      "  still served, but nothing has re-read them against the current surfaces:\n" +
+      stale.map((s) => `    ${s.task} (${s.at})\n`).join(""),
   );
 }
 process.exit(0);

--- a/knowledge/tools/routing/check-routes.mjs
+++ b/knowledge/tools/routing/check-routes.mjs
@@ -143,11 +143,12 @@ function checkAnchorRef(id, ref, where) {
     fail(id, `${where} "${ref}" — names an anchor but no page`);
     return;
   }
-  // Collapse "./" and "//" before anything compares this to a real path: those
-  // are valid spellings of the same page, and comparing the raw string to
-  // canonical output reported them as a casing mismatch when nothing was
-  // mis-cased.
-  const normalized = path.posix.normalize(rel);
+  // Collapse "./" and "//", and drop a leading "/" — all three are valid
+  // spellings of the same page, and comparing the raw string to canonical
+  // output reported them as a casing mismatch when nothing was mis-cased. A
+  // root-relative citation is relative to the repository, which is what the
+  // caller means by it.
+  const normalized = path.posix.normalize(rel.replace(/^\/+/, ""));
   if (normalized.startsWith("../")) {
     fail(id, `${where} "${ref}" — points outside the repository`);
     return;
@@ -270,8 +271,15 @@ for (const route of doc.tasks) {
   }
 
   // 1 — every docs anchor resolves.
-  for (const ref of route.docs ?? []) checkAnchorRef(id, ref, "docs");
-  if (!(route.docs ?? []).length) fail(id, "no docs: — a route must hand over an anchor to open");
+  if (route.docs !== undefined && !Array.isArray(route.docs)) {
+    // A bare string is iterable, so this used to be walked character by
+    // character: one bogus "no such page" per letter, and the "no docs" guard
+    // below silently satisfied by a non-empty string's length.
+    fail(id, `docs: is ${typeof route.docs}, not a list — write it as ["page.md#anchor"]`);
+  } else {
+    for (const ref of route.docs ?? []) checkAnchorRef(id, ref, "docs");
+    if (!(route.docs ?? []).length) fail(id, "no docs: — a route must hand over an anchor to open");
+  }
 
   // 2 — every symbol exists.
   for (const symbol of route.symbols ?? []) {
@@ -282,7 +290,11 @@ for (const route of doc.tasks) {
 
   // 3 and 4 — every constraint is a claimed behaviour, and that claim has a proof.
   for (const constraint of route.constraints ?? []) {
-    const holders = claims.behavior[constraint];
+    // hasOwn, not a bare lookup: a constraint named after an Object.prototype
+    // member ("toString", "constructor") is otherwise truthy, and the code below
+    // then dies on it with a TypeError that names no route and loses every error
+    // collected so far.
+    const holders = Object.hasOwn(claims.behavior, constraint) ? claims.behavior[constraint] : null;
     if (!holders) {
       fail(
         id,

--- a/knowledge/tools/routing/check-routes.mjs
+++ b/knowledge/tools/routing/check-routes.mjs
@@ -56,6 +56,14 @@ import { compareVersions, packVersionOf } from "./lib/pack-version.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HERE, "..", "..", "..");
+/**
+ * The same root as the operating system reports it, so a citation resolved with
+ * `realpathSync` is compared against a root that went through the same
+ * resolution. Comparing a canonical file path against a root reached through a
+ * symlink, a bind mount or a Windows `subst` drive made every citation in the
+ * file look mis-cased.
+ */
+const REPO_REAL = fs.realpathSync.native(REPO_ROOT);
 const TASKS_FILE = path.join(REPO_ROOT, "knowledge", "routing", "tasks.json");
 const API_DIR = path.join(REPO_ROOT, "knowledge", "api");
 const CLAIMS_INDEX = path.join(REPO_ROOT, "knowledge", "claims", "index.json");
@@ -135,7 +143,16 @@ function checkAnchorRef(id, ref, where) {
     fail(id, `${where} "${ref}" — names an anchor but no page`);
     return;
   }
-  const file = path.join(REPO_ROOT, ...rel.split("/"));
+  // Collapse "./" and "//" before anything compares this to a real path: those
+  // are valid spellings of the same page, and comparing the raw string to
+  // canonical output reported them as a casing mismatch when nothing was
+  // mis-cased.
+  const normalized = path.posix.normalize(rel);
+  if (normalized.startsWith("../")) {
+    fail(id, `${where} "${ref}" — points outside the repository`);
+    return;
+  }
+  const file = path.join(REPO_REAL, ...normalized.split("/"));
   // statSync rather than existsSync: a reference whose path half is a directory
   // ("docs/recipes#zebra") exists, passes the anchor guard below because it does
   // carry a fragment, and then dies inside readFileSync with an EISDIR stack
@@ -153,9 +170,17 @@ function checkAnchorRef(id, ref, where) {
   }
   // existsSync is case-insensitive on Windows and case-sensitive on the runner,
   // so a mis-cased citation passes here and fails on CI with "no such page",
-  // which reads as a missing file rather than as the casing it is.
-  const onDisk = path.relative(REPO_ROOT, fs.realpathSync.native(file)).split(path.sep).join("/");
-  if (onDisk !== rel) {
+  // which reads as a missing file rather than as the casing it is. Both sides of
+  // the comparison are realpath'd: resolving only the file compared a canonical
+  // path against a repo root reached through a symlink or a Windows subst drive,
+  // and reported every citation in the file as mis-cased.
+  const real = fs.realpathSync.native(file);
+  if (real !== REPO_REAL && !real.startsWith(REPO_REAL + path.sep)) {
+    fail(id, `${where} "${ref}" — resolves outside the repository`);
+    return;
+  }
+  const onDisk = path.relative(REPO_REAL, real).split(path.sep).join("/");
+  if (onDisk !== normalized) {
     fail(id, `${where} "${ref}" — the page on disk is "${onDisk}"; the citation's casing does not match`);
     return;
   }

--- a/knowledge/tools/routing/lib/anchors.mjs
+++ b/knowledge/tools/routing/lib/anchors.mjs
@@ -1,0 +1,115 @@
+/**
+ * knowledge/tools/routing/lib/anchors.mjs — resolve a heading reference the way
+ * GitHub does, because that is where the reader opens it.
+ *
+ * A route hands over exactly one anchor. If that anchor does not resolve in a
+ * browser the route is worse than no route: it carries the authority of a
+ * generated artifact to a page that scrolls nowhere. So the gate's rule has to
+ * be *GitHub's* rule, not an approximation of it.
+ *
+ * This repository already had that rule, written twice and disagreeing:
+ * `DocumentationLinkGuardTest.slug` in Java mirrors GitHub (`replaceAll("\\s",
+ * "-")` — one hyphen per whitespace character), while the routing gate collapsed
+ * runs (`replace(/\s+/g, "-")`). House style uses spaced em dashes, so the two
+ * differ on 121 of the 786 headings under `docs/`: `## Zebra — alternating row
+ * fills` is `#zebra--alternating-row-fills` on GitHub and was
+ * `#zebra-alternating-row-fills` to the gate. That is failure in *both*
+ * directions — CI red on a link that works, green on a link that 404s — which is
+ * why this is a module with fixtures rather than four lines inlined in the
+ * checker.
+ *
+ * The Java guard is the reference implementation; every rule here mirrors it
+ * deliberately, and `test/anchors.test.mjs` pins the cases where a naive version
+ * diverges.
+ */
+
+/** A fenced code block. Nothing inside one is a heading. */
+const FENCED_BLOCK = /^[ \t]*```[\s\S]*?^[ \t]*```[ \t]*$/gm;
+
+/** An ATX heading line. */
+const HEADING = /^#{1,6}[ \t]+(.+?)[ \t]*$/gm;
+
+/** A hand-written anchor: `<a name="x">` or `<a id="x">`. */
+const EXPLICIT_ANCHOR = /<a\s+(?:name|id)=["']([^"']+)["']/g;
+
+const HTML_TAG = /<[^>]+>/g;
+/** `[text](url)` inside a heading contributes only its text. */
+const HEADING_LINK = /\[([^\]]*)\]\([^)]*\)/g;
+/**
+ * Everything GitHub drops from an anchor: punctuation, but not spaces or
+ * hyphens.
+ *
+ * `\p{M}` is in the keep-set because GitHub keeps combining marks: a decomposed
+ * `Café` anchors with its accent intact, and stripping it produced `cafe-` where
+ * the rendered page offers `café-`. The Java guard kept marks and dropped
+ * non-decimal numerals; this keeps both, which is what the rendered page does.
+ */
+const NOT_IN_ANCHOR = /[^\p{L}\p{N}\p{M}_\s-]/gu;
+
+/**
+ * A repo-relative `path.md#anchor` written in prose.
+ *
+ * The leading boundary is the whole point. Without it the tail of an absolute
+ * URL matches: in `https://github.com/o/r/blob/develop/docs/x.md#y` a match can
+ * start right after the colon and yield `//github.com/o/r/blob/develop/docs/x.md`,
+ * which then fails `existsSync` and rejects the route for "no such page" — the
+ * gate blaming the author for the gate's own regex. `:` is in the lookbehind for
+ * exactly that reason.
+ */
+const PROSE_REF = /(?<![\w./:-])([\w.-][\w./-]*\.md)#([\w-]+)/g;
+
+/**
+ * GitHub's heading-to-anchor rule.
+ *
+ * @param {string} heading the heading text, without the leading `#`s
+ * @returns {string} the anchor GitHub would generate
+ */
+export function anchorOf(heading) {
+  let text = heading.trim().replace(HTML_TAG, "");
+  text = text.replace(HEADING_LINK, "$1");
+  text = text.replace(/`/g, "").toLowerCase();
+  text = text.replace(NOT_IN_ANCHOR, "");
+  // One hyphen per whitespace character, not per run: this is the line the two
+  // implementations disagreed on, and GitHub does not collapse.
+  return text.replace(/\s/g, "-");
+}
+
+/**
+ * Every anchor a Markdown document actually offers.
+ *
+ * Fenced blocks are stripped first, so a `# comment` inside a shell example is
+ * not an anchor — it renders as code, and a route citing it would hand the
+ * reader a link that lands nowhere while the gate stayed green.
+ *
+ * Repeated headings get GitHub's `-1`, `-2` suffixes, so a page with two
+ * `## Notes` offers `#notes` and `#notes-1`.
+ *
+ * @param {string} markdown the document text
+ * @returns {Set<string>} anchors that resolve on the rendered page
+ */
+export function anchorsIn(markdown) {
+  const body = markdown.replace(FENCED_BLOCK, "");
+  const anchors = new Set();
+  const seen = new Map();
+
+  for (const [, heading] of body.matchAll(HEADING)) {
+    const slug = anchorOf(heading);
+    const occurrence = seen.get(slug) ?? 0;
+    seen.set(slug, occurrence + 1);
+    anchors.add(occurrence === 0 ? slug : `${slug}-${occurrence}`);
+  }
+  for (const [, explicit] of body.matchAll(EXPLICIT_ANCHOR)) {
+    anchors.add(explicit);
+  }
+  return anchors;
+}
+
+/**
+ * Every repo-relative `page.md#anchor` reference written in a prose field.
+ *
+ * @param {string} prose the field text, or null/undefined
+ * @returns {string[]} each reference, as written
+ */
+export function anchorRefsIn(prose) {
+  return [...(prose ?? "").matchAll(PROSE_REF)].map((m) => `${m[1]}#${m[2]}`);
+}

--- a/knowledge/tools/routing/lib/anchors.mjs
+++ b/knowledge/tools/routing/lib/anchors.mjs
@@ -7,20 +7,24 @@
  * generated artifact to a page that scrolls nowhere. So the gate's rule has to
  * be *GitHub's* rule, not an approximation of it.
  *
- * This repository already had that rule, written twice and disagreeing:
- * `DocumentationLinkGuardTest.slug` in Java mirrors GitHub (`replaceAll("\\s",
- * "-")` — one hyphen per whitespace character), while the routing gate collapsed
- * runs (`replace(/\s+/g, "-")`). House style uses spaced em dashes, so the two
- * differ on 121 of the 786 headings under `docs/`: `## Zebra — alternating row
- * fills` is `#zebra--alternating-row-fills` on GitHub and was
+ * This repository had that rule written twice and disagreeing. The routing gate
+ * collapsed whitespace runs (`replace(/\s+/g, "-")`) where GitHub does not, and
+ * house style uses spaced em dashes, so the two differed on 121 of the 786
+ * headings under `docs/`: `## Zebra — alternating row fills` anchors as
+ * `#zebra--alternating-row-fills` on the rendered page and was
  * `#zebra-alternating-row-fills` to the gate. That is failure in *both*
  * directions — CI red on a link that works, green on a link that 404s — which is
  * why this is a module with fixtures rather than four lines inlined in the
  * checker.
  *
- * The Java guard is the reference implementation; every rule here mirrors it
- * deliberately, and `test/anchors.test.mjs` pins the cases where a naive version
- * diverges.
+ * Neither copy was GitHub's rule, and neither was found out by reading the code.
+ * The rule here was measured: headings were posted to `api.github.com/markdown`
+ * and the generated ids read back, and `test/anchors.test.mjs` pins those
+ * answers rather than this implementation's. `DocumentationLinkGuardTest.slug`
+ * in Java is the same rule for the markdown link guard, and the two are held
+ * together by asserting the identical table from both sides — neither can call
+ * the other across the language boundary, so a change to one reddens its own
+ * fixture.
  */
 
 /** A fenced code block. Nothing inside one is a heading. */
@@ -40,23 +44,38 @@ const HEADING_LINK = /\[([^\]]*)\]\([^)]*\)/g;
  *
  * The keep-set was read off GitHub rather than reasoned about, by posting
  * headings to `api.github.com/markdown` and reading the ids it generates. It
- * keeps letters of any script, combining marks, decimal digits, `_`, `-` and the
- * ASCII space — and drops everything else, *including every other kind of
- * whitespace*:
+ * keeps letters of any script, combining marks, decimal digits, letter numerals,
+ * connector punctuation (which is where `_` lives), `-` and the ASCII space —
+ * and drops everything else, *including every other kind of whitespace*:
  *
  *   `Zebra<NBSP>alternating rows`   -> `zebraalternating-rows`  (not `zebra-…`)
  *   `Row<EM SPACE>span`             -> `rowspan`
  *   `A<TAB>B`                       -> `ab`
- *   `Item <U+2460> first`           -> `item--first`  (the numeral goes, the spaces stay)
+ *   `Item <U+2460> first`           -> `item--first`  (a No numeral goes, its spaces stay)
+ *   `Chapter <U+2160> here`         -> `chapter-ⅰ-here` (an Nl numeral stays)
+ *   `a<U+203F>f b`                  -> `a‿f-b`        (a connector stays)
  *   `Café rules` (decomposed)       -> `café-rules`   (the combining mark stays)
  *   `Zebra — alternating row fills` -> `zebra--alternating-row-fills`
  *
- * Two earlier versions of this rule guessed instead. One collapsed whitespace
+ * Three earlier versions of this rule guessed instead. One collapsed whitespace
  * runs, which broke every heading with a spaced em dash. The next hyphenated all
- * Unicode whitespace and kept non-decimal numerals, on the theory that GitHub
- * would — it does neither.
+ * Unicode whitespace and kept every numeral. The third dropped letter numerals
+ * and connectors that GitHub keeps. Each was reasoned about; none was measured.
  */
-const NOT_IN_ANCHOR = /[^\p{L}\p{M}\p{Nd}_ -]/gu;
+const NOT_IN_ANCHOR = /[^\p{L}\p{M}\p{Nd}\p{Nl}\p{Pc} -]/gu;
+
+/**
+ * What GitHub strips from a heading's ends — only what Markdown itself strips,
+ * the ASCII spaces and tabs around the text.
+ *
+ * Not `String.prototype.trim()`, which also strips Unicode whitespace. GitHub
+ * does not: a heading beginning with an em space and then a space anchors as
+ * `-a`, because the em space is removed by the keep-set while the ASCII space
+ * beside it still becomes a hyphen. Java's `String.trim()` stops at U+0020, so
+ * matching it here is also what keeps the two implementations agreeing at a
+ * heading's edges — where a Unicode trim made them disagree.
+ */
+const ASCII_EDGE_SPACE = /^[ 	]+|[ 	]+$/g;
 
 /**
  * A repo-relative `path.md#anchor` written in prose.
@@ -73,8 +92,14 @@ const NOT_IN_ANCHOR = /[^\p{L}\p{M}\p{Nd}_ -]/gu;
  * `#café-rules` became `#caf` — and the gate then rejected the route for a link
  * that opens fine, while the identical reference written in `docs:` passed,
  * because that path never goes through this regex.
+ *
+ * A single leading `/` is accepted as repo-root-relative. Excluding it meant a
+ * citation written `/docs/x.md#y` matched nothing at all, so a dangling anchor
+ * spelled that way was never checked and the gate still said every route holds
+ * up. `//` is still refused: the lookbehind rejects a match preceded by `/` or
+ * `:`, so the authority half of an absolute URL cannot become a path.
  */
-const PROSE_REF = /(?<![\w./:-])([\w.-][\w./-]*\.md)#([\p{L}\p{M}\p{Nd}_-]+)/gu;
+const PROSE_REF = /(?<![\w./:-])(\/?[\w.-][\w./-]*\.md)#([\p{L}\p{M}\p{Nd}\p{Nl}\p{Pc}-]+)/gu;
 
 /**
  * GitHub's heading-to-anchor rule.
@@ -83,7 +108,7 @@ const PROSE_REF = /(?<![\w./:-])([\w.-][\w./-]*\.md)#([\p{L}\p{M}\p{Nd}_-]+)/gu;
  * @returns {string} the anchor GitHub would generate
  */
 export function anchorOf(heading) {
-  let text = heading.trim().replace(HTML_TAG, "");
+  let text = heading.replace(ASCII_EDGE_SPACE, "").replace(HTML_TAG, "");
   text = text.replace(HEADING_LINK, "$1");
   text = text.replace(/`/g, "").toLowerCase();
   text = text.replace(NOT_IN_ANCHOR, "");

--- a/knowledge/tools/routing/lib/anchors.mjs
+++ b/knowledge/tools/routing/lib/anchors.mjs
@@ -36,15 +36,27 @@ const HTML_TAG = /<[^>]+>/g;
 /** `[text](url)` inside a heading contributes only its text. */
 const HEADING_LINK = /\[([^\]]*)\]\([^)]*\)/g;
 /**
- * Everything GitHub drops from an anchor: punctuation, but not spaces or
- * hyphens.
+ * Everything GitHub drops from an anchor.
  *
- * `\p{M}` is in the keep-set because GitHub keeps combining marks: a decomposed
- * `Café` anchors with its accent intact, and stripping it produced `cafe-` where
- * the rendered page offers `café-`. The Java guard kept marks and dropped
- * non-decimal numerals; this keeps both, which is what the rendered page does.
+ * The keep-set was read off GitHub rather than reasoned about, by posting
+ * headings to `api.github.com/markdown` and reading the ids it generates. It
+ * keeps letters of any script, combining marks, decimal digits, `_`, `-` and the
+ * ASCII space — and drops everything else, *including every other kind of
+ * whitespace*:
+ *
+ *   `Zebra<NBSP>alternating rows`   -> `zebraalternating-rows`  (not `zebra-…`)
+ *   `Row<EM SPACE>span`             -> `rowspan`
+ *   `A<TAB>B`                       -> `ab`
+ *   `Item <U+2460> first`           -> `item--first`  (the numeral goes, the spaces stay)
+ *   `Café rules` (decomposed)       -> `café-rules`   (the combining mark stays)
+ *   `Zebra — alternating row fills` -> `zebra--alternating-row-fills`
+ *
+ * Two earlier versions of this rule guessed instead. One collapsed whitespace
+ * runs, which broke every heading with a spaced em dash. The next hyphenated all
+ * Unicode whitespace and kept non-decimal numerals, on the theory that GitHub
+ * would — it does neither.
  */
-const NOT_IN_ANCHOR = /[^\p{L}\p{N}\p{M}_\s-]/gu;
+const NOT_IN_ANCHOR = /[^\p{L}\p{M}\p{Nd}_ -]/gu;
 
 /**
  * A repo-relative `path.md#anchor` written in prose.
@@ -55,8 +67,14 @@ const NOT_IN_ANCHOR = /[^\p{L}\p{N}\p{M}_\s-]/gu;
  * which then fails `existsSync` and rejects the route for "no such page" — the
  * gate blaming the author for the gate's own regex. `:` is in the lookbehind for
  * exactly that reason.
+ *
+ * The anchor half accepts the same characters {@link anchorOf} can emit. An
+ * ASCII-only `[\w-]+` truncated a citation of a heading in any other script —
+ * `#café-rules` became `#caf` — and the gate then rejected the route for a link
+ * that opens fine, while the identical reference written in `docs:` passed,
+ * because that path never goes through this regex.
  */
-const PROSE_REF = /(?<![\w./:-])([\w.-][\w./-]*\.md)#([\w-]+)/g;
+const PROSE_REF = /(?<![\w./:-])([\w.-][\w./-]*\.md)#([\p{L}\p{M}\p{Nd}_-]+)/gu;
 
 /**
  * GitHub's heading-to-anchor rule.
@@ -69,9 +87,10 @@ export function anchorOf(heading) {
   text = text.replace(HEADING_LINK, "$1");
   text = text.replace(/`/g, "").toLowerCase();
   text = text.replace(NOT_IN_ANCHOR, "");
-  // One hyphen per whitespace character, not per run: this is the line the two
-  // implementations disagreed on, and GitHub does not collapse.
-  return text.replace(/\s/g, "-");
+  // One hyphen per ASCII space, not per run and not per whitespace character:
+  // GitHub does not collapse runs, and every other kind of whitespace has
+  // already been removed by the line above rather than hyphenated.
+  return text.replace(/ /g, "-");
 }
 
 /**

--- a/knowledge/tools/routing/lib/pack-version.mjs
+++ b/knowledge/tools/routing/lib/pack-version.mjs
@@ -1,0 +1,74 @@
+/**
+ * knowledge/tools/routing/lib/pack-version.mjs — what a pack version is, and
+ * when a route is genuinely behind one.
+ *
+ * Comparing these as strings is the bug this module exists to stop. The surfaces
+ * are stamped from the reactor pom, so during a cycle they read
+ * `2.4.0-SNAPSHOT` and at the tag `extract-api` re-stamps them `2.4.0` — while
+ * `tasks.json` still says `2.4.0-SNAPSHOT`, because a route is signed when it is
+ * written. String inequality calls every route in the file stale at every
+ * release, which is the same as calling none of them stale.
+ *
+ * So versions are ordered by their numeric head, and the qualifier is dropped:
+ * `2.4.0-SNAPSHOT` and `2.4.0` are one line of development.
+ *
+ * **This module has one deliberate duplicate.** `api-query.mjs` carries its own
+ * copy of {@link compareVersions}, because `build-bundle.mjs` ships that file
+ * alone as `bin/query.mjs` with no siblings beside it — an import here would
+ * make the published bundle fail to start. The copy is not free-floating:
+ * `test/pack-version.test.mjs` runs the same table through both, so the two
+ * cannot drift without a red build.
+ */
+
+/**
+ * The numeric head of a version, or null when it is not orderable.
+ *
+ * @param {string} version e.g. `2.4.0-SNAPSHOT`
+ * @returns {number[]|null} e.g. `[2, 4, 0]`
+ */
+export function versionParts(version) {
+  const head = String(version).trim().split("-")[0];
+  const parts = head.split(".");
+  if (!parts.length || parts.some((p) => !/^\d+$/.test(p))) return null;
+  return parts.map(Number);
+}
+
+/**
+ * Order a route's version against the pack's.
+ *
+ * @param {string} routeVersion the route's `verifiedAgainst`
+ * @param {string} packVersion the version stamped on the surfaces
+ * @returns {-1|0|1|null} -1 route behind · 0 same line · 1 route ahead · null unorderable
+ */
+export function compareVersions(routeVersion, packVersion) {
+  const a = versionParts(routeVersion);
+  const b = versionParts(packVersion);
+  if (!a || !b) return null;
+  for (let i = 0; i < Math.max(a.length, b.length); i += 1) {
+    const diff = (a[i] ?? 0) - (b[i] ?? 0);
+    if (diff !== 0) return diff < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * The version a set of surface documents was extracted from.
+ *
+ * Reads them in a caller-supplied order and takes the first stamp. The order
+ * has to be stable: taking whichever file the filesystem happens to yield first
+ * made the gate's verdict depend on directory iteration, which differs between
+ * NTFS name order and the runner's.
+ *
+ * `targetVersion` is deliberately not a fallback here. It is a line (`2.4.x`),
+ * not a version, and nothing can order it — accepting it would put a value into
+ * the comparison that {@link versionParts} has to reject.
+ *
+ * @param {object[]} surfaceDocs parsed surface JSON, in a stable order
+ * @returns {string|null} the stamped version, or null when none carries one
+ */
+export function packVersionOf(surfaceDocs) {
+  for (const doc of surfaceDocs) {
+    if (doc?.verifiedAgainst) return doc.verifiedAgainst;
+  }
+  return null;
+}

--- a/knowledge/tools/routing/test/anchors.test.mjs
+++ b/knowledge/tools/routing/test/anchors.test.mjs
@@ -54,28 +54,40 @@ check(
   "row-span--merge-a-cell",
 );
 
-// The four inputs on which this rule and its Java twin
-// (DocumentationLinkGuardTest.slug, which the markdown link guard resolves with)
-// were measured to disagree. Neither can call the other across the language
-// boundary, so the same table is asserted from both sides: change one rule and
-// its own fixture goes red. Escapes, not literals -- these characters are
-// invisible or indistinguishable in an editor.
+
+// Every expected value below was read off GitHub, by posting the heading to
+// api.github.com/markdown and taking the id it generated — not derived from the
+// implementation, and not reasoned about. Two earlier versions of this rule were
+// wrong precisely because they were reasoned about: one collapsed whitespace
+// runs, the next hyphenated all Unicode whitespace and kept non-decimal
+// numerals. GitHub does none of those things.
+//
+// The same table is asserted from the Java twin
+// (DocumentationLinkGuardTest.theAnchorRuleAgreesWithItsJavaScriptTwin), which
+// the markdown link guard resolves with; neither can call the other across the
+// language boundary, so change one rule and its own fixture goes red. Escapes,
+// not literals: these characters are invisible or indistinguishable in an editor.
 check(
-  "a non-breaking space hyphenates like any other whitespace",
+  "a non-breaking space is dropped, not hyphenated",
   anchorOf("Zebra alternating rows"),
-  "zebra-alternating-rows",
+  "zebraalternating-rows",
 );
-check("so does an em space", anchorOf("Row span"), "row-span");
+check("an em space is dropped too", anchorOf("Row span"), "rowspan");
+check("and a tab — only the ASCII space becomes a hyphen", anchorOf("A\tB"), "ab");
 check(
-  "a circled numeral is a number and survives, as it does on the page",
+  "a circled numeral is not a decimal digit, so it goes and its spaces stay",
   anchorOf("Item ① first"),
-  "item-①-first",
+  "item--first",
 );
 check(
   "a decomposed accent is a combining mark and stays with its letter",
   anchorOf("Café rules"),
   "café-rules",
 );
+check("letters of any script survive", anchorOf("Привет мир"), "привет-мир");
+check("so do digits, while the dots between them go", anchorOf("v1.8.0 fonts"), "v180-fonts");
+check("an underscore survives", anchorOf("snake_case name"), "snake_case-name");
+check("a dropped character leaves its spaces behind", anchorOf("A & B"), "a--b");
 
 check("punctuation is dropped, not hyphenated", anchorOf("Sidebar: page background vs. row"), "sidebar-page-background-vs-row");
 check("backticks are dropped", anchorOf("`fill()` and the slot"), "fill-and-the-slot");
@@ -148,6 +160,20 @@ check(
   anchorRefsIn("see //cdn.example.com/docs/x.md#y"),
   [],
 );
+// The matcher has to accept what anchorOf can emit. An ASCII-only anchor group
+// truncated this to "docs/recipes/tables.md#caf", and the gate then rejected the
+// route as "a heading was renamed" for a link that opens.
+check(
+  "a non-ASCII anchor is matched whole",
+  anchorRefsIn("see docs/recipes/tables.md#café-rules"),
+  ["docs/recipes/tables.md#café-rules"],
+);
+check(
+  "and one in another script",
+  anchorRefsIn("see docs/recipes/tables.md#привет-мир"),
+  ["docs/recipes/tables.md#привет-мир"],
+);
+
 check("a field with no reference yields none", anchorRefsIn("plain prose, no citation"), []);
 check("a null field is not an error", anchorRefsIn(null), []);
 

--- a/knowledge/tools/routing/test/anchors.test.mjs
+++ b/knowledge/tools/routing/test/anchors.test.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+/**
+ * knowledge/tools/routing/test/anchors.test.mjs — the anchor rule the routing
+ * gate resolves references with.
+ *
+ *   node knowledge/tools/routing/test/anchors.test.mjs
+ *
+ * Exit 0 all passed · 1 a case failed.
+ *
+ * Every case here is one the gate previously got wrong, in one of the two
+ * directions that matter:
+ *
+ *   accepts too little — CI red on a reference that works in a browser;
+ *   accepts too much   — CI green on a reference that 404s.
+ *
+ * The second is the dangerous one, and it is the reason this file exists at all:
+ * a gate that accepts everything reports zero problems for ever, which reads
+ * exactly like a gate that is working. Stub `anchorRefsIn` to return `[]` and
+ * `check-routes` still prints "5 routes hold up" — nothing but a fixture notices.
+ */
+
+import { anchorOf, anchorsIn, anchorRefsIn } from "../lib/anchors.mjs";
+
+let failures = 0;
+let passes = 0;
+
+function check(name, actual, expected) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a === e) {
+    passes += 1;
+    return;
+  }
+  failures += 1;
+  process.stdout.write(`  FAIL  ${name}\n        expected ${e}\n        actual   ${a}\n`);
+}
+
+// --------------------------------------------------------------- anchorOf ---
+
+check("a plain heading lowercases and hyphenates", anchorOf("The four tools"), "the-four-tools");
+
+// The divergence that motivated the module. House style spaces its em dashes,
+// so GitHub sees two whitespace characters and emits two hyphens. Collapsing
+// runs produced a single hyphen and disagreed with the rendered page on 121 of
+// the 786 headings under docs/.
+check(
+  "a spaced em dash yields two hyphens, as on GitHub",
+  anchorOf("Zebra — alternating row fills"),
+  "zebra--alternating-row-fills",
+);
+check(
+  "so does any other double space",
+  anchorOf("Row span  merge a cell"),
+  "row-span--merge-a-cell",
+);
+
+// The four inputs on which this rule and its Java twin
+// (DocumentationLinkGuardTest.slug, which the markdown link guard resolves with)
+// were measured to disagree. Neither can call the other across the language
+// boundary, so the same table is asserted from both sides: change one rule and
+// its own fixture goes red. Escapes, not literals -- these characters are
+// invisible or indistinguishable in an editor.
+check(
+  "a non-breaking space hyphenates like any other whitespace",
+  anchorOf("Zebra alternating rows"),
+  "zebra-alternating-rows",
+);
+check("so does an em space", anchorOf("Row span"), "row-span");
+check(
+  "a circled numeral is a number and survives, as it does on the page",
+  anchorOf("Item ① first"),
+  "item-①-first",
+);
+check(
+  "a decomposed accent is a combining mark and stays with its letter",
+  anchorOf("Café rules"),
+  "café-rules",
+);
+
+check("punctuation is dropped, not hyphenated", anchorOf("Sidebar: page background vs. row"), "sidebar-page-background-vs-row");
+check("backticks are dropped", anchorOf("`fill()` and the slot"), "fill-and-the-slot");
+check("a link in a heading contributes its text only", anchorOf("See [the guide](x.md)"), "see-the-guide");
+check("html is stripped", anchorOf("A <em>strong</em> claim"), "a-strong-claim");
+check("trailing space does not become a hyphen", anchorOf("  Trimmed  "), "trimmed");
+
+// --------------------------------------------------------------- anchorsIn ---
+
+check(
+  "headings become anchors",
+  [...anchorsIn("# One\n\n## Two words\n")],
+  ["one", "two-words"],
+);
+
+// A `#` line inside a fence renders as code. Treating it as a heading let a
+// route cite a phantom anchor and pass: docs/templates/v2-layered/
+// contributor-guide.md has `# 3. Normal run (...)` inside a bash fence.
+check(
+  "a comment inside a fenced block is not a heading",
+  [...anchorsIn("# Real\n\n```bash\n# 3. Normal run (defends against drift):\nmvn verify\n```\n")],
+  ["real"],
+);
+check(
+  "an indented fence is still a fence",
+  [...anchorsIn("# Real\n\n  ```\n  # not a heading\n  ```\n")],
+  ["real"],
+);
+
+check(
+  "a repeated heading gets GitHub's numeric suffix",
+  [...anchorsIn("## Notes\n\n## Notes\n\n## Notes\n")],
+  ["notes", "notes-1", "notes-2"],
+);
+
+check(
+  "a hand-written anchor counts",
+  [...anchorsIn("<a name=\"legacy-id\"></a>\n\n# Title\n")],
+  ["title", "legacy-id"],
+);
+
+// ------------------------------------------------------------ anchorRefsIn ---
+
+check(
+  "a repo-relative reference is found",
+  anchorRefsIn("see docs/recipes/tables.md#zebra for the rest"),
+  ["docs/recipes/tables.md#zebra"],
+);
+check(
+  "several references in one field are all found",
+  anchorRefsIn("docs/a.md#one and docs/b.md#two"),
+  ["docs/a.md#one", "docs/b.md#two"],
+);
+check(
+  "a reference inside a markdown link is found",
+  anchorRefsIn("[the guide](docs/recipes/tables.md#zebra)"),
+  ["docs/recipes/tables.md#zebra"],
+);
+
+// The URL case. Without the leading boundary a match starts after the colon and
+// yields `//github.com/...`, which fails existsSync — so the gate rejects the
+// route for "no such page" when the author wrote a perfectly good link.
+check(
+  "an absolute URL is not mistaken for a repo path",
+  anchorRefsIn("https://github.com/DemchaAV/GraphCompose/blob/develop/docs/recipes/tables.md#zebra"),
+  [],
+);
+check(
+  "nor is a bare host path",
+  anchorRefsIn("see //cdn.example.com/docs/x.md#y"),
+  [],
+);
+check("a field with no reference yields none", anchorRefsIn("plain prose, no citation"), []);
+check("a null field is not an error", anchorRefsIn(null), []);
+
+process.stdout.write(
+  failures ? `\n[anchors.test] ${failures} failed, ${passes} passed\n` : `[anchors.test] ${passes} passed\n`,
+);
+process.exit(failures ? 1 : 0);

--- a/knowledge/tools/routing/test/anchors.test.mjs
+++ b/knowledge/tools/routing/test/anchors.test.mjs
@@ -20,20 +20,9 @@
  */
 
 import { anchorOf, anchorsIn, anchorRefsIn } from "../lib/anchors.mjs";
+import { suite } from "../../lib/fixtures.mjs";
 
-let failures = 0;
-let passes = 0;
-
-function check(name, actual, expected) {
-  const a = JSON.stringify(actual);
-  const e = JSON.stringify(expected);
-  if (a === e) {
-    passes += 1;
-    return;
-  }
-  failures += 1;
-  process.stdout.write(`  FAIL  ${name}\n        expected ${e}\n        actual   ${a}\n`);
-}
+const { check, done } = suite("anchors.test");
 
 // --------------------------------------------------------------- anchorOf ---
 
@@ -85,6 +74,14 @@ check(
   "café-rules",
 );
 check("letters of any script survive", anchorOf("Привет мир"), "привет-мир");
+check("a letter numeral is kept, unlike the circled one above", anchorOf("Chapter Ⅰ here"), "chapter-ⅰ-here");
+check("connector punctuation is kept — that is where the underscore lives", anchorOf("a‿f b"), "a‿f-b");
+check(
+  "a non-ASCII space at an edge is dropped and its ASCII neighbour still hyphenates",
+  anchorOf("  A"),
+  "-a",
+);
+check("the same at the trailing edge", anchorOf("A  "), "a-");
 check("so do digits, while the dots between them go", anchorOf("v1.8.0 fonts"), "v180-fonts");
 check("an underscore survives", anchorOf("snake_case name"), "snake_case-name");
 check("a dropped character leaves its spaces behind", anchorOf("A & B"), "a--b");
@@ -177,7 +174,4 @@ check(
 check("a field with no reference yields none", anchorRefsIn("plain prose, no citation"), []);
 check("a null field is not an error", anchorRefsIn(null), []);
 
-process.stdout.write(
-  failures ? `\n[anchors.test] ${failures} failed, ${passes} passed\n` : `[anchors.test] ${passes} passed\n`,
-);
-process.exit(failures ? 1 : 0);
+done();

--- a/knowledge/tools/routing/test/pack-version.test.mjs
+++ b/knowledge/tools/routing/test/pack-version.test.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * knowledge/tools/routing/test/pack-version.test.mjs — version ordering, and the
+ * one copy of it that ships.
+ *
+ *   node knowledge/tools/routing/test/pack-version.test.mjs
+ *
+ * Exit 0 all passed · 1 a case failed.
+ *
+ * Two things are pinned here.
+ *
+ * The first is the release-tag case, which is the whole reason the rule is not
+ * string equality: at a tag the surfaces are re-stamped `2.4.0` while the routes
+ * still say `2.4.0-SNAPSHOT`, and a gate that calls that stale calls every route
+ * in the file stale on every release.
+ *
+ * The second is `api-query.mjs`'s private copy of the same rule. It cannot
+ * import this module — `build-bundle.mjs` publishes that one file as
+ * `bin/query.mjs` with nothing beside it — so the copy is held here instead, by
+ * running the identical table through the shipped CLI's own function. A
+ * duplicate nothing compares is a duplicate that drifts, and this one already
+ * did: the CLI shipped raw string comparison while the gate compared numeric
+ * heads.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { compareVersions, versionParts, packVersionOf } from "../lib/pack-version.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const API_QUERY = path.join(HERE, "..", "..", "api-query", "api-query.mjs");
+
+let failures = 0;
+let passes = 0;
+
+function check(name, actual, expected) {
+  const a = JSON.stringify(actual);
+  const e = JSON.stringify(expected);
+  if (a === e) {
+    passes += 1;
+    return;
+  }
+  failures += 1;
+  process.stdout.write(`  FAIL  ${name}\n        expected ${e}\n        actual   ${a}\n`);
+}
+
+// ----------------------------------------------------------- versionParts ---
+
+check("a release version parses", versionParts("2.4.0"), [2, 4, 0]);
+check("a snapshot drops its qualifier", versionParts("2.4.0-SNAPSHOT"), [2, 4, 0]);
+check("surrounding space is tolerated", versionParts(" 2.4.0 "), [2, 4, 0]);
+check("a typo is not orderable", versionParts("2.4.O-SNPASHOT"), null);
+check("a version line is not a version", versionParts("2.4.x"), null);
+check("an empty string is not orderable", versionParts(""), null);
+
+// --------------------------------------------------------- compareVersions ---
+
+/** The table both implementations must agree on. */
+const CASES = [
+  // The release tag. If this is anything but 0, every route in the file is
+  // reported stale the moment the qualifier is dropped.
+  ["2.4.0-SNAPSHOT", "2.4.0", 0],
+  ["2.4.0", "2.4.0-SNAPSHOT", 0],
+  ["2.4.0", "2.4.0", 0],
+  // Genuinely behind.
+  ["2.2.3-SNAPSHOT", "2.4.0-SNAPSHOT", -1],
+  ["2.3.9", "2.4.0", -1],
+  ["1.9.0", "2.0.0", -1],
+  // Ahead of the surfaces: not age, and not something to report as age.
+  ["2.5.0-SNAPSHOT", "2.4.0-SNAPSHOT", 1],
+  ["2.4.1", "2.4.0", 1],
+  // Shorter and longer heads compare on the parts they have.
+  ["2.4", "2.4.0", 0],
+  ["2.4.0.1", "2.4.0", 1],
+  // Unorderable on either side.
+  ["2.4.O-SNPASHOT", "2.4.0", null],
+  ["2.4.0", "2.4.x", null],
+];
+
+for (const [route, pack, expected] of CASES) {
+  check(`compare ${route} against ${pack}`, compareVersions(route, pack), expected);
+}
+
+// ---------------------------------------------------------- packVersionOf ---
+
+check(
+  "the first stamped surface wins",
+  packVersionOf([{ surface: "authoring" }, { verifiedAgainst: "2.4.0-SNAPSHOT" }]),
+  "2.4.0-SNAPSHOT",
+);
+check("no stamp anywhere yields null", packVersionOf([{ targetVersion: "2.4.x" }, {}]), null);
+check("an empty set yields null", packVersionOf([]), null);
+
+// ------------------------------------------- the copy that ships in the bundle ---
+
+// api-query.mjs is loaded as text and its comparison lifted out, because the
+// file is a CLI that runs on import-time argv. Failing to find the function is
+// itself a failure: a rename that silently ends this check would leave the
+// shipped copy unpinned, which is the state that let it drift in the first place.
+const source = fs.readFileSync(API_QUERY, "utf8");
+const shipped = source.match(/function compareVersions\([\s\S]*?\n}/);
+const shippedParts = source.match(/function versionParts\([\s\S]*?\n}/);
+
+if (!shipped || !shippedParts) {
+  failures += 1;
+  process.stdout.write(
+    "  FAIL  api-query.mjs no longer defines versionParts/compareVersions\n" +
+      "        the shipped copy of the rule is no longer pinned by this test\n",
+  );
+} else {
+  const shippedCompare = new Function(
+    `${shippedParts[0]}\n${shipped[0]}\nreturn compareVersions;`,
+  )();
+  for (const [route, pack, expected] of CASES) {
+    check(`[api-query copy] compare ${route} against ${pack}`, shippedCompare(route, pack), expected);
+  }
+}
+
+process.stdout.write(
+  failures ? `\n[pack-version.test] ${failures} failed, ${passes} passed\n` : `[pack-version.test] ${passes} passed\n`,
+);
+process.exit(failures ? 1 : 0);

--- a/knowledge/tools/routing/test/pack-version.test.mjs
+++ b/knowledge/tools/routing/test/pack-version.test.mjs
@@ -28,23 +28,12 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { compareVersions, versionParts, packVersionOf } from "../lib/pack-version.mjs";
+import { suite } from "../../lib/fixtures.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const API_QUERY = path.join(HERE, "..", "..", "api-query", "api-query.mjs");
 
-let failures = 0;
-let passes = 0;
-
-function check(name, actual, expected) {
-  const a = JSON.stringify(actual);
-  const e = JSON.stringify(expected);
-  if (a === e) {
-    passes += 1;
-    return;
-  }
-  failures += 1;
-  process.stdout.write(`  FAIL  ${name}\n        expected ${e}\n        actual   ${a}\n`);
-}
+const { check, fail, done } = suite("pack-version.test");
 
 // ----------------------------------------------------------- versionParts ---
 
@@ -104,10 +93,9 @@ const shipped = source.match(/function compareVersions\([\s\S]*?\n}/);
 const shippedParts = source.match(/function versionParts\([\s\S]*?\n}/);
 
 if (!shipped || !shippedParts) {
-  failures += 1;
-  process.stdout.write(
-    "  FAIL  api-query.mjs no longer defines versionParts/compareVersions\n" +
-      "        the shipped copy of the rule is no longer pinned by this test\n",
+  fail(
+    "api-query.mjs no longer defines versionParts/compareVersions — " +
+      "the shipped copy of the rule is no longer pinned by this test",
   );
 } else {
   const shippedCompare = new Function(
@@ -118,7 +106,4 @@ if (!shipped || !shippedParts) {
   }
 }
 
-process.stdout.write(
-  failures ? `\n[pack-version.test] ${failures} failed, ${passes} passed\n` : `[pack-version.test] ${passes} passed\n`,
-);
-process.exit(failures ? 1 : 0);
+done();

--- a/qa/src/test/java/com/demcha/compose/document/dsl/LineWidthUnitsContractTest.java
+++ b/qa/src/test/java/com/demcha/compose/document/dsl/LineWidthUnitsContractTest.java
@@ -1,0 +1,298 @@
+package com.demcha.compose.document.dsl;
+
+import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.api.DocumentSession;
+import com.demcha.compose.document.layout.LayoutGraph;
+import com.demcha.compose.document.layout.PlacedNode;
+import com.demcha.compose.document.node.RowArrangement;
+import com.demcha.compose.document.node.TextAlign;
+import com.demcha.compose.document.style.DocumentRowColumn;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * A contract probe: {@code horizontal(width)} is a width in points, and nothing
+ * clips it to the space it was given.
+ *
+ * {@code LineBuilder horizontal(double width)} is the one call in the row
+ * vocabulary whose argument has a plausible second reading. Every other number
+ * in the neighbourhood is a proportion — {@code weights(0.34, 0.66)},
+ * {@code PageBackgroundFill.leftColumn(0.34, ...)} — so {@code horizontal(100)}
+ * reads as "the full width" to anyone who has just written those, and the
+ * signature cannot say otherwise: a {@code double} named {@code width} is what a
+ * ratio looks like too.
+ *
+ * It is points. A 100pt rule in a 67.85pt slot does not shrink, does not wrap and
+ * does not warn — it is drawn at 100pt, straight across whatever is beside it, and
+ * the document renders clean. That combination (a wrong number, no clipping, no
+ * error) is why this is a test and not a sentence.
+ *
+ * The counterpart is asserted in the same file because the useful answer is not
+ * "points" but "here is what you wanted instead": {@code fill()} stretches a
+ * horizontal line to the slot it is placed in, so a divider meets the column edge
+ * without anyone computing the width.
+ *
+ * Then the three ways that repair goes wrong, each measured rather than argued:
+ * a flex row has no slot for {@code fill()} to fill, a flex row is entered by a
+ * non-{@code START} arrangement just as much as by a spacer, and an aligned
+ * heading in the {@code auto()} column silently leaves the rule nothing at all.
+ *
+ * <p><strong>Every number here is slot arithmetic.</strong> The left-hand child
+ * is a fixed-width shape rather than a heading precisely so that it is: the
+ * behaviour under test is how a row distributes width, which does not care
+ * whether the child is text, and pinning it to a paragraph would make these
+ * assertions depend on the default font's metrics. The one test that does use a
+ * paragraph asserts only the right edge of the weight column, which the column
+ * absorbs whatever the text measures.</p>
+ */
+class LineWidthUnitsContractTest {
+
+    private static final double PAGE_WIDTH = 175.7;
+    private static final float MARGIN = 20f;
+    private static final double ROW_LEFT = MARGIN;
+    /** Derived, not copied: a page-size change must move the expectations with it. */
+    private static final double ROW_WIDTH = PAGE_WIDTH - 2 * MARGIN;
+    private static final double ROW_RIGHT = ROW_LEFT + ROW_WIDTH;
+
+    private static final double GAP = 6;
+    private static final double HEAD_WIDTH = 40;
+
+    /** Larger than a slot in a two-child 135.7pt row, and deliberately readable as "100%". */
+    private static final double FIXED_RULE = 100;
+
+    private static final String HEADING = "CORE COMPETENCIES";
+
+    /** Width the row has left for its slots once the inter-child gaps are taken. */
+    private static double available(int children) {
+        return ROW_WIDTH - GAP * (children - 1);
+    }
+
+    private static LayoutGraph layout(DocumentSession session, Consumer<RowBuilder> row) {
+        session.compose(dsl -> dsl.pageFlow(flow -> flow.addRow(row)));
+        return session.layoutGraph();
+    }
+
+    private static PlacedNode node(LayoutGraph graph, String semanticName) {
+        return graph.nodes().stream()
+                .filter(n -> semanticName.equals(n.semanticName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no node named " + semanticName));
+    }
+
+    private static double rightEdge(PlacedNode n) {
+        return n.placementX() + n.placementWidth();
+    }
+
+    private static DocumentSession session() {
+        return GraphCompose.document()
+                .pageSize(PAGE_WIDTH, 400)
+                .margin(MARGIN, MARGIN, MARGIN, MARGIN)
+                .create();
+    }
+
+    @Test
+    void horizontalIsPointsAndTheLineIsNotClippedToItsSlot() throws Exception {
+        try (DocumentSession session = session()) {
+            LayoutGraph graph = layout(session, row -> row
+                    .addParagraph(p -> p.name("head").text(HEADING))
+                    .addLine(l -> l.name("rule").horizontal(FIXED_RULE)));
+
+            PlacedNode rule = node(graph, "rule");
+
+            assertThat(rule.placementWidth())
+                    .describedAs("100 is 100 points — not a percentage of the row, and not reduced to the "
+                            + "slot the even split handed it")
+                    .isCloseTo(FIXED_RULE, within(0.01));
+
+            // Two children and the row's default spacing of 0: each slot is half
+            // the row, so the rule starts at the midpoint and ends a fixed
+            // distance past the column. Nothing here depends on what the heading
+            // measures.
+            double slot = ROW_WIDTH / 2;
+            assertThat(rightEdge(rule))
+                    .describedAs("and nothing clips it: the rule is drawn past the right edge of the column "
+                            + "it lives in, which is how a sidebar divider ends up crossing the page")
+                    .isCloseTo(ROW_LEFT + slot + FIXED_RULE, within(0.01));
+            assertThat(rightEdge(rule)).isGreaterThan(ROW_RIGHT);
+        }
+    }
+
+    @Test
+    void fillStretchesTheRuleToItsColumnInsteadOfAFixedWidth() throws Exception {
+        try (DocumentSession session = session()) {
+            LayoutGraph graph = layout(session, row -> row
+                    .spacing(GAP)
+                    .columns(DocumentRowColumn.auto(), DocumentRowColumn.weight(1))
+                    .addParagraph(p -> p.name("head").text(HEADING))
+                    .addLine(l -> l.name("rule").fill()));
+
+            // The heading takes its natural width, the weight column takes the
+            // remainder, and fill() spends exactly that remainder — so the rule
+            // lands on the column edge without the author knowing where it is.
+            // This is the one assertion that may not name a width: the split
+            // between the two columns is a font metric, their sum is not.
+            assertThat(rightEdge(node(graph, "rule")))
+                    .describedAs("a fill() rule in a weight column ends on the column edge, whatever the "
+                            + "heading beside it measures")
+                    .isCloseTo(ROW_RIGHT, within(0.01));
+        }
+    }
+
+    @Test
+    void aGrowSpacerDoesNotRepairAFixedWidthRule() throws Exception {
+        try (DocumentSession session = session()) {
+            LayoutGraph graph = layout(session, row -> row
+                    .spacing(GAP)
+                    .addShape(s -> s.name("head").size(HEAD_WIDTH, 10))
+                    .flexSpacer()
+                    .addLine(l -> l.name("rule").horizontal(FIXED_RULE)));
+
+            PlacedNode rule = node(graph, "rule");
+
+            // The width is the claim. Asserting only the right edge would let the
+            // rule lose a third of its 100pt and still pass, which is exactly the
+            // regression the sentence "a spacer moves it, it does not shrink it"
+            // is there to catch.
+            assertThat(rule.placementWidth())
+                    .describedAs("a flex spacer moves the rule, it does not shrink it — the 100pt is intact")
+                    .isCloseTo(FIXED_RULE, within(0.01));
+
+            // Spacer collapses to zero because the children already overflow, so
+            // the rule sits one gap past the head and the overflow survives.
+            assertThat(rightEdge(rule))
+                    .describedAs("and the overflow survives the repair")
+                    .isCloseTo(ROW_LEFT + HEAD_WIDTH + 2 * GAP + FIXED_RULE, within(0.01));
+            assertThat(rightEdge(rule)).isGreaterThan(ROW_RIGHT);
+        }
+    }
+
+    @Test
+    void fillOverflowsARowThatHasAGrowSpacer() throws Exception {
+        try (DocumentSession session = session()) {
+            LayoutGraph graph = layout(session, row -> row
+                    .spacing(GAP)
+                    .addShape(s -> s.name("head").size(HEAD_WIDTH, 10))
+                    .flexSpacer()
+                    .addLine(l -> l.name("rule").fill()));
+
+            PlacedNode rule = node(graph, "rule");
+
+            // The trap: the fix for the fixed width and the fix for the position
+            // do not compose. In the flex path a fill line reports the row's whole
+            // available width as its natural width, and it is placed after the
+            // head and the spacer — so it ends further out than the fixed rule it
+            // replaced. Pinning the width, not just the direction, is what keeps a
+            // later partial clamp from passing here.
+            assertThat(rule.placementWidth())
+                    .describedAs("fill() has no slot to fill in a flex row, so it takes the row's whole "
+                            + "available width")
+                    .isCloseTo(available(3), within(0.01));
+            assertThat(rightEdge(rule))
+                    .describedAs("and is then pushed past the edge by the children before it")
+                    .isCloseTo(ROW_LEFT + HEAD_WIDTH + 2 * GAP + available(3), within(0.01));
+            assertThat(rightEdge(rule)).isGreaterThan(ROW_RIGHT);
+        }
+    }
+
+    @Test
+    void aNonStartArrangementEntersTheSameFlexPathWithNoSpacerPresent() throws Exception {
+        // The spacer is the obvious way into the flex path and not the only one:
+        // RowSlots.hasFlexLayout answers yes to any non-START arrangement too. A
+        // reader who never writes flexSpacer() but reaches for arrangement(...) to
+        // push the rule right walks into the identical overflow.
+        for (RowArrangement arrangement : RowArrangement.values()) {
+            if (arrangement == RowArrangement.START) {
+                continue;
+            }
+            try (DocumentSession session = session()) {
+                LayoutGraph graph = layout(session, row -> row
+                        .spacing(GAP)
+                        .arrangement(arrangement)
+                        .addShape(s -> s.name("head").size(HEAD_WIDTH, 10))
+                        .addLine(l -> l.name("rule").fill()));
+
+                PlacedNode rule = node(graph, "rule");
+                assertThat(rule.placementWidth())
+                        .describedAs("%s sizes the fill line to the row's whole available width, "
+                                + "exactly as a grow spacer does", arrangement)
+                        .isCloseTo(available(2), within(0.01));
+                assertThat(rightEdge(rule))
+                        .describedAs("%s therefore overflows the column with no spacer anywhere", arrangement)
+                        .isGreaterThan(ROW_RIGHT);
+            }
+        }
+    }
+
+    @Test
+    void theWeightColumnRepairIsRefusedOutrightInAFlexRow() throws Exception {
+        // The recommended repair does not silently stop working in a flex row —
+        // it is rejected at build time with a message naming both strategies.
+        // Worth pinning: "throws" and "silently misplaces" are very different
+        // things to tell a reader, and only one of them is true.
+        try (DocumentSession session = session()) {
+            assertThatThrownBy(() -> layout(session, row -> row
+                    .spacing(GAP)
+                    .arrangement(RowArrangement.SPACE_BETWEEN)
+                    .columns(DocumentRowColumn.auto(), DocumentRowColumn.weight(1))
+                    .addParagraph(p -> p.name("head").text(HEADING))
+                    .addLine(l -> l.name("rule").fill())))
+                    .describedAs("a weight column and a flex row are two distribution strategies, "
+                            + "and the row refuses to guess between them")
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("cannot combine flex")
+                    .hasMessageContaining("weights or columns");
+        }
+    }
+
+    @Test
+    void anAlignedHeadingLeavesTheWeightColumnNothingToFill() throws Exception {
+        // The recommended recipe's own failure mode, and the reason the route
+        // carries a constraint for it. A right- or centre-aligned paragraph claims
+        // the full row width; an auto() column grants it, because fixed+auto still
+        // fits; and the weight column is left zero. The rule does not overflow and
+        // does not throw — it disappears.
+        for (TextAlign align : new TextAlign[]{TextAlign.CENTER, TextAlign.RIGHT}) {
+            try (DocumentSession session = session()) {
+                LayoutGraph graph = layout(session, row -> row
+                        .spacing(GAP)
+                        .columns(DocumentRowColumn.auto(), DocumentRowColumn.weight(1))
+                        .addParagraph(p -> p.name("head").text(HEADING).align(align))
+                        .addLine(l -> l.name("rule").fill()));
+
+                assertThat(node(graph, "head").placementWidth())
+                        .describedAs("an %s-aligned paragraph claims the whole row, so the auto column is "
+                                + "the whole row", align)
+                        .isCloseTo(available(2), within(0.01));
+                assertThat(node(graph, "rule").placementWidth())
+                        .describedAs("which leaves the weight column zero: with align(%s) the rule is not "
+                                + "misplaced, it is not drawn at all", align)
+                        .isCloseTo(0.0, within(0.01));
+            }
+        }
+    }
+
+    @Test
+    void theSameRecipeWithAnUnalignedHeadingStillReachesTheEdge() throws Exception {
+        // The boundary, so the test above cannot pass by the recipe being broken
+        // for everyone: left-aligned, the rule is a real width ending on the edge.
+        try (DocumentSession session = session()) {
+            LayoutGraph graph = layout(session, row -> row
+                    .spacing(GAP)
+                    .columns(DocumentRowColumn.auto(), DocumentRowColumn.weight(1))
+                    .addParagraph(p -> p.name("head").text(HEADING).align(TextAlign.LEFT))
+                    .addLine(l -> l.name("rule").fill()));
+
+            assertThat(node(graph, "rule").placementWidth())
+                    .describedAs("without the alignment the weight column has a remainder to give")
+                    .isGreaterThan(0.0);
+            assertThat(rightEdge(node(graph, "rule")))
+                    .describedAs("and the rule still ends on the column edge")
+                    .isCloseTo(ROW_RIGHT, within(0.01));
+        }
+    }
+}

--- a/qa/src/test/java/com/demcha/compose/document/dsl/RowWidthDistributionContractTest.java
+++ b/qa/src/test/java/com/demcha/compose/document/dsl/RowWidthDistributionContractTest.java
@@ -1,0 +1,255 @@
+package com.demcha.compose.document.dsl;
+
+import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.api.DocumentSession;
+import com.demcha.compose.document.layout.LayoutGraph;
+import com.demcha.compose.document.layout.PlacedNode;
+import com.demcha.compose.document.node.RowArrangement;
+import com.demcha.compose.document.style.DocumentRowColumn;
+import com.demcha.compose.document.svg.SvgIcon;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * A contract probe: what a row does with its width when nobody tells it.
+ *
+ * A row with no {@code columns(...)}, no {@code weights(...)}, no grow spacer and
+ * the default {@code START} arrangement splits its inner width into equal shares
+ * — one per child, content playing no part. That is the whole rule, and nothing
+ * in {@code addRow(...)} hints at it: the natural reading of "put a 13pt icon
+ * next to a paragraph" is that the icon takes 13pt, and instead it takes half the
+ * row while the text is squeezed into the other half.
+ *
+ * The failure mode is what makes this worth pinning. Nothing throws and nothing
+ * looks wrong in the builder — the document renders, the icon is the right size,
+ * and only the paragraph's line count says anything happened. A reader comparing
+ * against a design sees "the text wraps too much" and goes looking at fonts.
+ *
+ * Three forms are asserted together rather than one, because the interesting
+ * fact is the difference between them. The even split is the default; an
+ * {@code auto()} + {@code weight(1)} column pair is the fix; and a grow spacer
+ * reaches the same widths by a different route — it switches the row to
+ * intrinsic sizing, which is why the same row laid out twice, once with a
+ * trailing {@code flexSpacer()} and once without, does not agree.
+ *
+ * Every number asserted here is slot arithmetic over the row's inner width, the
+ * gap and the child count — never a font metric. That rules two things out on
+ * purpose. The paragraph's height is font-dependent, so it is asserted as a
+ * comparison between two forms rather than as a number. And under a non-START
+ * arrangement the children's x coordinates are font-dependent too, because
+ * {@code RowSlots.flexJustify} spreads the leftover — the row minus the
+ * paragraph's measured width — as a leading offset; there only the widths are
+ * asserted.
+ */
+class RowWidthDistributionContractTest {
+
+    /** Page and margins chosen so the row's inner width is exactly 135.7pt — a CV sidebar column. */
+    private static final double PAGE_WIDTH = 175.7;
+    private static final float MARGIN = 20f;
+    private static final double ROW_LEFT = MARGIN;
+    /** Derived, not copied: a page-size change must move the expectations with it. */
+    private static final double ROW_WIDTH = PAGE_WIDTH - 2 * MARGIN;
+    private static final double GAP = 8;
+    private static final double ICON = 13;
+
+    private static final String TEXT = "Delivered 120+ events annually with 98% client satisfaction.";
+
+    private static LayoutGraph layout(DocumentSession session, Consumer<RowBuilder> row) {
+        session.compose(dsl -> dsl.pageFlow(flow -> flow.addRow(row)));
+        return session.layoutGraph();
+    }
+
+    private static PlacedNode node(LayoutGraph graph, String semanticName) {
+        return graph.nodes().stream()
+                .filter(n -> semanticName.equals(n.semanticName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no node named " + semanticName));
+    }
+
+    private static DocumentSession session() {
+        return GraphCompose.document()
+                .pageSize(PAGE_WIDTH, 400)
+                .margin(MARGIN, MARGIN, MARGIN, MARGIN)
+                .create();
+    }
+
+    @Test
+    void aRowWithNoColumnSpecSplitsItsWidthEvenlyRegardlessOfContent() throws Exception {
+        try (DocumentSession session = session()) {
+            LayoutGraph graph = layout(session, row -> row
+                    .spacing(GAP)
+                    .addShape(s -> s.name("icon").size(ICON, ICON))
+                    .addParagraph(p -> p.name("text").text(TEXT)));
+
+            // (135.7 - 8) / 2 = 63.85 per slot. The icon draws at its own 13pt,
+            // but it *occupies* 63.85 — so the text starts at 20 + 63.85 + 8.
+            double share = (ROW_WIDTH - GAP) / 2;
+            assertThat(node(graph, "text").placementX())
+                    .describedAs(
+                            "a 13pt icon and a paragraph each get half the row: the paragraph is pushed to "
+                                    + "the midpoint even though the icon needs 13pt of the 63.85pt it holds")
+                    .isCloseTo(ROW_LEFT + share + GAP, within(0.01));
+
+            assertThat(node(graph, "icon").placementWidth())
+                    .describedAs("the icon still draws at its own size — only its slot is oversized, "
+                            + "which is why nothing looks wrong until the text is read")
+                    .isCloseTo(ICON, within(0.01));
+        }
+    }
+
+    @Test
+    void anAutoColumnGivesTheIconItsWidthAndTheWeightColumnTakesTheRest() throws Exception {
+        try (DocumentSession session = session()) {
+            LayoutGraph graph = layout(session, row -> row
+                    .spacing(GAP)
+                    .columns(DocumentRowColumn.auto(), DocumentRowColumn.weight(1))
+                    .addShape(s -> s.name("icon").size(ICON, ICON))
+                    .addParagraph(p -> p.name("text").text(TEXT)));
+
+            assertThat(node(graph, "text").placementX())
+                    .describedAs("the auto column is the icon's own 13pt, so the text starts one gap after it")
+                    .isCloseTo(ROW_LEFT + ICON + GAP, within(0.01));
+        }
+    }
+
+    @Test
+    void theEvenSplitCostsTheParagraphItsLineCount() throws Exception {
+        try (DocumentSession even = session(); DocumentSession sized = session()) {
+            double evenHeight = node(layout(even, row -> row
+                    .spacing(GAP)
+                    .addShape(s -> s.name("icon").size(ICON, ICON))
+                    .addParagraph(p -> p.name("text").text(TEXT))), "text").placementHeight();
+
+            double sizedHeight = node(layout(sized, row -> row
+                    .spacing(GAP)
+                    .columns(DocumentRowColumn.auto(), DocumentRowColumn.weight(1))
+                    .addShape(s -> s.name("icon").size(ICON, ICON))
+                    .addParagraph(p -> p.name("text").text(TEXT))), "text").placementHeight();
+
+            // The whole visible symptom, in one assertion. Compared rather than
+            // pinned to a number: the line *count* is the contract, and the
+            // height of a line is a font metric this test has no business fixing.
+            assertThat(evenHeight)
+                    .describedAs(
+                            "the even split is not cosmetic — the same paragraph in the same row needs "
+                                    + "strictly more vertical space, which is how this defect is first noticed")
+                    .isGreaterThan(sizedHeight);
+        }
+    }
+
+    @Test
+    void theRuleAndTheRepairHoldForARealSvgIconNode() throws Exception {
+        // The three tests above use a ShapeNode as the fixed-size child, which
+        // keeps them independent of the SVG reader. The reported defect was an
+        // SvgIcon, and icon.node(13) is a LayerStackNode — a different branch of
+        // the row's allowed-child list and a different intrinsic measurement. If
+        // an auto() column could not measure a layer stack, the recommendation
+        // would be right about rows and wrong about icons, so it is asserted on
+        // the type the route actually sends people to.
+        SvgIcon icon = SvgIcon.parse(
+                "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\">"
+                        + "<path d=\"M2 2 L22 2 L22 22 L2 22 Z\" fill=\"#000000\"/></svg>");
+
+        try (DocumentSession even = session(); DocumentSession sized = session()) {
+            double share = (ROW_WIDTH - GAP) / 2;
+            assertThat(node(layout(even, row -> row
+                    .spacing(GAP)
+                    .add(icon.node(ICON))
+                    .addParagraph(p -> p.name("text").text(TEXT))), "text").placementX())
+                    .describedAs("a real icon node is no exception: with no column spec it holds half the row")
+                    .isCloseTo(ROW_LEFT + share + GAP, within(0.01));
+
+            assertThat(node(layout(sized, row -> row
+                    .spacing(GAP)
+                    .columns(DocumentRowColumn.auto(), DocumentRowColumn.weight(1))
+                    .add(icon.node(ICON))
+                    .addParagraph(p -> p.name("text").text(TEXT))), "text").placementX())
+                    .describedAs("and the auto column measures the layer stack at its own 13pt, "
+                            + "so the route's recommendation holds for the icon it was written for")
+                    .isCloseTo(ROW_LEFT + ICON + GAP, within(0.01));
+        }
+    }
+
+    @Test
+    void aGrowSpacerSizesEveryOtherChildToItsContent() throws Exception {
+        try (DocumentSession session = session()) {
+            LayoutGraph graph = layout(session, row -> row
+                    .spacing(GAP)
+                    .addShape(s -> s.name("icon").size(ICON, ICON))
+                    .addParagraph(p -> p.name("text").text(TEXT))
+                    .flexSpacer());
+
+            // The same row as the first test with one more child, and the answer
+            // changes completely: a grow spacer routes the row through the flex
+            // path, where every non-grow child takes its natural width instead of
+            // an equal share. This is why two rows that differ only by a trailing
+            // flexSpacer() do not lay out alike.
+            assertThat(node(graph, "text").placementX())
+                    .describedAs("with a grow spacer present the icon is sized to its content, "
+                            + "not to a third of the row — the text starts one gap after 13pt")
+                    .isCloseTo(ROW_LEFT + ICON + GAP, within(0.01));
+        }
+    }
+
+    @Test
+    void aNonStartArrangementSizesThemTheSameWayWithNoSpacerPresent() throws Exception {
+        // A grow spacer is the obvious way into the flex path and not the only
+        // one: RowSlots.hasFlexLayout answers yes to any non-START arrangement
+        // too. Pinned for every value, because a claim that named only the
+        // spacer would send a reader who reaches for arrangement(...) back to
+        // the even split they were trying to escape — or, worse, let them think
+        // the even-split rule still applies when it no longer does.
+        for (RowArrangement arrangement : RowArrangement.values()) {
+            if (arrangement == RowArrangement.START) {
+                continue;
+            }
+            try (DocumentSession session = session()) {
+                LayoutGraph graph = layout(session, row -> row
+                        .spacing(GAP)
+                        .arrangement(arrangement)
+                        .addShape(s -> s.name("icon").size(ICON, ICON))
+                        .addParagraph(p -> p.name("text").text(TEXT)));
+
+                // The icon's *width* is the contract and is arithmetic: in the
+                // flex path a non-grow child is its own content, whatever that
+                // content is. Its x is not asserted here, and neither is the
+                // text's: a non-START arrangement distributes the leftover as a
+                // leading offset (RowSlots.flexJustify), and the leftover is the
+                // row minus the paragraph's measured width — a font metric. The
+                // earlier version of this loop pinned that x and passed only
+                // because this particular string overflows the row and clamps
+                // the leftover to zero; a shorter string moved it by 10-20pt.
+                assertThat(node(graph, "icon").placementWidth())
+                        .describedAs("%s sizes the icon to its content, not to half the row", arrangement)
+                        .isCloseTo(ICON, within(0.01));
+                assertThat(node(graph, "icon").placementWidth())
+                        .describedAs("%s is not the even split — that would hand the icon %.2fpt",
+                                arrangement, (ROW_WIDTH - GAP) / 2)
+                        .isLessThan((ROW_WIDTH - GAP) / 2);
+            }
+        }
+    }
+
+    @Test
+    void theEvenSplitIsWhatTheStartArrangementDoes() throws Exception {
+        // The boundary for the loop above: START is the default and is the one
+        // arrangement that does NOT take the flex path, so the icon is back to
+        // holding half the row. Without this, the loop would pass just as well
+        // if the even split had been removed altogether.
+        try (DocumentSession session = session()) {
+            LayoutGraph graph = layout(session, row -> row
+                    .spacing(GAP)
+                    .arrangement(RowArrangement.START)
+                    .addShape(s -> s.name("icon").size(ICON, ICON))
+                    .addParagraph(p -> p.name("text").text(TEXT)));
+
+            assertThat(node(graph, "text").placementX())
+                    .describedAs("START keeps the even split — the icon still holds half the row")
+                    .isCloseTo(ROW_LEFT + (ROW_WIDTH - GAP) / 2 + GAP, within(0.01));
+        }
+    }
+}


### PR DESCRIPTION
## Why

A generated surface says what exists; it cannot say which of several ways is right. Two questions the pack could not answer produced two of the three dominant defects in an AI Flow CV run:

**A row with no column spec splits its inner width into equal shares, one per child** — content plays no part. So `row.add(icon.node(13)).addParagraph(...)` gives a 13pt icon half the row and wraps the text into twice the lines. Nothing looks broken: the icon still draws at 13pt, it merely occupies five times the width it needs, and the paragraph pays in line count. In a 135.7pt sidebar that is a 63.85pt slot each.

**`LineBuilder.horizontal(width)` takes points, not a percentage** — and nothing clips a line to the space it was given. Every neighbouring number is a ratio (`weights(0.34, 0.66)`, `leftColumn(0.34, ...)`), so `horizontal(100)` reads as "the full width"; it is drawn at 100pt, 32.15pt past the column, across whatever is beside it, with a clean render and no warning.

Neither fact is visible in a signature, and `knowledge/routing/tasks.json` is the only layer that can carry it.

## What the routes say

- **`layout.icon-beside-text`** recommends `columns(auto(), weight(1))`: `auto()` is the icon's own width, `weight(1)` is everything left, so the icon keeps its own size whatever the column is resized to. `weights(...)` is listed as the alternative it is *not* — a weight is a share, not a size, so `weights(0.1, 0.9)` at 135.7pt hands a 13pt icon a 12.77pt slot, and the figure moves with the row. (`fixed(13)` is as stable, and is the alternative for a rail of icons that must line up.)
- **`layout.rule-beside-a-heading`** recommends `fill()` in a weight column, with the two repairs that look right and are not: a `flexSpacer()` moves a fixed rule without sizing it, and `fill()` in a flex row takes the row's *whole* available width and ends further out than the rule it replaced.
- Both carry the failure modes as constraints, including one the recipe's own prose had never stated: a centre- or right-aligned heading claims the whole `auto()` column, leaving the weight column zero — **the rule is not misplaced, it is not drawn**.

`docs/recipes/layered-page-design.md` gains both sections with compiled fences (`doc-example`, not `doc-example-ignore`), and `LineBuilder.fill()`'s Javadoc now names the flex-row case it used to promise away — that Javadoc is the only prose an API-first reader gets, since the surfaces carry signatures and nothing else.

## What the gate now does

Writing the routes exposed that the gate admitting them was wrong in ways no existing route happened to trip.

- **The anchor rule was not GitHub's.** It collapsed whitespace runs where GitHub does not, so it disagreed with the rendered page on 121 of ~790 headings under `docs/` — failing CI on a link that works and passing one that 404s. It is now measured, not derived: headings were posted to `api.github.com/markdown` and the generated ids read back. GitHub keeps `\p{L} \p{M} \p{Nd} \p{Nl} \p{Pc}`, `-` and the ASCII space, drops everything else *including every other kind of whitespace*, hyphenates only the ASCII space, and trims nothing. `Zebra — alternating row fills` is `#zebra--alternating-row-fills`; `A<TAB>B` is `#ab`; `<EM SPACE><SPACE>A` is `#-a`.
- The rule exists twice — `DocumentationLinkGuardTest.slug` and `routing/lib/anchors.mjs` — and cannot call itself across the language boundary, so both assert the **same measured table** and a change to either reddens its own fixture.
- **Route citations are checked wherever they are written**, not only in `docs:`: `intent`, `recommendedBecause` and every alternative's `useWhen`/`tradeoffs` go through one resolver, so a renamed heading cannot be fixed in the gated copy and left dangling in the prose an agent actually reads.
- **Versions are ordered, not compared as strings.** At a tag the surfaces are re-stamped `2.4.0` while a route signed during the cycle still reads `2.4.0-SNAPSHOT`; string inequality reported the whole file stale on every release, which is the same as reporting none of it. A version that cannot be ordered, or one ahead of the surfaces, is now a failure rather than a note.
- **`api-query` carries the pack's own version with the answer.** It ships in the bundle without `check-routes`, so a bare `checked against: 2.2.3-SNAPSHOT` gave a reader nothing to compare against. Its copy of the ordering rule is deliberate — `build-bundle` publishes that one file as `bin/query.mjs` with nothing beside it — and `pack-version.test.mjs` runs the same table through both so the copy cannot drift.
- Smaller failures-to-report, each reproduced first: a directory in `docs:` killed the gate with an `EISDIR` stack trace naming no route; a constraint spelled `toString` reached `Object.prototype` and died on it, losing every error collected so far; a `docs:` written as a bare string was walked character by character; a mis-cased citation passed on Windows to fail on the runner as "no such page"; a root-relative `/docs/x.md#y` in prose matched nothing at all and was never checked.
- **`proof=test:Class#method`** — a proof resolved by class name only, so deleting the one method that held a behaviour left the claim reading as proven. The two claims a single method genuinely holds now name it; the rest stay class-level because more than one method holds them.
- CI discovers the fixture suites and then holds the discovered set against a declared list, so adding, renaming or deleting one goes red; `release.yml` runs them too, since `build-bundle --verify` asserts exit codes and cannot see whether the shipped copy orders versions correctly.

## Verification

`./mvnw -B -ntp clean verify -pl :graph-compose-core,:graph-compose-render-pdf,:graph-compose-render-docx,:graph-compose-render-pptx,:graph-compose-templates,:graph-compose-testing,:graph-compose-qa,:graph-compose-coverage -am` → **BUILD SUCCESS**.

Knowledge gates: `check-routes` exit 0 (5 routes), `check-claims --check` current (46 claims, 8 proofs), `build-bundle --verify` answers with no repository present. Fixture suites **23 / 18 / 35 / 33**.

New tests, and what each pins:

- `RowWidthDistributionContractTest` (7) — the even split and its cost in line count; `auto()` + `weight(1)` as the repair; a grow spacer *and* every non-`START` arrangement entering the same intrinsic-sizing path; `START` as the boundary that does not.
- `LineWidthUnitsContractTest` (8) — `horizontal(n)` is points and is not clipped; `fill()` spans its slot; a spacer neither shrinks a fixed rule nor gives `fill()` a slot; a flex row and a weight column are refused together; an aligned heading collapses the rule to zero width.
- `DocumentationLinkGuardTest` (+2 methods) — the one `docs/*.md#anchor` cited from production Java resolves (the guard is fail-closed on the scan root, not on citation count), and the anchor rule agrees with its JavaScript twin on the measured table.
- `anchors.test.mjs`, `pack-version.test.mjs` — new suites for the two libraries.

The geometry assertions are slot arithmetic, not font metrics: the left-hand child of a flex row is a fixed-width shape, and where a coordinate genuinely is font-dependent — a non-`START` arrangement spreads the leftover as a leading offset — only the widths are asserted, and the class says so.

## Notes for review

- The series reads as an audit trail on purpose. The anchor rule was wrong three times before it was measured, and the commits keep that visible rather than presenting a rule that looks like it was right first time.
- **Three routes still carry `verifiedAgainst: 2.2.3-SNAPSHOT`.** The new ordering makes them announce themselves as not re-read, which is honest — re-stamping them without actually re-reading would be a false attestation. Left for a deliberate pass.
- **`fill()` in a flex row still overflows.** It is documented, claimed and pinned by a test rather than fixed: `RowSlots.growOf` only recognises `SpacerNode`, so a repair is a new engine rule that moves rendered output for existing documents (`TocBuilder` already composes a `fill()` leader) — a behaviour decision, not an omission.
- Public API is unchanged; the only `src/main` edit is Javadoc, so `knowledge/api/` needed no regeneration. The CHANGELOG entry sits under develop's existing `## v2.4.0 — Planned`, beside its `### Layout`.

**Lane:** canonical (`knowledge/` routing + `docs/recipes`) with a shared-engine read-only touch — the two contract tests assert `RowSlots` behaviour without changing it.

