### PR TITLE
docs(text): correct what the RTL notes say about table cells and lists

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -20,7 +20,7 @@ authoring API; public application code should not import
 | [Layered page design](recipes/layered-page-design.md) | Page background vs. row vs. layer stack vs. canvas — choosing the layer; how a row splits its width, icon beside text, a rule that reaches the column edge |
 | [Absolute placement](recipes/absolute-placement.md) | `addCanvas` + `position(x, y)` for pixel-precise certificates and badges |
 | [Tables](recipes/tables.md) | Row span, zebra rows, totals row, repeated header on page break |
-| [Text direction](recipes/text-direction.md) | `TextDirection` — right-to-left paragraphs, `AUTO` resolved from the text, mixed lines, and the bundled Hebrew / Arabic families |
+| [Text direction](recipes/text-direction.md) | `TextDirection` — right-to-left paragraphs and table cells, `AUTO` resolved from the text, mixed lines, and the bundled Hebrew / Arabic families |
 | [Rich text](recipes/rich-text.md) | `RichText` mixed-style runs in one paragraph: bold/accent/styled segments, inline links, inline images, inline SVG icons, emoji shortcodes, inline shapes and checkboxes |
 | [Letter spacing](recipes/letter-spacing.md) | `DocumentLetterSpacing` — real typographic tracking for spaced caps, declared natively in PDF / PPTX / DOCX so the text layer still holds the word |
 | [Lists](recipes/lists.md) | `addList`: quick bulleted lists, marker customisation, nested lists with per-depth markers, spacing and styled items |

--- a/examples/README.md
+++ b/examples/README.md
@@ -115,7 +115,7 @@ are with the canonical DSL, then jump to its detailed section below.
 | [Rich text](#rich-text) | Every `RichText` method (bold / italic / underline / link / colour / accent / size / append) | [PDF](../assets/readme/examples/rich-text-showcase.pdf) · [Source](src/main/java/com/demcha/examples/features/text/RichTextShowcaseExample.java) |
 | [Text direction](#text-direction) | `TextDirection` — right-to-left paragraphs and table cells, `AUTO` resolved from the first strong character, and Latin embedded in Hebrew | [PDF](../assets/readme/examples/text-direction.pdf) · [Source](src/main/java/com/demcha/examples/features/text/TextDirectionExample.java) |
 | [Arabic article](#arabic-article) | A full right-to-left article — shaped Arabic joined by the engine, every line reordered, natural pagination onto a second page | [PDF](../assets/readme/examples/arabic-article.pdf) · [Source](src/main/java/com/demcha/examples/features/text/ArabicArticleExample.java) |
-| [Hebrew invoice](#hebrew-invoice) | A right-to-left invoice whose every line mixes Hebrew with digits and Latin names — built from rows, since a table cell carries no direction | [PDF](../assets/readme/examples/hebrew-invoice.pdf) · [Source](src/main/java/com/demcha/examples/features/text/HebrewInvoiceExample.java) |
+| [Hebrew invoice](#hebrew-invoice) | A right-to-left invoice whose every line mixes Hebrew with digits and Latin names — built from rows | [PDF](../assets/readme/examples/hebrew-invoice.pdf) · [Source](src/main/java/com/demcha/examples/features/text/HebrewInvoiceExample.java) |
 | [World scripts](#world-scripts) | One card per bundled script — Arabic, Hebrew, Georgian, Armenian, Korean — each set in its own `FontName` family | [PDF](../assets/readme/examples/world-scripts.pdf) · [Source](src/main/java/com/demcha/examples/features/text/WorldScriptsExample.java) |
 | [Inline shapes](#inline-shapes) | `InlineShapeRun` — dots, arrows, chevrons, diamonds, stars, checkmarks and checkboxes drawn as geometry on the text baseline | [PDF](../assets/readme/examples/inline-shapes.pdf) · [Source](src/main/java/com/demcha/examples/features/text/InlineShapesExample.java) |
 | [Inline highlight chips](#inline-highlight-chips) | `RichText.code(text)` / `chip(text, fg, bg)` / `highlight(text, style, bg, radius, padding)` — text on a rounded padded fill (inline code + status badges), wrapping across lines | [PDF](../assets/readme/examples/inline-highlight-chips.pdf) · [Source](src/main/java/com/demcha/examples/features/text/InlineHighlightExample.java) |
@@ -707,7 +707,8 @@ failures only appear at length: paragraphs wrap with every line reordered,
 the flow breaks onto a second page and keeps its direction, and Latin names
 and digits inside the Arabic keep running forwards. The one thing positioned
 by hand is the list — a list carries no direction of its own, so it declares
-`align(RIGHT)` or its bullets land on the wrong side.
+`align(RIGHT)` to sit against the right margin. Its items are still laid out as
+left-to-right paragraphs, so each bullet stays at the left end of its item.
 
 <!-- doc-example-ignore: quotes a runnable example; the source it is taken from is compiled and executed by the examples module -->
 ```java
@@ -728,9 +729,9 @@ page.addList(list -> list
 
 The document type where right-to-left text meets numbers: a Hebrew
 description beside a Latin product name, a date, a quantity, a total. Line
-items are **rows rather than a table**, because a table cell carries no
-writing direction. Latin runs whose trailing punctuation must stay put are
-wrapped in Unicode isolates.
+items are laid out as **rows**; a table cell takes a writing direction too,
+through `DocumentTableStyle.direction(...)`. Latin runs whose trailing
+punctuation must stay put are wrapped in Unicode isolates.
 
 <!-- doc-example-ignore: quotes a runnable example; the source it is taken from is compiled and executed by the examples module -->
 ```java

--- a/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/PdfRenderEnvironment.java
+++ b/render-pdf/src/main/java/com/demcha/compose/document/backend/fixed/pdf/PdfRenderEnvironment.java
@@ -189,8 +189,7 @@ public final class PdfRenderEnvironment {
      * <p>Reordering is the only way text reaches the page in a form that is not what an
      * author typed — Arabic is shaped into its joined forms on the same path — so this is
      * what tells the save whether the document's glyph maps are worth reading back. It is
-     * set from the paragraph and chip paths; a table cell carries no direction and so is
-     * never reordered.</p>
+     * set from the paragraph, chip and table-cell paths.</p>
      *
      * @since 2.2.0
      */


### PR DESCRIPTION
## Why

Four statements about right-to-left text no longer match the code.

- Three still say a table cell has no writing direction, which stopped being true when #558 gave `DocumentTableStyle` a `direction(...)` of its own: the Hebrew invoice row and section in `examples/README.md`, and the `PdfRenderEnvironment.markReorderedText` Javadoc, which adds that a table cell is never reordered, although the table-cell path marks reordered text the way the paragraph and chip paths do.
- The Arabic article section says a list declares `align(RIGHT)` or its bullets land on the wrong side. `align(RIGHT)` moves each item to the right margin, but an item is still a left-to-right paragraph with the bullet as its text prefix, so the bullet stays at the item's left end.

The recipe catalogue row for text direction also named paragraphs only.

## What changed

- `examples/README.md`: the Hebrew invoice row drops the stale reason, and the section says the line items are rows and that a table cell takes a writing direction through `DocumentTableStyle.direction(...)`, which is what `HebrewInvoiceExample`'s own Javadoc already says. The Arabic article section says what `align(RIGHT)` moves and what it leaves.
- `docs/recipes.md`: the text-direction row names table cells as well as paragraphs.
- `PdfRenderEnvironment.markReorderedText` Javadoc: set from the paragraph, chip and table-cell paths (`PdfParagraphFragmentRenderHandler`, `PdfTableRowFragmentRenderHandler`). Comment only.

## Verification

- Documentation guards: core `com.demcha.documentation.*` plus `EnginePdfBoundaryTest` (links and anchors, recipe catalogue, canonical surface, coverage) **115** green; qa `DocumentationSnippetCompileTest` + `DocumentationExamplesTest` **18** green.
- `RtlTableCellTest` 8 green; `javadoc:javadoc` on `graph-compose-render-pdf` clean (0 warnings, 0 errors).
- Examples module (`./mvnw -f examples/pom.xml test`) **75** green.
- `node knowledge/tools/claims/check-claims.mjs --check` and `node knowledge/tools/routing/check-routes.mjs` green; `git diff --check` clean.

## Notes

- Pairs with #679, which fixes `docs/recipes/text-direction.md` itself. The two are independent: nothing here links to #679's new anchor, so they merge in either order.
- Not covered here: the same list claim in the `ArabicArticleExample` Javadoc and code comment and in the released v2.2.0 CHANGELOG entry, and the README's Indic-reordering line, which needs its own investigation.

**Lane:** canonical — documentation and one Javadoc comment; no code.
