### PR TITLE
fix(knowledge): hold a proof to a test that runs, and pin the fixed-width margin geometry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,12 +31,6 @@ follow semantic versioning; release dates are ISO 8601.
   the call, and a sub-point width that can only fail at layout now fails naming
   the fixed width instead of blaming the parent's padding.
 
-  One configuration is knowingly still wrong: a fixed-width flow used as a *row
-  column* that also carries a horizontal margin is placed narrower than it asked
-  for, because the row path subtracts that margin twice before the width is
-  resolved. That defect predates this feature — it misplaces unconstrained boxes
-  in the same shape — and is fixed separately.
-
   The value is carried by a new canonical `DocumentFlowWidth`
   (`natural()` / `of(points)`) on `DocumentNode.flowWidth()`, stored on
   `SectionNode` and `ContainerNode`. Both records keep their previous

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,24 @@ follow semantic versioning; release dates are ISO 8601.
 
 ### Layout
 
+- **A decorated root flow and its children can disagree under per-page margins.**
+  A known limitation, now measured and written down rather than met by surprise.
+  A block is placed once and its background is that block's own box on every page
+  it spans, but a *direct child of the root* is seated in the column of the page
+  that child starts on. So when the root carries both a `fixedWidth` and a
+  background, and that width is narrower than a later page's column, such a child
+  is placed against the column and lands beside its own background — a 200pt root
+  banded at 20..220 gets a child at 80..280. A root at least as wide as the
+  column is unaffected, and so is a background put on a section *inside* the
+  root, which is seated as one box together with the content it decorates and is
+  the shape to prefer. Both sides are pinned in `FixedWidthPageMarginChromeTest`.
+  The inconsistency is in how the compiler seats a spanning parent's children —
+  such a parent has no single box to be — so the fix belongs there and not in the
+  decoration band, which cannot follow the page without abandoning the content of
+  any block that merely flows across the boundary.
+
+  Documented in [`docs/recipes/fixed-width-flows.md`](docs/recipes/fixed-width-flows.md).
+
 - **A composed table cell sits where its anchor says, and a spanning one stops
   falling to the foot of its span.** `emitComposedCellFragments` accepted the
   cell's height and never read it: a child authored with

--- a/docs/recipes/fixed-width-flows.md
+++ b/docs/recipes/fixed-width-flows.md
@@ -56,9 +56,13 @@ it: the content wraps at the same width it would have without the call.
 Nesting clamps against the *parent box*, not the page — a `fixedWidth(320)`
 section inside a `fixedWidth(200).padding(10)` parent is placed at 180pt.
 
-Under per-page margins the cap is per page: a box that spans onto a page with
-a narrower content column is capped to that column rather than keeping the
-width of the page it started on.
+Under per-page margins the column a block is measured against is the one on the
+page that block **starts** on. Blocks placed directly in the root flow are
+capped there: with a `fixedWidth(340)` root on a page whose margins widen to
+leave a 240pt column, a block starting on that page is placed within 240pt
+rather than keeping the 340 of the page before it. Merely *continuing* onto a
+narrower page does not re-cap anything — a block is measured and placed once,
+and keeps that width for every page it spans.
 
 ## Where it applies
 
@@ -68,20 +72,28 @@ width of the page it started on.
 | Module | `module(m -> m.fixedWidth(240)…)` |
 | Root page flow | `pageFlow(page -> page.fixedWidth(200)…)` |
 
-Two boundaries to know:
+Four boundaries to know:
 
 - **Default off.** A flow that never calls `fixedWidth` keeps the
   shrink-to-fit measurement it always had — an unpadded section still reports
   the width of its widest child, capped at the column.
 - **Bleed still wins.** On an edge declared through `bleed(...)` the
   background reaches the trimmed page edge, because that is the point of
-  asking for it.
-- **One case is currently off.** A flow used as a *row column* that also
-  carries a horizontal `margin` is placed narrower than it asked for, because
-  the row subtracts that margin twice before the width is resolved. The
-  underlying row defect predates this feature (it misplaces unconstrained
-  boxes too) and is being fixed separately; a fixed-width column with no
-  horizontal margin is unaffected.
+  asking for it — on every page the block spans.
+- **A row column keeps its width.** A fixed-width flow used as a row column is
+  placed at the width it asked for, with or without a horizontal `margin`, as
+  long as that width plus the margin fits the slot.
+- **A decorated root plus per-page margins can overhang.** Give the root
+  `pageFlow` both a `fixedWidth` and a background, and its band is the root's
+  single box, while each direct child is seated in the column of the page that
+  child starts on. When the root is *narrower* than that page's column, a child
+  starting there is placed against the column and ends up beside its own
+  background — a `fixedWidth(200)` root whose band runs 20..220 gets a child at
+  80..280, overhanging by 60pt. A root at least as wide as the column (say
+  `fixedWidth(340)` against a 240pt column) already covers it and the child
+  lands inside. Put the background on a section inside the root rather than on
+  the root itself and the question does not arise: that section is seated as one
+  box together with the content it decorates.
 
 `fixedWidth` rejects NaN, infinity, zero and negative values outright, so a
 computed width that went wrong fails at the call rather than at layout time.

--- a/knowledge/tools/README.md
+++ b/knowledge/tools/README.md
@@ -27,7 +27,7 @@ library's to define. That is what moving the generator here fixes.
 | `api-surface/lib/provenance.mjs` | records what a run read: commit, timestamp, artifact digests |
 | `api-query/api-query.mjs` | answers a question about the surfaces instead of making you read them |
 | `claims/check-claims.mjs` | holds a page to what it claims, and builds the reverse index |
-| `claims/lib/claims.mjs` | reads the claim markers and resolves a symbol against the surfaces |
+| `claims/lib/claims.mjs` | reads the claim markers, resolves a symbol against the surfaces, and decides whether a Java file really holds a named, enabled test |
 | `routing/check-routes.mjs` | the gate a route must pass: anchors resolve, symbols exist, constraints are proven |
 | `routing/lib/anchors.mjs` | GitHub's heading-to-anchor rule, and the references a prose field makes |
 | `routing/lib/pack-version.mjs` | orders a route's `verifiedAgainst` against the version the surfaces carry |

--- a/knowledge/tools/claims/check-claims.mjs
+++ b/knowledge/tools/claims/check-claims.mjs
@@ -31,7 +31,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { parseClaims, resolveSymbol } from "./lib/claims.mjs";
+import { declaresTestMethod, parseClaims, resolveSymbol } from "./lib/claims.mjs";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(HERE, "..", "..", "..");
@@ -107,10 +107,15 @@ function loadProofTargets() {
         // Path as well as name: the registry has to say *where* a proof lives,
         // or a consumer holding the bundle can read that a claim is proven and
         // still have no way to look at the thing proving it.
-        tests.set(
-          entry.name.slice(0, -".java".length),
-          path.relative(REPO_ROOT, full).split(path.sep).join("/"),
-        );
+        //
+        // Every path, not the last one seen: a proof names a class, so two
+        // modules holding the same simple name used to collapse to whichever
+        // the walk reached last, and `#method` was then checked against the
+        // other module's file without saying so.
+        const simpleName = entry.name.slice(0, -".java".length);
+        const relative = path.relative(REPO_ROOT, full).split(path.sep).join("/");
+        if (tests.has(simpleName)) tests.get(simpleName).push(relative);
+        else tests.set(simpleName, [relative]);
       }
     }
   };
@@ -229,8 +234,8 @@ for (const file of docPages()) {
         // exists. Naming the method closes that, and stays optional so no
         // existing claim has to change to keep working.
         const [className, method] = id.split("#");
-        const testPath = proofTargets.tests.get(className);
-        if (!testPath) {
+        const testPaths = proofTargets.tests.get(className);
+        if (!testPaths) {
           errors.push({
             file: claim.file,
             line: claim.line,
@@ -239,16 +244,35 @@ for (const file of docPages()) {
           });
           continue;
         }
+        if (testPaths.length > 1) {
+          errors.push({
+            file: claim.file,
+            line: claim.line,
+            heading: claim.heading,
+            message:
+              `proof "${claim.proof}" is ambiguous — ${testPaths.length} test classes are named ` +
+              `"${className}" (${testPaths.join(", ")}). Rename one, or the proof points at ` +
+              "whichever the walk happened to reach last.",
+          });
+          continue;
+        }
+        const testPath = testPaths[0];
         if (method) {
           const source = fs.readFileSync(path.join(REPO_ROOT, testPath), "utf8");
-          if (!new RegExp(`\\b${method}\\s*\\(`).test(source)) {
+          // A live test, not a mention of one. Searching the raw file for
+          // `method(` accepted a comment, a string or a call as proof that the
+          // method survived, so deleting the assertion and leaving a
+          // `// Former test: name()` line behind kept the claim reading as held.
+          // Requiring the annotation also refuses a method whose `@Test` was
+          // dropped or replaced by `@Disabled` — neither runs, so neither proves.
+          if (!declaresTestMethod(source, method)) {
             errors.push({
               file: claim.file,
               line: claim.line,
               heading: claim.heading,
               message:
-                `proof "${claim.proof}" names no method "${method}" in ${testPath} — ` +
-                "the assertion that held this claim was renamed or removed.",
+                `proof "${claim.proof}" names no enabled test "${method}" in ${testPath} — ` +
+                "the test that held this claim was renamed, removed or disabled.",
             });
             continue;
           }
@@ -354,7 +378,9 @@ for (const claim of allClaims) {
   const id = claim.proof.slice(claim.proof.indexOf(":") + 1);
   const entry = (proofs[claim.proof] ??= {
     kind: scheme,
-    ...(scheme === "test" ? { path: proofTargets.tests.get(id.split("#")[0]) ?? null } : {}),
+    // One path in the index, as before. An ambiguous class is already an error
+    // above, so anything reaching here has exactly one.
+    ...(scheme === "test" ? { path: proofTargets.tests.get(id.split("#")[0])?.[0] ?? null } : {}),
     ...(scheme === "snippet" ? { page: proofTargets.snippets.get(id) ?? null } : {}),
     ...(scheme === "probe" || scheme === "render" ? { unresolved: "no registry for this scheme yet" } : {}),
     holds: [],

--- a/knowledge/tools/claims/lib/claims.mjs
+++ b/knowledge/tools/claims/lib/claims.mjs
@@ -43,6 +43,19 @@ const CLAIM_RE = /^<!--\s*claim:\s*(.+?)\s*-->\s*$/;
 
 const KINDS = ["symbol", "capability", "behavior"];
 
+/** `Class`, or `Class#method`, both Java identifiers and nothing else. */
+const TEST_PROOF_RE = /^[A-Za-z_$][A-Za-z0-9_$]*(?:#[A-Za-z_$][A-Za-z0-9_$]*)?$/;
+
+/**
+ * Whether a `test:` proof id is well formed.
+ *
+ * @param {string} id the part after `test:`
+ * @returns {boolean} true for `Class` or `Class#method`
+ */
+export function isTestProofId(id) {
+  return TEST_PROOF_RE.test(id);
+}
+
 /** `symbol=A.b proof=snippet:c` → `{symbol: "A.b", proof: "snippet:c"}`. */
 function parseAttributes(text) {
   const out = {};
@@ -110,6 +123,20 @@ export function parseClaims(text, file) {
       return;
     }
 
+    // A `test:` id is read back as Java identifiers, never as free text. The
+    // method half used to reach a RegExp by interpolation, where a `.` or a `|`
+    // in it silently widened what counted as a match; rejecting the shape here
+    // means nothing downstream has to sanitise it.
+    if (attributes.proof?.startsWith("test:") && !isTestProofId(attributes.proof.slice("test:".length))) {
+      errors.push({
+        ...at,
+        message:
+          `proof "${attributes.proof}" is not a test reference — expected test:Class or ` +
+          "test:Class#method with Java identifiers.",
+      });
+      return;
+    }
+
     // A behaviour nobody can reproduce is an opinion. Signatures are checkable
     // against the surfaces and intents are resolved by routing, but a claim that
     // the engine *does* something has nothing holding it up but a probe.
@@ -155,4 +182,214 @@ export function resolveSymbol(index, symbol) {
   }
 
   return { found: false, type: null, reason: `no type in "${symbol}"` };
+}
+
+/**
+ * Java source with every comment, string, character and text-block body
+ * replaced by spaces of the same length.
+ *
+ * Offsets are preserved so a match in the result points at the same place in
+ * the original. Blanking rather than deleting is what lets the caller read the
+ * characters *before* a match and still be looking at real code.
+ *
+ * @param {string} source Java source
+ * @returns {string} the same length, with only code left
+ */
+export function stripCommentsAndLiterals(source) {
+  const out = source.split("");
+  const blank = (from, to) => {
+    for (let k = from; k < to && k < out.length; k++) {
+      if (out[k] !== "\n" && out[k] !== "\r") out[k] = " ";
+    }
+  };
+
+  for (let i = 0; i < source.length; ) {
+    const two = source.slice(i, i + 2);
+    if (two === "//") {
+      let end = source.indexOf("\n", i);
+      if (end === -1) end = source.length;
+      blank(i, end);
+      i = end;
+    } else if (two === "/*") {
+      let end = source.indexOf("*/", i + 2);
+      end = end === -1 ? source.length : end + 2;
+      blank(i, end);
+      i = end;
+    } else if (source.startsWith('"""', i)) {
+      let end = source.indexOf('"""', i + 3);
+      end = end === -1 ? source.length : end + 3;
+      blank(i, end);
+      i = end;
+    } else if (source[i] === '"' || source[i] === "'") {
+      const quote = source[i];
+      let j = i + 1;
+      while (j < source.length && source[j] !== quote) {
+        if (source[j] === "\\") j++;
+        if (source[j] === "\n") break;
+        j++;
+      }
+      const end = Math.min(j + 1, source.length);
+      blank(i, end);
+      i = end;
+    } else {
+      i++;
+    }
+  }
+  return out.join("");
+}
+
+/**
+ * Annotations that mark a method JUnit will actually run.
+ */
+const TEST_ANNOTATIONS = new Set([
+  "Test", "ParameterizedTest", "RepeatedTest", "TestFactory", "TestTemplate",
+]);
+
+/**
+ * Skips a balanced bracket pair starting at {@code open}.
+ *
+ * @param {string} code comment- and literal-free Java source
+ * @param {number} open index of the opening bracket
+ * @param {string} openCh the opening bracket character
+ * @param {string} closeCh the matching closing bracket character
+ * @returns {number} index just past the matching close, or the source length
+ */
+function skipPair(code, open, openCh, closeCh) {
+  let depth = 0;
+  for (let i = open; i < code.length; i++) {
+    if (code[i] === openCh) depth++;
+    else if (code[i] === closeCh && --depth === 0) return i + 1;
+  }
+  return code.length;
+}
+
+/** Advances past whitespace. */
+function skipSpace(code, at) {
+  let i = at;
+  while (i < code.length && /\s/.test(code[i])) i++;
+  return i;
+}
+
+/**
+ * The annotation names in the run beginning at {@code at}, without requiring the
+ * run to resolve to a method — a run on a type resolves to none.
+ *
+ * @param {string} code comment- and literal-free Java source
+ * @param {number} at index of the first `@` in the run
+ * @returns {string[]} the annotation simple names, in source order
+ */
+function readRunAnnotations(code, at) {
+  const names = [];
+  let i = at;
+  while (i < code.length && code[i] === "@") {
+    const m = /^@\s*([A-Za-z_$][\w$]*)/.exec(code.slice(i));
+    if (!m) break;
+    names.push(m[1]);
+    i = skipSpace(code, i + m[0].length);
+    if (code[i] === "(") i = skipPair(code, i, "(", ")");
+    i = skipSpace(code, i);
+  }
+  return names;
+}
+
+/**
+ * Reads the method name of the declaration that begins at {@code at} — a
+ * position just past a leading annotation.
+ *
+ * Only annotations, modifiers, a type-parameter list and a return type can stand
+ * between an annotation and the name, and none of them is an expression. That is
+ * what makes this readable without parsing Java: scanning FORWARD from an anchor
+ * meets a fixed grammar, where scanning backward from `name(` meets arbitrary
+ * code that happens to end in the same characters.
+ *
+ * @param {string} code comment- and literal-free Java source
+ * @param {number} at index just past the anchoring annotation
+ * @returns {{name: string, annotations: string[]}|null} the declaration, or null
+ */
+function readDeclaration(code, at) {
+  const annotations = [];
+  let i = skipSpace(code, at);
+  let last = null;
+
+  while (i < code.length) {
+    const c = code[i];
+    if (c === "@") {
+      const m = /^@\s*([A-Za-z_$][\w$]*)/.exec(code.slice(i));
+      if (!m) return null;
+      annotations.push(m[1]);
+      i = skipSpace(code, i + m[0].length);
+      if (code[i] === "(") i = skipPair(code, i, "(", ")");
+      i = skipSpace(code, i);
+      continue;
+    }
+    if (c === "<") {
+      // A type-parameter list, or the type arguments of the return type.
+      i = skipSpace(code, skipPair(code, i, "<", ">"));
+      continue;
+    }
+    if (c === "[" || c === "]" || c === ".") {
+      i = skipSpace(code, i + 1);
+      continue;
+    }
+    if (/[A-Za-z_$]/.test(c)) {
+      const m = /^[A-Za-z_$][\w$]*/.exec(code.slice(i));
+      last = m[0];
+      i = skipSpace(code, i + m[0].length);
+      if (code[i] === "(") return { name: last, annotations };
+      continue;
+    }
+    // A field, a nested type, or anything else this anchor did not introduce.
+    return null;
+  }
+  return null;
+}
+
+/**
+ * Whether Java source declares a JUnit test method of this name that would
+ * actually run.
+ *
+ * A `proof=test:Class#method` marker asserts that a named test holds a claim, so
+ * the question is not "does some method of that name exist" — it is "is that
+ * test there and enabled". Searching the file for `method\s*\(` — which this
+ * replaced — answered neither: a mention in a comment, in a string, or at a call
+ * site all counted, so a claim whose proof had been deleted went on reading as
+ * proven.
+ *
+ * Anchoring on the test annotation and reading FORWARD is what makes the answer
+ * decidable. The reverse — finding `name(` and asking what precedes it — cannot
+ * be done by scanning: `Map<K, V> name(` and `a < b ? c > name(1)` are the same
+ * characters, and `?` is both a wildcard and a ternary. Between an annotation and
+ * the name there are no expressions at all.
+ *
+ * A `@Disabled` test proves nothing and is refused. The name is compared by
+ * string equality against an identifier the scan read, so a name carrying a regex
+ * metacharacter simply matches nothing — it reaches no pattern to be one in.
+ *
+ * @param {string} source Java source
+ * @param {string} method the method name
+ * @returns {boolean} true when the source declares it as a live test
+ */
+export function declaresTestMethod(source, method) {
+  const code = stripCommentsAndLiterals(source);
+  let found = false;
+
+  for (const m of code.matchAll(/@s*[A-Za-z_$][w$]*/g)) {
+    const declared = readDeclaration(code, m.index);
+    const disabled = declared === null || declared.annotations.includes("Disabled");
+
+    // A run that carries @Disabled but resolves to no method annotates a TYPE,
+    // and a disabled class runs none of its tests. Refusing the whole file is
+    // coarser than JUnit — a disabled nested class takes the outer ones with it —
+    // and it is the safe direction: the cost is a claim that has to name another
+    // test, against a claim that reads as proven by something that never runs.
+    if (declared === null) {
+      if (readRunAnnotations(code, m.index).includes("Disabled")) return false;
+      continue;
+    }
+    if (declared.name !== method) continue;
+    if (!declared.annotations.some((a) => TEST_ANNOTATIONS.has(a))) continue;
+    if (disabled) return false;
+    found = true;
+  }
+  return found;
 }

--- a/knowledge/tools/claims/test/claims.test.mjs
+++ b/knowledge/tools/claims/test/claims.test.mjs
@@ -13,8 +13,17 @@
  * indistinguishable from working.
  */
 
-import { parseClaims, resolveSymbol } from "../lib/claims.mjs";
+import {
+  declaresTestMethod,
+  isTestProofId,
+  parseClaims,
+  resolveSymbol,
+  stripCommentsAndLiterals,
+} from "../lib/claims.mjs";
 import { suite } from "../../lib/fixtures.mjs";
+import fsSync from "node:fs";
+import { fileURLToPath } from "node:url";
+import nodePath from "node:path";
 
 const { check, done } = suite("claims.test");
 
@@ -127,5 +136,286 @@ check(
   resolveSymbol(index, "GraphCompose.pageSize").found,
   false,
 );
+
+// --- a proof names a test that really runs ------------------------------------
+
+// The checker used to search the whole test file for `method(`, so a claim whose
+// assertion had been deleted kept reading as proven for as long as the name
+// survived anywhere in the file — including in the comment left behind by the
+// person who deleted it.
+const JAVA = `
+class T {
+    @Test
+    void declared() throws Exception {
+        helper();
+    }
+
+    // Former test: removedButMentioned()
+    @Test
+    void other() {
+        String s = "alsoMentioned() in a string";
+        this.qualified();
+        int n = compute(1);
+    }
+
+    private int compute(int x) { return x; }
+
+    @TestFactory
+    List<DynamicTest> generic() { return null; }
+
+    @Test
+    byte[] arrayReturn() { return null; }
+}
+`;
+
+check("a declared test is accepted", declaresTestMethod(JAVA, "declared"), true);
+check("a method absent from the file is rejected", declaresTestMethod(JAVA, "neverThere"), false);
+check("a name only in a comment is not a test", declaresTestMethod(JAVA, "removedButMentioned"), false);
+check("a name only in a string literal is not a test", declaresTestMethod(JAVA, "alsoMentioned"), false);
+check("an unqualified call is not a test", declaresTestMethod(JAVA, "helper"), false);
+check("a qualified call is not a test", declaresTestMethod(JAVA, "qualified"), false);
+// `compute` is declared AND called here — and is still not a proof, because it is
+// a helper: only a method JUnit would run can hold a claim up.
+check("an unannotated helper is not a test", declaresTestMethod(JAVA, "compute"), false);
+check("a generic return type still reads as a test", declaresTestMethod(JAVA, "generic"), true);
+check("an array return type still reads as a test", declaresTestMethod(JAVA, "arrayReturn"), true);
+check(
+  "a longer identifier containing the name is not a match",
+  declaresTestMethod("class T { @Test void recompute() {} }", "compute"),
+  false,
+);
+check(
+  "a name inside a block comment is not a test",
+  declaresTestMethod("class T { /* @Test void ghost() {} */ }", "ghost"),
+  false,
+);
+
+// The name reached a RegExp by interpolation, so a metacharacter in it matched
+// more than the literal name it was meant to be.
+check("a name that is a regex pattern matches nothing", declaresTestMethod(JAVA, "declare."), false);
+check("a regex alternation in the name matches nothing", declaresTestMethod(JAVA, "declared|other"), false);
+
+// A proof asserts that a named test HOLDS a claim. A method JUnit does not run
+// holds nothing, so dropping the annotation or disabling the test has to read the
+// same as deleting it — otherwise the check only moves the false confirmation up
+// one level.
+check(
+  "a method whose @Test was removed no longer proves anything",
+  declaresTestMethod("class T { void held() { assertTrue(x); } }", "held"),
+  false,
+);
+check(
+  "a disabled test proves nothing",
+  declaresTestMethod('class T { @Test @Disabled("flaky") void held() { assertTrue(x); } }', "held"),
+  false,
+);
+// The anchor is the TEST annotation, not any annotation: a lifecycle method or
+// an override runs, but neither is a test, and neither can hold a claim.
+check(
+  "a lifecycle method is not a test",
+  declaresTestMethod("class T { @BeforeEach void setUp() {} }", "setUp"),
+  false,
+);
+check(
+  "an overridden method is not a test",
+  declaresTestMethod("class T { @Override public String toStringy() { return null; } }", "toStringy"),
+  false,
+);
+// `@Disabled` can be written on either side of `@Test`, and on the class — all
+// three mean the same thing to JUnit, so all three have to mean the same thing
+// here. A run is read whole, from its first annotation, for exactly this reason.
+check(
+  "a disabled test proves nothing when @Disabled comes first",
+  declaresTestMethod('class T { @Disabled("x") @Test void held() {} }', "held"),
+  false,
+);
+check(
+  "a test in a disabled class proves nothing",
+  declaresTestMethod("@Disabled class T { @Test void held() {} }", "held"),
+  false,
+);
+check(
+  "a test in a disabled nested class proves nothing",
+  declaresTestMethod("class T { @Disabled static class I { @Test void held() {} } }", "held"),
+  false,
+);
+check(
+  "a helper in a dead nested class is not a test",
+  declaresTestMethod("class T { static class H { void ghost() {} } }", "ghost"),
+  false,
+);
+check(
+  "a constructor is not a test",
+  declaresTestMethod("class Ghost { public Ghost(int x) {} }", "Ghost"),
+  false,
+);
+check(
+  "an annotation element is not a test",
+  declaresTestMethod("@interface A { String ghost(); }", "ghost"),
+  false,
+);
+
+// Every JUnit annotation that makes a method run, and the shapes that sit between
+// one and the method name: further annotations, modifiers, a type-parameter list,
+// a generic or annotated return type.
+check(
+  "@ParameterizedTest counts",
+  declaresTestMethod("class T { @ParameterizedTest @ValueSource(ints = {1, 2}) void p(int n) {} }", "p"),
+  true,
+);
+check("@RepeatedTest counts", declaresTestMethod("class T { @RepeatedTest(3) void r() {} }", "r"), true);
+check("@TestTemplate counts", declaresTestMethod("class T { @TestTemplate void t() {} }", "t"), true);
+check(
+  "a second annotation between the anchor and the name is skipped",
+  declaresTestMethod('class T { @Test @DisplayName("x") void named() {} }', "named"),
+  true,
+);
+check(
+  "modifiers between the anchor and the name are skipped",
+  declaresTestMethod("class T { @Test public static void mods() {} }", "mods"),
+  true,
+);
+check(
+  "a type-parameter list is skipped",
+  declaresTestMethod("class T { @Test <X> void generic(X x) {} }", "generic"),
+  true,
+);
+check(
+  "a nested generic return type is still a test",
+  declaresTestMethod("class T { @TestFactory Map<K, List<V>> real() { return null; } }", "real"),
+  true,
+);
+check(
+  "a wildcard generic return type is still a test",
+  declaresTestMethod("class T { @TestFactory List<? extends Number> real() { return null; } }", "real"),
+  true,
+);
+check(
+  "a type-use annotation carrying arguments is still a test",
+  declaresTestMethod("class T { @TestFactory List<@Size(min = 1) String> real() { return null; } }", "real"),
+  true,
+);
+check(
+  "a test inside a @Nested class counts",
+  declaresTestMethod("class T { @Nested class Inner { @Test void nested() {} } }", "nested"),
+  true,
+);
+
+// Reading BACKWARD from `name(` is what the first attempt did, and it cannot be
+// made right: `Map<K, V> name(` and `a < b ? c > name(1)` are the same characters,
+// `?` is both a wildcard and a ternary, and `{` `}` `;` all appear inside argument
+// lists. Every one of these is a CALL, and every one defeated a backward scan.
+for (const [label, body] of [
+  ["a lambda arrow", "list.forEach(x -> ghost(x));"],
+  ["a switch arrow", "switch (v) { case A -> ghost(1); }"],
+  ["a relational operator", "if (n > ghost(1)) {}"],
+  ["an explicit type witness", "Collections.<String>ghost();"],
+  ["a method reference with a type witness", "var f = this::<String>ghost;"],
+  ["a comparison pair in an argument list", "assertThat(lo < hi && count > ghost(1)).isTrue();"],
+  ["a comparison pair with a comma", "check(a < b, c > ghost(1));"],
+  ["a comparison pair after a lambda block", "run(() -> { helper(); }, a < b, c > ghost(1));"],
+  ["a comparison pair after an array initializer", "check(new int[]{1}, a < b, c > ghost(1));"],
+  ["a comparison pair after an anonymous class", "run(new R() { int f = 1; }, a < b, c > ghost(1));"],
+  ["a statement-level ternary", "Object x = a < b ? c > ghost(1) : 2;"],
+  ["a ternary in a condition", "if (a < b ? c > ghost(1) : x) {}"],
+]) {
+  check(
+    `${label} before the name is not a test`,
+    declaresTestMethod(`class T { @Test void t() { ${body} } }`, "ghost"),
+    false,
+  );
+}
+check(
+  "a ternary in a field initializer is not a test",
+  declaresTestMethod("class T { Object f = a < b ? c > ghost(1) : 2; }", "ghost"),
+  false,
+);
+
+// --- the blanking every check above rests on ---------------------------------
+
+// A comment or a literal is blanked while every other character keeps the index
+// it already had, so a match found afterwards still points at the same place in
+// the real source.
+const sameLength = (src) => stripCommentsAndLiterals(src).length === src.length;
+
+check("blanking preserves offsets", sameLength('class T { String s = "x"; /* c */ }'), true);
+check(
+  "blanking preserves offsets over a text block",
+  sameLength('class T { String s = """\nvoid ghost() {}\n"""; }'),
+  true,
+);
+check("blanking preserves offsets over CRLF", sameLength("class T {\r\n  // c\r\n}"), true);
+check("a line comment is blanked", stripCommentsAndLiterals("a // b\nc").includes("b"), false);
+check(
+  "an escaped quote does not end the string early",
+  stripCommentsAndLiterals('String s = "a\\"b"; int real;').includes("real"),
+  true,
+);
+check(
+  "an escaped backslash does end the string",
+  stripCommentsAndLiterals('String s = "a\\\\"; int real;').includes("real"),
+  true,
+);
+check(
+  "a quote inside a char literal does not open a string",
+  stripCommentsAndLiterals("char c = '\"'; int real;").includes("real"),
+  true,
+);
+check(
+  "an escaped quote char literal is handled",
+  stripCommentsAndLiterals("char c = '\\''; int real;").includes("real"),
+  true,
+);
+check(
+  "a comment marker inside a string is not a comment",
+  stripCommentsAndLiterals('String s = "// not a comment"; int real;').includes("real"),
+  true,
+);
+check(
+  "a division is not a comment",
+  stripCommentsAndLiterals("int n = a / b; int real;").includes("real"),
+  true,
+);
+check(
+  "a text block hides the code inside it",
+  declaresTestMethod('class T { String s = """\n@Test void ghost() {}\n"""; }', "ghost"),
+  false,
+);
+
+check("test:Class is a valid proof id", isTestProofId("LineWidthUnitsContractTest"), true);
+check("test:Class#method is a valid proof id", isTestProofId("SomeTest#someMethod"), true);
+check("a proof id with a regex metacharacter is refused", isTestProofId("SomeTest#a.b"), false);
+check("a proof id with two hashes is refused", isTestProofId("SomeTest#a#b"), false);
+check("an empty method half is refused", isTestProofId("SomeTest#"), false);
+
+// The older `test:Class` form carries no method and must keep parsing.
+check(
+  "a bare test:Class proof still parses",
+  claims("<!-- claim: behavior=x.y proof=test:SomeTest -->"),
+  [{ kind: "behavior", value: "x.y", proof: "test:SomeTest" }],
+);
+check(
+  "a test proof whose method half is a pattern is rejected at parse time",
+  messages("<!-- claim: behavior=x.y proof=test:SomeTest#a.b -->"),
+  [
+    'proof "test:SomeTest#a.b" is not a test reference — expected test:Class or ' +
+      "test:Class#method with Java identifiers.",
+  ],
+);
+
+// --- the gate is actually wired to it ----------------------------------------
+
+// Everything above tests the library. Nothing above notices if the gate stops
+// calling it: reverting check-claims.mjs to the old `new RegExp(method)` search
+// leaves every check here green and the repository check green, because the old
+// search is strictly more permissive. This is the only thing standing between
+// that revert and a silent return to false confirmation.
+const GATE = fsSync.readFileSync(
+  nodePath.join(nodePath.dirname(fileURLToPath(import.meta.url)), "..", "check-claims.mjs"),
+  "utf8",
+);
+
+check("the gate asks the library about a proof method", GATE.includes("declaresTestMethod(source, method)"), true);
+check("the gate builds no pattern from a proof name", /new RegExp/.test(GATE), false);
 
 done();

--- a/qa/src/test/java/com/demcha/compose/document/api/FixedWidthPageMarginChromeTest.java
+++ b/qa/src/test/java/com/demcha/compose/document/api/FixedWidthPageMarginChromeTest.java
@@ -1,0 +1,335 @@
+package com.demcha.compose.document.api;
+
+import com.demcha.compose.GraphCompose;
+import com.demcha.compose.document.dsl.PageFlowBuilder;
+import com.demcha.compose.document.layout.LayoutGraph;
+import com.demcha.compose.document.layout.PlacedFragment;
+import com.demcha.compose.document.layout.PlacedNode;
+import com.demcha.compose.document.layout.payloads.ShapeFragmentPayload;
+import com.demcha.compose.document.node.TextAlign;
+import com.demcha.compose.document.style.DocumentColor;
+import com.demcha.compose.document.style.DocumentEdge;
+import com.demcha.compose.document.style.DocumentInsets;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+
+/**
+ * What a decorated block's background does when {@code pageMargins(...)} changes
+ * the content column under it.
+ *
+ * <p><strong>The rule the engine holds:</strong> a block is placed once, and its
+ * band is that block's own box on every page it spans. Only the band's vertical
+ * edges follow each page's margins; the horizontal ones do not move, because the
+ * block itself does not.</p>
+ *
+ * <p><strong>The gap that leaves:</strong> the compiler re-seats a <em>direct
+ * child of the root</em> into the column of the page that child starts on
+ * ({@code boolean pageColumn = depth == 1 && state.hasPageGeometry()} in
+ * {@code LayoutCompiler}), while the root around it keeps one box. A decorated
+ * root can therefore have a child sitting outside its background. That is a
+ * compiler-level inconsistency — a parent spanning two columns has no single box
+ * to be — and it is not something the decoration band can resolve: a band that
+ * chased the painted page's column instead abandons the text of any block whose
+ * content merely <em>flows</em> across the boundary, which is the same defect one
+ * level down.</p>
+ *
+ * <p><strong>What it takes to see it:</strong> both conjuncts, plus a root narrow
+ * enough to be the binding constraint. Per-page margins must exist at all, the
+ * overhanging node must be a direct child of the root, and the root's fixed width
+ * must be narrower than the later page's column — at
+ * {@code fixedWidth(340)} the root's box already covers page 2's column and the
+ * child lands inside it. Both cases are pinned below, with their measured
+ * numbers, so the boundary is on record and not just the failure.</p>
+ *
+ * <p>Page 1 keeps a 20pt margin and page 2 onwards takes 80pt, so page 1 offers a
+ * 360pt column (20..380) and page 2 offers 240pt (80..320).</p>
+ */
+class FixedWidthPageMarginChromeTest {
+
+    private static final double PAGE_WIDTH = 400;
+    private static final double PAGE_HEIGHT = 300;
+    private static final double WIDE_MARGIN = 80;
+
+    // --- the rule: a band is its own block's box on every page ---------------
+
+    @Test
+    void aBandKeepsItsBlocksBoxOnEveryPageItSpans() {
+        try (DocumentSession document = document(true)) {
+            document.pageFlow(page -> page.addSection(band -> band
+                    .name("Band")
+                    .fillColor(DocumentColor.rgb(220, 230, 240))
+                    .addParagraph(p -> p.name("Body").text(longBody()).align(TextAlign.CENTER))));
+
+            PlacedNode band = node(document, "Band");
+            assertThat(band.endPage()).as("the band must span the margin change").isGreaterThan(0);
+
+            for (int page = band.startPage(); page <= band.endPage(); page++) {
+                PlacedFragment fill = fillOnPage(document, band, page);
+                assertThat(fill.x()).as("page " + page + " x").isCloseTo(band.placementX(), within(0.01));
+                assertThat(fill.width()).as("page " + page + " width")
+                        .isCloseTo(band.placementWidth(), within(0.01));
+            }
+        }
+    }
+
+    @Test
+    void aFlowingBlocksTextStaysInsideItsOwnBandOnEveryPage() {
+        try (DocumentSession document = document(true)) {
+            document.pageFlow(page -> page.addSection(band -> band
+                    .name("Band")
+                    .fillColor(DocumentColor.rgb(220, 230, 240))
+                    // Padding is what makes this test say something the box test
+                    // does not: without it the content's box IS the band's box and
+                    // the assertion below is an identity. With it the content is
+                    // inset 10pt on each side and genuinely measured against the
+                    // paint.
+                    .padding(DocumentInsets.of(10))
+                    .addParagraph(p -> p.name("Body").text(longBody()).align(TextAlign.CENTER))));
+
+            PlacedNode band = node(document, "Band");
+            PlacedNode body = node(document, "Body");
+            assertThat(band.endPage()).as("the band must span the margin change").isGreaterThan(0);
+            assertThat(body.placementWidth())
+                    .as("the content must be narrower than the band, or this proves nothing")
+                    .isLessThan(band.placementWidth() - 1.0);
+
+            // The content is placed once, so it must sit inside the band as PAINTED
+            // on each page — not merely inside the band's own record, which would
+            // hold whatever the band did. A band that followed the painted page's
+            // column would narrow to 240pt on page 2 and leave this 340pt-wide
+            // text hanging outside it.
+            for (int page = band.startPage(); page <= band.endPage(); page++) {
+                PlacedFragment fill = fillOnPage(document, band, page);
+                assertThat(body.placementX())
+                        .as("page " + page + " left")
+                        .isGreaterThanOrEqualTo(fill.x() - 0.01);
+                assertThat(body.placementX() + body.placementWidth())
+                        .as("page " + page + " right")
+                        .isLessThanOrEqualTo(fill.x() + fill.width() + 0.01);
+            }
+        }
+    }
+
+    @Test
+    void theBandsVerticalEdgesStillFollowEachPagesMargins() {
+        try (DocumentSession document = document(true)) {
+            document.pageFlow(page -> page.addSection(band -> band
+                    .name("Band")
+                    .fillColor(DocumentColor.rgb(220, 230, 240))
+                    // Long enough for a MIDDLE page. On the band's last page the
+                    // bottom edge is the content's own, so the per-page clamp never
+                    // binds there and an assertion on it passes with 88pt of slack
+                    // however the clamp is written. Only a page the band crosses
+                    // entirely exercises both edges.
+                    .addParagraph(longBody().repeat(3))));
+
+            PlacedNode band = node(document, "Band");
+            assertThat(band.endPage()).as("the band needs a page it crosses entirely").isGreaterThan(1);
+
+            // The horizontal axis is frozen to the block's box; the vertical one is
+            // not, and clamps to the page being painted.
+            for (int page = band.startPage() + 1; page < band.endPage(); page++) {
+                PlacedFragment middle = fillOnPage(document, band, page);
+                assertThat(middle.y() + middle.height())
+                        .as("page " + page + " top")
+                        .isCloseTo(PAGE_HEIGHT - WIDE_MARGIN, within(0.01));
+                assertThat(middle.y())
+                        .as("page " + page + " bottom")
+                        .isCloseTo(WIDE_MARGIN, within(0.01));
+            }
+        }
+    }
+
+    @Test
+    void declaringPageMarginsDoesNotMoveABandHorizontally() {
+        double[] withRule = bandBox(true);
+        double[] withoutRule = bandBox(false);
+
+        // Whatever the rules say, the horizontal band geometry is the block's own.
+        assertThat(withRule[0]).isCloseTo(withoutRule[0], within(0.01));
+        assertThat(withRule[1]).isCloseTo(withoutRule[1], within(0.01));
+    }
+
+    // --- the gap: a re-seated child can leave its root's band ----------------
+
+    @Test
+    void aReSeatedChildCanSitOutsideItsDecoratedRootsBand() {
+        try (DocumentSession document = document(true)) {
+            compose(document, page -> page.fixedWidth(200));
+
+            // `PageTwo` is the direct child of the root — the node the compiler
+            // actually re-seats. `Body` is one level further down and merely
+            // inherits the region, so asserting on it would name the wrong
+            // mechanism.
+            PlacedNode reSeated = node(document, "PageTwo");
+            PlacedFragment fill = fillOnPage(document, node(document, "Flow"), 1);
+
+            assertThat(reSeated.startPage()).as("the child must start on page 2").isEqualTo(1);
+
+            // Documented gap, not an aspiration, and the numbers are the record:
+            // the root keeps one box while its child is re-seated into page 2's
+            // column, so the child ends up beside its own background. When the
+            // seating rule is fixed this test should fail — and the fix belongs in
+            // LayoutCompiler, not in the decoration band.
+            assertThat(fill.x()).as("band left").isCloseTo(20.0, within(0.01));
+            assertThat(fill.width()).as("band width").isCloseTo(200.0, within(0.01));
+            assertThat(reSeated.placementX()).as("child left").isCloseTo(80.0, within(0.01));
+            assertThat(reSeated.placementWidth()).as("child width").isCloseTo(200.0, within(0.01));
+            assertThat(reSeated.placementX() + reSeated.placementWidth() - (fill.x() + fill.width()))
+                    .as("the child overhangs its root's band on the right")
+                    .isCloseTo(60.0, within(0.01));
+        }
+    }
+
+    @Test
+    void aRootWideEnoughToCoverTheNarrowerPageHasNoOverhang() {
+        try (DocumentSession document = document(true)) {
+            compose(document, page -> page.fixedWidth(340));
+
+            PlacedNode reSeated = node(document, "PageTwo");
+            PlacedFragment fill = fillOnPage(document, node(document, "Flow"), 1);
+
+            assertThat(reSeated.startPage()).as("the child must start on page 2").isEqualTo(1);
+
+            // The other side of the boundary. The same re-seating happens — the
+            // child is still placed against page 2's column at x=80 — but the root's
+            // box (20..360) already covers that column, and the child is capped to
+            // it (240pt), so it lands inside its own background. The gap needs a
+            // root NARROWER than the later page's column; the seating rule is
+            // inconsistent either way.
+            assertThat(fill.x()).as("band left").isCloseTo(20.0, within(0.01));
+            assertThat(fill.width()).as("band width").isCloseTo(340.0, within(0.01));
+            assertThat(reSeated.placementX()).as("child left").isCloseTo(80.0, within(0.01));
+            assertThat(reSeated.placementWidth()).as("child width").isCloseTo(240.0, within(0.01));
+            assertThat(reSeated.placementX() + reSeated.placementWidth())
+                    .as("the child stays inside the band")
+                    .isLessThanOrEqualTo(fill.x() + fill.width() + 0.01);
+        }
+    }
+
+    @Test
+    void decoratingASectionInsideTheRootAvoidsTheOverhang() {
+        try (DocumentSession document = document(true)) {
+            // The remedy the recipe prescribes, held to the same numbers as the gap
+            // above: keep the fixed width on the root, move the background off it and
+            // onto a section inside. That section is re-seated as one box together
+            // with the content it decorates, so the band and its children agree —
+            // which is exactly what a decorated ROOT cannot do.
+            document.pageFlow(page -> page
+                    .name("Flow")
+                    .fixedWidth(200)
+                    .addSection(a -> a.name("PageOne").addParagraph("First page."))
+                    .addPageBreak(br -> br.name("ToPageTwo"))
+                    .addSection(b -> b
+                            .name("Card")
+                            .fillColor(DocumentColor.rgb(220, 230, 240))
+                            .addParagraph(p -> p.name("Body").text("Short.").align(TextAlign.CENTER))));
+
+            PlacedNode card = node(document, "Card");
+            PlacedNode body = node(document, "Body");
+            PlacedFragment fill = fillOnPage(document, card, 1);
+
+            assertThat(card.startPage()).as("the card must start on page 2").isEqualTo(1);
+            assertThat(fill.x()).as("band left").isCloseTo(card.placementX(), within(0.01));
+            assertThat(fill.width()).as("band width").isCloseTo(card.placementWidth(), within(0.01));
+            assertThat(body.placementX()).as("content left").isGreaterThanOrEqualTo(fill.x() - 0.01);
+            assertThat(body.placementX() + body.placementWidth())
+                    .as("content stays inside its own background")
+                    .isLessThanOrEqualTo(fill.x() + fill.width() + 0.01);
+        }
+    }
+
+    // --- bleed ---------------------------------------------------------------
+
+    @Test
+    void bleedStillReachesThePageEdgeOnEveryPageItSpans() {
+        try (DocumentSession document = document(true)) {
+            document.pageFlow(page -> page.addSection(band -> band
+                    .name("Band")
+                    .fillColor(DocumentColor.rgb(220, 230, 240))
+                    .bleedToEdge(DocumentEdge.LEFT, DocumentEdge.RIGHT)
+                    .addParagraph(longBody())));
+
+            PlacedNode band = node(document, "Band");
+            assertThat(band.endPage()).as("the band must span the margin change").isGreaterThan(0);
+
+            for (int page = band.startPage(); page <= band.endPage(); page++) {
+                PlacedFragment fill = fillOnPage(document, band, page);
+                assertThat(fill.x()).as("page " + page + " left").isCloseTo(0.0, within(0.01));
+                assertThat(fill.width()).as("page " + page + " width").isCloseTo(PAGE_WIDTH, within(0.01));
+            }
+        }
+    }
+
+    // --- helpers ------------------------------------------------------------
+
+    private static String longBody() {
+        return ("A band long enough to run from the first page onto the second, where "
+                + "the margins are wider. ").repeat(14);
+    }
+
+    /** `{x, width}` of the band's fill on its second page, with or without page-margin rules. */
+    private static double[] bandBox(boolean declarePageMargins) {
+        try (DocumentSession document = document(declarePageMargins)) {
+            document.pageFlow(page -> page.addSection(band -> band
+                    .name("Band")
+                    .fillColor(DocumentColor.rgb(220, 230, 240))
+                    .addParagraph(longBody())));
+            PlacedFragment fill = fillOnPage(document, node(document, "Band"), 1);
+            return new double[] {fill.x(), fill.width()};
+        }
+    }
+
+    private static DocumentSession document(boolean widenFromPageTwo) {
+        DocumentSession session = GraphCompose.document()
+                .pageSize(PAGE_WIDTH, PAGE_HEIGHT)
+                .margin(DocumentInsets.of(20))
+                .create();
+        if (widenFromPageTwo) {
+            session.pageMargins(List.of(PageMarginRule.from(2, DocumentInsets.of(WIDE_MARGIN))));
+        }
+        return session;
+    }
+
+    /** A filled root flow, a page break, then a centred paragraph on page 2. */
+    private static void compose(DocumentSession document, Consumer<PageFlowBuilder> shape) {
+        document.pageFlow(page -> {
+            page.name("Flow").fillColor(DocumentColor.rgb(220, 230, 240));
+            shape.accept(page);
+            page.addSection(a -> a.name("PageOne").addParagraph("First page."))
+                    .addPageBreak(br -> br.name("ToPageTwo"))
+                    .addSection(b -> b.name("PageTwo")
+                            .addParagraph(p -> p.name("Body").text("Short.").align(TextAlign.CENTER)));
+        });
+    }
+
+    /**
+     * The decoration band {@code owner} paints on {@code pageIndex}. Keyed on the
+     * owner's path: several nodes paint a shape on one page, and taking whichever
+     * comes first would let a test pass by measuring somebody else's background.
+     */
+    private static PlacedFragment fillOnPage(DocumentSession document, PlacedNode owner, int pageIndex) {
+        LayoutGraph graph = document.layoutGraph();
+        List<PlacedFragment> fills = graph.fragments().stream()
+                .filter(f -> f.pageIndex() == pageIndex
+                        && owner.path().equals(f.path())
+                        && f.payload() instanceof ShapeFragmentPayload)
+                .toList();
+        assertThat(fills)
+                .as("fills painted by '" + owner.semanticName() + "' on page " + pageIndex)
+                .hasSize(1);
+        return fills.get(0);
+    }
+
+    private static PlacedNode node(DocumentSession document, String semanticName) {
+        return document.layoutGraph().nodes().stream()
+                .filter(n -> semanticName.equals(n.semanticName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("no node named '" + semanticName + "'"));
+    }
+}

--- a/qa/src/test/java/com/demcha/compose/document/api/FlowFixedWidthLayoutTest.java
+++ b/qa/src/test/java/com/demcha/compose/document/api/FlowFixedWidthLayoutTest.java
@@ -255,11 +255,11 @@ class FlowFixedWidthLayoutTest {
                     .name("Band")
                     .addSection(s -> s
                             .name("Card")
-                            // A horizontal margin is what makes the two bases differ: the
-                            // row prepares this child against the slot less its margin and
-                            // then hands placement the whole slot. Content is kept short so
-                            // the row's own (pre-existing, unrelated) height check does not
-                            // fire and hide the width assertion below.
+                            // A horizontal margin used to make the two bases disagree: the
+                            // row prepared this child against the slot less its margin and
+                            // then handed placement the whole slot, so the margin came off
+                            // twice and the card was placed at 100pt. It comes off once
+                            // now, and 120 + 40 fits inside the 180pt slot.
                             .margin(new DocumentInsets(0, 20, 0, 20))
                             .fixedWidth(120)
                             // A centred paragraph reports the full width it was given
@@ -273,16 +273,38 @@ class FlowFixedWidthLayoutTest {
             PlacedNode card = node(document, "Card");
             PlacedNode body = node(document, "Body");
 
-            // Whichever base placement re-derived, the children sit inside the box that
-            // is actually painted — text can never wrap wider than its own background.
-            // The painted width itself is NOT asserted here: a row column with a
-            // horizontal margin has its margin subtracted twice before any clamp, so
-            // this card lands narrower than the 120pt it asked for. That is a
-            // pre-existing row defect (it reproduces with no fixedWidth at all) and is
-            // fixed separately; the width contract is pinned by the no-margin case below.
+            // The width the author asked for, not a fraction of it: two 180pt slots,
+            // a 40pt horizontal margin, and a card that must still be exactly 120.
+            assertThat(card.placementWidth()).isCloseTo(120.0, within(0.01));
+            // And the children sit inside the box that is actually painted — text can
+            // never wrap wider than its own background.
             assertThat(body.placementWidth()).isLessThanOrEqualTo(card.placementWidth() + 0.01);
             assertThat(body.placementX() + body.placementWidth())
                     .isLessThanOrEqualTo(card.placementX() + card.placementWidth() + 0.01);
+        }
+    }
+
+    @Test
+    void aRowColumnWiderThanItsSlotLessTheMarginIsClampedToWhatIsLeft() {
+        try (DocumentSession document = document()) {
+            document.pageFlow(page -> page.addRow(row -> row
+                    .name("Band")
+                    .addSection(s -> s
+                            .name("Card")
+                            // The other side of "as long as that width plus the margin
+                            // fits the slot": 160 + 40 does not fit 180, so the clamp
+                            // that makes a computed width safe resolves it to the 140
+                            // the margin leaves rather than overflowing the row.
+                            .margin(new DocumentInsets(0, 20, 0, 20))
+                            .fixedWidth(160)
+                            .addParagraph(p -> p.name("Body").text("Short.").align(TextAlign.CENTER)))
+                    .addSection(s -> s.name("Filler").addParagraph("f"))));
+
+            PlacedNode card = node(document, "Card");
+            assertThat(card.placementWidth()).isCloseTo(140.0, within(0.01));
+            assertThat(card.placementX() + card.placementWidth())
+                    .as("the card stays inside its slot")
+                    .isLessThanOrEqualTo(20.0 + INNER_WIDTH / 2 - 20.0 + 0.01);
         }
     }
 


### PR DESCRIPTION
## Why

Two things were confirming themselves.

**The claims gate.** `proof=test:Class#method` was checked by searching the test file for `method\s*\(`. A comment left where the assertion used to be (`// Former test: name()`), the name inside a string literal, or any call site all counted, so a claim whose proof had been deleted went on reading as proven for as long as the name survived anywhere in the file. The name also reached that pattern by interpolation, so one carrying a regex metacharacter matched more than itself. The one tool whose "no" has to hold was answering "yes" on the evidence of a comment.

**A fixed-width flow's background under changing page margins.** A root `pageFlow` with both a `fixedWidth` and a fill was reported as painting its background somewhere its content is not. Reproducing it on a 400x300 page whose margin widens from 20 to 80 at page 2 shows the decoration band is not the defect, and that the obvious fix inverts it.

## What changed

**`declaresTestMethod` replaces the file search** (`knowledge/tools/claims/lib/claims.mjs`). A proof asserts that a named test *holds* a claim, so the question is not whether some method of that name exists — it is whether that test is there and runs. Comments, string and character literals and text blocks are blanked first (offset-preserving, so later matches still point at the real source), then each annotation run is read forward to the method it introduces. A run without `@Test`, `@ParameterizedTest`, `@RepeatedTest`, `@TestFactory` or `@TestTemplate` proves nothing, and neither does one carrying `@Disabled` — on either side of the test annotation, or on the class.

Reading *forward from the annotation* is what makes the answer decidable, and the reason the first attempt (scan backward from `name(`, classify what precedes it) was abandoned rather than patched: `Map<K, V> name(` and `a < b ? c > name(1)` are the same characters, `?` is both a wildcard and a ternary, and `{`, `}` and `;` all appear inside argument lists — so a statement-level ternary and a comparison pair after a lambda block both read as declarations. Between an annotation and the method name there are no expressions at all, only annotations, modifiers and a type.

**Ambiguous proof classes are refused** (`check-claims.mjs`). The test walk kept one path per simple name, last write wins, so two classes sharing a name collapsed and `#method` was checked against the other module's file without saying so — `InternalEnginePackageMarkerTest` exists in both `render-pdf` and `render-pptx` today. Every path is kept and an ambiguous proof now fails by name. Class-level `@Disabled` is handled coarsely on purpose (it disables the whole file's proofs): the cost is a claim that must name another test, against a claim reading as proven by something that never runs.

`test:Class` with no method half keeps its previous meaning.

**The margin behaviour is pinned, not patched** (`FixedWidthPageMarginChromeTest`, 8 tests). A block is measured and placed once; its band is that block's own box on every page it spans, and only the vertical edges follow each page's margins. Making the band chase the painted page's column instead abandons the text of any block whose content merely *flows* across the boundary — the same defect one level down — so that variant is not shipped.

What is genuinely inconsistent sits in the compiler: a direct child of the root is re-seated into the column of the page that child starts on (`depth == 1 && state.hasPageGeometry()`), while the root around it keeps one box. A parent spanning two columns has no single box to be. The tests carry the numbers rather than the direction, because the numbers are the record: a `fixedWidth(200)` root bands at 20..220 and its re-seated child runs 80..280 — a 60pt overhang. The boundary is pinned beside it: at `fixedWidth(340)` the root already covers page 2's column and the child lands inside, so the gap needs a root *narrower* than the later page's column. A background moved onto a section inside the root avoids it entirely — that section is seated as one box with the content it decorates — and that remedy has its own test.

**The row-column width is asserted** (`FlowFixedWidthLayoutTest`). Since #666 the row child's horizontal margin comes off once, so a card with a 20pt side margin and `fixedWidth(120)` in a 180pt slot is placed at 120, not the 100 the double subtraction produced. That test asserted only that content stayed inside the painted box — deliberately, because the width was wrong at the time — so nothing held the number. The other side of the clamp gets a test too: 160 plus the same margin does not fit the slot and resolves to the 140 the margin leaves, rather than overflowing the row.

**No production Java changed.** `git diff origin/develop...HEAD --name-only | grep src/main` is empty — no render moved, so no committed preview or example owes regeneration.

## Verification

`./mvnw -B -ntp clean verify -pl <the eight CI modules> -am` → **BUILD SUCCESS**, 11 modules, **2097 tests, 0 failures**. `./mvnw -B -ntp javadoc:javadoc` → **BUILD SUCCESS**.

Knowledge gates: `claims.test.mjs` **84 passed** (from 47), `check-claims --check` → `46 claims, 10 proofs, both current` (exit 0), `check-routes` exit 0, `classifier` 23 / `anchors` 35 / `pack-version` 33.

Every mechanism was checked by restoring the defect, not by inspection:

- **7/7 claims mutations go red** — accepting `@Disabled` (method-level and type-level), dropping the test-annotation requirement, skipping the comment/literal blanking, not skipping annotation arguments, not skipping generic brackets, and reverting the gate's call site to the old `new RegExp`. That last one matters most: the old search is strictly more permissive, so it left every check and the repository gate green — a guard now stands on the wiring itself.
- **5/8 chrome tests go red** under a band-chases-the-painted-column change; the per-page bottom clamp goes red when dropped. That assertion needed a 3-page band to bind at all — on the band's *last* page the bottom edge is the content's own, so the clamp never applies and an assertion there passes with 88pt of slack however the clamp is written.
- **The row test goes red at `100.0`** against pre-#666 core, and is the only one of the 25 that does.

Corpus sweep of `declaresTestMethod` against an independent line-anchored reference: **434 test files, 2137 test methods, zero disagreements** in either direction.

**Lane:** test + build/tooling — knowledge gate, qa layout tests, recipe and CHANGELOG; no engine or public API surface touched.

## Notes

The compiler seating rule is left alone deliberately. Fixing it means giving a spanning parent and its re-seated children one box, which is a change to `LayoutCompiler.compileComposite`, not to the decoration; `FixedWidthPageMarginChromeTest` is written so it goes **red** when that lands, which is the point of recording the numbers.

`proof=test:X#y` is stricter than before: `y` must now be a runnable, enabled test rather than any declared method. Both live `#method` proofs already satisfy it, so nothing in the repository changes today.

`InternalEnginePackageMarkerTest` existing twice is now a latent error for any proof that cites it — worth renaming one, separately.
