### PR TITLE
fix(knowledge): record package-level @Beta, and guard the stability doc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,7 @@ jobs:
         run: |
           expected=$(printf '%s\n' \
             knowledge/tools/api-surface/test/classifier.test.mjs \
+            knowledge/tools/api-surface/test/stability-doc.test.mjs \
             knowledge/tools/claims/test/claims.test.mjs \
             knowledge/tools/routing/test/anchors.test.mjs \
             knowledge/tools/routing/test/pack-version.test.mjs)
@@ -264,6 +265,13 @@ jobs:
       - name: Knowledge pack — API surface is current
         if: matrix.java == '17'
         run: node knowledge/tools/api-surface/extract-api.mjs --from-reactor --check
+
+      # docs/api-stability.md is where a reader asks "what is still moving", and
+      # nothing was checking that it still names what carries @Beta. The test it
+      # cites as its guard examines the annotation type, never what is annotated.
+      - name: Knowledge pack — the stability document names every @Beta
+        if: matrix.java == '17'
+        run: node knowledge/tools/api-surface/check-stability-doc.mjs
 
       # A claim is a promise a published page makes to a reader. This fails when
       # a page names API that no surface has — which a reader would discover by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,6 +172,24 @@ follow semantic versioning; release dates are ISO 8601.
   neither shrinks a fixed rule nor gives `fill()` a slot, and a centre- or right-aligned
   heading claims the whole `auto()` column and leaves the rule zero width.
 
+- **The stability document is guarded, and the pack records a beta *package*.**
+  `docs/api-stability.md` is where a reader asks what is still moving, and nothing was
+  checking that it still names what carries `@Beta`: the guard it cites,
+  `BetaAnnotationDocumentationTest`, examines the annotation type — its retention, its
+  targets, its own Javadoc — and never what is annotated.
+  `knowledge/tools/api-surface/check-stability-doc.mjs` now runs in CI and fails when a
+  marker written on a package, type or member goes unnamed. It found two things at once.
+  Four `@Beta` members of the otherwise-Stable PDF backend were undocumented —
+  `PdfFixedLayoutBackend.renderSections` / `writeSections`, and `Builder.deterministic`
+  in both overloads — and the document now names them. And the generated surfaces
+  recorded no package-level stability at all: every `knowledge/api/*.json` described
+  zero beta packages while two `package-info.java` files declare `@Beta`, so the pack
+  presented fifteen PPTX handler types as fifteen separate beta decisions rather than
+  one beta package. The extractor now carries `packageStability` through to the package
+  entry and the Markdown view marks the package heading `[beta]` the way it already
+  marked types and members, so a consumer can tell a beta package from a package whose
+  one admitted type happens to be beta.
+
 ## v2.3.0 — 2026-08-31
 
 ### Public API

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -56,6 +56,18 @@ matrix.
 > methods on `DocumentSession` (`toPptxBytes`, `writePptx`, `buildPptx`).
 > Geometry identity with the PDF backend is a design invariant and will not
 > change; the API shape around it may still move in a minor release.
+>
+> Four members of the otherwise-Stable **PDF backend** also carry `@Beta`. The
+> package is not Experimental — these are:
+> `PdfFixedLayoutBackend.renderSections` / `writeSections`, the low-level seam
+> that concatenates several sections into one document, where
+> `MultiSectionDocument` via `GraphCompose.documents()` is the settled entry
+> point most callers want instead; and
+> `PdfFixedLayoutBackend.Builder.deterministic` in both overloads, which pins
+> `CreationDate` / `ModDate` and derives the `/ID` from metadata so a document
+> renders byte-identically across runs. Determinism is off by default, and what
+> reproducible builds depend on is the *behaviour* — it is the shape of the
+> opt-in that may still move.
 
 ### What each tier promises
 

--- a/knowledge/api/backends.json
+++ b/knowledge/api/backends.json
@@ -4009,6 +4009,7 @@
     },
     {
       "name": "com.demcha.compose.document.backend.fixed.pptx",
+      "stability": "beta",
       "types": [
         {
           "name": "PptxCoordinates",
@@ -4620,6 +4621,7 @@
     },
     {
       "name": "com.demcha.compose.document.backend.fixed.pptx.handlers",
+      "stability": "beta",
       "types": [
         {
           "name": "PptxAnchorMarkerRenderHandler",

--- a/knowledge/api/backends.md
+++ b/knowledge/api/backends.md
@@ -386,7 +386,7 @@ Types: 69 · methods: 371 · constants: 18 · compiler-generated members: 189
 ### PdfWatermarkPosition (enum)
 - constants: `CENTER`, `TOP_LEFT`, `TOP_RIGHT`, `BOTTOM_LEFT`, `BOTTOM_RIGHT`, `TILE`
 
-## com.demcha.compose.document.backend.fixed.pptx
+## com.demcha.compose.document.backend.fixed.pptx   [beta]
 
 ### PptxCoordinates (class)   [beta]
 - `double topY(double canvasHeight, double y, double height)   [beta]`
@@ -434,7 +434,7 @@ Types: 69 · methods: 371 · constants: 18 · compiler-generated members: 189
 - `XSLFPictureData resolvePicture(ImageData imageData)   [beta]`
 - `void registerAnchor(PlacedFragment fragment, String anchor)   [beta]`
 
-## com.demcha.compose.document.backend.fixed.pptx.handlers
+## com.demcha.compose.document.backend.fixed.pptx.handlers   [beta]
 
 ### PptxAnchorMarkerRenderHandler (class)   [beta]
 - `new PptxAnchorMarkerRenderHandler()   [beta]`

--- a/knowledge/api/extension-spi.json
+++ b/knowledge/api/extension-spi.json
@@ -300,6 +300,7 @@
     },
     {
       "name": "com.demcha.compose.document.backend.fixed.pptx",
+      "stability": "beta",
       "types": [
         {
           "name": "PptxFragmentRenderHandler",

--- a/knowledge/api/extension-spi.md
+++ b/knowledge/api/extension-spi.md
@@ -60,7 +60,7 @@ Types: 9 · methods: 26 · constants: 0 · compiler-generated members: 26
 - `Class<T> payloadType()`
 - `void render(PlacedFragment, T, PdfRenderEnvironment)`
 
-## com.demcha.compose.document.backend.fixed.pptx
+## com.demcha.compose.document.backend.fixed.pptx   [beta]
 
 ### PptxFragmentRenderHandler (interface)   [beta]
 - `Class<T> payloadType()   [beta]`

--- a/knowledge/tools/README.md
+++ b/knowledge/tools/README.md
@@ -17,6 +17,8 @@ library's to define. That is what moving the generator here fixes.
 | Path | Job |
 |---|---|
 | `api-surface/extract-api.mjs` | reads class files with `javap`, writes the surface JSON and its Markdown view |
+| `api-surface/check-stability-doc.mjs` | the gate that `docs/api-stability.md` still names everything carrying `@Beta` |
+| `api-surface/lib/stability-doc.mjs` | which markers originate a `@Beta` and which inherit one from their package or type |
 | `api-surface/lib/javap.mjs` | drives `javap` and normalises what it prints |
 | `api-surface/lib/source-names.mjs` | lifts real parameter names out of a sources jar |
 | `api-surface/lib/zip.mjs` | reads a jar without unpacking it |

--- a/knowledge/tools/api-surface/check-stability-doc.mjs
+++ b/knowledge/tools/api-surface/check-stability-doc.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * knowledge/tools/api-surface/check-stability-doc.mjs — does the stability
+ * document still name everything that carries `@Beta`?
+ *
+ *   node knowledge/tools/api-surface/check-stability-doc.mjs
+ *
+ * Exit 0 every originating `@Beta` is named · 1 something is unnamed · 2 usage.
+ *
+ * `docs/api-stability.md` is where a reader goes to ask "what is still moving".
+ * It answers by naming things — the PPTX packages, `NodeDefinition`, the PPTX
+ * convenience methods on `DocumentSession` — and a name that stops being true,
+ * or a marker that never acquires one, is invisible until someone reads both the
+ * document and the code side by side.
+ *
+ * Nothing was checking that. The document cites `BetaAnnotationDocumentationTest`
+ * as its guard, but that test examines the *annotation type* — its retention,
+ * its targets, its own Javadoc. It never looks at what carries the annotation.
+ * So four `@Beta` members of the PDF backend went undocumented while every other
+ * beta surface was enumerated carefully: not neglect, just an unguarded seam.
+ *
+ * The rule for what must be named lives in `lib/stability-doc.mjs`, where
+ * `test/stability-doc.test.mjs` holds it to fixtures. This file is the file
+ * plumbing around that rule.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { originatingBetas, unnamedOrigins, countByKind } from "./lib/stability-doc.mjs";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(HERE, "..", "..", "..");
+const API_DIR = path.join(REPO_ROOT, "knowledge", "api");
+const DOC = path.join(REPO_ROOT, "docs", "api-stability.md");
+
+if (process.argv.length > 2) {
+  process.stdout.write(
+    "usage: node knowledge/tools/api-surface/check-stability-doc.mjs\n\n" +
+      "exit: 0 every originating @Beta is named | 1 something is unnamed | 2 usage\n",
+  );
+  process.exit(process.argv[2] === "--help" || process.argv[2] === "-h" ? 0 : 2);
+}
+
+if (!fs.existsSync(API_DIR)) {
+  process.stderr.write("[stability-doc] no surfaces — run extract-api.mjs --from-reactor first\n");
+  process.exit(1);
+}
+
+const doc = fs.readFileSync(DOC, "utf8");
+
+// `excluded.json` records what the surfaces leave out rather than what they
+// admit, so it carries no packages to read markers from.
+const surfaces = fs
+  .readdirSync(API_DIR)
+  .filter((f) => f.endsWith(".json") && f !== "excluded.json")
+  .map((f) => JSON.parse(fs.readFileSync(path.join(API_DIR, f), "utf8")));
+
+const origins = originatingBetas(surfaces);
+const unnamed = unnamedOrigins(origins, doc);
+
+if (unnamed.length) {
+  process.stderr.write(
+    `[stability-doc] ${unnamed.length} thing(s) carry @Beta and are not named in docs/api-stability.md:\n\n` +
+      unnamed.map((o) => `    ${o.kind.padEnd(8)} ${o.what}\n`).join("") +
+      "\n  A reader asking what is still moving reads that document, so a marker it\n" +
+      "  does not mention is a promise nobody made. Name it, or drop the marker.\n",
+  );
+  process.exit(1);
+}
+
+const counts = countByKind(origins);
+process.stdout.write(
+  `[stability-doc] every originating @Beta is named — ` +
+    `${counts.package ?? 0} package(s), ${counts.type ?? 0} type(s), ${counts.member ?? 0} member(s)\n`,
+);

--- a/knowledge/tools/api-surface/extract-api.mjs
+++ b/knowledge/tools/api-surface/extract-api.mjs
@@ -49,6 +49,7 @@ import { readAnnotations, memberKeyForMember } from "./lib/annotations.mjs";
 import {
   admit,
   stability,
+  BETA,
   memberStability,
   SURFACES,
   inImplementationRoot,
@@ -537,6 +538,7 @@ function buildSurface({ version, artifacts, javap }) {
       name: type.name,
       binaryName: type.binaryName,
       package: type.package,
+      packageStability: type.packageAnnotations.includes(BETA) ? "beta" : "stable",
       kind: type.kind,
       modifiers: type.modifiers,
       artifact: type.artifact,
@@ -645,10 +647,18 @@ function surfaceDocument({ surface, version, types, artifacts }) {
   for (const type of sorted) {
     let bucket = packages[packages.length - 1];
     if (!bucket || bucket.name !== type.package) {
-      bucket = { name: type.package, types: [] };
+      bucket = {
+        name: type.package,
+        // Recorded rather than inferred. A consumer cannot tell a beta *package*
+        // from a package whose one admitted type happens to be beta, and
+        // `document.layout` is exactly that: everything in it is excluded except
+        // `NodeDefinition`, which is beta.
+        ...(type.packageStability === "beta" ? { stability: "beta" } : {}),
+        types: [],
+      };
       packages.push(bucket);
     }
-    const { package: _drop, ...rest } = type;
+    const { package: _drop, packageStability: _drop2, ...rest } = type;
     bucket.types.push(rest);
   }
 

--- a/knowledge/tools/api-surface/lib/render-markdown.mjs
+++ b/knowledge/tools/api-surface/lib/render-markdown.mjs
@@ -81,7 +81,7 @@ export function renderMarkdown(surface) {
   );
 
   for (const pkg of surface.packages) {
-    out.push("", `## ${pkg.name}`, "");
+    out.push("", `## ${pkg.name}${mark(pkg.stability)}`, "");
     for (const type of pkg.types) {
       out.push(`### ${type.name} (${type.kind})${mark(type.stability)}`);
       for (const member of type.members) {

--- a/knowledge/tools/api-surface/lib/stability-doc.mjs
+++ b/knowledge/tools/api-surface/lib/stability-doc.mjs
@@ -1,0 +1,71 @@
+/**
+ * knowledge/tools/api-surface/lib/stability-doc.mjs — which `@Beta` markers the
+ * stability document has to name, and which of them it does not.
+ *
+ * Split out of `check-stability-doc.mjs` so the rule can be held to fixtures.
+ * The rule is the whole value of that gate: a check that reports everything is
+ * as useless as one that reports nothing, and neither is visible from a green
+ * CI run.
+ */
+
+/**
+ * Everything that *originates* a beta marker, across the surfaces given.
+ *
+ * A surface document records inherited stability the same way as declared, so
+ * the two are told apart here: a type is an origin when its package is not
+ * beta, and a member is an origin when its type is not.
+ *
+ * **Only originating markers are required.** A type that is beta because its
+ * package is, or a member that is beta because its type is, inherits the status
+ * and is covered by the entry naming its origin — demanding a line for each of
+ * the fifteen PPTX handlers would produce a document nobody finishes reading.
+ * What must be named is every place the marker is actually *written*.
+ *
+ * @param {Array<{packages?: Array<object>}>} surfaces parsed surface documents
+ * @returns {Array<{what: string, kind: "package"|"type"|"member"}>} deduplicated by name
+ */
+export function originatingBetas(surfaces) {
+  const origins = new Map();
+  for (const surface of surfaces) {
+    for (const pkg of surface.packages ?? []) {
+      const packageIsBeta = pkg.stability === "beta";
+      if (packageIsBeta) origins.set(pkg.name, { what: pkg.name, kind: "package" });
+
+      for (const type of pkg.types ?? []) {
+        const typeIsBeta = type.stability === "beta";
+        if (typeIsBeta && !packageIsBeta) origins.set(type.name, { what: type.name, kind: "type" });
+        for (const member of type.members ?? []) {
+          if (member.stability === "beta" && !typeIsBeta) {
+            origins.set(`${type.name}.${member.name}`, {
+              what: `${type.name}.${member.name}`,
+              kind: "member",
+            });
+          }
+        }
+      }
+    }
+  }
+  return [...origins.values()];
+}
+
+/**
+ * The origins the document does not name, sorted so the report is stable.
+ *
+ * Named is "the document contains this identifier": the doc writes short forms
+ * (`toPptxBytes`, `…pptx.handlers`), so requiring a fully-qualified match would
+ * fail on prose that is perfectly clear.
+ *
+ * @param {Array<{what: string, kind: string}>} origins from {@link originatingBetas}
+ * @param {string} doc the stability document's text
+ */
+export function unnamedOrigins(origins, doc) {
+  const shortName = (what) => what.split(".").pop();
+  return origins
+    .filter((o) => !doc.includes(o.what) && !doc.includes(shortName(o.what)))
+    .sort((a, b) => a.what.localeCompare(b.what));
+}
+
+/** How many origins of each kind, for the line a passing run prints. */
+export function countByKind(origins) {
+  return origins.reduce((acc, o) => ({ ...acc, [o.kind]: (acc[o.kind] ?? 0) + 1 }), {});
+}

--- a/knowledge/tools/api-surface/test/stability-doc.test.mjs
+++ b/knowledge/tools/api-surface/test/stability-doc.test.mjs
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+/**
+ * knowledge/tools/api-surface/test/stability-doc.test.mjs — which `@Beta`
+ * markers the stability document has to name.
+ *
+ *   node knowledge/tools/api-surface/test/stability-doc.test.mjs
+ *
+ * Exit 0 all passed · 1 a case failed.
+ *
+ * The gate has two ways to become useless and a green run tells them apart from
+ * working in neither direction. Report too much and the document grows a line
+ * per inherited marker — fifteen PPTX handlers instead of the one package that
+ * declares them — until nobody finishes reading it. Report too little and it
+ * passes for ever, which is what it looked like before the gate existed. So the
+ * cases below come in pairs: what must be named, and what must not be demanded.
+ */
+
+import { suite } from "../../lib/fixtures.mjs";
+
+import { originatingBetas, unnamedOrigins, countByKind } from "../lib/stability-doc.mjs";
+
+const { check, done } = suite("stability-doc.test");
+
+/** A surface document with one package, spelled the way `extract-api` emits it. */
+const surface = (pkg) => ({ packages: [pkg] });
+const names = (origins) => origins.map((o) => `${o.kind}:${o.what}`).sort();
+
+// --- what originates a marker ------------------------------------------------
+
+check(
+  "a beta package is an origin",
+  names(originatingBetas([surface({ name: "a.b.pptx", stability: "beta", types: [] })])),
+  ["package:a.b.pptx"],
+);
+
+// The inheritance case the document's readability depends on: the package entry
+// already tells the reader everything its types are.
+check(
+  "a type inside a beta package is not an origin",
+  names(
+    originatingBetas([
+      surface({
+        name: "a.b.pptx",
+        stability: "beta",
+        types: [{ name: "PptxImageHandler", stability: "beta", members: [] }],
+      }),
+    ]),
+  ),
+  ["package:a.b.pptx"],
+);
+
+check(
+  "a beta type in a stable package is an origin",
+  names(
+    originatingBetas([
+      surface({ name: "a.b", types: [{ name: "NodeDefinition", stability: "beta", members: [] }] }),
+    ]),
+  ),
+  ["type:NodeDefinition"],
+);
+
+check(
+  "a member of a beta type is not an origin",
+  names(
+    originatingBetas([
+      surface({
+        name: "a.b",
+        types: [
+          { name: "NodeDefinition", stability: "beta", members: [{ name: "emit", stability: "beta" }] },
+        ],
+      }),
+    ]),
+  ),
+  ["type:NodeDefinition"],
+);
+
+// The case that started this: `PdfFixedLayoutBackend` is Stable, four of its
+// members are not, and nothing named them.
+check(
+  "a beta member of a stable type is an origin, qualified by its type",
+  names(
+    originatingBetas([
+      surface({
+        name: "a.b",
+        types: [
+          {
+            name: "PdfFixedLayoutBackend",
+            members: [
+              { name: "renderSections", stability: "beta" },
+              { name: "writeSections", stability: "beta" },
+              { name: "build" },
+            ],
+          },
+        ],
+      }),
+    ]),
+  ),
+  ["member:PdfFixedLayoutBackend.renderSections", "member:PdfFixedLayoutBackend.writeSections"],
+);
+
+check(
+  "a surface with nothing beta originates nothing",
+  originatingBetas([surface({ name: "a.b", types: [{ name: "Stable", members: [{ name: "x" }] }] })]),
+  [],
+);
+
+// A package admitted by two surfaces (`…fixed.pptx` is in both `backends` and
+// `extension-spi`) is one thing to name, not two.
+check(
+  "the same package in two surfaces is one origin",
+  names(
+    originatingBetas([
+      surface({ name: "a.b.pptx", stability: "beta", types: [] }),
+      surface({ name: "a.b.pptx", stability: "beta", types: [] }),
+    ]),
+  ),
+  ["package:a.b.pptx"],
+);
+
+// --- what counts as named ----------------------------------------------------
+
+const origins = [
+  { what: "com.demcha.a.pptx", kind: "package" },
+  { what: "NodeDefinition", kind: "type" },
+];
+
+check(
+  "a fully-qualified mention names it",
+  unnamedOrigins(origins, "the com.demcha.a.pptx package, and NodeDefinition"),
+  [],
+);
+
+// The document writes `…pptx.handlers` and `toPptxBytes`; demanding the binary
+// name would fail on prose that is perfectly clear.
+check(
+  "a short-form mention names it",
+  unnamedOrigins(origins, "the `…a.pptx` package moves, and so does NodeDefinition"),
+  [],
+);
+
+check(
+  "an unmentioned origin is reported",
+  unnamedOrigins(origins, "NodeDefinition is experimental").map((o) => o.what),
+  ["com.demcha.a.pptx"],
+);
+
+// Sorted so a failing run reads the same twice and diffs cleanly.
+check(
+  "the report is sorted by name",
+  unnamedOrigins(
+    [
+      { what: "Zebra", kind: "type" },
+      { what: "Alpha", kind: "type" },
+      { what: "Middle", kind: "type" },
+    ],
+    "",
+  ).map((o) => o.what),
+  ["Alpha", "Middle", "Zebra"],
+);
+
+// A substring match is what makes short forms work, and it is also its limit:
+// this is a reminder that the gate proves a name is present, not that the prose
+// around it is true.
+check(
+  "a name that is a substring of a longer word counts as named",
+  unnamedOrigins([{ what: "Beta", kind: "type" }], "BetaAnnotationDocumentationTest"),
+  [],
+);
+
+// --- the summary line --------------------------------------------------------
+
+check(
+  "kinds are counted separately",
+  countByKind([
+    { what: "p", kind: "package" },
+    { what: "q", kind: "package" },
+    { what: "T", kind: "type" },
+  ]),
+  { package: 2, type: 1 },
+);
+
+check("counting nothing is an empty tally", countByKind([]), {});
+
+done();


### PR DESCRIPTION
## Why

The generated surfaces recorded no package-level stability at all. Across all five
surfaces, `knowledge/api/*.json` described **zero** beta packages while two
`package-info.java` files — `document.backend.fixed.pptx` and
`…pptx.handlers` — carry `@Beta`. A consumer reading the pack met fifteen PPTX
handler types each looking like its own beta decision, with nothing saying they
inherit one marker from the package that declares it. The Markdown view had the
same hole one layer up: `render-markdown.mjs` marked `[beta]` on types and
members but never on the package heading.

`CLAUDE.md` sells the pack as generated from the compiled classes and gated in CI
"so it cannot disagree with the code silently". This is a place where it did.

Separately, `docs/api-stability.md` is where a reader asks what is still moving,
and nothing checked that it still names what carries `@Beta`. The guard the
document cites, `BetaAnnotationDocumentationTest`, examines the *annotation type*
— its retention, its targets, its own Javadoc — and never what is annotated. Four
`@Beta` members of the otherwise-Stable PDF backend had gone undocumented.

## What changed

- `extract-api.mjs` carries `packageStability` from the package's own annotations
  through to the package entry, so `stability: "beta"` is *recorded* rather than
  left to be inferred. Inferring it does not work: a consumer cannot tell a beta
  package from a package whose one admitted type happens to be beta, and
  `document.layout` is exactly that — 92 types excluded, one admitted
  (`NodeDefinition`), and it is beta.
- `lib/render-markdown.mjs` marks the package heading `[beta]` through the same
  `mark()` helper the type and member lines already used.
- **New gate** `check-stability-doc.mjs` fails when a marker written on a package,
  type or member is not named in `docs/api-stability.md`. Only *originating*
  markers are required — a type that is beta because its package is inherits the
  status — so the document keeps one line per package instead of one per handler.
- The rule lives in `lib/stability-doc.mjs`, matching how `claims` and `routing`
  split CLI from logic, with `test/stability-doc.test.mjs` holding it to 14
  fixtures. Both directions are covered: a guard that reports everything is as
  useless as one that reports nothing, and a green run distinguishes neither.
- `ci.yml` runs the gate on the baseline JDK after the surface-currency check, and
  the new suite is added to the declared fixture list — that step compares the
  discovered set against the list and goes red on a mismatch, so it caught the
  omission before CI would have.
- `docs/api-stability.md` names the four members: `PdfFixedLayoutBackend`'s
  `renderSections` / `writeSections`, and `Builder.deterministic` in both
  overloads.

## Verification

`./mvnw -B -ntp clean verify -pl :graph-compose-core,:graph-compose-render-pdf,:graph-compose-render-docx,:graph-compose-render-pptx,:graph-compose-templates,:graph-compose-testing,:graph-compose-qa,:graph-compose-coverage -am`
→ **BUILD SUCCESS**, 10 modules.

All nine knowledge gates green: surfaces current, stability doc, `check-claims`
(46 claims / 10 proofs), `check-routes` (5 routes), and the fixture suites —
`stability-doc.test` **14 passed** (new), `classifier.test` 23, `claims.test` 84,
`anchors.test` 35, `pack-version.test` 33.

The new gate is proven fail-closed, not assumed: removing `&& !packageIsBeta` from
the origin rule turns the suite red on `a type inside a beta package is not an
origin` with the expected/actual pair. The gate itself reported 18 unnamed markers
against the pre-change surfaces, 15 after the document paragraph alone, and 0 once
the extractor recorded the package — the 15 PPTX handlers collapsing into the one
package entry is the behaviour under test.

Regeneration is 3 JSON lines and 3 Markdown headings; no other surface content moved.

## Notes

- Changing a package heading changes its GitHub anchor. Nothing in the repository
  anchors into `knowledge/api/*.md` — the routing table references only
  `docs/recipes/*.md` — so `check-routes` and `anchors.test` are unaffected.
- `GENERATOR_VERSION` stays `2.0.0` and `schemaVersion` stays `2`: the package
  object gained an optional field, which is additive, and nothing reads
  `generatorVersion` as a compatibility contract (it is provenance metadata).
- No Java changed, so there is no `### Public API` entry; the CHANGELOG line sits
  under `### Documentation` in `## v2.4.0 — Planned`.

**Lane:** build/CI + docs — the extractor, its gate, the workflow and two documents;
no engine, canonical or template code is touched.
