### PR TITLE
fix(layout): give an anchor that spans pages the slice on each of them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,22 @@ follow semantic versioning; release dates are ISO 8601.
 
 ### Layout
 
+- **A resolved anchor on content that spans pages is now that page's slice of the box.**
+  It reported the whole subtree on every page instead — a section across five pages said
+  453.25pt five times, with tops hundreds of points outside the page — which was written
+  down as a limitation because nothing yet needed the per-page extent. Something does now,
+  and the numbers were unusable rather than merely imprecise, so the semantics are fixed
+  rather than documented: one occurrence per page occupied, each the border-box slice
+  lying on that page. The first runs from the node's top to the bottom of that page's
+  content band, a middle one is the whole band, and the last runs from the band's top to
+  the node's bottom; all of them share one id. The bands are the ones a spanning node's
+  border already clamps to, per-page margins included, so there is one formula rather than
+  two drifting apart. A child's margin comes off the edges its slice actually contains —
+  the top margin only on the first page, the bottom only on the last, neither in the
+  middle — while horizontal margins come off every slice as before. **An anchor whose
+  content fits on one page is unchanged**, which is every anchor that exists today.
+
+
 - **A built-in feature can now draw from geometry the layout has already resolved.**
   Some things cannot be drawn while laying out because they depend on where other things
   ended up — a rail running between markers, a bracket spanning sections, a leader joining

--- a/core/src/main/java/com/demcha/compose/document/layout/LayoutAnchorNode.java
+++ b/core/src/main/java/com/demcha/compose/document/layout/LayoutAnchorNode.java
@@ -9,17 +9,18 @@ import java.util.Objects;
  * Wraps one node so the finished layout reports where it landed.
  *
  * <p>The wrapper is transparent: it measures to exactly its child's size and adds no
- * spacing, so inserting one changes no geometry. What it adds is a single non-visual
- * fragment carrying {@link com.demcha.compose.document.layout.payloads.LayoutAnchorPayload},
- * which a post-layout pass can find by identity.</p>
+ * spacing, so inserting one changes no geometry. What it adds is a non-visual fragment
+ * carrying {@link com.demcha.compose.document.layout.payloads.LayoutAnchorPayload}, which a
+ * post-layout pass can find by identity — <b>one per page the child occupies</b>, each
+ * carrying that page's slice of the box.</p>
  *
  * <p>Measuring to the child rather than to the available width is not a detail. It is what
  * makes the anchor's box the child's box, so a caller reading the anchor learns where the
  * <em>marker</em> is, not where its container is. What comes back is the child's border
  * box — margin excluded, padding included; see
- * {@link ResolvedLayoutAnchor} for the whole contract. Wrap the node you want to measure:
- * anchor a marker and you get the marker, anchor the container it sits in and you get the
- * container.</p>
+ * {@link ResolvedLayoutAnchor} for the whole contract, including how a box that spans pages
+ * is sliced. Wrap the node you want to measure: anchor a marker and you get the marker,
+ * anchor the container it sits in and you get the container.</p>
  *
  * <p>Lives in this {@code @Internal} package on purpose. Anchoring is engine plumbing that
  * a built-in feature uses to reach its own resolved geometry; whether authors should ever

--- a/core/src/main/java/com/demcha/compose/document/layout/ResolvedLayoutAnchor.java
+++ b/core/src/main/java/com/demcha/compose/document/layout/ResolvedLayoutAnchor.java
@@ -17,12 +17,26 @@ import java.util.Objects;
  * particular shape has to ask that shape. And it is the box of the node that was
  * <em>wrapped</em> — anchor a container and the container is what comes back.</p>
  *
- * @param id        the anchor's identity
- * @param pageIndex zero-based page the anchor landed on
+ * <p><b>One of these per page the node occupies</b>, each the slice of that box lying on
+ * its own page. A node that fits on one page has one, and it is the whole box. A node that
+ * spans pages has one per page: the first runs from the node's top to the bottom of that
+ * page's content band, a middle one is the whole band, and the last runs from the band's
+ * top to the node's bottom. They share an id, so a consumer asking for an owner gets the
+ * slices in page order and can draw each on its own page without arithmetic of its own.
+ * The bands come from the geometry a spanning node's border already uses, per-page margins
+ * included.</p>
+ *
+ * <p>The margin comes off the edges a slice actually contains — the top margin only on the
+ * node's first page, the bottom margin only on its last, neither in the middle, both when
+ * there is only one. Horizontally every slice is the full box, so the left and right
+ * margins always come off.</p>
+ *
+ * @param id        the anchor's identity, shared by every page's slice
+ * @param pageIndex zero-based page this slice lies on
  * @param x         left edge, page coordinates
- * @param y         bottom edge, page coordinates
+ * @param y         bottom edge of this page's slice, page coordinates
  * @param width     the wrapped node's border-box width
- * @param height    the wrapped node's border-box height
+ * @param height    the height of this page's slice, not of the whole node
  * @author Artem Demchyshyn
  * @since 2.4.0
  */

--- a/core/src/main/java/com/demcha/compose/document/layout/definitions/LayoutAnchorDefinition.java
+++ b/core/src/main/java/com/demcha/compose/document/layout/definitions/LayoutAnchorDefinition.java
@@ -30,6 +30,10 @@ import java.util.List;
  * into, its own margin excluded and its padding included. Two boxes are in play and only
  * one of them is useful to a consumer — see {@link #emitFragments}.</p>
  *
+ * <p>For a child that spans pages it reports <b>one slice per page</b>, from the placement
+ * the compiler already computed for that page, so the anchor of a tall section is usable on
+ * every page it crosses rather than a single box that fits on none of them.</p>
+ *
  * @author Artem Demchyshyn
  * @since 2.4.0
  */
@@ -74,23 +78,33 @@ public final class LayoutAnchorDefinition implements NodeDefinition<LayoutAnchor
     public List<LayoutFragment> emitFragments(PreparedNode<LayoutAnchorNode> prepared,
                                               FragmentContext ctx,
                                               FragmentPlacement placement) {
-        // The child's border box, which is not the wrapper's. prepare() measured the
-        // child's *margin* box, because that is the space the wrapper has to occupy for
-        // the surrounding flow to be right; reporting it would be wrong for the one thing
-        // this seam is for. A marker with margin(top 2, right 4, bottom 6, left 8) would
-        // have its anchor centre land 2pt off its own ink in both directions, and a rail
-        // drawn through that centre would visibly miss it. So the margin comes back off
-        // here, in the offset and in the size. Measured rather than assumed: the compiler
-        // seats the child at the anchor's bottom-left plus (left, bottom) — y grows up.
+        // The slice of the child's border box that lands on *this* page.
+        //
+        // The placement already is that slice. A composite's fragments are emitted once
+        // per page it occupies, and the band each segment clamps to is computed by
+        // CompositeDecoration — the same geometry that puts a spanning section's border on
+        // every page it crosses, per-page margins included. Reading the placement is what
+        // keeps this one formula instead of a second one drifting beside it. Taking the
+        // measured height instead reported the whole subtree on every page: a section
+        // across five pages said 453.25pt five times, with tops far outside the page.
+        //
+        // The margin is a separate matter and comes off per edge. It is part of the flow
+        // extent the wrapper has to occupy but no part of the box being reported, and a
+        // slice only meets the edges it actually contains — the top margin is inside the
+        // first page's slice, the bottom margin inside the last page's, and a middle page
+        // holds neither. A node that fits on one page is both, so it loses both, exactly
+        // as before. Horizontally every slice spans the whole box, so both sides always go.
         DocumentInsets margin = prepared.node().child().margin();
-        MeasureResult measured = prepared.measureResult();
-        double width = Math.max(0.0, measured.width() - margin.horizontal());
-        double height = Math.max(0.0, measured.height() - margin.vertical());
+        double topInset = placement.pageIndex() == placement.startPage() ? margin.top() : 0.0;
+        double bottomInset = placement.pageIndex() == placement.endPage() ? margin.bottom() : 0.0;
+
+        double width = Math.max(0.0, placement.width() - margin.horizontal());
+        double height = Math.max(0.0, placement.height() - topInset - bottomInset);
         return List.of(new LayoutFragment(
                 placement.path(),
                 0,
                 margin.left(),
-                margin.bottom(),
+                bottomInset,
                 width,
                 height,
                 new LayoutAnchorPayload(prepared.node().id(), width, height)));

--- a/core/src/main/java/com/demcha/compose/document/layout/payloads/LayoutAnchorPayload.java
+++ b/core/src/main/java/com/demcha/compose/document/layout/payloads/LayoutAnchorPayload.java
@@ -7,27 +7,25 @@ import java.util.Objects;
 /**
  * Non-visual marker fragment payload that reports where an anchored subtree landed.
  *
- * <p>One of these is emitted per {@code LayoutAnchorNode}, and it draws nothing — the
- * backends register a no-op handler for it. A post-layout pass reads the resolved
- * fragments, keeps the ones carrying this payload, and gets the anchor's page and
+ * <p>One of these is emitted per page a {@code LayoutAnchorNode} occupies, and it draws
+ * nothing — the backends register a no-op handler for it. A post-layout pass reads the
+ * resolved fragments, keeps the ones carrying this payload, and gets the anchor's page and
  * position without knowing anything about what the anchored subtree drew.</p>
  *
- * <p><strong>The size is declared, not observed.</strong> It comes from the anchored
- * child's own measurement, never from the placement the anchor was handed. That
- * distinction is the whole point: an 8×8 marker inside a table cell is placed in a
- * 16pt-wide cell, and a payload built from {@code placement.width()} would report the
- * cell. A marker drawn as three stacked shapes still gets one anchor with one box, which
- * is what makes the anchor a <em>logical owner</em> rather than a particular draw
- * fragment.</p>
+ * <p><strong>The size is the anchored child's, not its container's.</strong> An 8×8 marker
+ * inside a table cell is placed in a 16pt-wide cell, and an anchor reporting the cell would
+ * be no use to anything looking for the marker. A marker drawn as three stacked shapes
+ * still gets one box, which is what makes the anchor a <em>logical owner</em> rather than a
+ * particular draw fragment.</p>
  *
- * <p>The box is the child's <b>border box</b> — its margin excluded, its padding included.
- * {@code LayoutAnchorDefinition} takes the margin back off both the size and the offset,
- * because the wrapper has to <em>occupy</em> the margin box for the flow to be right while
- * a consumer drawing to the anchor means the ink.</p>
+ * <p>The box is the child's <b>border box</b> — its margin excluded, its padding included —
+ * and, when the child spans pages, the <b>slice of that box on this page</b> rather than
+ * the whole subtree. {@code LayoutAnchorDefinition} holds the details, including which
+ * margin edge comes off which slice.</p>
  *
- * @param id     the anchor's identity
+ * @param id     the anchor's identity, shared by every page's slice
  * @param width  the anchored child's border-box width
- * @param height the anchored child's border-box height
+ * @param height the height of this page's slice of that box
  * @author Artem Demchyshyn
  * @since 2.4.0
  */

--- a/qa/src/test/java/com/demcha/compose/document/api/ResolvedLayoutPassTest.java
+++ b/qa/src/test/java/com/demcha/compose/document/api/ResolvedLayoutPassTest.java
@@ -338,10 +338,9 @@ class ResolvedLayoutPassTest {
     void ananchoredSubtreeThatSpansPagesReportsOneAnchorPerPage() throws Exception {
         // Pinned because it contradicts the obvious reading of "one anchor per wrapper".
         // A composite emits its fragments once per page it occupies, so an anchor wrapping
-        // content that paginates reports one per page — sharing an id, and each carrying
-        // the subtree's whole height rather than the slice on that page. Small atomic
-        // content, which is what anchors are for, never hits it. A consumer that anchors
-        // something tall has to group by page itself, and had better learn that here.
+        // content that paginates reports one per page, sharing an id — and each one is the
+        // slice of the box on *that* page, clamped to the same band a spanning section's
+        // border uses.
         Object group = new Object();
         StringBuilder body = new StringBuilder();
         for (int i = 0; i < 30; i++) {
@@ -359,6 +358,139 @@ class ResolvedLayoutPassTest {
                 .hasSize(graph.totalPages());
         assertThat(anchors.stream().map(ResolvedLayoutAnchor::pageIndex))
                 .containsExactlyElementsOf(java.util.stream.IntStream.range(0, graph.totalPages()).boxed().toList());
+
+        // The page is 200pt tall with a 20pt margin, so the band is 20..180. Every slice
+        // sits inside it and none is the whole subtree — which is what this reported
+        // before, once per page, with tops off the page entirely.
+        double subtreeHeight = anchors.stream().mapToDouble(ResolvedLayoutAnchor::height).sum();
+        assertThat(anchors).allSatisfy(anchor -> {
+            assertThat(anchor.y()).as("inside the band").isGreaterThanOrEqualTo(20.0 - 1e-9);
+            assertThat(anchor.pointY(1.0)).isLessThanOrEqualTo(180.0 + 1e-9);
+            assertThat(anchor.height()).isLessThan(subtreeHeight);
+        });
+        assertThat(anchors.get(0).pointY(1.0))
+                .as("the first slice starts at the node's top")
+                .isEqualTo(180.0, within(1e-9));
+        assertThat(anchors.get(0).y())
+                .as("and runs to the bottom of the band, because the content continues")
+                .isEqualTo(20.0, within(1e-9));
+        assertThat(anchors.get(anchors.size() - 1).pointY(1.0))
+                .as("the last slice starts at the top of its band")
+                .isEqualTo(180.0, within(1e-9));
+        assertThat(anchors.get(anchors.size() - 1).y())
+                .as("and stops where the content does, above the band bottom")
+                .isGreaterThan(20.0);
+    }
+
+    @Test
+    void aMiddlePageSliceIsTheWholeContentBand() throws Exception {
+        LayoutGraph graph = tallAnchor(60, null);
+        List<ResolvedLayoutAnchor> anchors = anchorsOf(graph);
+
+        assertThat(anchors.size()).as("three pages, so one of them is a middle").isGreaterThanOrEqualTo(3);
+        ResolvedLayoutAnchor middle = anchors.get(1);
+        assertThat(middle.y()).as("band bottom").isEqualTo(20.0, within(1e-9));
+        assertThat(middle.pointY(1.0)).as("band top").isEqualTo(180.0, within(1e-9));
+    }
+
+    @Test
+    void anAsymmetricMarginComesOffTheEdgeTheSliceActuallyContains() throws Exception {
+        // The rule the slice makes necessary. A margin is part of the flow extent the
+        // wrapper occupies but no part of the box reported, and a slice only meets the
+        // edges it contains: the top margin is inside the first page's slice, the bottom
+        // margin inside the last page's, and a middle page holds neither.
+        DocumentInsets margin = new DocumentInsets(9, 4, 5, 8);
+        LayoutGraph marginedGraph = tallAnchor(60, margin);
+        List<ResolvedLayoutAnchor> margined = anchorsOf(marginedGraph);
+
+        assertThat(margined.size()).isGreaterThanOrEqualTo(3);
+        assertThat(margined.get(0).pointY(1.0))
+                .as("the first slice's top is inset by the top margin")
+                .isEqualTo(180.0 - 9.0, within(1e-9));
+        assertThat(margined.get(1).y())
+                .as("a middle slice keeps the whole band, bottom")
+                .isEqualTo(20.0, within(1e-9));
+        assertThat(margined.get(1).pointY(1.0))
+                .as("and top")
+                .isEqualTo(180.0, within(1e-9));
+
+        // The bottom edge, on the page that actually holds it. The section has no padding,
+        // so its border box ends where its last content does — and the 5pt of margin below
+        // that is flow extent the slice must not claim.
+        ResolvedLayoutAnchor last = margined.get(margined.size() - 1);
+        double lastInk = ink(marginedGraph, last.pageIndex())
+                .mapToDouble(PlacedFragment::y).min().orElseThrow();
+        assertThat(last.y())
+                .as("the last slice stops at the content, not %.1fpt below it", margin.bottom())
+                .isEqualTo(lastInk, within(1e-9));
+
+        // Both horizontal edges, checked inside this one document rather than against a
+        // second one: the section shrinks to its text, and text laid out in a narrower
+        // column wraps differently, so the two documents' widths are not comparable —
+        // 198.802 against 198.478 for this paragraph. The section has no padding, so its
+        // border box is exactly its widest content, and an anchor that had kept the right
+        // margin would be 4pt wider than the paragraph it holds.
+        double inkLeft = ink(marginedGraph, 0).mapToDouble(PlacedFragment::x).min().orElseThrow();
+        double inkWidth = ink(marginedGraph, 0).mapToDouble(PlacedFragment::width).max().orElseThrow();
+        assertThat(margined.get(0).x())
+                .as("the left margin is outside the box")
+                .isEqualTo(inkLeft, within(1e-9));
+        assertThat(margined.get(0).width())
+                .as("and so is the right one, which only the width shows")
+                .isEqualTo(inkWidth, within(1e-9));
+    }
+
+    /** The paragraph fragments on one page — the anchored section's own content. */
+    private static java.util.stream.Stream<PlacedFragment> ink(LayoutGraph graph, int pageIndex) {
+        return graph.fragments().stream()
+                .filter(f -> f.pageIndex() == pageIndex)
+                .filter(f -> f.payload() != null
+                        && f.payload().getClass().getSimpleName().contains("Paragraph"));
+    }
+
+    @Test
+    void everySliceCarriesTheSameIdentity() throws Exception {
+        List<ResolvedLayoutAnchor> anchors = anchorsOf(tallAnchor(40, null));
+
+        assertThat(anchors.size()).isGreaterThan(1);
+        assertThat(anchors).allSatisfy(anchor -> {
+            assertThat(anchor.id().kind()).isSameAs(Kind.MARKER);
+            assertThat(anchor.id().index()).isEqualTo(0);
+        });
+        assertThat(anchors.stream().map(a -> a.id().groupKey()).distinct())
+                .as("one owner, however many pages it took")
+                .hasSize(1);
+    }
+
+    @Test
+    void slicesFollowEachPagesOwnMarginRatherThanTheDocumentDefault() throws Exception {
+        // Per-page margins are the case a second, independent band formula would get
+        // wrong. These slices come from the geometry a spanning section's border already
+        // uses, so the page the rule widened reports the band that rule gave it.
+        Object group = new Object();
+        StringBuilder body = new StringBuilder();
+        for (int i = 0; i < 60; i++) {
+            body.append("Sentence ").append(i).append(" of a body long enough to paginate. ");
+        }
+        try (DocumentSession session = GraphCompose.document()
+                .pageSize(240, 200)
+                .margin(DocumentInsets.of(20))
+                .create()) {
+            session.pageMargins(List.of(PageMarginRule.page(2, DocumentInsets.of(40))));
+            session.pageFlow()
+                    .add(new LayoutAnchorNode("", new LayoutAnchorId(group, Kind.MARKER, 0),
+                            new SectionBuilder().addParagraph(body.toString()).build()))
+                    .build();
+
+            List<ResolvedLayoutAnchor> anchors =
+                    ResolvedLayoutMetadata.from(session.layoutGraph()).anchors(group, Kind.MARKER);
+            assertThat(anchors.size()).isGreaterThanOrEqualTo(2);
+            assertThat(anchors.get(0).y()).as("page 0 keeps the 20pt band").isEqualTo(20.0, within(1e-9));
+            assertThat(anchors.get(1).y())
+                    .as("page 1 is the one the rule widened, and its slice says so")
+                    .isEqualTo(40.0, within(1e-9));
+            assertThat(anchors.get(1).pointY(1.0)).isEqualTo(160.0, within(1e-9));
+        }
     }
 
     // --- 4. the owner carries the feature's own configuration -----------------
@@ -485,6 +617,24 @@ class ResolvedLayoutPassTest {
     }
 
     // --- helpers -------------------------------------------------------------
+
+    /** One anchored section tall enough to paginate, optionally with a margin on it. */
+    private static LayoutGraph tallAnchor(int sentences, DocumentInsets margin) throws Exception {
+        StringBuilder body = new StringBuilder();
+        for (int i = 0; i < sentences; i++) {
+            body.append("Sentence ").append(i).append(" of a body long enough to paginate. ");
+        }
+        SectionBuilder section = new SectionBuilder().addParagraph(body.toString());
+        if (margin != null) {
+            section.margin(margin);
+        }
+        return compile(flow -> flow.add(new LayoutAnchorNode("",
+                new LayoutAnchorId(new Object(), Kind.MARKER, 0), section.build())), List.of());
+    }
+
+    private static List<ResolvedLayoutAnchor> anchorsOf(LayoutGraph graph) {
+        return ResolvedLayoutMetadata.from(graph).anchors();
+    }
 
     private static EllipseNode dot(double size) {
         return new EllipseNode("dot", size, size, INK, null, null, null, null, null);


### PR DESCRIPTION
## Problem

A `LayoutAnchorNode` wrapping content taller than a page emitted one resolved anchor per
page it occupied — and every one of them repeated the **full measured subtree height**.

A section spanning five pages, on a 320×150 page with a 20pt margin (content band 20..130):

| page | reported y | reported height | reported top |
|---|---|---|---|
| 0 | 20.000 | 453.250 | **473.250** |
| 1 | 20.000 | 453.250 | **473.250** |
| 2 | 20.000 | 453.250 | **473.250** |
| 3 | 20.000 | 453.250 | **473.250** |
| 4 | 91.150 | 453.250 | **544.400** |

Every top is hundreds of points off the page. Nothing could use an anchor on content taller
than one page: not "where does this start on page 2", not "how tall is it here". The
per-page occurrences were there, but each carried a number belonging to no page.

This was written down as a limitation rather than fixed, on the grounds that no consumer
needed the per-page extent yet. One does now, and the numbers turned out to be unusable
rather than merely imprecise.

## Fix

Each occurrence reports the wrapped node's actual **border-box slice on that page**, taken
from the `FragmentPlacement` the compiler had already computed for it.

The placement was always the answer. A composite's fragments are emitted once per page it
occupies, and `CompositeDecoration` clamps each segment to that page's content band — the
same geometry that puts a spanning section's border on every page it crosses, per-page
margins included. `LayoutAnchorDefinition` was discarding it and reading
`prepared.measureResult()` instead. Reading the placement is also what keeps this one
formula rather than a second one drifting beside it.

Same case, after:

| page | y | height | top |
|---|---|---|---|
| 0 | 20.000 | 110.000 | 130.000 |
| 1 | 20.000 | 110.000 | 130.000 |
| 2 | 20.000 | 110.000 | 130.000 |
| 3 | 20.000 | 110.000 | 130.000 |
| 4 | 91.150 | 38.850 | 130.000 |

### Checked against the thing it has to agree with

An anchored section and an `accentLeft` section of the same shape, laid out across the same
five pages — the border fragment is the independent implementation of "this box, clamped to
this page", so the anchor slices have to match it:

| page | accentLeft (y, h) | anchor (y, h) | Δy | Δh |
|---|---|---|---|---|
| 0 | 20.000, 110.000 | 20.000, 110.000 | +0.000000 | +0.000000 |
| 1 | 20.000, 110.000 | 20.000, 110.000 | +0.000000 | +0.000000 |
| 2 | 20.000, 110.000 | 20.000, 110.000 | +0.000000 | +0.000000 |
| 3 | 20.000, 110.000 | 20.000, 110.000 | +0.000000 | +0.000000 |
| 4 | 64.200, 65.800 | 64.200, 65.800 | +0.000000 | +0.000000 |

Page 4 includes the section's own 14pt bottom padding inside the border, and the anchor
reports it too.

### Margins come off per edge

A margin is part of the flow extent the wrapper has to occupy but no part of the box being
reported, and a slice only meets the edges it actually contains:

- the **top** margin is inside the **first** page's slice;
- the **bottom** margin is inside the **last** page's slice;
- a **middle** page holds neither, so it is the whole content band;
- a node that fits on **one** page is both first and last, so it loses both — exactly as
  before;
- **horizontally** every slice spans the whole box, so left and right always come off.

## Unchanged

- **Anchors on content that fits on one page**, which is every anchor that exists today.
  The atomic 8×8 marker, the marker carrying an asymmetric margin, and the marker inside a
  table cell all report the same numbers to 1e-9.
- Border-box semantics: margin excluded, padding included, the wrapped node's box and not
  its container's.
- One `LayoutAnchorId` across every slice — same `groupKey`, `kind` and `index`.
- No path or name inference anywhere.
- **Public API**: nothing added, removed or moved; `extract-api --check` is current
  without regenerating.

## Verification

`./mvnw -B -ntp clean verify -pl :graph-compose-core,:graph-compose-render-pdf,:graph-compose-render-docx,:graph-compose-render-pptx,:graph-compose-templates,:graph-compose-testing,:graph-compose-qa,:graph-compose-coverage -am`
→ **BUILD SUCCESS**. `javadoc:javadoc` green; the knowledge gates green (surfaces current,
stability doc, claims, routes, bundle verify); the backends' no-op handler tests green.

`ResolvedLayoutPassTest` gains four cases, each written against a measurement rather than
against the implementation:

- a multi-page zero-margin anchor: first slice node-top → band bottom, last slice band top
  → node bottom, none of them the whole subtree;
- a middle page is the whole band;
- an asymmetric margin comes off the edge its slice contains, and horizontally off all of
  them;
- per-page margins: a page the rule widened to 40pt reports a 40..160 band, not the
  document default.

Proven fail-closed by putting `measureResult()` back: those four go red and the identity
case stays green, which is right — identity was never the broken part.

**Lane:** shared-engine — `document.layout` only. No Timeline file is touched; the word
does not appear in the diff.
