### PR TITLE
feat(api): fixed-width flow containers with content-driven height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,17 @@ follow semantic versioning; release dates are ISO 8601.
   width (a `fixedWidth(240).padding(20)` card occupies 240pt and gives its
   children 200pt), and a request wider than the surrounding region is clamped to
   that region rather than overflowing it, which makes the call safe on a computed
-  width. Nesting clamps against the parent box, not the page. NaN, infinity, zero
-  and negative values are rejected at the call.
+  width. Nesting clamps against the parent box, not the page, and under per-page
+  margins the cap follows the page a block starts on rather than the page it
+  began the document on. NaN, infinity, zero and negative values are rejected at
+  the call, and a sub-point width that can only fail at layout now fails naming
+  the fixed width instead of blaming the parent's padding.
+
+  One configuration is knowingly still wrong: a fixed-width flow used as a *row
+  column* that also carries a horizontal margin is placed narrower than it asked
+  for, because the row path subtracts that margin twice before the width is
+  resolved. That defect predates this feature — it misplaces unconstrained boxes
+  in the same shape — and is fixed separately.
 
   The value is carried by a new canonical `DocumentFlowWidth`
   (`natural()` / `of(points)`) on `DocumentNode.flowWidth()`, stored on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ follow semantic versioning; release dates are ISO 8601.
 
 ## v2.4.0 — Planned
 
+### Public API
+
+- **A vertical flow can pin its width and still grow with its content.**
+  `AbstractFlowBuilder.fixedWidth(double)` — so `addSection(s -> s.fixedWidth(240))`,
+  `module(m -> m.fixedWidth(240))` and `pageFlow(page -> page.fixedWidth(200))` —
+  measures, decorates and places the box at exactly the requested width, and wraps
+  its children inside that width less the flow's own padding. Narrowing a box used
+  to mean expressing the width as something else: a row whose neighbouring slot
+  soaks up the remainder, or a large one-sided `margin`. Neither pins a width —
+  both leave the box free to shrink to its content inside the space they carve
+  out — and both make the width a property of the box's surroundings rather than
+  of the box that wants it.
+
+  The constraint is horizontal only. The height is the same natural,
+  content-driven measurement it always was, so a fixed-width box still grows as
+  paragraphs are added and paginates exactly as it did — there is no
+  `fixedHeight` counterpart and no fixed box. Padding is inside the requested
+  width (a `fixedWidth(240).padding(20)` card occupies 240pt and gives its
+  children 200pt), and a request wider than the surrounding region is clamped to
+  that region rather than overflowing it, which makes the call safe on a computed
+  width. Nesting clamps against the parent box, not the page. NaN, infinity, zero
+  and negative values are rejected at the call.
+
+  The value is carried by a new canonical `DocumentFlowWidth`
+  (`natural()` / `of(points)`) on `DocumentNode.flowWidth()`, stored on
+  `SectionNode` and `ContainerNode`. Both records keep their previous
+  constructors, so existing callers compile and link unchanged, and both default
+  to `natural()` — a flow that never calls `fixedWidth` keeps the shrink-to-fit
+  measurement it already had, and every committed layout snapshot is unchanged.
+
+  Documented in [`docs/recipes/fixed-width-flows.md`](docs/recipes/fixed-width-flows.md).
+
 ### Layout
 
 - **A composed table cell sits where its anchor says, and a spanning one stops

--- a/core/src/main/java/com/demcha/compose/document/dsl/AbstractFlowBuilder.java
+++ b/core/src/main/java/com/demcha/compose/document/dsl/AbstractFlowBuilder.java
@@ -38,6 +38,7 @@ public abstract class AbstractFlowBuilder<T extends AbstractFlowBuilder<T, N>, N
     private DocumentCornerRadius cornerRadius = DocumentCornerRadius.ZERO;
     private DocumentBorders borders = DocumentBorders.NONE;
     private DocumentBleed bleed = DocumentBleed.none();
+    private DocumentFlowWidth flowWidth = DocumentFlowWidth.natural();
 
     /**
      * Creates a base flow builder.
@@ -184,6 +185,33 @@ public abstract class AbstractFlowBuilder<T extends AbstractFlowBuilder<T, N>, N
      */
     public T bleedToEdge(DocumentEdge... edges) {
         return bleed(DocumentBleed.of(edges));
+    }
+
+    /**
+     * Pins the flow's horizontal size: the box is measured, decorated and placed at
+     * exactly {@code points} wide, and its children wrap inside
+     * {@code points} minus the flow's own padding.
+     *
+     * <p>Only the horizontal axis is fixed. The height stays the natural,
+     * content-driven measurement it already was, so the box still grows as content
+     * is added to it and paginates unchanged — this is a fixed <em>width</em>, not
+     * a fixed box. Without this call a flow is measured at the width its parent
+     * offers, which is the unchanged default.</p>
+     *
+     * <p>The request is clamped to the width the parent actually offers, so a value
+     * wider than the surrounding region degrades to that region's width rather than
+     * overflowing it. On an edge declared through {@link #bleed(DocumentBleed)} the
+     * bleed still wins: the background reaches the trimmed page edge, because that
+     * is the whole point of asking for it.</p>
+     *
+     * @param points fixed outer width in points; must be finite and greater than zero
+     * @return this builder
+     * @throws IllegalArgumentException if {@code points} is NaN, infinite, zero or negative
+     * @since 2.4.0
+     */
+    public T fixedWidth(double points) {
+        this.flowWidth = DocumentFlowWidth.of(points);
+        return self();
     }
 
     /**
@@ -1193,6 +1221,10 @@ public abstract class AbstractFlowBuilder<T extends AbstractFlowBuilder<T, N>, N
 
     protected DocumentBleed bleed() {
         return bleed;
+    }
+
+    protected DocumentFlowWidth flowWidth() {
+        return flowWidth;
     }
 }
 

--- a/core/src/main/java/com/demcha/compose/document/dsl/ModuleBuilder.java
+++ b/core/src/main/java/com/demcha/compose/document/dsl/ModuleBuilder.java
@@ -333,8 +333,8 @@ public final class ModuleBuilder extends AbstractFlowBuilder<ModuleBuilder, Sect
                     .build());
         }
         moduleChildren.addAll(children());
-        // A module does not bleed (matching its long-standing behaviour) — thread
-        // only the bookmark, leaving bleed at none().
+        // A module does not bleed (matching its long-standing behaviour) — thread the
+        // bookmark and the flow width, leaving bleed at none().
         return new SectionNode(name(), moduleChildren, spacing(), padding(), margin(), fillColor(),
                 stroke(), cornerRadius(), borders(), keepTogether, anchor(), DocumentBleed.none(), bookmarkOptions(),
                 false, flowWidth());

--- a/core/src/main/java/com/demcha/compose/document/dsl/ModuleBuilder.java
+++ b/core/src/main/java/com/demcha/compose/document/dsl/ModuleBuilder.java
@@ -336,7 +336,8 @@ public final class ModuleBuilder extends AbstractFlowBuilder<ModuleBuilder, Sect
         // A module does not bleed (matching its long-standing behaviour) — thread
         // only the bookmark, leaving bleed at none().
         return new SectionNode(name(), moduleChildren, spacing(), padding(), margin(), fillColor(),
-                stroke(), cornerRadius(), borders(), keepTogether, anchor(), DocumentBleed.none(), bookmarkOptions());
+                stroke(), cornerRadius(), borders(), keepTogether, anchor(), DocumentBleed.none(), bookmarkOptions(),
+                false, flowWidth());
     }
 
     /**

--- a/core/src/main/java/com/demcha/compose/document/dsl/PageFlowBuilder.java
+++ b/core/src/main/java/com/demcha/compose/document/dsl/PageFlowBuilder.java
@@ -23,7 +23,7 @@ public final class PageFlowBuilder extends AbstractFlowBuilder<PageFlowBuilder, 
 
     @Override
     protected ContainerNode buildNode() {
-        return new ContainerNode(name(), children(), spacing(), padding(), margin(), fillColor(), stroke(), cornerRadius(), borders(), anchor(), bookmarkOptions());
+        return new ContainerNode(name(), children(), spacing(), padding(), margin(), fillColor(), stroke(), cornerRadius(), borders(), anchor(), bookmarkOptions(), flowWidth());
     }
 
     /**

--- a/core/src/main/java/com/demcha/compose/document/dsl/SectionBuilder.java
+++ b/core/src/main/java/com/demcha/compose/document/dsl/SectionBuilder.java
@@ -83,7 +83,7 @@ public final class SectionBuilder extends AbstractFlowBuilder<SectionBuilder, Se
     protected SectionNode buildNode() {
         return new SectionNode(name(), children(), spacing(), padding(), margin(), fillColor(),
                 stroke(), cornerRadius(), borders(), keepTogether, anchor(), bleed(), bookmarkOptions(),
-                keepWithNext);
+                keepWithNext, flowWidth());
     }
 
     /**

--- a/core/src/main/java/com/demcha/compose/document/layout/LayoutCompiler.java
+++ b/core/src/main/java/com/demcha/compose/document/layout/LayoutCompiler.java
@@ -151,9 +151,16 @@ public final class LayoutCompiler {
         }
 
         if (availableWidth <= EPS) {
+            // Name the node's own fixed width when it has one: a sub-point request
+            // survives DocumentFlowWidth.of and dies here, and blaming the parent's
+            // padding would send the author to the wrong knob.
             throw new IllegalStateException("Node '" + path
                                             + "' has no horizontal layout space. "
-                                            + "Reduce padding or margin on the parent, or increase the page width.");
+                                            + (node.flowWidth().isFixed()
+                                               ? "Its fixed width of " + node.flowWidth().points()
+                                                 + "pt leaves nothing to lay out in — raise it above "
+                                                 + EPS + "pt."
+                                               : "Reduce padding or margin on the parent, or increase the page width."));
         }
 
         MeasureResult naturalMeasure = prepared.measureResult();
@@ -293,8 +300,7 @@ public final class LayoutCompiler {
         // each direct child is measured at the content width of the page it begins on
         // (carried over from the previous pass via the fixed point). Nested composites
         // keep their parent-allocated geometry. With no per-page margins both branches
-        // resolve to the same width, so the layout is byte-identical. A fixed-width box
-        // owns its width across every page it touches, so it re-seats only its x.
+        // resolve to the same width, so the layout is byte-identical.
         boolean pageColumn = depth == 1 && state.hasPageGeometry();
 
         for (int index = 0; index < children.size(); index++) {
@@ -304,10 +310,16 @@ public final class LayoutCompiler {
             if (pageColumn) {
                 int childStartPage = prepareContext.assignedStartPage(
                         pathFor(child, path, index), state.pageIndex);
-                if (!fixedWidth) {
-                    double pageRegionWidth = state.innerWidthForPage(childStartPage);
-                    thisChildRegionWidth = Math.max(0.0, (pageRegionWidth - margin.horizontal()) - padding.horizontal());
+                double pageAvailableWidth =
+                        Math.max(0.0, state.innerWidthForPage(childStartPage) - margin.horizontal());
+                // A fixed-width box keeps its own width from page to page — but never
+                // more than the column of the page the child starts on. Without that
+                // cap the width stays the start page's while the x below moves to a
+                // later page's margin, which walks the child off a narrower page.
+                if (fixedWidth) {
+                    pageAvailableWidth = Math.min(naturalMeasure.width(), pageAvailableWidth);
                 }
+                thisChildRegionWidth = Math.max(0.0, pageAvailableWidth - padding.horizontal());
                 thisChildRegionX = state.marginLeftForPage(childStartPage) + margin.left() + padding.left();
             }
             PreparedNode<DocumentNode> childPrepared =
@@ -1216,7 +1228,7 @@ public final class LayoutCompiler {
      * measured width instead — see the {@code fixedWidth} branches in
      * {@code compileComposite} and {@code compileNodeInFixedSlot}.</p>
      *
-     * <p>{@link DocumentFlowWidth#natural()}, which every node carries unless it
+     * <p>A natural {@code DocumentFlowWidth}, which every node carries unless it
      * opted in, resolves to the region width and leaves this exactly as it was.</p>
      */
     private double childAvailableWidth(double regionWidth, DocumentNode node) {

--- a/core/src/main/java/com/demcha/compose/document/layout/LayoutCompiler.java
+++ b/core/src/main/java/com/demcha/compose/document/layout/LayoutCompiler.java
@@ -279,12 +279,22 @@ public final class LayoutCompiler {
         state.advanceSpace(startReservation);
         List<DocumentNode> children = definition.children(node);
         double childRegionX = placementX + padding.left();
-        double childRegionWidth = Math.max(0.0, availableWidth - padding.horizontal());
+        // A fixed-width box seats its children inside the width it was MEASURED at,
+        // not inside the one re-derived here. The two are not always the same
+        // number: a row column prepares its child against the slot less the child's
+        // margin and then hands placement the whole slot, so a re-derivation would
+        // wrap text at one width while the box paints at another. Taking the
+        // measured width makes the painted box and the wrapping width the same
+        // number by construction, whatever base the caller used.
+        boolean fixedWidth = node.flowWidth().isFixed();
+        double childRegionWidth = Math.max(0.0,
+                (fixedWidth ? naturalMeasure.width() : availableWidth) - padding.horizontal());
         // At the root level the page margin defines the document's content column, so
         // each direct child is measured at the content width of the page it begins on
         // (carried over from the previous pass via the fixed point). Nested composites
         // keep their parent-allocated geometry. With no per-page margins both branches
-        // resolve to the same width, so the layout is byte-identical.
+        // resolve to the same width, so the layout is byte-identical. A fixed-width box
+        // owns its width across every page it touches, so it re-seats only its x.
         boolean pageColumn = depth == 1 && state.hasPageGeometry();
 
         for (int index = 0; index < children.size(); index++) {
@@ -294,8 +304,10 @@ public final class LayoutCompiler {
             if (pageColumn) {
                 int childStartPage = prepareContext.assignedStartPage(
                         pathFor(child, path, index), state.pageIndex);
-                double pageRegionWidth = state.innerWidthForPage(childStartPage);
-                thisChildRegionWidth = Math.max(0.0, (pageRegionWidth - margin.horizontal()) - padding.horizontal());
+                if (!fixedWidth) {
+                    double pageRegionWidth = state.innerWidthForPage(childStartPage);
+                    thisChildRegionWidth = Math.max(0.0, (pageRegionWidth - margin.horizontal()) - padding.horizontal());
+                }
                 thisChildRegionX = state.marginLeftForPage(childStartPage) + margin.left() + padding.left();
             }
             PreparedNode<DocumentNode> childPrepared =
@@ -1003,7 +1015,11 @@ public final class LayoutCompiler {
             }
 
             double childRegionX = placementX + padding.left();
-            double childRegionWidth = Math.max(0.0, availableWidth - padding.horizontal());
+            // Same rule as the flow walk: a fixed-width box seats its children inside
+            // the width it was measured at, so a row slot that hands placement a wider
+            // base than prepare saw cannot wrap text past the painted box.
+            double childRegionWidth = Math.max(0.0,
+                    (node.flowWidth().isFixed() ? measure.width() : availableWidth) - padding.horizontal());
             double childTopY = placementTopY - padding.top();
 
             if (layoutSpec.axis() == CompositeLayoutSpec.Axis.HORIZONTAL) {
@@ -1187,9 +1203,26 @@ public final class LayoutCompiler {
         return prepareContext.prepare(node, BoxConstraints.natural(childAvailableWidth(regionWidth, node)));
     }
 
+    /**
+     * The width a node is both measured at and laid out inside: the region its
+     * parent offers, less the node's own margin, narrowed to the node's declared
+     * horizontal size constraint.
+     *
+     * <p>This caps the width a node may occupy, which is what the overflow guard in
+     * {@code compileNode} compares a measurement against. It is deliberately NOT
+     * the number a fixed-width box seats its children in: callers reach this method
+     * with different bases (a row column passes the whole slot to placement but the
+     * slot less the child's margin to prepare), so a box's children follow its
+     * measured width instead — see the {@code fixedWidth} branches in
+     * {@code compileComposite} and {@code compileNodeInFixedSlot}.</p>
+     *
+     * <p>{@link DocumentFlowWidth#natural()}, which every node carries unless it
+     * opted in, resolves to the region width and leaves this exactly as it was.</p>
+     */
     private double childAvailableWidth(double regionWidth, DocumentNode node) {
         Margin margin = toMargin(node.margin());
-        return Math.max(0.0, regionWidth - margin.horizontal());
+        double available = Math.max(0.0, regionWidth - margin.horizontal());
+        return node.flowWidth().resolve(available);
     }
 
     /**

--- a/core/src/main/java/com/demcha/compose/document/layout/NodeDefinitionSupport.java
+++ b/core/src/main/java/com/demcha/compose/document/layout/NodeDefinitionSupport.java
@@ -353,25 +353,6 @@ public final class NodeDefinitionSupport {
 
     /**
      * Measures a vertical composite node by preparing children inside the
-     * padding-adjusted inner width, at the natural (content-driven) width.
-     *
-     * @param children    semantic child nodes
-     * @param spacing     vertical spacing between children
-     * @param padding     engine padding
-     * @param ctx         prepare context
-     * @param constraints parent constraints
-     * @return measured outer size
-     */
-    public static MeasureResult measureComposite(List<DocumentNode> children,
-                                                 double spacing,
-                                                 Padding padding,
-                                                 PrepareContext ctx,
-                                                 BoxConstraints constraints) {
-        return measureComposite(children, spacing, padding, ctx, constraints, DocumentFlowWidth.natural());
-    }
-
-    /**
-     * Measures a vertical composite node by preparing children inside the
      * padding-adjusted inner width, honouring the node's horizontal size
      * constraint.
      *

--- a/core/src/main/java/com/demcha/compose/document/layout/NodeDefinitionSupport.java
+++ b/core/src/main/java/com/demcha/compose/document/layout/NodeDefinitionSupport.java
@@ -353,7 +353,7 @@ public final class NodeDefinitionSupport {
 
     /**
      * Measures a vertical composite node by preparing children inside the
-     * padding-adjusted inner width.
+     * padding-adjusted inner width, at the natural (content-driven) width.
      *
      * @param children    semantic child nodes
      * @param spacing     vertical spacing between children
@@ -367,7 +367,43 @@ public final class NodeDefinitionSupport {
                                                  Padding padding,
                                                  PrepareContext ctx,
                                                  BoxConstraints constraints) {
-        double innerWidth = Math.max(0.0, constraints.availableWidth() - padding.horizontal());
+        return measureComposite(children, spacing, padding, ctx, constraints, DocumentFlowWidth.natural());
+    }
+
+    /**
+     * Measures a vertical composite node by preparing children inside the
+     * padding-adjusted inner width, honouring the node's horizontal size
+     * constraint.
+     *
+     * <p>A {@link DocumentFlowWidth#natural()} width leaves the measurement
+     * exactly as it has always been: children are measured inside the width the
+     * parent offers, and the box reports shrink-to-fit. A fixed width narrows the
+     * measurement to {@link DocumentFlowWidth#resolve(double)} — clamped to the
+     * parent's available width — and the box reports that width whether or not its
+     * content fills it, so the decoration and the placed box are the width that was
+     * asked for. The vertical axis is untouched either way: the height is the same
+     * accumulated content height, measured through
+     * {@link BoxConstraints#natural(double)} as before.</p>
+     *
+     * @param children    semantic child nodes
+     * @param spacing     vertical spacing between children
+     * @param padding     engine padding
+     * @param ctx         prepare context
+     * @param constraints parent constraints
+     * @param flowWidth   the node's horizontal size constraint
+     * @return measured outer size
+     * @since 2.4.0
+     */
+    public static MeasureResult measureComposite(List<DocumentNode> children,
+                                                 double spacing,
+                                                 Padding padding,
+                                                 PrepareContext ctx,
+                                                 BoxConstraints constraints,
+                                                 DocumentFlowWidth flowWidth) {
+        // Resolving against the incoming width is idempotent, so this is correct
+        // whether the caller already narrowed the constraints or not.
+        double outerWidth = flowWidth.resolve(constraints.availableWidth());
+        double innerWidth = Math.max(0.0, outerWidth - padding.horizontal());
         double totalHeight = padding.vertical();
         double maxWidth = 0.0;
 
@@ -384,7 +420,7 @@ public final class NodeDefinitionSupport {
         }
 
         return new MeasureResult(
-                Math.min(constraints.availableWidth(), padding.horizontal() + maxWidth),
+                flowWidth.isFixed() ? outerWidth : Math.min(outerWidth, padding.horizontal() + maxWidth),
                 totalHeight);
     }
 

--- a/core/src/main/java/com/demcha/compose/document/layout/definitions/ContainerDefinition.java
+++ b/core/src/main/java/com/demcha/compose/document/layout/definitions/ContainerDefinition.java
@@ -31,7 +31,8 @@ public final class ContainerDefinition implements NodeDefinition<ContainerNode> 
     public PreparedNode<ContainerNode> prepare(ContainerNode node, PrepareContext ctx, BoxConstraints constraints) {
         return PreparedNode.composite(
                 node,
-                measureComposite(node.children(), node.spacing(), toPadding(node.padding()), ctx, constraints),
+                measureComposite(node.children(), node.spacing(), toPadding(node.padding()), ctx, constraints,
+                        node.flowWidth()),
                 new CompositeLayoutSpec(node.spacing()));
     }
 

--- a/core/src/main/java/com/demcha/compose/document/layout/definitions/SectionDefinition.java
+++ b/core/src/main/java/com/demcha/compose/document/layout/definitions/SectionDefinition.java
@@ -31,7 +31,8 @@ public final class SectionDefinition implements NodeDefinition<SectionNode> {
     public PreparedNode<SectionNode> prepare(SectionNode node, PrepareContext ctx, BoxConstraints constraints) {
         return PreparedNode.composite(
                 node,
-                measureComposite(node.children(), node.spacing(), toPadding(node.padding()), ctx, constraints),
+                measureComposite(node.children(), node.spacing(), toPadding(node.padding()), ctx, constraints,
+                        node.flowWidth()),
                 new CompositeLayoutSpec(node.spacing()));
     }
 

--- a/core/src/main/java/com/demcha/compose/document/node/ContainerNode.java
+++ b/core/src/main/java/com/demcha/compose/document/node/ContainerNode.java
@@ -21,6 +21,9 @@ import java.util.Objects;
  *                     destination at the container's top-left, or {@code null} for none
  * @param bookmarkOptions optional PDF outline entry placed at the container's top on
  *                        its start page, or {@code null} for none
+ * @param flowWidth    horizontal size constraint; {@link DocumentFlowWidth#natural()}
+ *                     measures the container at the width its parent offers, a fixed
+ *                     value pins that width while leaving the height content-driven
  * @author Artem Demchyshyn
  */
 public record ContainerNode(
@@ -34,7 +37,8 @@ public record ContainerNode(
         DocumentCornerRadius cornerRadius,
         DocumentBorders borders,
         String anchor,
-        DocumentBookmarkOptions bookmarkOptions
+        DocumentBookmarkOptions bookmarkOptions,
+        DocumentFlowWidth flowWidth
 ) implements DocumentNode {
     /**
      * Creates a normalized vertical flow container.
@@ -48,9 +52,41 @@ public record ContainerNode(
         cornerRadius = cornerRadius == null ? DocumentCornerRadius.ZERO : cornerRadius;
         borders = borders == null ? DocumentBorders.NONE : borders;
         anchor = anchor == null || anchor.isBlank() ? null : anchor.trim();
+        flowWidth = flowWidth == null ? DocumentFlowWidth.natural() : flowWidth;
         if (spacing < 0 || Double.isNaN(spacing) || Double.isInfinite(spacing)) {
             throw new IllegalArgumentException("spacing must be finite and non-negative: " + spacing);
         }
+    }
+
+    /**
+     * Backward-compatible constructor without the flow-width constraint (defaults to
+     * {@link DocumentFlowWidth#natural()}).
+     *
+     * @param name         node name used in snapshots and layout graph paths
+     * @param children     child semantic nodes in source order
+     * @param spacing      vertical spacing between children
+     * @param padding      inner padding
+     * @param margin       outer margin
+     * @param fillColor    optional background fill
+     * @param stroke       optional uniform border stroke
+     * @param cornerRadius optional render-only corner radius
+     * @param borders      optional per-side border strokes overriding the uniform stroke
+     * @param anchor       optional navigation anchor name
+     * @param bookmarkOptions optional PDF outline entry, or {@code null} for none
+     */
+    public ContainerNode(String name,
+                         List<DocumentNode> children,
+                         double spacing,
+                         DocumentInsets padding,
+                         DocumentInsets margin,
+                         DocumentColor fillColor,
+                         DocumentStroke stroke,
+                         DocumentCornerRadius cornerRadius,
+                         DocumentBorders borders,
+                         String anchor,
+                         DocumentBookmarkOptions bookmarkOptions) {
+        this(name, children, spacing, padding, margin, fillColor, stroke, cornerRadius, borders, anchor,
+                bookmarkOptions, DocumentFlowWidth.natural());
     }
 
     /**

--- a/core/src/main/java/com/demcha/compose/document/node/DocumentNode.java
+++ b/core/src/main/java/com/demcha/compose/document/node/DocumentNode.java
@@ -1,6 +1,7 @@
 package com.demcha.compose.document.node;
 
 import com.demcha.compose.document.style.DocumentBleed;
+import com.demcha.compose.document.style.DocumentFlowWidth;
 import com.demcha.compose.document.style.DocumentInsets;
 
 import java.util.List;
@@ -116,6 +117,25 @@ public interface DocumentNode {
      */
     default DocumentBleed bleed() {
         return DocumentBleed.none();
+    }
+
+    /**
+     * Horizontal size constraint for this node. Default
+     * {@link DocumentFlowWidth#natural()} — the node is measured and placed at the
+     * width its parent offers, exactly as it was before this constraint existed.
+     *
+     * <p>Carried by the vertical flow boxes that can honour it,
+     * {@link SectionNode} and {@link ContainerNode}, and authored through
+     * {@link com.demcha.compose.document.dsl.AbstractFlowBuilder#fixedWidth(double)}.
+     * A fixed value pins only the horizontal axis: the height stays the natural,
+     * content-driven measurement, so the box still grows with its content and
+     * paginates unchanged.</p>
+     *
+     * @return the flow width constraint; never {@code null}
+     * @since 2.4.0
+     */
+    default DocumentFlowWidth flowWidth() {
+        return DocumentFlowWidth.natural();
     }
 }
 

--- a/core/src/main/java/com/demcha/compose/document/node/SectionNode.java
+++ b/core/src/main/java/com/demcha/compose/document/node/SectionNode.java
@@ -30,6 +30,9 @@ import java.util.Objects;
  *                     follows it — it is relocated to the next page rather than
  *                     stranded at a page bottom apart from the first line of the
  *                     following content (see {@link DocumentNode#keepWithNext()})
+ * @param flowWidth    horizontal size constraint; {@link DocumentFlowWidth#natural()}
+ *                     measures the section at the width its parent offers, a fixed
+ *                     value pins that width while leaving the height content-driven
  * @author Artem Demchyshyn
  */
 public record SectionNode(
@@ -46,7 +49,8 @@ public record SectionNode(
         String anchor,
         DocumentBleed bleed,
         DocumentBookmarkOptions bookmarkOptions,
-        boolean keepWithNext
+        boolean keepWithNext,
+        DocumentFlowWidth flowWidth
 ) implements DocumentNode {
     /**
      * Normalizes optional section fields and validates child spacing.
@@ -61,9 +65,47 @@ public record SectionNode(
         borders = borders == null ? DocumentBorders.NONE : borders;
         anchor = anchor == null || anchor.isBlank() ? null : anchor.trim();
         bleed = bleed == null ? DocumentBleed.none() : bleed;
+        flowWidth = flowWidth == null ? DocumentFlowWidth.natural() : flowWidth;
         if (spacing < 0 || Double.isNaN(spacing) || Double.isInfinite(spacing)) {
             throw new IllegalArgumentException("spacing must be finite and non-negative: " + spacing);
         }
+    }
+
+    /**
+     * Backward-compatible constructor without the flow-width constraint (defaults to
+     * {@link DocumentFlowWidth#natural()}).
+     *
+     * @param name            node name
+     * @param children        child nodes
+     * @param spacing         vertical spacing
+     * @param padding         inner padding
+     * @param margin          outer margin
+     * @param fillColor       optional background fill
+     * @param stroke          optional uniform border stroke
+     * @param cornerRadius    optional render-only corner radius
+     * @param borders         optional per-side borders
+     * @param keepTogether    keep-together relocation flag
+     * @param anchor          optional navigation anchor name
+     * @param bleed           optional bleed declaration
+     * @param bookmarkOptions optional PDF outline entry, or {@code null} for none
+     * @param keepWithNext    keep-with-next relocation flag
+     */
+    public SectionNode(String name,
+                       List<DocumentNode> children,
+                       double spacing,
+                       DocumentInsets padding,
+                       DocumentInsets margin,
+                       DocumentColor fillColor,
+                       DocumentStroke stroke,
+                       DocumentCornerRadius cornerRadius,
+                       DocumentBorders borders,
+                       boolean keepTogether,
+                       String anchor,
+                       DocumentBleed bleed,
+                       DocumentBookmarkOptions bookmarkOptions,
+                       boolean keepWithNext) {
+        this(name, children, spacing, padding, margin, fillColor, stroke, cornerRadius, borders, keepTogether,
+                anchor, bleed, bookmarkOptions, keepWithNext, DocumentFlowWidth.natural());
     }
 
     /**

--- a/core/src/main/java/com/demcha/compose/document/style/DocumentFlowWidth.java
+++ b/core/src/main/java/com/demcha/compose/document/style/DocumentFlowWidth.java
@@ -42,6 +42,10 @@ public record DocumentFlowWidth(double points) {
         if (Double.isNaN(points) || Double.isInfinite(points) || points < 0.0) {
             throw new IllegalArgumentException("flow width must be finite and non-negative: " + points);
         }
+        // -0.0 slips through the check above (it is not < 0.0) and lays out exactly
+        // like the natural width, but would compare unequal to it and hash to
+        // Integer.MIN_VALUE. Fold it onto +0.0 so one behaviour has one value.
+        points = points == 0.0 ? 0.0 : points;
     }
 
     /**

--- a/core/src/main/java/com/demcha/compose/document/style/DocumentFlowWidth.java
+++ b/core/src/main/java/com/demcha/compose/document/style/DocumentFlowWidth.java
@@ -1,0 +1,92 @@
+package com.demcha.compose.document.style;
+
+/**
+ * Horizontal size constraint for a vertical flow box &mdash; a
+ * {@link com.demcha.compose.document.node.SectionNode} or a
+ * {@link com.demcha.compose.document.node.ContainerNode}.
+ *
+ * <p>A flow box is normally measured shrink-to-fit inside the width its parent
+ * offers. A <em>fixed</em> flow width pins that horizontal size instead: the box
+ * is measured, decorated and placed at exactly {@link #points()}, and its
+ * children are laid out inside {@code points - padding.horizontal()}. The
+ * vertical axis is untouched &mdash; height stays the natural, content-driven
+ * measurement, so a fixed-width box still grows as content is added to it and
+ * still paginates the way it did before.</p>
+ *
+ * <p>The requested width is clamped to the width the parent actually offers
+ * (see {@link #resolve(double)}), so asking for more than the page can give
+ * degrades to the available width rather than overflowing the region or failing
+ * the compiler's width guard.</p>
+ *
+ * <p>{@link #natural()} is the neutral value carried by every node that has not
+ * opted in, and it resolves to the parent's available width &mdash; i.e. exactly
+ * the pre-existing behaviour. Instances are immutable and thread-safe.</p>
+ *
+ * @param points fixed outer width in points, or {@code 0} for the natural
+ *               (unconstrained) width
+ * @author Artem Demchyshyn
+ * @see com.demcha.compose.document.dsl.AbstractFlowBuilder#fixedWidth(double)
+ * @since 2.4.0
+ */
+public record DocumentFlowWidth(double points) {
+
+    private static final DocumentFlowWidth NATURAL = new DocumentFlowWidth(0.0);
+
+    /**
+     * Validates the width &mdash; finite and non-negative, where {@code 0} is the
+     * natural (unconstrained) width.
+     *
+     * @param points fixed outer width in points, or {@code 0} for natural
+     */
+    public DocumentFlowWidth {
+        if (Double.isNaN(points) || Double.isInfinite(points) || points < 0.0) {
+            throw new IllegalArgumentException("flow width must be finite and non-negative: " + points);
+        }
+    }
+
+    /**
+     * Returns the natural, content-driven width &mdash; the flow box takes the
+     * width its parent offers, exactly as it did before this constraint existed.
+     *
+     * @return the unconstrained flow width
+     */
+    public static DocumentFlowWidth natural() {
+        return NATURAL;
+    }
+
+    /**
+     * Returns a fixed flow width.
+     *
+     * @param points fixed outer width in points; must be finite and greater than zero
+     * @return a fixed flow width
+     * @throws IllegalArgumentException if {@code points} is NaN, infinite, zero or negative
+     */
+    public static DocumentFlowWidth of(double points) {
+        if (Double.isNaN(points) || Double.isInfinite(points) || points <= 0.0) {
+            throw new IllegalArgumentException(
+                    "fixed flow width must be finite and greater than zero: " + points);
+        }
+        return new DocumentFlowWidth(points);
+    }
+
+    /**
+     * Whether this value pins the horizontal size.
+     *
+     * @return true when a fixed width was requested, false for {@link #natural()}
+     */
+    public boolean isFixed() {
+        return points > 0.0;
+    }
+
+    /**
+     * Resolves the effective width to measure and place a flow box at, clamping a
+     * fixed request to the width the parent offers.
+     *
+     * @param availableWidth width the parent offers, in points
+     * @return the requested width capped at {@code availableWidth}, or
+     *         {@code availableWidth} itself for {@link #natural()}
+     */
+    public double resolve(double availableWidth) {
+        return isFixed() ? Math.min(points, availableWidth) : availableWidth;
+    }
+}

--- a/core/src/test/java/com/demcha/compose/document/dsl/FlowFixedWidthApiTest.java
+++ b/core/src/test/java/com/demcha/compose/document/dsl/FlowFixedWidthApiTest.java
@@ -1,0 +1,102 @@
+package com.demcha.compose.document.dsl;
+
+import com.demcha.compose.document.node.ContainerNode;
+import com.demcha.compose.document.node.DocumentNode;
+import com.demcha.compose.document.node.ParagraphNode;
+import com.demcha.compose.document.node.SectionNode;
+import com.demcha.compose.document.style.DocumentFlowWidth;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * The authoring half of the fixed-width flow: what {@code fixedWidth(...)} puts on
+ * the node, what it refuses, and that a flow which never calls it carries the same
+ * natural width it always did.
+ */
+class FlowFixedWidthApiTest {
+
+    @Test
+    void aSectionCarriesTheRequestedFixedWidth() {
+        SectionNode section = new SectionBuilder().name("Card").fixedWidth(240).build();
+
+        assertThat(section.flowWidth()).isEqualTo(DocumentFlowWidth.of(240));
+        assertThat(section.flowWidth().isFixed()).isTrue();
+    }
+
+    @Test
+    void aModuleCarriesTheRequestedFixedWidth() {
+        SectionNode module = new ModuleBuilder().title("Aside").fixedWidth(180).build();
+
+        assertThat(module.flowWidth()).isEqualTo(DocumentFlowWidth.of(180));
+    }
+
+    @Test
+    void aSectionThatNeverAsksIsNatural() {
+        SectionNode section = new SectionBuilder().name("Plain").addParagraph("body").build();
+
+        assertThat(section.flowWidth()).isEqualTo(DocumentFlowWidth.natural());
+        assertThat(section.flowWidth().isFixed()).isFalse();
+    }
+
+    @Test
+    void everyOtherNodeKindIsNaturalByDefault() {
+        DocumentNode paragraph = new ParagraphBuilder().text("body").build();
+
+        assertThat(paragraph).isInstanceOf(ParagraphNode.class);
+        assertThat(paragraph.flowWidth()).isEqualTo(DocumentFlowWidth.natural());
+    }
+
+    @Test
+    void fixedWidthRejectsZero() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new SectionBuilder().fixedWidth(0));
+    }
+
+    @Test
+    void fixedWidthRejectsNegativeValues() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new SectionBuilder().fixedWidth(-12));
+    }
+
+    @Test
+    void fixedWidthRejectsNaNAndInfinity() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new SectionBuilder().fixedWidth(Double.NaN));
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new SectionBuilder().fixedWidth(Double.POSITIVE_INFINITY));
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new SectionBuilder().fixedWidth(Double.NEGATIVE_INFINITY));
+    }
+
+    @Test
+    void aRejectedWidthLeavesTheBuilderUntouched() {
+        SectionBuilder builder = new SectionBuilder().name("Untouched");
+
+        assertThatIllegalArgumentException().isThrownBy(() -> builder.fixedWidth(0));
+
+        assertThat(builder.build().flowWidth()).isEqualTo(DocumentFlowWidth.natural());
+    }
+
+    @Test
+    void theCompatibilityConstructorsDefaultBothNodesToNatural() {
+        SectionNode section = new SectionNode("S", List.of(), 0, null, null, null, null, null, null,
+                false, null, null, null, false);
+        ContainerNode container = new ContainerNode("C", List.of(), 0, null, null, null, null, null, null,
+                null, null);
+
+        assertThat(section.flowWidth()).isEqualTo(DocumentFlowWidth.natural());
+        assertThat(container.flowWidth()).isEqualTo(DocumentFlowWidth.natural());
+    }
+
+    @Test
+    void aNullFlowWidthNormalizesToNatural() {
+        SectionNode section = new SectionNode("S", List.of(), 0, null, null, null, null, null, null,
+                false, null, null, null, false, null);
+        ContainerNode container = new ContainerNode("C", List.of(), 0, null, null, null, null, null, null,
+                null, null, null);
+
+        assertThat(section.flowWidth()).isEqualTo(DocumentFlowWidth.natural());
+        assertThat(container.flowWidth()).isEqualTo(DocumentFlowWidth.natural());
+    }
+}

--- a/core/src/test/java/com/demcha/compose/document/style/DocumentFlowWidthTest.java
+++ b/core/src/test/java/com/demcha/compose/document/style/DocumentFlowWidthTest.java
@@ -88,4 +88,17 @@ class DocumentFlowWidthTest {
         assertThatIllegalArgumentException().isThrownBy(() -> new DocumentFlowWidth(Double.POSITIVE_INFINITY));
         assertThatIllegalArgumentException().isThrownBy(() -> new DocumentFlowWidth(-3));
     }
+
+    @Test
+    void negativeZeroIsFoldedOntoNaturalRatherThanBecomingAnUnequalTwin() {
+        DocumentFlowWidth negativeZero = new DocumentFlowWidth(-0.0);
+
+        // -0.0 is not < 0.0, so it passes validation and lays out exactly like the
+        // natural width. Without folding it would compare unequal to natural() and
+        // hash to Integer.MIN_VALUE, so two identical layouts would look different.
+        assertThat(negativeZero).isEqualTo(DocumentFlowWidth.natural());
+        assertThat(negativeZero.hashCode()).isEqualTo(DocumentFlowWidth.natural().hashCode());
+        assertThat(negativeZero.isFixed()).isFalse();
+        assertThat(negativeZero.resolve(360)).isEqualTo(360.0);
+    }
 }

--- a/core/src/test/java/com/demcha/compose/document/style/DocumentFlowWidthTest.java
+++ b/core/src/test/java/com/demcha/compose/document/style/DocumentFlowWidthTest.java
@@ -1,0 +1,91 @@
+package com.demcha.compose.document.style;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+/**
+ * The flow-width value itself: what it accepts, what it refuses, and how it
+ * resolves against the width a parent offers.
+ */
+class DocumentFlowWidthTest {
+
+    @Test
+    void naturalIsUnconstrainedAndResolvesToWhateverTheParentOffers() {
+        DocumentFlowWidth natural = DocumentFlowWidth.natural();
+
+        assertThat(natural.isFixed()).isFalse();
+        assertThat(natural.points()).isZero();
+        assertThat(natural.resolve(500)).isEqualTo(500);
+        assertThat(natural.resolve(0)).isZero();
+    }
+
+    @Test
+    void naturalIsASingleton() {
+        assertThat(DocumentFlowWidth.natural()).isSameAs(DocumentFlowWidth.natural());
+    }
+
+    @Test
+    void fixedWidthResolvesToTheRequestedWidthWhenTheParentCanGiveIt() {
+        DocumentFlowWidth fixed = DocumentFlowWidth.of(240);
+
+        assertThat(fixed.isFixed()).isTrue();
+        assertThat(fixed.points()).isEqualTo(240.0);
+        assertThat(fixed.resolve(500)).isEqualTo(240.0);
+        assertThat(fixed.resolve(240)).isEqualTo(240.0);
+    }
+
+    @Test
+    void fixedWidthIsClampedToTheParentAvailableWidth() {
+        assertThat(DocumentFlowWidth.of(900).resolve(360)).isEqualTo(360.0);
+        assertThat(DocumentFlowWidth.of(900).resolve(0)).isZero();
+    }
+
+    @Test
+    void resolveIsIdempotentSoASecondNarrowingCannotShrinkTheBoxAgain() {
+        DocumentFlowWidth fixed = DocumentFlowWidth.of(180);
+
+        double once = fixed.resolve(400);
+
+        assertThat(fixed.resolve(once)).isEqualTo(once);
+    }
+
+    @Test
+    void ofRejectsZero() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> DocumentFlowWidth.of(0))
+                .withMessageContaining("greater than zero");
+    }
+
+    @Test
+    void ofRejectsNegativeWidth() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> DocumentFlowWidth.of(-1))
+                .withMessageContaining("greater than zero");
+    }
+
+    @Test
+    void ofRejectsNaN() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> DocumentFlowWidth.of(Double.NaN))
+                .withMessageContaining("finite");
+    }
+
+    @Test
+    void ofRejectsInfinity() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> DocumentFlowWidth.of(Double.POSITIVE_INFINITY))
+                .withMessageContaining("finite");
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> DocumentFlowWidth.of(Double.NEGATIVE_INFINITY))
+                .withMessageContaining("finite");
+    }
+
+    @Test
+    void theCanonicalConstructorRejectsNonFiniteAndNegativeValuesToo() {
+        assertThatIllegalArgumentException().isThrownBy(() -> new DocumentFlowWidth(Double.NaN));
+        assertThatIllegalArgumentException().isThrownBy(() -> new DocumentFlowWidth(Double.POSITIVE_INFINITY));
+        assertThatIllegalArgumentException().isThrownBy(() -> new DocumentFlowWidth(-3));
+    }
+}

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -11,6 +11,7 @@ authoring API; public application code should not import
 | --- | --- |
 | [Charts](recipes/charts.md) | Native vector bar / line / area / pie-donut charts: data–spec–style layers, axis & grid toggles, point markers, value-label halos, legend placement, translucent area fills |
 | [Keep-together pagination](recipes/keep-together.md) | `keepTogether()` / `keepEntriesTogether()` — blocks that relocate whole instead of orphaning a heading at a page break |
+| [Fixed-width flows](recipes/fixed-width-flows.md) | `fixedWidth(points)` — a section, module or page flow pinned to a narrow width, with the height left content-driven |
 | [Themes](recipes/themes.md) | `BrandTheme` token bundle (palette / typography / spacing / decoration), theme factories per family, page background, direct DSL styling |
 | [Shapes and visual primitives](recipes/shapes.md) | Filled cards, dividers, spacers, lines, ellipses, image fit modes, soft panels |
 | [Shape-as-container](recipes/shape-as-container.md) | `addCircle` / `addEllipse` / `addContainer` with `ClipPolicy` (clipped layered children) |

--- a/docs/recipes/fixed-width-flows.md
+++ b/docs/recipes/fixed-width-flows.md
@@ -56,6 +56,10 @@ it: the content wraps at the same width it would have without the call.
 Nesting clamps against the *parent box*, not the page — a `fixedWidth(320)`
 section inside a `fixedWidth(200).padding(10)` parent is placed at 180pt.
 
+Under per-page margins the cap is per page: a box that spans onto a page with
+a narrower content column is capped to that column rather than keeping the
+width of the page it started on.
+
 ## Where it applies
 
 | Surface | Call |
@@ -72,6 +76,12 @@ Two boundaries to know:
 - **Bleed still wins.** On an edge declared through `bleed(...)` the
   background reaches the trimmed page edge, because that is the point of
   asking for it.
+- **One case is currently off.** A flow used as a *row column* that also
+  carries a horizontal `margin` is placed narrower than it asked for, because
+  the row subtracts that margin twice before the width is resolved. The
+  underlying row defect predates this feature (it misplaces unconstrained
+  boxes too) and is being fixed separately; a fixed-width column with no
+  horizontal margin is unaffected.
 
 `fixedWidth` rejects NaN, infinity, zero and negative values outright, so a
 computed width that went wrong fails at the call rather than at layout time.

--- a/docs/recipes/fixed-width-flows.md
+++ b/docs/recipes/fixed-width-flows.md
@@ -1,0 +1,77 @@
+# Fixed-width flows: a narrow box in a wide column
+
+A vertical flow — a section, a module, the root page flow — is measured
+against the width its parent offers. That is right for body content, and
+wrong for a callout card, a sidebar aside, or a signature block that should
+stay narrow while the page around it stays wide.
+
+`fixedWidth(points)` pins the horizontal axis and leaves the vertical one
+alone:
+
+```java
+document.pageFlow()
+        .addSection("Callout", section -> section
+                .fixedWidth(240)                       // the box is 240pt wide
+                .softPanel(DocumentColor.WHITE, 8, 12) // fill, radius, padding
+                .addParagraph("Wraps inside 216pt of inner width."))
+        .build();
+```
+
+The box is measured, decorated and placed at exactly 240pt. Its children wrap
+inside `240 − padding.horizontal()`, so text re-flows into the narrower
+column instead of overflowing it.
+
+## Width is fixed, height is not
+
+This is a fixed **width**, not a fixed box. The height stays the natural,
+content-driven measurement it always was:
+
+| Change | Width | Height |
+|---|---|---|
+| Add a paragraph | unchanged | grows |
+| Narrow the fixed width | as requested | grows (more wrapped lines) |
+| Content shorter than the box | still the full fixed width | shrinks |
+
+There is no `fixedHeight` counterpart, and pagination is untouched: a
+fixed-width section flows and relocates exactly as it did before.
+
+## Padding is inside the fixed width
+
+The requested width is the **outer** width. Padding eats into it rather than
+being added on top, so a `fixedWidth(240).padding(20)` card occupies 240pt of
+the column and gives its children 200pt.
+
+## A request wider than the parent is clamped
+
+Asking for more width than the surrounding region can give resolves to the
+region's width rather than overflowing it or failing layout:
+
+```java
+section.fixedWidth(900)   // in a 360pt column → placed at 360pt
+```
+
+Clamping changes the reported width only, never the line breaking underneath
+it: the content wraps at the same width it would have without the call.
+
+Nesting clamps against the *parent box*, not the page — a `fixedWidth(320)`
+section inside a `fixedWidth(200).padding(10)` parent is placed at 180pt.
+
+## Where it applies
+
+| Surface | Call |
+|---|---|
+| Section | `addSection(s -> s.fixedWidth(240)…)` |
+| Module | `module(m -> m.fixedWidth(240)…)` |
+| Root page flow | `pageFlow(page -> page.fixedWidth(200)…)` |
+
+Two boundaries to know:
+
+- **Default off.** A flow that never calls `fixedWidth` keeps the
+  shrink-to-fit measurement it always had — an unpadded section still reports
+  the width of its widest child, capped at the column.
+- **Bleed still wins.** On an edge declared through `bleed(...)` the
+  background reaches the trimmed page edge, because that is the point of
+  asking for it.
+
+`fixedWidth` rejects NaN, infinity, zero and negative values outright, so a
+computed width that went wrong fails at the call rather than at layout time.

--- a/knowledge/api/authoring.json
+++ b/knowledge/api/authoring.json
@@ -22,10 +22,10 @@
     "graph-compose-testing:sources"
   ],
   "counts": {
-    "types": 232,
-    "methods": 2064,
+    "types": 233,
+    "methods": 2076,
     "constants": 230,
-    "generated": 1106
+    "generated": 1111
   },
   "packages": [
     {
@@ -5476,6 +5476,20 @@
                 {
                   "type": "DocumentEdge...",
                   "name": "edges"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "fixedWidth",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "T",
+              "params": [
+                {
+                  "type": "double",
+                  "name": "points"
                 }
               ]
             },
@@ -16571,6 +16585,64 @@
                 {
                   "type": "DocumentBookmarkOptions",
                   "name": null
+                },
+                {
+                  "type": "DocumentFlowWidth",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "constructor",
+              "name": "ContainerNode",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "String",
+                  "name": "name"
+                },
+                {
+                  "type": "List<DocumentNode>",
+                  "name": "children"
+                },
+                {
+                  "type": "double",
+                  "name": "spacing"
+                },
+                {
+                  "type": "DocumentInsets",
+                  "name": "padding"
+                },
+                {
+                  "type": "DocumentInsets",
+                  "name": "margin"
+                },
+                {
+                  "type": "DocumentColor",
+                  "name": "fillColor"
+                },
+                {
+                  "type": "DocumentStroke",
+                  "name": "stroke"
+                },
+                {
+                  "type": "DocumentCornerRadius",
+                  "name": "cornerRadius"
+                },
+                {
+                  "type": "DocumentBorders",
+                  "name": "borders"
+                },
+                {
+                  "type": "String",
+                  "name": "anchor"
+                },
+                {
+                  "type": "DocumentBookmarkOptions",
+                  "name": "bookmarkOptions"
                 }
               ]
             },
@@ -16847,6 +16919,15 @@
               "origin": "generated",
               "typeParameters": null,
               "returns": "DocumentBookmarkOptions",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "flowWidth",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "DocumentFlowWidth",
               "params": []
             }
           ]
@@ -17303,6 +17384,15 @@
               "origin": "generated",
               "typeParameters": null,
               "returns": "DocumentBleed",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "flowWidth",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "DocumentFlowWidth",
               "params": []
             }
           ]
@@ -22371,6 +22461,76 @@
                 {
                   "type": "boolean",
                   "name": null
+                },
+                {
+                  "type": "DocumentFlowWidth",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "constructor",
+              "name": "SectionNode",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "String",
+                  "name": "name"
+                },
+                {
+                  "type": "List<DocumentNode>",
+                  "name": "children"
+                },
+                {
+                  "type": "double",
+                  "name": "spacing"
+                },
+                {
+                  "type": "DocumentInsets",
+                  "name": "padding"
+                },
+                {
+                  "type": "DocumentInsets",
+                  "name": "margin"
+                },
+                {
+                  "type": "DocumentColor",
+                  "name": "fillColor"
+                },
+                {
+                  "type": "DocumentStroke",
+                  "name": "stroke"
+                },
+                {
+                  "type": "DocumentCornerRadius",
+                  "name": "cornerRadius"
+                },
+                {
+                  "type": "DocumentBorders",
+                  "name": "borders"
+                },
+                {
+                  "type": "boolean",
+                  "name": "keepTogether"
+                },
+                {
+                  "type": "String",
+                  "name": "anchor"
+                },
+                {
+                  "type": "DocumentBleed",
+                  "name": "bleed"
+                },
+                {
+                  "type": "DocumentBookmarkOptions",
+                  "name": "bookmarkOptions"
+                },
+                {
+                  "type": "boolean",
+                  "name": "keepWithNext"
                 }
               ]
             },
@@ -22848,6 +23008,15 @@
               "origin": "generated",
               "typeParameters": null,
               "returns": "boolean",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "flowWidth",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "DocumentFlowWidth",
               "params": []
             }
           ]
@@ -28456,6 +28625,86 @@
               "static": true,
               "origin": "generated",
               "type": "DocumentEdge"
+            }
+          ]
+        },
+        {
+          "name": "DocumentFlowWidth",
+          "binaryName": "com.demcha.compose.document.style.DocumentFlowWidth",
+          "kind": "record",
+          "modifiers": [
+            "final"
+          ],
+          "artifact": "graph-compose-core",
+          "members": [
+            {
+              "kind": "constructor",
+              "name": "DocumentFlowWidth",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": null,
+              "params": [
+                {
+                  "type": "double",
+                  "name": null
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "natural",
+              "static": true,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "DocumentFlowWidth",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "of",
+              "static": true,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "DocumentFlowWidth",
+              "params": [
+                {
+                  "type": "double",
+                  "name": "points"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "isFixed",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "boolean",
+              "params": []
+            },
+            {
+              "kind": "method",
+              "name": "resolve",
+              "static": false,
+              "origin": "source",
+              "typeParameters": null,
+              "returns": "double",
+              "params": [
+                {
+                  "type": "double",
+                  "name": "availableWidth"
+                }
+              ]
+            },
+            {
+              "kind": "method",
+              "name": "points",
+              "static": false,
+              "origin": "generated",
+              "typeParameters": null,
+              "returns": "double",
+              "params": []
             }
           ]
         },

--- a/knowledge/api/authoring.md
+++ b/knowledge/api/authoring.md
@@ -28,7 +28,7 @@ note: "Generated from the pinned artifact's class files. Authoritative closed se
 
 **GraphCompose version:** 2.4.0-SNAPSHOT
 
-Types: 232 · methods: 2064 · constants: 230 · compiler-generated members: 1106
+Types: 233 · methods: 2076 · constants: 230 · compiler-generated members: 1111
 
 ## com.demcha.compose
 
@@ -478,6 +478,7 @@ Types: 232 · methods: 2064 · constants: 230 · compiler-generated members: 110
 - `T margin(float top, float right, float bottom, float left)`
 - `T bleed(DocumentBleed bleed)`
 - `T bleedToEdge(DocumentEdge... edges)`
+- `T fixedWidth(double points)`
 - `T fillColor(Color fillColor)`
 - `T fillColor(DocumentColor fillColor)`
 - `T stroke(DocumentStroke stroke)`
@@ -1250,7 +1251,8 @@ Types: 232 · methods: 2064 · constants: 230 · compiler-generated members: 110
 - `DocumentInsets padding()`
 
 ### ContainerNode (record)
-- `new ContainerNode(String, List<DocumentNode>, double, DocumentInsets, DocumentInsets, DocumentColor, DocumentStroke, DocumentCornerRadius, DocumentBorders, String, DocumentBookmarkOptions)`
+- `new ContainerNode(String, List<DocumentNode>, double, DocumentInsets, DocumentInsets, DocumentColor, DocumentStroke, DocumentCornerRadius, DocumentBorders, String, DocumentBookmarkOptions, DocumentFlowWidth)`
+- `new ContainerNode(String name, List<DocumentNode> children, double spacing, DocumentInsets padding, DocumentInsets margin, DocumentColor fillColor, DocumentStroke stroke, DocumentCornerRadius cornerRadius, DocumentBorders borders, String anchor, DocumentBookmarkOptions bookmarkOptions)`
 - `new ContainerNode(String name, List<DocumentNode> children, double spacing, DocumentInsets padding, DocumentInsets margin, DocumentColor fillColor, DocumentStroke stroke, DocumentCornerRadius cornerRadius, DocumentBorders borders, String anchor)`
 - `new ContainerNode(String name, List<DocumentNode> children, double spacing, DocumentInsets padding, DocumentInsets margin, DocumentColor fillColor, DocumentStroke stroke, DocumentCornerRadius cornerRadius, DocumentBorders borders)`
 - `new ContainerNode(String name, List<DocumentNode> children, double spacing, DocumentInsets padding, DocumentInsets margin, DocumentColor fillColor, DocumentStroke stroke, DocumentCornerRadius cornerRadius)`
@@ -1266,6 +1268,7 @@ Types: 232 · methods: 2064 · constants: 230 · compiler-generated members: 110
 - `DocumentBorders borders()`
 - `String anchor()`
 - `DocumentBookmarkOptions bookmarkOptions()`
+- `DocumentFlowWidth flowWidth()`
 
 ### DocumentBarcodeOptions (class)
 - `DocumentBarcodeOptions.DocumentBarcodeOptionsBuilder builder()`
@@ -1311,6 +1314,7 @@ Types: 232 · methods: 2064 · constants: 230 · compiler-generated members: 110
 - `boolean keepTogether()`
 - `boolean keepWithNext()`
 - `DocumentBleed bleed()`
+- `DocumentFlowWidth flowWidth()`
 
 ### EllipseNode (record)
 - `new EllipseNode(String, double, double, DocumentColor, DocumentStroke, DocumentLinkTarget, DocumentBookmarkOptions, DocumentInsets, DocumentInsets, DocumentTransform, String)`
@@ -1625,7 +1629,8 @@ Types: 232 · methods: 2064 · constants: 230 · compiler-generated members: 110
 - constants: `TOP`, `CENTER`, `BOTTOM`
 
 ### SectionNode (record)
-- `new SectionNode(String, List<DocumentNode>, double, DocumentInsets, DocumentInsets, DocumentColor, DocumentStroke, DocumentCornerRadius, DocumentBorders, boolean, String, DocumentBleed, DocumentBookmarkOptions, boolean)`
+- `new SectionNode(String, List<DocumentNode>, double, DocumentInsets, DocumentInsets, DocumentColor, DocumentStroke, DocumentCornerRadius, DocumentBorders, boolean, String, DocumentBleed, DocumentBookmarkOptions, boolean, DocumentFlowWidth)`
+- `new SectionNode(String name, List<DocumentNode> children, double spacing, DocumentInsets padding, DocumentInsets margin, DocumentColor fillColor, DocumentStroke stroke, DocumentCornerRadius cornerRadius, DocumentBorders borders, boolean keepTogether, String anchor, DocumentBleed bleed, DocumentBookmarkOptions bookmarkOptions, boolean keepWithNext)`
 - `new SectionNode(String name, List<DocumentNode> children, double spacing, DocumentInsets padding, DocumentInsets margin, DocumentColor fillColor, DocumentStroke stroke, DocumentCornerRadius cornerRadius, DocumentBorders borders, boolean keepTogether, String anchor, DocumentBleed bleed, DocumentBookmarkOptions bookmarkOptions)`
 - `new SectionNode(String name, List<DocumentNode> children, double spacing, DocumentInsets padding, DocumentInsets margin, DocumentColor fillColor, DocumentStroke stroke, DocumentCornerRadius cornerRadius, DocumentBorders borders, boolean keepTogether, String anchor, DocumentBleed bleed)`
 - `new SectionNode(String name, List<DocumentNode> children, double spacing, DocumentInsets padding, DocumentInsets margin, DocumentColor fillColor, DocumentStroke stroke, DocumentCornerRadius cornerRadius, DocumentBorders borders, boolean keepTogether, String anchor)`
@@ -1647,6 +1652,7 @@ Types: 232 · methods: 2064 · constants: 230 · compiler-generated members: 110
 - `DocumentBleed bleed()`
 - `DocumentBookmarkOptions bookmarkOptions()`
 - `boolean keepWithNext()`
+- `DocumentFlowWidth flowWidth()`
 
 ### ShapeContainerNode (record)
 - `new ShapeContainerNode(String name, ShapeOutline outline, List<LayerStackNode.Layer> layers, ClipPolicy clipPolicy, DocumentColor fillColor, DocumentStroke stroke, DocumentInsets padding, DocumentInsets margin)`
@@ -2130,6 +2136,14 @@ Types: 232 · methods: 2064 · constants: 230 · compiler-generated members: 110
 
 ### DocumentEdge (enum)
 - constants: `TOP`, `RIGHT`, `BOTTOM`, `LEFT`
+
+### DocumentFlowWidth (record)
+- `new DocumentFlowWidth(double)`
+- `DocumentFlowWidth natural()`
+- `DocumentFlowWidth of(double points)`
+- `boolean isFixed()`
+- `double resolve(double availableWidth)`
+- `double points()`
 
 ### DocumentInsets (record)
 - `new DocumentInsets(double, double, double, double)`

--- a/qa/src/test/java/com/demcha/compose/document/api/FlowFixedWidthLayoutTest.java
+++ b/qa/src/test/java/com/demcha/compose/document/api/FlowFixedWidthLayoutTest.java
@@ -1,10 +1,13 @@
 package com.demcha.compose.document.api;
 
 import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.layout.PlacedFragment;
 import com.demcha.compose.document.layout.PlacedNode;
+import com.demcha.compose.document.layout.payloads.ShapeFragmentPayload;
 import com.demcha.compose.document.node.SectionNode;
 import com.demcha.compose.document.node.TextAlign;
 import com.demcha.compose.document.style.DocumentColor;
+import com.demcha.compose.document.style.DocumentEdge;
 import com.demcha.compose.document.style.DocumentFlowWidth;
 import com.demcha.compose.document.style.DocumentInsets;
 import com.demcha.compose.testing.layout.LayoutSnapshotAssertions;
@@ -19,6 +22,7 @@ import java.util.List;
 import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.within;
 
 /**
@@ -271,9 +275,56 @@ class FlowFixedWidthLayoutTest {
 
             // Whichever base placement re-derived, the children sit inside the box that
             // is actually painted — text can never wrap wider than its own background.
+            // The painted width itself is NOT asserted here: a row column with a
+            // horizontal margin has its margin subtracted twice before any clamp, so
+            // this card lands narrower than the 120pt it asked for. That is a
+            // pre-existing row defect (it reproduces with no fixedWidth at all) and is
+            // fixed separately; the width contract is pinned by the no-margin case below.
             assertThat(body.placementWidth()).isLessThanOrEqualTo(card.placementWidth() + 0.01);
             assertThat(body.placementX() + body.placementWidth())
                     .isLessThanOrEqualTo(card.placementX() + card.placementWidth() + 0.01);
+        }
+    }
+
+    @Test
+    void aFixedWidthSectionInARowSlotIsPlacedAtTheRequestedWidth() {
+        try (DocumentSession document = document()) {
+            document.pageFlow(page -> page.addRow(row -> row
+                    .name("Band")
+                    .addSection(s -> s
+                            .name("Card")
+                            .fixedWidth(120)
+                            .addParagraph(p -> p.name("Body").text("Short.").align(TextAlign.CENTER)))
+                    .addSection(s -> s.name("Filler").addParagraph("f"))));
+
+            // The row slot is 180pt wide; the card asked for 120 and must get exactly
+            // that, not the slot and not some re-derived fraction of it.
+            assertThat(node(document, "Card").placementWidth()).isCloseTo(120.0, within(0.01));
+            assertThat(node(document, "Body").placementWidth()).isCloseTo(120.0, within(0.01));
+        }
+    }
+
+    @Test
+    void bleedStillReachesThePageEdgeOnAFixedWidthSection() {
+        try (DocumentSession document = document()) {
+            document.pageFlow(page -> page.addSection(s -> s
+                    .name("Band")
+                    .fixedWidth(120)
+                    .fillColor(DocumentColor.rgb(226, 236, 245))
+                    .bleedToEdge(DocumentEdge.LEFT, DocumentEdge.RIGHT)
+                    .addParagraph("Bled band")));
+
+            PlacedNode band = node(document, "Band");
+            PlacedFragment fill = document.layoutGraph().fragments().stream()
+                    .filter(f -> f.payload() instanceof ShapeFragmentPayload)
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("no fill fragment for the bled band"));
+
+            // The documented precedence: the node keeps the width it asked for, while
+            // the decoration it opted to bleed still reaches both trimmed page edges.
+            assertThat(band.placementWidth()).isCloseTo(120.0, within(0.01));
+            assertThat(fill.x()).isCloseTo(0.0, within(0.01));
+            assertThat(fill.width()).isCloseTo(PAGE_WIDTH, within(0.01));
         }
     }
 
@@ -298,6 +349,54 @@ class FlowFixedWidthLayoutTest {
 
             assertThat(flow.placementWidth()).isCloseTo(200.0, within(0.01));
             assertThat(body.placementWidth()).isLessThanOrEqualTo(200.0 + 0.01);
+        }
+    }
+
+    @Test
+    void aFixedWidthRootFlowIsCappedByTheColumnOfALaterNarrowerPage() {
+        try (DocumentSession document = GraphCompose.document()
+                .pageSize(PAGE_WIDTH, PAGE_HEIGHT)
+                .margin(DocumentInsets.of(20))
+                .create()) {
+            // Page 2 onwards has an 80pt margin, so its content column is 240pt wide
+            // against page 1's 360pt. The root asks for 340pt: legal on page 1, wider
+            // than page 2 can hold. The x of a child starting on page 2 is re-seated to
+            // that page's margin, so a width left at page 1's value walks the child off
+            // the sheet — 80 + 340 = 420 on a 400pt page.
+            document.pageMargins(List.of(PageMarginRule.from(2, DocumentInsets.of(80))));
+            document.pageFlow(page -> page
+                    .name("WideFlow")
+                    .fixedWidth(340)
+                    .addSection(a -> a.name("PageOne").addParagraph("First page."))
+                    .addPageBreak(br -> br.name("ToPageTwo"))
+                    .addSection(b -> b.name("PageTwo")
+                            .addParagraph(p -> p.name("Body").text("Short.").align(TextAlign.CENTER))));
+
+            PlacedNode body = node(document, "Body");
+
+            assertThat(body.startPage()).as("the probe must actually land on page 2").isEqualTo(1);
+            assertThat(body.placementX() + body.placementWidth())
+                    .as("right edge must stay inside page 2's content column")
+                    .isLessThanOrEqualTo(PAGE_WIDTH - 80 + 0.01);
+            assertThat(body.placementWidth()).isLessThanOrEqualTo(240.0 + 0.01);
+        }
+    }
+
+    @Test
+    void aSubPointFixedWidthFailsNamingTheFixedWidthNotTheParent() {
+        try (DocumentSession document = document()) {
+            // A width below the engine's floor passes DocumentFlowWidth.of and can only
+            // fail at layout. The message has to name the knob the author actually
+            // turned, not send them to the parent's padding.
+            assertThatThrownBy(() -> {
+                document.pageFlow(page -> page.addSection(s -> s
+                        .name("Sliver")
+                        .fixedWidth(1e-9)
+                        .addParagraph(BODY)));
+                document.layoutGraph();
+            })
+                    .isInstanceOf(IllegalStateException.class)
+                    .hasMessageContaining("fixed width");
         }
     }
 

--- a/qa/src/test/java/com/demcha/compose/document/api/FlowFixedWidthLayoutTest.java
+++ b/qa/src/test/java/com/demcha/compose/document/api/FlowFixedWidthLayoutTest.java
@@ -1,0 +1,414 @@
+package com.demcha.compose.document.api;
+
+import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.layout.PlacedNode;
+import com.demcha.compose.document.node.SectionNode;
+import com.demcha.compose.document.node.TextAlign;
+import com.demcha.compose.document.style.DocumentColor;
+import com.demcha.compose.document.style.DocumentFlowWidth;
+import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.testing.layout.LayoutSnapshotAssertions;
+import com.demcha.compose.testing.layout.LayoutSnapshotJson;
+import com.demcha.testing.VisualTestOutputs;
+import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * Geometry for {@code fixedWidth(...)} on a vertical flow: the box takes the width
+ * it asked for, the height stays whatever the content measures to, and a flow that
+ * never asks keeps the layout it always had.
+ *
+ * <p>The page is 400&times;300 with a 20pt margin, so every scenario runs against a
+ * 360pt content column — wide enough that a 240pt request is honoured outright and
+ * a 900pt one has something to be clamped to.</p>
+ */
+class FlowFixedWidthLayoutTest {
+
+    private static final double PAGE_WIDTH = 400;
+    private static final double PAGE_HEIGHT = 300;
+    private static final double INNER_WIDTH = 360;
+    private static final String BODY =
+            "A fixed width pins the horizontal axis and leaves the height to the content.";
+
+    // --- the width is the width that was asked for -------------------------
+
+    @Test
+    void aFixedWidthSectionIsPlacedAtTheRequestedWidth() {
+        try (DocumentSession document = document()) {
+            document.pageFlow(page -> page.addSection(s -> s
+                    .name("Card")
+                    .fixedWidth(240)
+                    .addParagraph(BODY)));
+
+            assertThat(node(document, "Card").placementWidth()).isCloseTo(240.0, within(0.01));
+        }
+    }
+
+    @Test
+    void aFixedWidthSectionWithOneParagraphMatchesItsLayoutSnapshot() throws Exception {
+        try (DocumentSession document = document()) {
+            document.pageFlow(page -> page
+                    .name("FixedWidthFlow")
+                    .addSection(s -> s.name("Card").fixedWidth(240).addParagraph(BODY)));
+
+            LayoutSnapshotAssertions.assertMatches(document, "flow-fixed-width/section_fixed_width");
+        }
+    }
+
+    @Test
+    void anUnconstrainedSectionKeepsItsShrinkToFitWidth() {
+        try (DocumentSession document = document()) {
+            document.pageFlow(page -> page.addSection(s -> s
+                    .name("Plain")
+                    .addParagraph(p -> p.name("Body").text(BODY))));
+
+            PlacedNode plain = node(document, "Plain");
+            PlacedNode body = node(document, "Body");
+
+            // The pre-existing measurement, untouched: an unpadded section reports the
+            // width of its widest child, capped at the column — it hugs its content
+            // rather than filling the column.
+            assertThat(plain.placementWidth()).isCloseTo(body.placementWidth(), within(0.01));
+            assertThat(plain.placementWidth()).isLessThanOrEqualTo(INNER_WIDTH);
+        }
+    }
+
+    @Test
+    void aFixedWidthSectionPinsItsWidthWhereAnUnconstrainedOneHugsItsContent() {
+        PlacedNode fixed = cardWith(s -> s.fixedWidth(240).addParagraph(BODY));
+        PlacedNode hugging = cardWith(s -> s.addParagraph(BODY));
+
+        // The whole point of the feature: the fixed box is the width that was asked
+        // for even though its content does not fill it.
+        assertThat(fixed.placementWidth()).isCloseTo(240.0, within(0.01));
+        assertThat(hugging.placementWidth()).isNotCloseTo(240.0, within(0.01));
+    }
+
+    // --- height stays content-driven ---------------------------------------
+
+    @Test
+    void growingTheContentAddsHeightAndLeavesTheWidthAlone() {
+        PlacedNode one = cardWith(s -> s.fixedWidth(240).addParagraph(BODY));
+        PlacedNode three = cardWith(s -> s.fixedWidth(240)
+                .addParagraph(BODY)
+                .addParagraph(BODY)
+                .addParagraph(BODY));
+
+        assertThat(three.placementWidth()).isCloseTo(one.placementWidth(), within(0.01));
+        assertThat(three.placementHeight()).isGreaterThan(one.placementHeight());
+    }
+
+    @Test
+    void theFixedWidthNeverIntroducesAFixedHeight() {
+        PlacedNode shortCard = cardWith(s -> s.fixedWidth(240).addParagraph("One line."));
+        PlacedNode tallCard = cardWith(s -> s.fixedWidth(240).addParagraph(BODY + " " + BODY));
+
+        assertThat(tallCard.placementHeight()).isGreaterThan(shortCard.placementHeight());
+    }
+
+    // --- narrowing re-wraps -------------------------------------------------
+
+    @Test
+    void narrowingTheFixedWidthReWrapsTheContentIntoMoreLines() {
+        PlacedNode wide = cardWith(s -> s.fixedWidth(300).addParagraph(BODY));
+        PlacedNode narrow = cardWith(s -> s.fixedWidth(120).addParagraph(BODY));
+
+        assertThat(narrow.placementWidth()).isCloseTo(120.0, within(0.01));
+        assertThat(wide.placementWidth()).isCloseTo(300.0, within(0.01));
+        // Same words in a third of the width: the only way for them to fit is more
+        // lines, which is height the box did not have before.
+        assertThat(narrow.placementHeight()).isGreaterThan(wide.placementHeight());
+    }
+
+    @Test
+    void theChildIsMeasuredInsideTheFixedWidthNotTheParentColumn() {
+        try (DocumentSession document = document()) {
+            document.pageFlow(page -> page.addSection(s -> s
+                    .name("Card")
+                    .fixedWidth(160)
+                    .addSection(inner -> inner.name("Body").addParagraph(BODY))));
+
+            assertThat(node(document, "Body").placementWidth()).isLessThanOrEqualTo(160.0);
+        }
+    }
+
+    // --- padding sits inside the fixed outer width --------------------------
+
+    @Test
+    void paddingStaysInsideTheFixedOuterWidth() {
+        try (DocumentSession document = document()) {
+            document.pageFlow(page -> page.addSection(s -> s
+                    .name("Card")
+                    .fixedWidth(240)
+                    .padding(DocumentInsets.of(20))
+                    .addSection(inner -> inner.name("Body").addParagraph(BODY))));
+
+            PlacedNode card = node(document, "Card");
+            PlacedNode body = node(document, "Body");
+
+            // The fixed width is the OUTER width: padding eats into it rather than
+            // being added on top of it.
+            assertThat(card.placementWidth()).isCloseTo(240.0, within(0.01));
+            assertThat(body.placementX()).isCloseTo(card.placementX() + 20, within(0.01));
+            assertThat(body.placementWidth()).isLessThanOrEqualTo(200.0 + 0.01);
+            assertThat(body.placementX() + body.placementWidth())
+                    .isLessThanOrEqualTo(card.placementX() + 240.0 + 0.01);
+        }
+    }
+
+    // --- clamping -----------------------------------------------------------
+
+    @Test
+    void aWidthWiderThanTheParentIsClampedToTheParent() {
+        PlacedNode clamped = cardWith(s -> s.fixedWidth(900).addParagraph(BODY));
+
+        assertThat(clamped.placementWidth()).isCloseTo(INNER_WIDTH, within(0.01));
+    }
+
+    @Test
+    void aClampedWidthWrapsItsContentTheSameWayAnUnconstrainedFlowDoes() {
+        PlacedNode clamped = cardWith(s -> s.fixedWidth(900).addParagraph(BODY));
+        PlacedNode unconstrained = cardWith(s -> s.addParagraph(BODY));
+
+        // Both measure their children inside the same 360pt column, so the content
+        // wraps identically and the box is the same height — clamping changes the
+        // reported width, never the line breaking underneath it.
+        assertThat(clamped.placementHeight()).isCloseTo(unconstrained.placementHeight(), within(0.01));
+        assertThat(clamped.placementY()).isCloseTo(unconstrained.placementY(), within(0.01));
+        assertThat(clamped.placementWidth()).isCloseTo(INNER_WIDTH, within(0.01));
+    }
+
+    @Test
+    void aClampedWidthNeverOverflowsTheColumn() {
+        PlacedNode clamped = cardWith(s -> s.fixedWidth(900).addParagraph(BODY));
+
+        assertThat(clamped.placementX() + clamped.placementWidth())
+                .isLessThanOrEqualTo(20 + INNER_WIDTH + 0.01);
+    }
+
+    // --- nesting ------------------------------------------------------------
+
+    @Test
+    void nestedFixedWidthFlowsEachHonourTheirOwnWidth() {
+        try (DocumentSession document = document()) {
+            document.pageFlow(page -> page.addSection(outer -> outer
+                    .name("Outer")
+                    .fixedWidth(300)
+                    .addSection(inner -> inner.name("Inner").fixedWidth(160).addParagraph(BODY))));
+
+            assertThat(node(document, "Outer").placementWidth()).isCloseTo(300.0, within(0.01));
+            assertThat(node(document, "Inner").placementWidth()).isCloseTo(160.0, within(0.01));
+        }
+    }
+
+    @Test
+    void aNestedFlowIsClampedByItsFixedWidthParentNotByThePage() {
+        try (DocumentSession document = document()) {
+            document.pageFlow(page -> page.addSection(outer -> outer
+                    .name("Outer")
+                    .fixedWidth(200)
+                    .padding(DocumentInsets.of(10))
+                    .addSection(inner -> inner.name("Inner").fixedWidth(320).addParagraph(BODY))));
+
+            // The inner box asked for more than the outer box's 180pt inner width and
+            // is clamped to it, not to the page's 360pt column.
+            assertThat(node(document, "Inner").placementWidth()).isCloseTo(180.0, within(0.01));
+        }
+    }
+
+    @Test
+    void nestedFixedWidthFlowMatchesItsLayoutSnapshot() throws Exception {
+        try (DocumentSession document = document()) {
+            document.pageFlow(page -> page
+                    .name("NestedFixedWidthFlow")
+                    .addSection(outer -> outer
+                            .name("Outer")
+                            .fixedWidth(300)
+                            .padding(DocumentInsets.of(12))
+                            .addSection(inner -> inner
+                                    .name("Inner")
+                                    .fixedWidth(160)
+                                    .addParagraph(BODY))));
+
+            LayoutSnapshotAssertions.assertMatches(document, "flow-fixed-width/nested_fixed_width");
+        }
+    }
+
+    // --- the painted box and the wrapping width are the same number ---------
+
+    @Test
+    void aFixedWidthSectionInARowSlotSeatsItsChildrenInsideThePaintedBox() {
+        try (DocumentSession document = document()) {
+            document.pageFlow(page -> page.addRow(row -> row
+                    .name("Band")
+                    .addSection(s -> s
+                            .name("Card")
+                            // A horizontal margin is what makes the two bases differ: the
+                            // row prepares this child against the slot less its margin and
+                            // then hands placement the whole slot. Content is kept short so
+                            // the row's own (pre-existing, unrelated) height check does not
+                            // fire and hide the width assertion below.
+                            .margin(new DocumentInsets(0, 20, 0, 20))
+                            .fixedWidth(120)
+                            // A centred paragraph reports the full width it was given
+                            // rather than shrinking to its longest line, so its placed
+                            // width IS the region the box handed its children — which is
+                            // the number under test. A left-aligned one would hug its
+                            // text and hide the difference.
+                            .addParagraph(p -> p.name("Body").text("Short.").align(TextAlign.CENTER)))
+                    .addSection(s -> s.name("Filler").addParagraph("f"))));
+
+            PlacedNode card = node(document, "Card");
+            PlacedNode body = node(document, "Body");
+
+            // Whichever base placement re-derived, the children sit inside the box that
+            // is actually painted — text can never wrap wider than its own background.
+            assertThat(body.placementWidth()).isLessThanOrEqualTo(card.placementWidth() + 0.01);
+            assertThat(body.placementX() + body.placementWidth())
+                    .isLessThanOrEqualTo(card.placementX() + card.placementWidth() + 0.01);
+        }
+    }
+
+    @Test
+    void aFixedWidthRootFlowKeepsItsWidthUnderPerPageMargins() {
+        try (DocumentSession document = GraphCompose.document()
+                .pageSize(PAGE_WIDTH, PAGE_HEIGHT)
+                .margin(DocumentInsets.of(20))
+                .create()) {
+            // Per-page margins send the ROOT walk down the page-column branch, which
+            // re-derives each direct child's region from the page it starts on — a
+            // different number from the root's own width (280 here, not 200). A
+            // fixed-width root owns its width there too, so its children stay inside it.
+            document.pageMargins(List.of(PageMarginRule.page(1, DocumentInsets.of(60))));
+            document.pageFlow(page -> page
+                    .name("NarrowFlow")
+                    .fixedWidth(200)
+                    .addParagraph(p -> p.name("Body").text("Short.").align(TextAlign.CENTER)));
+
+            PlacedNode flow = node(document, "NarrowFlow");
+            PlacedNode body = node(document, "Body");
+
+            assertThat(flow.placementWidth()).isCloseTo(200.0, within(0.01));
+            assertThat(body.placementWidth()).isLessThanOrEqualTo(200.0 + 0.01);
+        }
+    }
+
+    // --- the root flow container -------------------------------------------
+
+    @Test
+    void aFixedWidthRootFlowNarrowsItselfAndItsChildren() {
+        try (DocumentSession document = document()) {
+            document.pageFlow(page -> page
+                    .name("NarrowFlow")
+                    .fixedWidth(200)
+                    .addSection(s -> s.name("Card").addParagraph(BODY)));
+
+            assertThat(node(document, "NarrowFlow").placementWidth()).isCloseTo(200.0, within(0.01));
+            assertThat(node(document, "Card").placementWidth()).isLessThanOrEqualTo(200.0 + 0.01);
+        }
+    }
+
+    // --- nothing moved for flows that never opted in ------------------------
+
+    /**
+     * Proves the compatibility constructor defaults to {@code natural()} and that the
+     * default is inert down to the serialized snapshot. It does <em>not</em> by itself
+     * prove compatibility with pre-change output — the evidence for that is every
+     * committed layout snapshot in the repository still matching after this change.
+     */
+    @Test
+    void aSectionBuiltThroughTheCompatibilityConstructorLaysOutIdenticallyToOneGivenNatural() throws Exception {
+        String viaCompatibilityConstructor = snapshotJsonOf(new SectionNode(
+                "Card", List.of(paragraph()), 6, DocumentInsets.of(8), DocumentInsets.zero(),
+                null, null, null, null, false, null, null, null, false));
+        String viaCanonicalConstructor = snapshotJsonOf(new SectionNode(
+                "Card", List.of(paragraph()), 6, DocumentInsets.of(8), DocumentInsets.zero(),
+                null, null, null, null, false, null, null, null, false, DocumentFlowWidth.natural()));
+
+        // The new record component is inert unless something asks for it: the old
+        // constructor and the new one agree down to the serialized snapshot.
+        assertThat(viaCanonicalConstructor).isEqualTo(viaCompatibilityConstructor);
+    }
+
+    // --- visual artifact ----------------------------------------------------
+
+    @Test
+    void fixedWidthFlowRendersToPdf() throws Exception {
+        try (DocumentSession document = GraphCompose.document()
+                .pageSize(PAGE_WIDTH, PAGE_HEIGHT)
+                .margin(DocumentInsets.of(20))
+                .create()) {
+            document.pageFlow(page -> page
+                    .name("FixedWidthShowcase")
+                    .spacing(10)
+                    .addParagraph("Unconstrained — hugs its content.")
+                    // The fills are what make the pinned width visible: the panel is
+                    // the box, so a reader can see 240 and 120 rather than infer them
+                    // from where the text happens to wrap.
+                    .addSection(s -> s
+                            .name("Card240")
+                            .fixedWidth(240)
+                            .softPanel(DocumentColor.rgb(226, 236, 245), 6, 8)
+                            .addParagraph("fixedWidth(240), padding inside it. " + BODY))
+                    .addSection(s -> s
+                            .name("Card120")
+                            .fixedWidth(120)
+                            .softPanel(DocumentColor.rgb(245, 232, 226), 6, 8)
+                            .addParagraph("fixedWidth(120) — same words, more lines.")));
+
+            byte[] pdf = document.toPdfBytes();
+            Path output = VisualTestOutputs.preparePdf("flow_fixed_width", "flow-fixed-width");
+            Files.write(output, pdf);
+
+            assertThat(pdf).isNotEmpty();
+            assertThat(new String(pdf, 0, 5, StandardCharsets.US_ASCII)).isEqualTo("%PDF-");
+        }
+    }
+
+    // --- helpers ------------------------------------------------------------
+
+    private static DocumentSession document() {
+        return GraphCompose.document()
+                .pageSize(PAGE_WIDTH, PAGE_HEIGHT)
+                .margin(DocumentInsets.of(20))
+                .create();
+    }
+
+    private static com.demcha.compose.document.node.ParagraphNode paragraph() {
+        return new com.demcha.compose.document.dsl.ParagraphBuilder().name("Body").text(BODY).build();
+    }
+
+    /** Lays out a single named "Card" section configured by {@code spec} and returns its placed node. */
+    private static PlacedNode cardWith(Consumer<com.demcha.compose.document.dsl.SectionBuilder> spec) {
+        try (DocumentSession document = document()) {
+            document.pageFlow(page -> page.addSection(s -> {
+                s.name("Card");
+                spec.accept(s);
+            }));
+            return node(document, "Card");
+        }
+    }
+
+    private static String snapshotJsonOf(SectionNode section) throws java.io.IOException {
+        try (DocumentSession document = document()) {
+            document.pageFlow(page -> page.name("Flow").add(section));
+            return LayoutSnapshotJson.toJson(document.layoutSnapshot());
+        }
+    }
+
+    private static PlacedNode node(DocumentSession document, String semanticName) {
+        return document.layoutGraph().nodes().stream()
+                .filter(n -> semanticName.equals(n.semanticName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "no node named '" + semanticName + "' in the layout graph"));
+    }
+}

--- a/qa/src/test/resources/layout-snapshots/flow-fixed-width/nested_fixed_width.json
+++ b/qa/src/test/resources/layout-snapshots/flow-fixed-width/nested_fixed_width.json
@@ -1,0 +1,137 @@
+{
+  "formatVersion" : "2.0",
+  "canvas" : {
+    "pageWidth" : 400.0,
+    "pageHeight" : 300.0,
+    "innerWidth" : 360.0,
+    "innerHeight" : 260.0,
+    "margin" : {
+      "top" : 20.0,
+      "right" : 20.0,
+      "bottom" : 20.0,
+      "left" : 20.0
+    }
+  },
+  "totalPages" : 1,
+  "nodes" : [ {
+    "path" : "NestedFixedWidthFlow[0]",
+    "entityName" : "NestedFixedWidthFlow",
+    "entityKind" : "ContainerNode",
+    "parentPath" : null,
+    "childIndex" : 0,
+    "depth" : 1,
+    "layer" : 1,
+    "computedX" : 20.0,
+    "computedY" : 204.2,
+    "placementX" : 20.0,
+    "placementY" : 204.2,
+    "placementWidth" : 300.0,
+    "placementHeight" : 75.8,
+    "startPage" : 0,
+    "endPage" : 0,
+    "contentWidth" : 300.0,
+    "contentHeight" : 75.8,
+    "margin" : {
+      "top" : 0.0,
+      "right" : 0.0,
+      "bottom" : 0.0,
+      "left" : 0.0
+    },
+    "padding" : {
+      "top" : 0.0,
+      "right" : 0.0,
+      "bottom" : 0.0,
+      "left" : 0.0
+    }
+  }, {
+    "path" : "NestedFixedWidthFlow[0]/Outer[0]",
+    "entityName" : "Outer",
+    "entityKind" : "SectionNode",
+    "parentPath" : "NestedFixedWidthFlow[0]",
+    "childIndex" : 0,
+    "depth" : 2,
+    "layer" : 2,
+    "computedX" : 20.0,
+    "computedY" : 204.2,
+    "placementX" : 20.0,
+    "placementY" : 204.2,
+    "placementWidth" : 300.0,
+    "placementHeight" : 75.8,
+    "startPage" : 0,
+    "endPage" : 0,
+    "contentWidth" : 300.0,
+    "contentHeight" : 75.8,
+    "margin" : {
+      "top" : 0.0,
+      "right" : 0.0,
+      "bottom" : 0.0,
+      "left" : 0.0
+    },
+    "padding" : {
+      "top" : 12.0,
+      "right" : 12.0,
+      "bottom" : 12.0,
+      "left" : 12.0
+    }
+  }, {
+    "path" : "NestedFixedWidthFlow[0]/Outer[0]/Inner[0]",
+    "entityName" : "Inner",
+    "entityKind" : "SectionNode",
+    "parentPath" : "NestedFixedWidthFlow[0]/Outer[0]",
+    "childIndex" : 0,
+    "depth" : 3,
+    "layer" : 3,
+    "computedX" : 32.0,
+    "computedY" : 216.2,
+    "placementX" : 32.0,
+    "placementY" : 216.2,
+    "placementWidth" : 160.0,
+    "placementHeight" : 51.8,
+    "startPage" : 0,
+    "endPage" : 0,
+    "contentWidth" : 160.0,
+    "contentHeight" : 51.8,
+    "margin" : {
+      "top" : 0.0,
+      "right" : 0.0,
+      "bottom" : 0.0,
+      "left" : 0.0
+    },
+    "padding" : {
+      "top" : 0.0,
+      "right" : 0.0,
+      "bottom" : 0.0,
+      "left" : 0.0
+    }
+  }, {
+    "path" : "NestedFixedWidthFlow[0]/Outer[0]/Inner[0]/ParagraphNode[0]",
+    "entityName" : null,
+    "entityKind" : "ParagraphNode",
+    "parentPath" : "NestedFixedWidthFlow[0]/Outer[0]/Inner[0]",
+    "childIndex" : 0,
+    "depth" : 4,
+    "layer" : 4,
+    "computedX" : 32.0,
+    "computedY" : 216.2,
+    "placementX" : 32.0,
+    "placementY" : 216.2,
+    "placementWidth" : 144.76,
+    "placementHeight" : 51.8,
+    "startPage" : 0,
+    "endPage" : 0,
+    "contentWidth" : 144.76,
+    "contentHeight" : 51.8,
+    "margin" : {
+      "top" : 0.0,
+      "right" : 0.0,
+      "bottom" : 0.0,
+      "left" : 0.0
+    },
+    "padding" : {
+      "top" : 0.0,
+      "right" : 0.0,
+      "bottom" : 0.0,
+      "left" : 0.0
+    }
+  } ]
+}

--- a/qa/src/test/resources/layout-snapshots/flow-fixed-width/section_fixed_width.json
+++ b/qa/src/test/resources/layout-snapshots/flow-fixed-width/section_fixed_width.json
@@ -1,0 +1,107 @@
+{
+  "formatVersion" : "2.0",
+  "canvas" : {
+    "pageWidth" : 400.0,
+    "pageHeight" : 300.0,
+    "innerWidth" : 360.0,
+    "innerHeight" : 260.0,
+    "margin" : {
+      "top" : 20.0,
+      "right" : 20.0,
+      "bottom" : 20.0,
+      "left" : 20.0
+    }
+  },
+  "totalPages" : 1,
+  "nodes" : [ {
+    "path" : "FixedWidthFlow[0]",
+    "entityName" : "FixedWidthFlow",
+    "entityKind" : "ContainerNode",
+    "parentPath" : null,
+    "childIndex" : 0,
+    "depth" : 1,
+    "layer" : 1,
+    "computedX" : 20.0,
+    "computedY" : 254.1,
+    "placementX" : 20.0,
+    "placementY" : 254.1,
+    "placementWidth" : 240.0,
+    "placementHeight" : 25.9,
+    "startPage" : 0,
+    "endPage" : 0,
+    "contentWidth" : 240.0,
+    "contentHeight" : 25.9,
+    "margin" : {
+      "top" : 0.0,
+      "right" : 0.0,
+      "bottom" : 0.0,
+      "left" : 0.0
+    },
+    "padding" : {
+      "top" : 0.0,
+      "right" : 0.0,
+      "bottom" : 0.0,
+      "left" : 0.0
+    }
+  }, {
+    "path" : "FixedWidthFlow[0]/Card[0]",
+    "entityName" : "Card",
+    "entityKind" : "SectionNode",
+    "parentPath" : "FixedWidthFlow[0]",
+    "childIndex" : 0,
+    "depth" : 2,
+    "layer" : 2,
+    "computedX" : 20.0,
+    "computedY" : 254.1,
+    "placementX" : 20.0,
+    "placementY" : 254.1,
+    "placementWidth" : 240.0,
+    "placementHeight" : 25.9,
+    "startPage" : 0,
+    "endPage" : 0,
+    "contentWidth" : 240.0,
+    "contentHeight" : 25.9,
+    "margin" : {
+      "top" : 0.0,
+      "right" : 0.0,
+      "bottom" : 0.0,
+      "left" : 0.0
+    },
+    "padding" : {
+      "top" : 0.0,
+      "right" : 0.0,
+      "bottom" : 0.0,
+      "left" : 0.0
+    }
+  }, {
+    "path" : "FixedWidthFlow[0]/Card[0]/ParagraphNode[0]",
+    "entityName" : null,
+    "entityKind" : "ParagraphNode",
+    "parentPath" : "FixedWidthFlow[0]/Card[0]",
+    "childIndex" : 0,
+    "depth" : 3,
+    "layer" : 3,
+    "computedX" : 20.0,
+    "computedY" : 254.1,
+    "placementX" : 20.0,
+    "placementY" : 254.1,
+    "placementWidth" : 225.708,
+    "placementHeight" : 25.9,
+    "startPage" : 0,
+    "endPage" : 0,
+    "contentWidth" : 225.708,
+    "contentHeight" : 25.9,
+    "margin" : {
+      "top" : 0.0,
+      "right" : 0.0,
+      "bottom" : 0.0,
+      "left" : 0.0
+    },
+    "padding" : {
+      "top" : 0.0,
+      "right" : 0.0,
+      "bottom" : 0.0,
+      "left" : 0.0
+    }
+  } ]
+}


### PR DESCRIPTION
## Why

A vertical flow — a section, a module, the root page flow — is measured against the
width its parent offers. That is right for body content and wrong for a callout card,
a sidebar aside, or a signature block that should stay narrow while the page around it
stays wide.

Narrowing one used to mean expressing the width as something else: a row whose
neighbouring slot soaks up the remainder, or a large one-sided `margin`. Neither pins a
width — both leave the box free to shrink to its content inside the space they carve
out — and both make the width a property of the box's surroundings rather than of the
box that wants it.

## What changed

- **`AbstractFlowBuilder.fixedWidth(double)`** pins the horizontal axis, so
  `addSection(s -> s.fixedWidth(240))`, `module(m -> m.fixedWidth(240))` and
  `pageFlow(page -> page.fixedWidth(200))` all measure, decorate and place the box at
  exactly that width and wrap its children inside it less the flow's own padding. Only
  the horizontal axis: the height stays the natural content measurement, so the box
  still grows as paragraphs are added and paginates unchanged. There is deliberately no
  `fixedHeight` counterpart — a fixed box is a different feature with different
  pagination consequences.
- **`DocumentFlowWidth`** (`natural()` / `of(points)`) carries the value, reachable
  through a new `DocumentNode.flowWidth()` default and stored on `SectionNode` and
  `ContainerNode`. Both records keep their previous constructors and default to
  `natural()`, so existing callers compile, link and lay out unchanged.
- **Measurement** resolves the constraint in `NodeDefinitionSupport.measureComposite`
  through `BoxConstraints.natural(width)` rather than duplicating the height logic; a
  fixed box reports the requested width whether or not its content fills it, so the
  decoration is the width that was asked for instead of shrink-to-fit.
- **Placement** caps a node's own width in `LayoutCompiler.childAvailableWidth`. Callers
  reach that seam with different bases — a row column prepares its child against the
  slot less the child's margin but hands placement the whole slot — so a fixed box seats
  its children inside the width it was **measured** at rather than a re-derived one.
  That is what keeps the painted box and the wrapping width the same number.
- **Per-page margins**: the root walk re-derives each direct child's region from the page
  that child starts on, and it re-seats the child's x there too. A fixed width is
  therefore capped by the column of the page the child lands on, not left at the start
  page's value — otherwise the width stays wide while the x moves to a narrower page's
  margin and walks the child off the sheet.
- **Validation**: `NaN`, infinity, zero and negative are rejected at the call. `-0.0` is
  folded onto `+0.0` in the canonical constructor, since it lays out exactly like
  `natural()` but would compare unequal to it and hash to `Integer.MIN_VALUE`. A
  sub-point width can only fail at layout, and now fails naming the fixed width instead
  of blaming the parent's padding.

Also removed the 5-arg `measureComposite` overload: it has no caller, and the
`@Internal` layout package is excluded from the binary gate, so nothing obliged it.
Left in place it invites the next composite definition to measure at natural width while
its constraint has already been narrowed.

## Verification

`./mvnw -B -ntp clean verify -pl :graph-compose-core,:graph-compose-render-pdf,:graph-compose-render-docx,:graph-compose-render-pptx,:graph-compose-templates,:graph-compose-testing,:graph-compose-qa,:graph-compose-coverage -am`
→ **BUILD SUCCESS**, 11/11 modules, **2078 tests**, 0 failures, on a branch rebased onto
current `develop`.

**+45 tests**, in three classes:

- `DocumentFlowWidthTest` (11) — natural is a singleton resolving to whatever the parent
  offers; a fixed value resolves to the request and clamps to the parent; `resolve` is
  idempotent; every rejected input (`0`, negative, `NaN`, ±infinity) throws; `-0.0` folds
  onto `natural()` with an equal `hashCode`.
- `FlowFixedWidthApiTest` (10) — all three builders carry the value onto their node,
  every other node kind is natural by default, a rejected width leaves the builder
  untouched, and both compatibility constructors (plus a `null`) default to `natural()`.
- `FlowFixedWidthLayoutTest` (24) — the placed geometry: the box is the requested width
  while an unconstrained one hugs its content; growing content adds height and leaves
  the width alone; narrowing re-wraps into more lines; padding stays inside the fixed
  outer width; a request wider than the parent clamps without changing how content
  wraps; nested flows each honour their own width and clamp against the parent box; a
  fixed root flow is capped by the column of a later, narrower page; and `bleed` still
  reaches the trimmed page edge on a fixed-width section.

Two layout-snapshot baselines are added (`flow-fixed-width/section_fixed_width`,
`nested_fixed_width`) and a preview lands at
`target/visual-tests/flow-fixed-width/flow_fixed_width.pdf`. **No committed snapshot or
preview moves** — a flow that never calls `fixedWidth` keeps the shrink-to-fit
measurement it already had, and each changed expression reduces to the previous one
under `natural()`.

Binary compatibility: `-P japicmp` against the 2.0.0 baseline reports **only additions**
for these types — the previous `SectionNode` / `ContainerNode` constructors survive.
`javadoc:javadoc` and the knowledge-pack gates (`extract-api --check`, `check-claims`,
`check-routes`, fixture suites) are green; `knowledge/api/authoring.{json,md}` are
regenerated in the same change.

## Notes

One configuration is knowingly still wrong: a fixed-width flow used as a **row column
that also carries a horizontal margin** is placed narrower than it asked for, because
the row path subtracts that margin twice before the width is resolved. That defect
predates this feature — it misplaces unconstrained boxes in the same shape, throwing
`exceeds row inner height` for ordinary content — so it is fixed separately rather than
worked around here. The row test pins the width for the no-margin case and says why the
margin case asserts containment only; the recipe and CHANGELOG both name the limit.

Documented in [`docs/recipes/fixed-width-flows.md`](docs/recipes/fixed-width-flows.md),
linked from the recipe catalogue, with a CHANGELOG entry under `## v2.4.0 — Planned`.

**Lane:** canonical (`document.style` / `document.dsl` / `document.node` public surface)
plus shared-engine (`document.layout` measurement and placement seams) — the public
value type and builder method are canonical; the two clamp seams are engine internals.
