### PR TITLE
fix(layout): take a margin off once between measure and placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,32 @@ follow semantic versioning; release dates are ISO 8601.
   templates, the examples or the fixtures puts a horizontal margin on a row
   child, which is also why neither gate caught this.
 
+- **A margin on composed table-cell content is honoured, and honoured by both
+  passes.** The node handed to `DocumentTableCell.node(...)` was measured at the
+  cell's full inner width with its margin left in, and then laid out by the
+  fixed-box walk, which removes that margin itself — so the content re-wrapped
+  one margin narrower than the row had been sized for and painted below its own
+  table, while its box shifted right and overhung the next column. The vertical
+  axis failed the other way round: the cell height ignored the margin outright
+  while placement still applied `margin.top`, dropping the content through the
+  cell floor. On a leaf child — a bare paragraph or image — the margin was
+  discarded altogether.
+
+  A cell's inner box is now the content's margin box, the same contract a row
+  slot uses: the measure subtracts the margin once and the row reserves it on
+  both axes. The seam that made this possible is also closed. A
+  `FragmentPlacement` is a *content* box — every caller builds one at the exact
+  rectangle the content should occupy and passes `Margin.zero()` — but
+  `emitCompositeSubtree` handed it to the fixed-box walk, which reads a *margin*
+  box; it now converts between the two, so a composite child is laid out in the
+  rectangle its owner reserved rather than one margin inside it.
+
+  **This changes output only for composed cell content that carries a margin**,
+  which now sits inside the room the cell reserves for it instead of spilling
+  out. Content without one is untouched — every conversion is an identity at
+  zero — and no layout snapshot, pixel baseline or committed preview moves:
+  every composed cell in the templates and the examples uses zero margins.
+
 ### Documentation
 
 - **A row's width rule, and what `fill()` does when there is no slot.** Two things a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,37 @@ follow semantic versioning; release dates are ISO 8601.
   neither gate; the coverage for this change is the unit test and the two
   previews.
 
+- **A row child with a horizontal margin is measured and placed at the same
+  width.** A row band is sized in two passes over the same children:
+  `measureRow` prepares each child inside its slot less that child's own margin
+  and takes the tallest result as the band height, then `LayoutCompiler`
+  prepares it again to place it. The placement pass handed
+  `prepareForRegionWidth` a width the margin had already been taken out of —
+  and that helper subtracts the margin itself — so the child was laid out at
+  `slot - 2 * margin` against a band measured from `slot - margin`. Given
+  enough text to wrap, the second subtraction bought an extra line and the
+  row's own guard rejected the document it had just measured: `Row '…' child
+  'SectionNode' measured height … exceeds row inner height`. A left or right
+  inset on a row child was the whole trigger; a section wrapping a paragraph is
+  the shortest way to reach it.
+
+  Both copies of the seating loop are fixed — the page-level row band and
+  `placeRowBandInFixedSlot`, which seats a row nested in a LayerStack layer or
+  a composed table cell — so the whole slot goes in and the margin comes off
+  once. Only the page-level band throws; the other two symptoms were silent. In
+  a fixed-slot band there is no inner-height guard, so a margin-carrying tallest
+  child was simply seated above its band and spilled through the top under a
+  non-`TOP` `verticalAlign`. And `compileNodeInFixedSlot` always derived its own
+  region as `slot - margin`, so a composite row child reported one width while
+  its own children were laid out in another.
+
+  **This changes output only for a row child carrying a left or right margin**,
+  which now occupies its slot less that margin rather than less twice it. A row
+  child without one is untouched, the arithmetic being identical at zero, and
+  no layout snapshot, pixel baseline or committed preview moves: nothing in the
+  templates, the examples or the fixtures puts a horizontal margin on a row
+  child, which is also why neither gate caught this.
+
 ### Documentation
 
 - **A row's width rule, and what `fill()` does when there is no slot.** Two things a

--- a/core/src/main/java/com/demcha/compose/document/layout/DocumentLayoutPassContext.java
+++ b/core/src/main/java/com/demcha/compose/document/layout/DocumentLayoutPassContext.java
@@ -200,14 +200,23 @@ public final class DocumentLayoutPassContext implements PrepareContext, Fragment
         if (subtreeCompiler == null) {
             subtreeCompiler = new LayoutCompiler(registry);
         }
+        // A FragmentPlacement is the child's CONTENT box — every caller builds one
+        // at the exact rectangle the content should occupy and passes
+        // Margin.zero(). The fixed-box walk takes a slot, which is a MARGIN box,
+        // and removes the node's margin itself, so the box is grown by that margin
+        // here and comes back out the same rectangle. Without this the margin came
+        // off a second time and the subtree was laid out narrower and lower than
+        // the owner reserved for it. Identity when the margin is zero, which is
+        // every composed cell and chart primitive shipped today.
+        com.demcha.compose.document.style.DocumentInsets margin = child.node().margin();
         List<PlacedFragment> placed = subtreeCompiler.compileFixedBoxSubtree(
                 child,
                 placement.parentPath(),
                 placement.childIndex(),
                 placement.depth(),
-                placement.x(),
-                placement.y() + placement.height(),
-                placement.width(),
+                placement.x() - margin.left(),
+                placement.y() + placement.height() + margin.top(),
+                placement.width() + margin.horizontal(),
                 placement.pageIndex(),
                 canvas,
                 this,

--- a/core/src/main/java/com/demcha/compose/document/layout/LayoutCompiler.java
+++ b/core/src/main/java/com/demcha/compose/document/layout/LayoutCompiler.java
@@ -485,10 +485,14 @@ public final class LayoutCompiler {
                 Margin childMargin = toMargin(child.margin());
                 double slotWidth = slotWidths[index];
                 double childRegionX = cursorX + childMargin.left();
-                double childInnerWidth = Math.max(0.0, slotWidth - childMargin.horizontal());
 
+                // The whole slot goes in — prepareForRegionWidth removes the child's
+                // margin itself. Pre-subtracting it here took it off twice, so the
+                // child was prepared at slot - 2 * margin while measureRow had sized
+                // the band from slot - margin, and the extra wrap tripped the guard
+                // below.
                 PreparedNode<DocumentNode> childPrepared =
-                        prepareForRegionWidth(prepareContext, child, childInnerWidth);
+                        prepareForRegionWidth(prepareContext, child, slotWidth);
                 MeasureResult childMeasure = childPrepared.measureResult();
                 @SuppressWarnings("unchecked")
                 NodeDefinition<DocumentNode> childDefinition =
@@ -1181,9 +1185,9 @@ public final class LayoutCompiler {
             DocumentNode child = children.get(index);
             Margin childMargin = toMargin(child.margin());
             double slotWidth = slotWidths[index];
-            double childInnerWidth = Math.max(0.0, slotWidth - childMargin.horizontal());
+            // Whole slot, one margin subtraction — see the page-level row band.
             PreparedNode<DocumentNode> childPrepared =
-                    prepareForRegionWidth(prepareContext, child, childInnerWidth);
+                    prepareForRegionWidth(prepareContext, child, slotWidth);
 
             // Cross-axis seating, identical to the page-level row band: TOP
             // yields offset 0.0, so a TOP row places exactly where the plain
@@ -1209,6 +1213,21 @@ public final class LayoutCompiler {
         }
     }
 
+    /**
+     * Prepares a node for the region its <em>margin box</em> occupies.
+     *
+     * <p>Pass the whole region — the parent's content width, or a row slot — never
+     * one the node's own margin has already been taken out of: the subtraction
+     * happens here, in {@link #childAvailableWidth}. Pre-subtracting takes the
+     * margin off twice and prepares the node narrower than
+     * {@link NodeDefinitionSupport#measureRow} measured it, which is what the row
+     * band's inner-height guard then rejects.</p>
+     *
+     * @param prepareContext measurement context
+     * @param node           the node to prepare
+     * @param regionWidth    width of the region the node's margin box sits in
+     * @return the node prepared at the width {@link #childAvailableWidth} resolves for it
+     */
     private PreparedNode<DocumentNode> prepareForRegionWidth(PrepareContext prepareContext,
                                                              DocumentNode node,
                                                              double regionWidth) {
@@ -1220,16 +1239,20 @@ public final class LayoutCompiler {
      * parent offers, less the node's own margin, narrowed to the node's declared
      * horizontal size constraint.
      *
-     * <p>This caps the width a node may occupy, which is what the overflow guard in
-     * {@code compileNode} compares a measurement against. It is deliberately NOT
-     * the number a fixed-width box seats its children in: callers reach this method
-     * with different bases (a row column passes the whole slot to placement but the
-     * slot less the child's margin to prepare), so a box's children follow its
-     * measured width instead — see the {@code fixedWidth} branches in
-     * {@code compileComposite} and {@code compileNodeInFixedSlot}.</p>
+     * <p>{@code regionWidth} is the region the node's <em>margin box</em> occupies,
+     * and the margin comes off here — every caller passes a whole region, never one
+     * it has already inset. This caps the width a node may occupy, which is what the
+     * overflow guard in {@code compileNode} compares a measurement against. It is
+     * deliberately NOT the number a fixed-width box seats its children in: a box's
+     * children follow its measured width instead — see the {@code fixedWidth}
+     * branches in {@code compileComposite} and {@code compileNodeInFixedSlot}.</p>
      *
      * <p>A natural {@code DocumentFlowWidth}, which every node carries unless it
      * opted in, resolves to the region width and leaves this exactly as it was.</p>
+     *
+     * @param regionWidth width of the region the node's margin box sits in
+     * @param node        the node whose margin is removed
+     * @return the width available to the node itself, never negative
      */
     private double childAvailableWidth(double regionWidth, DocumentNode node) {
         Margin margin = toMargin(node.margin());

--- a/core/src/main/java/com/demcha/compose/document/layout/NodeDefinitionSupport.java
+++ b/core/src/main/java/com/demcha/compose/document/layout/NodeDefinitionSupport.java
@@ -733,7 +733,14 @@ public final class NodeDefinitionSupport {
                 style.padding() == null
                         ? com.demcha.compose.engine.components.style.Padding.zero()
                         : style.padding();
-        double childWidth = Math.max(0.0, cellWidth - padding.horizontal());
+        // The cell's inner box is the content's margin box — the same contract a
+        // row slot uses — so the placement handed on below is the content box
+        // inside it. TableLayoutSupport measures against exactly these two
+        // quantities, which is what keeps the reserved row and the drawn content
+        // the same size.
+        DocumentInsets contentMargin = child.node().margin();
+        double childWidth = Math.max(0.0,
+                cellWidth - padding.horizontal() - contentMargin.horizontal());
         double childHeight = Math.max(0.0, child.measureResult().height());
         // Where in the cell's box the child sits. Follows resolveTextLines on
         // the vertical axis: same default (centre, from
@@ -750,11 +757,11 @@ public final class NodeDefinitionSupport {
         // input reachable today produces that: a row is sized from the content
         // it holds, so this is a guard, not a behaviour anyone can observe.
         double innerHeight = Math.max(0.0, cellHeight - padding.vertical());
-        double slack = Math.max(0.0, innerHeight - childHeight);
+        double slack = Math.max(0.0, innerHeight - childHeight - contentMargin.vertical());
         Anchor anchor = style.textAnchor() == null
                 ? Anchor.centerLeft()
                 : style.textAnchor();
-        double contentBottom = padding.bottom() + switch (anchor.v()) {
+        double contentBottom = padding.bottom() + contentMargin.bottom() + switch (anchor.v()) {
             case TOP -> slack;
             case MIDDLE -> slack / 2.0;
             case BOTTOM, DEFAULT -> 0.0;
@@ -764,7 +771,7 @@ public final class NodeDefinitionSupport {
         // absolute location so the child node's emitFragments lays
         // its content out as if it were a top-level placement of the
         // cell's content area.
-        double childAbsoluteX = parentPlacement.x() + cellLocalX + padding.left();
+        double childAbsoluteX = parentPlacement.x() + cellLocalX + padding.left() + contentMargin.left();
         double childAbsoluteY = parentPlacement.y() + cellLocalY + contentBottom;
         String childPath = parentPlacement.path() + ".cell" + cellLocalX + "x" + cellLocalY;
         FragmentPlacement childPlacement = new FragmentPlacement(
@@ -790,7 +797,7 @@ public final class NodeDefinitionSupport {
         if (childFragments.isEmpty()) {
             return List.of();
         }
-        double offsetX = cellLocalX + padding.left();
+        double offsetX = cellLocalX + padding.left() + contentMargin.left();
         // Same anchor as the placement above. These two have to agree: the
         // placement decides where the child measures itself against, this
         // decides where its fragments land, and a difference between them

--- a/core/src/main/java/com/demcha/compose/document/layout/TableLayoutSupport.java
+++ b/core/src/main/java/com/demcha/compose/document/layout/TableLayoutSupport.java
@@ -190,8 +190,15 @@ final class TableLayoutSupport {
                 TableCellLayoutStyle style = stylesGrid[rowIndex][logical.startColumn()];
                 Padding padding = style.padding() == null ? Padding.zero() : style.padding();
                 double cellInnerWidth = Math.max(0.0, cellOuterWidth - padding.horizontal());
+                // The cell's inner box is the content's MARGIN box, as a row slot
+                // is: measure inside the margin, because the fragment pass places
+                // the content inside it too. Measuring at the full inner width
+                // instead re-wrapped the content narrower than the row was sized
+                // for, and it painted below its own table.
+                double contentWidth = Math.max(0.0,
+                        cellInnerWidth - src.content().margin().horizontal());
                 PreparedNode<?> child = prepareContext.prepare(src.content(),
-                        BoxConstraints.unboundedHeight(cellInnerWidth));
+                        BoxConstraints.unboundedHeight(contentWidth));
                 prepared.put(new CellKey(rowIndex, logical.startColumn()), child);
             }
         }
@@ -217,7 +224,11 @@ final class TableLayoutSupport {
                         + ") was not prepared.");
             }
             Padding padding = style.padding() == null ? Padding.zero() : style.padding();
-            return prepared.measureResult().height() + padding.vertical();
+            // The content's own vertical margin is part of what the cell has to
+            // reserve — placement offsets it by margin.top, so a height that
+            // ignored the margin dropped the content through the cell floor.
+            double margin = logical.source().content().margin().vertical();
+            return prepared.measureResult().height() + margin + padding.vertical();
         }
         return cellNaturalHeight(logical.sanitizedLines(), style, measurement);
     }

--- a/qa/src/test/java/com/demcha/compose/document/layout/RowChildMarginWidthTest.java
+++ b/qa/src/test/java/com/demcha/compose/document/layout/RowChildMarginWidthTest.java
@@ -1,0 +1,228 @@
+package com.demcha.compose.document.layout;
+
+import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.api.DocumentSession;
+import com.demcha.compose.document.node.DocumentNode;
+import com.demcha.compose.document.node.LayerStackNode;
+import com.demcha.compose.document.node.ParagraphNode;
+import com.demcha.compose.document.node.RowNode;
+import com.demcha.compose.document.node.RowVerticalAlign;
+import com.demcha.compose.document.node.SectionNode;
+import com.demcha.compose.document.node.TextAlign;
+import com.demcha.compose.document.style.DocumentBorders;
+import com.demcha.compose.document.style.DocumentCornerRadius;
+import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.document.style.DocumentTextStyle;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * A row child that carries a horizontal margin is measured and placed at one
+ * and the same width.
+ *
+ * <p>A row band is sized in two passes over the same children.
+ * {@code NodeDefinitionSupport.measureRow} prepares each child inside its slot
+ * minus that child's own margin and takes the tallest result as the band
+ * height; {@code LayoutCompiler} then prepares the child a second time to place
+ * it. Both passes must start from the same base, or the band is sized against
+ * one wrap and drawn from another.</p>
+ *
+ * <p>The placement pass used to hand {@code prepareForRegionWidth} a width the
+ * child's margin had already been taken out of, and that helper subtracts the
+ * margin itself — so placement ran at {@code slot - 2 * margin} against the
+ * measure pass's {@code slot - margin}. The child wrapped into more lines than
+ * the band was measured for, and the row band's own guard rejected the layout:
+ * <em>child 'SectionNode' measured height … exceeds row inner height</em>.</p>
+ *
+ * <p>Two of the three symptoms never threw. The fixed-slot band — a row nested
+ * in a LayerStack layer or a composed table cell — carries no such guard, so
+ * there the child simply spilled through the top of its band; and a composite
+ * row child reported one width while its own children were laid out in another.
+ * The assertions below read the width base back out directly rather than
+ * waiting for an exception, so they cover the silent cases too.</p>
+ */
+class RowChildMarginWidthTest {
+
+    /** Page 400 wide with 20pt page margins: a 360pt content region. */
+    private static final double PAGE_WIDTH = 400;
+    private static final double PAGE_HEIGHT = 300;
+    private static final double PAGE_MARGIN = 20;
+
+    /** Two children, no gap, no weights: each slot is half the region. */
+    private static final double SLOT_WIDTH = (PAGE_WIDTH - 2 * PAGE_MARGIN) / 2;
+    private static final double CHILD_MARGIN = 20;
+    private static final double EXPECTED_CHILD_WIDTH = SLOT_WIDTH - 2 * CHILD_MARGIN;
+
+    private static final double TOLERANCE = 0.01;
+
+    /**
+     * A paragraph that reports the width it was measured at. A LEFT-aligned
+     * paragraph shrink-wraps to its longest line, which would hide the base
+     * behind the text metrics; CENTER resolves to the full available width, so
+     * the placed width is the measurement base itself.
+     */
+    private static ParagraphNode fillingParagraph(String name, DocumentInsets margin) {
+        return fillingParagraph(name, "Card body", margin);
+    }
+
+    private static ParagraphNode fillingParagraph(String name, String text, DocumentInsets margin) {
+        return new ParagraphNode(name, text, DocumentTextStyle.DEFAULT, TextAlign.CENTER, 0.0,
+                DocumentInsets.zero(), margin);
+    }
+
+    /** A row whose first child carries a 20pt margin on each side. */
+    private static RowNode rowWithAMarginCarryingChild(String name) {
+        return new RowNode(name,
+                List.of(fillingParagraph("Card", new DocumentInsets(0, CHILD_MARGIN, 0, CHILD_MARGIN)),
+                        fillingParagraph("Filler", DocumentInsets.zero())),
+                List.of(), 0.0,
+                DocumentInsets.zero(), DocumentInsets.zero(),
+                null, null, DocumentCornerRadius.ZERO);
+    }
+
+    private static double placedWidthOf(DocumentNode root, String semanticName) throws Exception {
+        try (DocumentSession session = GraphCompose.document()
+                .pageSize(PAGE_WIDTH, PAGE_HEIGHT)
+                .margin(DocumentInsets.of(PAGE_MARGIN))
+                .create()) {
+            session.add(root);
+            return placedNode(session.layoutGraph(), semanticName).placementWidth();
+        }
+    }
+
+    private static PlacedNode placedNode(LayoutGraph graph, String semanticName) {
+        return graph.nodes().stream()
+                .filter(node -> semanticName.equals(node.semanticName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(semanticName + " was not placed"));
+    }
+
+    /** Top edge of a placed node in PDF coordinates, where y grows upward. */
+    private static double topOf(PlacedNode node) {
+        return node.placementY() + node.placementHeight();
+    }
+
+    @Test
+    void aRowChildWithAHorizontalMarginIsPlacedAtItsSlotMinusThatMarginOnce() throws Exception {
+        assertThat(placedWidthOf(rowWithAMarginCarryingChild("Band"), "Card"))
+                .describedAs("a %spt slot less one %spt horizontal margin", SLOT_WIDTH, 2 * CHILD_MARGIN)
+                .isCloseTo(EXPECTED_CHILD_WIDTH, within(TOLERANCE));
+    }
+
+    @Test
+    void aRowChildInsideAFixedRectangleUsesTheSameBase() throws Exception {
+        // The fixed-slot row band (a LayerStack layer, a composed table cell) is a
+        // second copy of the same seating loop, and carried the same double
+        // subtraction. A row fills its region and a stack shrink-wraps to its
+        // widest layer, so the nested row band is the same 360pt wide.
+        DocumentNode stack = new LayerStackNode(
+                "Stack",
+                List.of(new LayerStackNode.Layer(rowWithAMarginCarryingChild("LayerBand"))),
+                DocumentInsets.zero(), DocumentInsets.zero());
+
+        assertThat(placedWidthOf(stack, "Card"))
+                .describedAs("a row band in a fixed rectangle measures its children like a page-level row")
+                .isCloseTo(EXPECTED_CHILD_WIDTH, within(TOLERANCE));
+    }
+
+    @Test
+    void aCompositeRowChildAgreesWithTheRegionItsOwnChildrenAreLaidOutIn() throws Exception {
+        // A composite row child is seated by compileNodeInFixedSlot, which derives
+        // the region for its children from the whole slot on its own. So the
+        // composite used to disagree with itself: its own reported width came from
+        // the double-subtracted prepare (slot - 2 * margin) while its children were
+        // laid out in slot - margin. Reading the section and the paragraph inside it
+        // is what exposes that — the child alone was always right.
+        DocumentNode row = new RowNode("Band",
+                List.of(new SectionNode("Card",
+                                List.of(fillingParagraph("Body", DocumentInsets.zero())),
+                                0.0, DocumentInsets.zero(),
+                                new DocumentInsets(0, CHILD_MARGIN, 0, CHILD_MARGIN),
+                                null, null, DocumentCornerRadius.ZERO, DocumentBorders.NONE, false),
+                        fillingParagraph("Filler", DocumentInsets.zero())),
+                List.of(), 0.0,
+                DocumentInsets.zero(), DocumentInsets.zero(),
+                null, null, DocumentCornerRadius.ZERO);
+
+        try (DocumentSession session = GraphCompose.document()
+                .pageSize(PAGE_WIDTH, PAGE_HEIGHT)
+                .margin(DocumentInsets.of(PAGE_MARGIN))
+                .create()) {
+            session.add(row);
+            LayoutGraph graph = session.layoutGraph();
+            double cardWidth = placedNode(graph, "Card").placementWidth();
+
+            assertThat(cardWidth)
+                    .describedAs("the composite row child takes its slot less one margin")
+                    .isCloseTo(EXPECTED_CHILD_WIDTH, within(TOLERANCE));
+            assertThat(cardWidth)
+                    .describedAs("the composite's own width matches the region its children were given")
+                    .isCloseTo(placedNode(graph, "Body").placementWidth(), within(TOLERANCE));
+        }
+    }
+
+    @Test
+    void aMarginCarryingChildStaysInsideAFixedSlotBandThatHasNoGuard() throws Exception {
+        // The page-level row band throws when a child outgrows it. The fixed-slot
+        // band has no such guard, so there the same disagreement was silent: the
+        // tallest child, measured wider than it was placed, came out taller than
+        // the band sized for it, the cross-axis slack went negative, and a
+        // non-TOP alignment pushed the child up and out through the band's top.
+        RowNode band = new RowNode("LayerBand",
+                List.of(fillingParagraph("Card",
+                                "A fixed width pins the horizontal axis and leaves the height to the content.",
+                                new DocumentInsets(0, CHILD_MARGIN, 0, CHILD_MARGIN)),
+                        fillingParagraph("Filler", DocumentInsets.zero())),
+                List.of(), 0.0,
+                DocumentInsets.zero(), DocumentInsets.zero(),
+                null, null, DocumentCornerRadius.ZERO, DocumentBorders.NONE, List.of(),
+                RowVerticalAlign.CENTER);
+        DocumentNode stack = new LayerStackNode(
+                "Stack",
+                List.of(new LayerStackNode.Layer(band)),
+                DocumentInsets.zero(), DocumentInsets.zero());
+
+        try (DocumentSession session = GraphCompose.document()
+                .pageSize(PAGE_WIDTH, PAGE_HEIGHT)
+                .margin(DocumentInsets.of(PAGE_MARGIN))
+                .create()) {
+            session.add(stack);
+            LayoutGraph graph = session.layoutGraph();
+
+            assertThat(topOf(placedNode(graph, "Card")))
+                    .describedAs("the tallest row child must not be seated above the band that holds it")
+                    .isLessThanOrEqualTo(topOf(placedNode(graph, "Stack")) + TOLERANCE);
+        }
+    }
+
+    @Test
+    void aMarginCarryingSectionDoesNotOutgrowTheBandItWasMeasuredFor() {
+        // The reported repro. The section is measured at slot - margin, wraps to
+        // the band height that produced, and was then placed at slot - 2 * margin —
+        // where the same text needs one line more than the band has room for, and
+        // the row band's own guard throws.
+        assertThatCode(() -> {
+            try (DocumentSession session = GraphCompose.document()
+                    .pageSize(PAGE_WIDTH, PAGE_HEIGHT)
+                    .margin(DocumentInsets.of(PAGE_MARGIN))
+                    .create()) {
+                session.pageFlow(page -> page.addRow(row -> row
+                        .name("Band")
+                        .addSection(s -> s
+                                .name("Card")
+                                .margin(new DocumentInsets(0, CHILD_MARGIN, 0, CHILD_MARGIN))
+                                .addSection(inner -> inner.name("Body").addParagraph(
+                                        "A fixed width pins the horizontal axis and leaves the height to the content.")))
+                        .addSection(s -> s.name("Filler").addParagraph("filler"))));
+                session.layoutGraph();
+            }
+        })
+                .describedAs("a row child's wrap must not disagree with the band measured for it")
+                .doesNotThrowAnyException();
+    }
+}

--- a/qa/src/test/java/com/demcha/compose/document/table/ComposedCellMarginTest.java
+++ b/qa/src/test/java/com/demcha/compose/document/table/ComposedCellMarginTest.java
@@ -1,0 +1,133 @@
+package com.demcha.compose.document.table;
+
+import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.api.DocumentSession;
+import com.demcha.compose.document.layout.LayoutGraph;
+import com.demcha.compose.document.layout.PlacedFragment;
+import com.demcha.compose.document.layout.payloads.ParagraphFragmentPayload;
+import com.demcha.compose.document.layout.payloads.TableRowFragmentPayload;
+import com.demcha.compose.document.node.DocumentNode;
+import com.demcha.compose.document.node.ParagraphNode;
+import com.demcha.compose.document.node.SectionNode;
+import com.demcha.compose.document.node.TableNode;
+import com.demcha.compose.document.node.TextAlign;
+import com.demcha.compose.document.style.DocumentBorders;
+import com.demcha.compose.document.style.DocumentCornerRadius;
+import com.demcha.compose.document.style.DocumentInsets;
+import com.demcha.compose.document.style.DocumentTextStyle;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * A margin on the node handed to {@link DocumentTableCell#node} is honoured,
+ * and honoured in both passes.
+ *
+ * <p>The cell reserves a box for its composed content, then the fragment pass
+ * lays that content out inside the box. Those two have to start from the same
+ * geometry. They did not: the cell was measured at its full inner width with
+ * the node's margin left in, and the fixed-box walk that places a composite
+ * subtracts that margin itself — so the content re-wrapped one margin narrower
+ * than the row was sized for and painted below the table, while its own box
+ * shifted right and overhung the next column. On the vertical axis the cell
+ * height ignored the margin outright while placement applied {@code margin.top},
+ * dropping the content through the cell floor. A margin on a leaf composed
+ * child was discarded entirely.</p>
+ *
+ * <p>Every assertion here is containment: the content of a cell stays inside
+ * the table that reserved room for it. That is the property a margin must not
+ * be able to break, and it holds whatever the font metrics are.</p>
+ */
+class ComposedCellMarginTest {
+
+    private static final double TOLERANCE = 0.5;
+
+    /** Wide enough that the text wraps, so a narrower placement costs a line. */
+    private static final String BODY =
+            "A fixed width pins the horizontal axis and leaves the height to the content.";
+
+    private static ParagraphNode paragraph(String name, DocumentInsets margin) {
+        return new ParagraphNode(name, BODY, DocumentTextStyle.DEFAULT, TextAlign.LEFT, 0.0,
+                DocumentInsets.zero(), margin);
+    }
+
+    /** A composite composed child — the branch that goes through the fixed-box walk. */
+    private static DocumentNode section(DocumentInsets margin) {
+        return new SectionNode("Card", List.of(paragraph("Body", DocumentInsets.zero())),
+                0.0, DocumentInsets.zero(), margin,
+                null, null, DocumentCornerRadius.ZERO, DocumentBorders.NONE, false);
+    }
+
+    private static TableNode tableWith(DocumentNode composed) {
+        return new TableNode(
+                "MarginTable",
+                List.of(DocumentTableColumn.fixed(260)),
+                List.of(List.of(DocumentTableCell.node(composed))),
+                DocumentTableStyle.empty(),
+                260.0,
+                DocumentInsets.zero(),
+                DocumentInsets.zero());
+    }
+
+    private static LayoutGraph layout(DocumentNode composed) {
+        try (DocumentSession session = GraphCompose.document()
+                .pageSize(400, 400)
+                .margin(DocumentInsets.of(20))
+                .create()) {
+            session.add(tableWith(composed));
+            return session.layoutGraph();
+        }
+    }
+
+    private static PlacedFragment text(LayoutGraph graph) {
+        List<PlacedFragment> paragraphs = graph.fragments().stream()
+                .filter(f -> f.payload() instanceof ParagraphFragmentPayload)
+                .toList();
+        assertThat(paragraphs).as("the composed cell contributes paragraph fragments").isNotEmpty();
+        return paragraphs.get(paragraphs.size() - 1);
+    }
+
+    /** The table row's own box — the room the measure pass reserved. */
+    private static PlacedFragment row(LayoutGraph graph) {
+        List<PlacedFragment> rows = graph.fragments().stream()
+                .filter(f -> f.payload() instanceof TableRowFragmentPayload)
+                .toList();
+        assertThat(rows).hasSize(1);
+        return rows.get(0);
+    }
+
+    @Test
+    void aHorizontalMarginOnComposedContentDoesNotPushItBelowItsOwnTable() {
+        LayoutGraph graph = layout(section(new DocumentInsets(0, 20, 0, 20)));
+
+        assertThat(text(graph).y())
+                .describedAs("content measured at one width and placed at another outgrows its row")
+                .isGreaterThanOrEqualTo(row(graph).y() - TOLERANCE);
+    }
+
+    @Test
+    void aVerticalMarginOnComposedContentIsReservedByTheCell() {
+        LayoutGraph graph = layout(section(new DocumentInsets(20, 0, 20, 0)));
+
+        // Placement applies margin.top; the cell height has to have counted it,
+        // or the content drops straight through the floor of its own table.
+        assertThat(text(graph).y())
+                .describedAs("a vertical margin the row never reserved drops the content out of it")
+                .isGreaterThanOrEqualTo(row(graph).y() - TOLERANCE);
+    }
+
+    @Test
+    void aMarginOnALeafComposedChildIsNotDiscarded() {
+        // A leaf goes straight to its own emitFragments rather than the
+        // fixed-box walk, and used to be placed as if it had no margin at all.
+        double withMargin = text(layout(paragraph("Leaf", new DocumentInsets(0, 0, 0, 40)))).x();
+        double withoutMargin = text(layout(paragraph("Leaf", DocumentInsets.zero()))).x();
+
+        assertThat(withMargin)
+                .describedAs("a 40pt left margin must move a leaf composed child right")
+                .isCloseTo(withoutMargin + 40.0, within(TOLERANCE));
+    }
+}


### PR DESCRIPTION
## Why

A node's margin was subtracted twice between the two passes that lay it out, in two unrelated places, because the seam between them was never written down.

A row band is sized by `NodeDefinitionSupport.measureRow`, which prepares each child inside its slot less that child's own margin, then placed by `LayoutCompiler`, which prepares it again. The placement pass handed `prepareForRegionWidth` a width the margin had already been taken out of — and that helper subtracts the margin itself. The child was laid out at `slot - 2 * margin` against a band measured from `slot - margin`, wrapped into a line the band had no room for, and the row's own guard rejected the document it had just measured:

```
IllegalStateException: Row 'ContainerNode[0]/Band[0]' child 'SectionNode'
measured height 77.7000023983419 exceeds row inner height.
```

Only that one path throws. The same disagreement is silent in `placeRowBandInFixedSlot` (a row in a LayerStack layer or a composed table cell), which has no inner-height guard: the tallest child is seated above its band and spills through the top under a non-`TOP` `verticalAlign`. And `compileNodeInFixedSlot` always derived its own region as `slot - margin`, so a composite row child reported one width while its own children were laid out in another.

A multi-angle review of that fix found the same defect class one layer away, in composed table cells, and it is fixed in the second commit. `DocumentTableCell.node(...)` measured its content at the cell's full inner width with the margin left in; the fixed-box walk then removed it. On a 260pt column a section with a 20pt side margin measured 3 lines and drew 4, painting 8.95pt below its own table while its box, still carrying the wider measured width but shifted right by `margin.left`, reached 295.34 against a cell edge of 280. Vertically it failed the other way: the cell height ignored the margin outright while placement still applied `margin.top`, dropping the content 16.00pt through the cell floor. On a leaf child the margin was discarded entirely.

## What changed

- **`LayoutCompiler`** — both row-seating loops pass the whole slot to `prepareForRegionWidth` and let `childAvailableWidth` perform the single subtraction. That is the contract the other five callers already used: each passes a region with only the *parent's* margin and padding removed. The clamp is unchanged — the removed `Math.max` at the call sites is the same one the helper still applies.
- **`prepareForRegionWidth` / `childAvailableWidth`** — now carry Javadoc stating that the argument is the region the node's *margin box* occupies. The undocumented contract is what let one bug exist in two places.
- **`TableLayoutSupport`** — a cell's inner box is the content's margin box, the same contract a row slot uses: `prepareComposedCellContents` measures inside the margin and `naturalCellHeight` reserves it on the vertical axis.
- **`NodeDefinitionSupport.emitComposedCellFragments`** — places the content one margin in on both axes, and computes the anchor slack against the content's outer height.
- **`DocumentLayoutPassContext.emitCompositeSubtree`** — a `FragmentPlacement` is a *content* box (both callers, the composed cell and `ChartDefinition`, build one at the exact rectangle and pass `Margin.zero()`), but the fixed-box walk reads a *margin* box. The bridge now converts between the two. Every conversion is an identity at zero margin, so nothing shipped today moves a point.

**Behaviour change.** Output moves only for a row child, or composed cell content, that carries a margin — it now occupies the room reserved for it instead of a smaller box. Content without a margin is untouched; the arithmetic is identical at zero.

## Verification

`./mvnw -B -ntp clean verify -pl :graph-compose-core,:graph-compose-render-pdf,:graph-compose-render-docx,:graph-compose-render-pptx,:graph-compose-templates,:graph-compose-testing,:graph-compose-qa,:graph-compose-coverage -am` → **BUILD SUCCESS, 2043 tests, 0 failures**, on this branch rebased onto current `develop`. Knowledge surfaces, claims and routes all current.

- `RowChildMarginWidthTest` (5) — the width base read back out of the placed node at each row-seating site; a composite row child's own width against the region its children were given; the fixed-slot child kept inside its band; and the reported repro. Verified fails-closed per hunk: reverting the page-level site alone turns three red, reverting the fixed-slot site turns the other two red.
- `ComposedCellMarginTest` (3) — a horizontal margin must not push content below its own table, a vertical margin must be reserved by the cell, and a leaf child's margin must not be discarded. All three fail on the unfixed engine.

Assertions are containment and derived widths rather than absolute coordinates, so none depends on a font metric.

**No layout snapshot, pixel baseline or committed preview moves.** Independently established three ways: 154 row children across the 64 committed layout snapshots, 124 across all 33 shipped presets, and a full `PlacedNode`/`PlacedFragment` dump of those presets under both engines that diffs empty. Nothing in the templates, the examples or the fixtures puts a horizontal margin on a row child, or a margin on composed cell content — which is also why neither gate caught either bug.

**Lane:** shared-engine — layout compiler and table measurement; no public API surface changed (`document.layout` is `@Internal` at package level, and `LayoutCompiler` is excluded from the knowledge surfaces).

### Known gaps, deliberately not in this PR

- `placeRowBandInFixedSlot` still has no inner-height guard. Adding the throw is a behaviour change for documents that currently overflow silently, and the state it would catch was only reachable through the composed-cell bug fixed here.
- The row seating loop is duplicated between the page-level path and `placeRowBandInFixedSlot` — it was created by copying that loop, carrying the double subtraction with it, which is why this one-line fix had to be applied twice. Extracting it is the durable fix and belongs in its own PR.
